### PR TITLE
Add macOS lwjgl dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,8 @@
                  [cheshire "5.8.0"]
                  [org.lwjgl/lwjgl "3.2.0" :classifier "natives-linux" :native-prefix ""]
                  [org.lwjgl/lwjgl-lmdb "3.2.0" :classifier "natives-linux" :native-prefix ""]
+                 [org.lwjgl/lwjgl "3.2.0" :classifier "natives-macos" :native-prefix ""]
+                 [org.lwjgl/lwjgl-lmdb "3.2.0" :classifier "natives-macos" :native-prefix ""]
                  [org.lwjgl/lwjgl-lmdb "3.2.0"]
                  [org.apache.kafka/kafka-clients "2.0.0"]
                  [org.eclipse.rdf4j/rdf4j-rio-ntriples "2.3.2" :exclusions [commons-io]]


### PR DESCRIPTION
Not sure if you want to sully your codebase with macOS support, but I was able to make the tests pass on macOS after adding these.