### PR TITLE
Move tx-ops spec to api

### DIFF
--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -129,7 +129,7 @@ toc::[]
 ----
   (tx-log [system tx-log-context from-tx-id with-documents?]
     "Reads the transaction log lazily. Optionally includes
-    documents, which allow the contents under the :crux.tx/tx-ops
+    documents, which allow the contents under the :crux.api/tx-ops
     key to be piped into (submit-tx tx-ops) of another
     Crux instance.
     tx-log-context  a context from (new-tx-log-context system)

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -237,7 +237,7 @@ curl -X GET $nodeURL/tx-log
 [source,clj]
 ----
 ({:crux.tx/tx-time #inst "2019-01-07T15:11:13.411-00:00",
-  :crux.tx/tx-ops [[
+  :crux.api/tx-ops [[
     :crux.tx/put "a15f8b81a160b4eebe5c84e9e3b65c87b9b2f18e" "c28f6d258397651106b7cb24bb0d3be234dc8bd1"
     #inst "2019-01-07T14:57:08.462-00:00"]],
   :crux.tx/tx-id 0}

--- a/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -382,7 +382,7 @@
             [:thead
              [:th (str :crux.tx/tx-id)]
              [:th (str :crux.tx/tx-time)]
-             [:th (str :crux.tx/tx-ops)]]
+             [:th (str :crux.api/tx-ops)]]
             [:tbody
              (for [{:crux.tx/keys [tx-id tx-time tx-ops]} tx-log
                    :let [tx-time-str (format-date tx-time)]]

--- a/src/crux/api/ICruxAPI.java
+++ b/src/crux/api/ICruxAPI.java
@@ -141,7 +141,7 @@ public interface ICruxAPI extends Closeable {
 
     /**
      * Reads the transaction log lazily. Optionally includes
-     * documents, which allow the contents under the :crux.tx/tx-ops
+     * documents, which allow the contents under the :crux.api/tx-ops
      * key to be piped into {@link #submitTx(List txOps)} of another
      * Crux instance.
      *

--- a/src/crux/bootstrap.clj
+++ b/src/crux/bootstrap.clj
@@ -100,7 +100,7 @@
     (for [tx-log-entry (db/tx-log tx-log tx-log-context from-tx-id)]
       (if with-documents?
         (update tx-log-entry
-                :crux.tx/tx-ops
+                :crux.api/tx-ops
                 #(with-open [snapshot (kv/new-snapshot kv-store)]
                    (tx/enrich-tx-ops-with-documents snapshot object-store %)))
         tx-log-entry)))

--- a/test/crux/api_test.clj
+++ b/test/crux/api_test.clj
@@ -147,7 +147,7 @@
             (t/is (instance? LazySeq result))
             (t/is (not (realized? result)))
             (t/is (= [(assoc submitted-tx
-                             :crux.tx/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
+                             :crux.api/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
                      result))
             (t/is (realized? result))))
 
@@ -157,7 +157,7 @@
               (t/is (instance? LazySeq result))
               (t/is (not (realized? result)))
               (t/is (= [(assoc submitted-tx
-                               :crux.tx/tx-ops [[:crux.tx/put (c/new-id :ivan) {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+                               :crux.api/tx-ops [[:crux.tx/put (c/new-id :ivan) {:crux.db/id :ivan :name "Ivan"} valid-time]])]
                        result))
               (t/is (realized? result)))))
 

--- a/test/crux/fixtures.clj
+++ b/test/crux/fixtures.clj
@@ -56,7 +56,7 @@
     (db/index-doc (tx/->KvIndexer kv this object-store) content-hash doc))
 
   (submit-tx [this tx-ops]
-    (s/assert :crux.tx/tx-ops tx-ops)
+    (s/assert :crux.api/tx-ops tx-ops)
     (let [transact-time (cio/next-monotonic-date)
           tx-id (.getTime transact-time)
           tx-events (tx/tx-ops->tx-events tx-ops)
@@ -81,7 +81,7 @@
     (let [i (kv/new-iterator tx-log-context)]
       (for [[k v] (idx/all-keys-in-prefix i (c/encode-tx-log-key-to nil from-tx-id) (c/encode-tx-log-key-to nil) true)]
         (assoc (c/decode-tx-log-key-from k)
-               :crux.tx/tx-ops (nippy/fast-thaw (mem/->on-heap v))))))
+               :crux.api/tx-ops (nippy/fast-thaw (mem/->on-heap v))))))
 
   Closeable
   (close [_]))

--- a/test/crux/index_test.clj
+++ b/test/crux/index_test.clj
@@ -391,11 +391,11 @@
         (t/is (not (realized? log)))
         (t/is (= [{:crux.tx/tx-id tx1-id
                    :crux.tx/tx-time tx1-tx-time
-                   :crux.tx/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
+                   :crux.api/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
                   {:crux.tx/tx-id tx2-id
                    :crux.tx/tx-time tx2-tx-time
-                   :crux.tx/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
-                                    [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
+                   :crux.api/tx-ops [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
+                                     [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
                  log))))))
 
 (t/deftest test-can-perform-unary-join

--- a/test/crux/kafka_test.clj
+++ b/test/crux/kafka_test.clj
@@ -104,9 +104,9 @@
               ;; with random ids.
               (t/is (= {:crux.tx/tx-time tx-time
                         :crux.tx/tx-id tx-id}
-                       (dissoc (first log) :crux.tx/tx-ops)))
+                       (dissoc (first log) :crux.api/tx-ops)))
               (t/is (= 1 (count log)))
-              (t/is (= 3 (count (:crux.tx/tx-ops (first log))))))))))))
+              (t/is (= 3 (count (:crux.api/tx-ops (first log))))))))))))
 
 (t/deftest test-can-process-compacted-documents
   ;; when doing a evict a tombstone document will be written to


### PR DESCRIPTION
Moved `tx-ops` over to api. 

Could also do the same for `tx-time` and `tx-id` for continuity before merged if necessary. 