### PR TITLE
Make index Reducible

### DIFF
--- a/test/crux/index_test.clj
+++ b/test/crux/index_test.clj
@@ -738,6 +738,11 @@
              (->> (idx/idx->seq r)
                   (map second))))
 
+    (t/is (= [1 2 3 4 5]
+             (into []
+                   (map second)
+                   (idx/idx->series r))))
+
     (t/is (= [1 2 3]
              (->> (idx/idx->seq (idx/new-less-than-virtual-index r 4))
                   (map second))))


### PR DESCRIPTION
related to xtdb/xtdb#2034 

Baby steps, I didn't touch where it's used, just modified the impl. so that we can get there eventually.

* added `crux.index/idx->series` that returns a reified index "serie" that can be consumed as a reducible or a seq

* replace the impl of `crux.index/idx->seq` to leverage `crux.index/idx->series`

* updated test so that both new impl are verified as valid (seq version still works as expected and reducible works on similar test using into+xf)

* killed some un-used imports on modified namespaces

Still to do: 

* doing something similar for `crux.index/layered-idx->seq`
* building more high level api surface on top of new reducible interface

