### PR TITLE
Fixes #208 Remove ID from put and cas outside of doc

### DIFF
--- a/bench/src/crux_bench/watdiv.clj
+++ b/bench/src/crux_bench/watdiv.clj
@@ -402,7 +402,6 @@
               (crux/submit-tx
                 crux
                 [[:crux.tx/put
-                  ::watdiv-ingestion-status
                   {:crux.db/id ::watdiv-ingestion-status :done? false}]])]
           (crux/db crux tx-time tx-time) ;; block until indexed
           (crux/db
@@ -411,7 +410,6 @@
              (crux/submit-tx
                crux
                [[:crux.tx/put
-                 ::watdiv-ingestion-status
                  {:crux.db/id ::watdiv-ingestion-status
                   :watdiv/ingest-start-time time-before
                   :watdiv/kafka-ingest-time (- (.getTime kafka-ingest-done) (.getTime time-before))

--- a/dev/patrik.clj
+++ b/dev/patrik.clj
@@ -166,13 +166,13 @@
 
   (crux.api/submit-tx
     crux
-    [[:crux.tx/put :a1
+    [[:crux.tx/put
       {:crux.db/id :a1 :user/name "patrik" :user/post 1 :post/cost 30}]
-     [:crux.tx/put :a2
+     [:crux.tx/put
       {:crux.db/id :a2 :user/name "patrik" :user/post 2 :post/cost 35}]
-     [:crux.tx/put :a3
+     [:crux.tx/put
       {:crux.db/id :a3 :user/name "patrik" :user/post 3 :post/cost 5}]
-     [:crux.tx/put :a4
+     [:crux.tx/put
       {:crux.db/id :a4 :user/name "niclas" :user/post 1 :post/cost 8}]])
 
   (clojure.pprint/pprint

--- a/docs/crux_node_only_system.clj
+++ b/docs/crux_node_only_system.clj
@@ -37,7 +37,7 @@
 
   (db/submit-tx
     (:tx-log (:crux/cluster-node system))
-    [[:crux.tx/put :dbpedia.resource/Pablo-Picasso
+    [[:crux.tx/put
       {:crux.db/id :dbpedia.resource/Pablo-Picasso
        :name "Pablo"
        :last-name "Picasso"}

--- a/docs/examples.clj
+++ b/docs/examples.clj
@@ -28,8 +28,8 @@
 ;; tag::submit-tx[]
 (crux/submit-tx
  system
- [[:crux.tx/put :dbpedia.resource/Pablo-Picasso ; id for Kafka
-   {:crux.db/id :dbpedia.resource/Pablo-Picasso ; id for Crux
+ [[:crux.tx/put
+   {:crux.db/id :dbpedia.resource/Pablo-Picasso ; id
     :name "Pablo"
     :last-name "Picasso"}
    #inst "2018-05-18T09:20:27.966-00:00"]]) ; valid time

--- a/docs/get_started.adoc
+++ b/docs/get_started.adoc
@@ -39,9 +39,6 @@ experiment with the <<rest.adoc#,REST API>>.
 ----
 include::./examples.clj[tags=submit-tx]
 ----
-Note that the ID for the Kafka transaction and the ID within the Crux document
-must be the same. Restating the ID within the Crux document is currently necessary
-although this may change in the future, as the standard API evolves.
 
 == Querying
 

--- a/docs/patterns.adoc
+++ b/docs/patterns.adoc
@@ -36,7 +36,6 @@ link to it.
                 txs# (mapv
                        (fn [old-ent# ent#]
                          [:crux.tx/cas
-                          (:crux.db/id old-ent#)
                           old-ent#
                           ent#])
                        entities#
@@ -83,7 +82,7 @@ link to it.
   [entity-id new-attrs valid-time]
   (let [entity-prev-value (crux/entity (crux/db system) entity-id)]
     (crux/submit-tx system
-      [[:crux.tx/put entity-id
+      [[:crux.tx/put
         (merge entity-prev-value new-attrs)
         valid-time]])))
 
@@ -160,7 +159,7 @@ link to it.
                           :delete :crux.tx/delete-op
                           :cas :crux.tx/cas-op
                           :evict :crux.tx/evict-op)
-   [:crux.tx/cas #uuid "6f0232d0-f3f9-4020-a75f-17b067f41203"
+   [:crux.tx/cas
     {:crux.db/id #uuid "6f0232d0-f3f9-4020-a75f-17b067f41203"
      :name "John Wayne"
      :username "jwa"}

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -238,7 +238,7 @@ curl -X GET $nodeURL/tx-log
 ----
 ({:crux.tx/tx-time #inst "2019-01-07T15:11:13.411-00:00",
   :crux.api/tx-ops [[
-    :crux.tx/put "a15f8b81a160b4eebe5c84e9e3b65c87b9b2f18e" "c28f6d258397651106b7cb24bb0d3be234dc8bd1"
+    :crux.tx/put "c28f6d258397651106b7cb24bb0d3be234dc8bd1"
     #inst "2019-01-07T14:57:08.462-00:00"]],
   :crux.tx/tx-id 0}
 
@@ -255,8 +255,8 @@ Takes a vector of transactions (any combination of `:put`, `:delete`, `:cas` and
 ----
 curl -X POST \
      -H "Content-Type: application/edn" \
-     -d '[[:crux.tx/put :ivan {:crux.db/id :ivan, :name "Ivan" :last-name "Petrov"}],
-          [:crux.tx/put :boris {:crux.db/id :boris, :name "Boris" :last-name "Petrov"}],
+     -d '[[:crux.tx/put {:crux.db/id :ivan, :name "Ivan" :last-name "Petrov"}],
+          [:crux.tx/put {:crux.db/id :boris, :name "Boris" :last-name "Petrov"}],
           [:crux.tx/delete :maria  #inst "2012-05-07T14:57:08.462-00:00"]]' \
      $nodeURL/tx-log
 ----

--- a/docs/transactions.adoc
+++ b/docs/transactions.adoc
@@ -28,7 +28,7 @@ sequence of transaction operations:
 
 [source,clj]
 ----
-[[:crux.tx/put :dbpedia.resource/Pablo-Picasso
+[[:crux.tx/put
  {:crux.db/id :dbpedia.resource/Pablo-Picasso
   :name "Pablo"
   :last-name "Picasso"}
@@ -68,15 +68,13 @@ the supplied `valid time`.
 [source,clojure]
 ----
 [:crux.tx/put
- :dbpedia.resource/Pablo-Picasso <1>
- {:crux.db/id :dbpedia.resource/Pablo-Picasso :first-name :Pablo} <2>
- #inst "2018-05-18T09:20:27.966-00:00"] <3>
+ {:crux.db/id :dbpedia.resource/Pablo-Picasso :first-name :Pablo} <1>
+ #inst "2018-05-18T09:20:27.966-00:00"] <2>
 ----
 
-<1> The ID of the document to be used for the transaction log.
-<2> The document itself. Note that the ID must also be included as part of the
-document (this requirement to state the ID twice may change in future).
-<3> `valid time`
+<1> The document itself. Note that the ID must be included as part of the
+document.
+<2> `valid time`
 
 Note that `valid time` is optional and defaults to transaction time,
 which is taken from the Kafka log.
@@ -93,16 +91,14 @@ newer one, if the existing document is as expected.
 [source,clojure]
 ----
 [:crux.tx/cas
- :dbpedia.resource/Pablo-Picasso <1>
+ {..} <1>
  {..} <2>
- {..} <3>
-  #inst "2018-05-18T09:21:31.846-00:00"] <4>
+  #inst "2018-05-18T09:21:31.846-00:00"] <3>
 ----
 
-<1> The ID of the document being written
-<2> Expected Document
-<3> New document
-<4> `valid time`
+<1> Expected Document
+<2> New document
+<3> `valid time`
 
 == Delete
 

--- a/example/backup-restore/src/example_backup_restore/main.clj
+++ b/example/backup-restore/src/example_backup_restore/main.clj
@@ -30,10 +30,10 @@
 
   (api/submit-tx
            syst
-           [[:crux.tx/put :id/jeff
+           [[:crux.tx/put
              {:crux.db/id :id/jeff
               :person/name "Jeff"}]
-            [:crux.tx/put :id/lia
+            [:crux.tx/put
              {:crux.db/id :id/lia
               :person/name "Lia"}]])
 
@@ -44,4 +44,3 @@
   (api/document
     (api/db syst #inst "2019-02-02"
             #inst "2019-04-16T12:35:05.042-00:00")))
-

--- a/example/imdb/src/imdb/main.clj
+++ b/example/imdb/src/imdb/main.clj
@@ -46,7 +46,7 @@
                                         (update doc key str/split #"\,"))
                                       doc
                                       (filter list-columns? (keys doc)))]
-                            [:crux.tx/put doc-id (assoc doc :crux.db/id doc-id)])))))))
+                            [:crux.tx/put (assoc doc :crux.db/id doc-id)])))))))
               (log/infof "completed %s" file-path))))]
     (doseq [f futures] @f)))
 

--- a/example/repl-walkthrough/walkthrough.clj
+++ b/example/repl-walkthrough/walkthrough.clj
@@ -6,18 +6,18 @@
 
 
 (def crux-options
-  {:kv-backend "crux.kv.memdb.MemKv" ; in-memory, see docs for LMDB/RocksDB storage 
+  {:kv-backend "crux.kv.memdb.MemKv" ; in-memory, see docs for LMDB/RocksDB storage
    :db-dir     "data/db-dir-1"}) ; :db-dir is ignored when using MemKv
 
 
 (def system (crux/start-standalone-system crux-options))
 
 
-; transaction containing a `put` operation, optionally specifying a valid time 
+; transaction containing a `put` operation, optionally specifying a valid time
 (crux/submit-tx
   system
-  [[:crux.tx/put :dbpedia.resource/Pablo-Picasso ; id used for the transaction log
-    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; same id inside the document
+  [[:crux.tx/put
+    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; id
      :name "Pablo"
      :last-name "Picasso"
      :location "Spain"}
@@ -27,13 +27,12 @@
 ; transaction containing a `cas` (compare-and-swap) operation
 (crux/submit-tx
   system
-  [[:crux.tx/cas 
-    :dbpedia.resource/Pablo-Picasso ; id used for the transaction log
-    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; old version 
+  [[:crux.tx/cas
+    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; old version
      :name "Pablo"
      :last-name "Picasso"
      :location "Spain"}
-    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; new version 
+    {:crux.db/id :dbpedia.resource/Pablo-Picasso ; new version
      :name "Pablo"
      :last-name "Picasso"
      :height 1.63
@@ -77,8 +76,7 @@
 ; `put` the new version of the document again
 (crux/submit-tx
   system
-  [[:crux.tx/put 
-    :dbpedia.resource/Pablo-Picasso
+  [[:crux.tx/put
     {:crux.db/id :dbpedia.resource/Pablo-Picasso
      :name "Pablo"
      :last-name "Picasso"

--- a/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -575,7 +575,6 @@
           (api/submit-tx
            crux
            [[:crux.tx/put
-             id
              {:crux.db/id id
               :message-post/created created
               :message-post/name name
@@ -614,7 +613,6 @@
           (api/submit-tx
            crux
            [[:crux.tx/put
-             id
              {:crux.db/id id
               :message-post/created (instant/read-instant-date created)
               :message-post/edited now

--- a/src/crux/api.clj
+++ b/src/crux/api.clj
@@ -16,7 +16,6 @@
 (defmulti tx-op first)
 
 (defmethod tx-op :crux.tx/put [_] (s/cat :op #{:crux.tx/put}
-                                         :id :crux.db/id
                                          :doc ::doc
                                          :start-valid-time (s/? date?)
                                          :end-valid-time (s/? date?)))
@@ -27,7 +26,6 @@
                                             :end-valid-time (s/? date?)))
 
 (defmethod tx-op :crux.tx/cas [_] (s/cat :op #{:crux.tx/cas}
-                                         :id :crux.db/id
                                          :old-doc (s/nilable ::doc)
                                          :new-doc ::doc
                                          :at-valid-time (s/? date?)))

--- a/src/crux/codec.clj
+++ b/src/crux/codec.clj
@@ -32,7 +32,7 @@
 
 ; how they work
 (comment
-  (api/submit-tx syst [:crux.tx/put :ids/ivan {:crux.db/id :ids/ivan :name "ivan"}])
+  (api/submit-tx syst [:crux.tx/put {:crux.db/id :ids/ivan :name "ivan"}])
 
   ; [roughly speaking] for queries by attr name and value
   ; in attribute+value+entity+content-hash-index-id

--- a/src/crux/rdf.clj
+++ b/src/crux/rdf.clj
@@ -219,7 +219,7 @@
                  (when (zero? (long (mod n *ntriples-log-size*)))
                    (log/debug "submitted" n))
                  (let [tx-ops (vec (for [entity entities]
-                                     [:crux.tx/put (:crux.db/id entity) entity]))]
+                                     [:crux.tx/put entity]))]
                    (db/submit-tx tx-log tx-ops))
                  (+ n (count entities)))
                0)))

--- a/src/crux/tx.clj
+++ b/src/crux/tx.clj
@@ -176,22 +176,37 @@
     {:crux.index/index-version (idx/current-index-version kv)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
+(defmulti tx-op-format first)
+
+(defmethod tx-op-format ::put [tx-op] (let [[op doc & args] tx-op
+                                            id (:crux.db/id doc)]
+                                        (into [::put id doc] args)))
+
+(defmethod tx-op-format ::cas [tx-op] (let [[op old-doc new-doc & args] tx-op
+                                            new-id (:crux.db/id new-doc)
+                                            old-id (:crux.db/id old-doc)]
+                                        (if (or (= nil old-id) (= new-id old-id))
+                                          (into [::cas new-id old-doc new-doc] args)
+                                          (throw (IllegalArgumentException.
+                                                  (str "CAS, document id's do not match: " old-id " " new-id))))))
+
+(defmethod tx-op-format :default [tx-op] tx-op)
+
 (defn tx-ops->docs [tx-ops]
-  (vec (for [[_ id & args] tx-ops
-             doc (filter map? args)]
-         (if (= (c/new-id id) (c/new-id (get doc :crux.db/id)))
-           doc
-           (throw (IllegalArgumentException.
-                   (str "Document's id does not match the operation id: " (get doc :crux.db/id) " " id)))))))
+  (let [tx-ops-w-id (into [] (for [tx-op tx-ops] (tx-op-format tx-op)))]
+    (vec (for [[op id & args] tx-ops-w-id
+               doc (filter map? args)]
+           doc))))
 
 (defn tx-ops->tx-events [tx-ops]
-  (let [tx-events (mapv (fn [[op id & args]]
+  (let [tx-ops-w-id (into [] (for [tx-op tx-ops] (tx-op-format tx-op)))
+        tx-events (mapv (fn [[op id & args]]
                           (into [op (str (c/new-id id))]
                                 (for [arg args]
                                   (if (map? arg)
                                     (-> arg c/new-id str)
                                     arg))))
-                        tx-ops)]
+                        tx-ops-w-id)]
     (s/assert :crux.tx.event/tx-events tx-events)
     tx-events))
 

--- a/test/crux/api_test.clj
+++ b/test/crux/api_test.clj
@@ -29,9 +29,9 @@
         content-ivan {:crux.db/id :ivan :name "Ivan"}]
 
     (t/testing "put works with no id"
-      (t/is (.submitTx f/*api* [[:crux.tx/put content-ivan valid-time]])))
-
-    (Thread/sleep 1000)
+      (t/is
+       (let [submitted-tx (.submitTx f/*api* [[:crux.tx/put content-ivan valid-time]])]
+         (.db f/*api* valid-time (:crux.tx/tx-time submitted-tx)))))
 
     (t/testing "Delete works with id"
       (t/is (.submitTx f/*api* [[:crux.tx/delete :ivan]])))))

--- a/test/crux/api_test.clj
+++ b/test/crux/api_test.clj
@@ -22,7 +22,19 @@
         content-ivan {:crux.db/id :ivan :name "Ivan"}
         content-hash (str (c/new-id content-ivan))]
     (t/is (thrown-with-msg? Exception (re-pattern  (str content-hash "|HTTP status 400"))
-                            (.submitTx f/*api* [[:crux.tx/put :ivan content-hash valid-time]])))))
+                            (.submitTx f/*api* [[:crux.tx/put content-hash valid-time]])))))
+
+(t/deftest test-single-id
+  (let [valid-time (Date.)
+        content-ivan {:crux.db/id :ivan :name "Ivan"}]
+
+    (t/testing "put works with no id"
+      (t/is (.submitTx f/*api* [[:crux.tx/put content-ivan valid-time]])))
+
+    (Thread/sleep 1000)
+
+    (t/testing "Delete works with id"
+      (t/is (.submitTx f/*api* [[:crux.tx/delete :ivan]])))))
 
 (t/deftest test-can-use-api-to-access-crux
   (t/testing "status"
@@ -44,7 +56,7 @@
     (let [valid-time (Date.)
           {:keys [crux.tx/tx-time
                   crux.tx/tx-id]
-           :as submitted-tx} (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+           :as submitted-tx} (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
       (t/is (true? (.hasSubmittedTxUpdatedEntity f/*api* submitted-tx :ivan)))
       (t/is (= tx-time (.sync f/*api* (Duration/ofMillis 1000))))
       (t/is (= tx-time (.sync f/*api* nil)))
@@ -177,7 +189,7 @@
           (let [valid-time (Date.)
                 {:keys [crux.tx/tx-time
                         crux.tx/tx-id]
-                 :as submitted-tx} (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
+                 :as submitted-tx} (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
             (t/is (true? (.hasSubmittedTxUpdatedEntity f/*api* submitted-tx :ivan)))
             (t/is (= tx-time (.sync f/*api* (Duration/ofMillis 1000))))
             (t/is (= tx-time (.sync f/*api* nil))))
@@ -202,10 +214,10 @@
               (t/is (= 0 (:name stats))))))))))
 
 (t/deftest test-document-bug-123
-  (let [version-1-submitted-tx (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan" :version 1}]])]
+  (let [version-1-submitted-tx (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1}]])]
     (t/is (true? (.hasSubmittedTxUpdatedEntity f/*api* version-1-submitted-tx :ivan))))
 
-  (let [version-2-submitted-tx (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan" :version 2}]])]
+  (let [version-2-submitted-tx (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2}]])]
     (t/is (true? (.hasSubmittedTxUpdatedEntity f/*api* version-2-submitted-tx :ivan))))
 
   (let [history (.history f/*api* :ivan)]
@@ -216,12 +228,11 @@
                (.document f/*api* content-hash))))))
 
 (t/deftest test-db-history-api
-  (let [version-1-submitted-tx (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan" :version 1} #inst "2019-02-01"]])
-        version-2-submitted-tx (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan" :version 2} #inst "2019-02-02"]])
-        version-3-submitted-tx (.submitTx f/*api* [[:crux.tx/put :ivan {:crux.db/id :ivan :name "Ivan" :version 3} #inst "2019-02-03"]])]
+  (let [version-1-submitted-tx (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1} #inst "2019-02-01"]])
+        version-2-submitted-tx (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2} #inst "2019-02-02"]])
+        version-3-submitted-tx (.submitTx f/*api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 3} #inst "2019-02-03"]])]
     (t/is (true? (.hasSubmittedTxUpdatedEntity f/*api* version-3-submitted-tx :ivan)))
     (let [version-2-corrected-submitted-tx (.submitTx f/*api* [[:crux.tx/put
-                                                                :ivan
                                                                 {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
                                                                 #inst "2019-02-02"]])]
       (t/is (true? (.hasSubmittedTxCorrectedEntity f/*api* version-2-corrected-submitted-tx #inst "2019-02-02" :ivan)))

--- a/test/crux/fixtures.clj
+++ b/test/crux/fixtures.clj
@@ -245,10 +245,10 @@
 (defn maps->tx-ops
   ([maps]
    (vec (for [m maps]
-          [:crux.tx/put (:crux.db/id m) m])))
+          [:crux.tx/put m])))
   ([maps ts]
    (vec (for [m maps]
-          [:crux.tx/put (:crux.db/id m) m ts]))))
+          [:crux.tx/put m ts]))))
 
 (defn transact!
   "Helper fn for transacting entities"

--- a/test/crux/kafka_test.clj
+++ b/test/crux/kafka_test.clj
@@ -37,7 +37,7 @@
   (with-open [in (io/input-stream (io/resource resource))]
     (vec (for [entity (->> (rdf/ntriples-seq in)
                            (rdf/statements->maps))]
-           [:crux.tx/put (:crux.db/id entity) entity]))))
+           [:crux.tx/put entity]))))
 
 (t/deftest test-can-transact-entities
   (let [tx-topic "test-can-transact-entities-tx"
@@ -136,8 +136,8 @@
             evicted-doc-hash
             (do @(db/submit-tx
                    tx-log
-                   [[:crux.tx/put (:crux.db/id evicted-doc) evicted-doc]
-                    [:crux.tx/put (:crux.db/id non-evicted-doc) non-evicted-doc]])
+                   [[:crux.tx/put evicted-doc]
+                    [:crux.tx/put non-evicted-doc]])
 
                 (k/consume-and-index-entities consume-opts)
                 (while (not= {:txs 0 :docs 0} (k/consume-and-index-entities consume-opts)))
@@ -149,7 +149,7 @@
               @(db/submit-tx tx-log [[:crux.tx/evict (:crux.db/id evicted-doc)]])
                 @(db/submit-tx
                    tx-log
-                   [[:crux.tx/put (:crux.db/id after-evict-doc) after-evict-doc]]))]
+                   [[:crux.tx/put after-evict-doc]]))]
 
         (while (not= {:txs 0 :docs 0} (k/consume-and-index-entities consume-opts)))
 

--- a/test/crux/lubm_test.clj
+++ b/test/crux/lubm_test.clj
@@ -30,7 +30,7 @@
   (with-open [in (io/input-stream (io/resource resource))]
     (vec (for [entity (->> (rdf/ntriples-seq in)
                            (rdf/statements->maps))]
-           [:crux.tx/put (:crux.db/id entity) entity]))))
+           [:crux.tx/put entity]))))
 
 (defn with-lubm-data [f]
   (let [tx-ops (->> (concat (load-ntriples-example "lubm/univ-bench.ntriples")

--- a/test/crux/query_test.clj
+++ b/test/crux/query_test.clj
@@ -1206,8 +1206,8 @@
   (t/testing "can create new user"
     (let [{:crux.tx/keys [tx-time
                           tx-id] :as submitted-tx}
-          (api/submit-tx *api* [[:crux.tx/cas :ivan nil {:crux.db/id :ivan
-                                                         :name "Ivan 1st"}]])]
+          (api/submit-tx *api* [[:crux.tx/cas nil {:crux.db/id :ivan
+                                                   :name "Ivan 1st"}]])]
 
       (t/is (true? (api/submitted-tx-updated-entity? *api* submitted-tx :ivan)))
       (t/is (false? (api/submitted-tx-updated-entity? *api* submitted-tx :petr)))
@@ -1224,8 +1224,8 @@
   (t/testing "cannot create existing user"
     (let [{:crux.tx/keys [tx-time
                           tx-id] :as submitted-tx}
-          (api/submit-tx *api* [[:crux.tx/cas :ivan nil {:crux.db/id :ivan
-                                                         :name "Ivan 2nd"}]])]
+          (api/submit-tx *api* [[:crux.tx/cas nil {:crux.db/id :ivan
+                                                   :name "Ivan 2nd"}]])]
 
       (t/is (false? (api/submitted-tx-updated-entity? *api* submitted-tx :ivan)))
 
@@ -1237,7 +1237,7 @@
 
   (t/testing "can update existing user"
     (let [{:crux.tx/keys [tx-time] :as submitted-update-tx}
-          (api/submit-tx *api* [[:crux.tx/cas :ivan
+          (api/submit-tx *api* [[:crux.tx/cas
                                  {:crux.db/id :ivan
                                   :name "Ivan 1st"}
                                  {:crux.db/id :ivan
@@ -1250,12 +1250,12 @@
 
       (t/testing "last CAS command in tx wins"
         (let [{:crux.tx/keys [tx-time] :as submitted-tx}
-              (api/submit-tx *api* [[:crux.tx/cas :ivan
+              (api/submit-tx *api* [[:crux.tx/cas
                                      {:crux.db/id :ivan
                                       :name "Ivan 2nd"}
                                      {:crux.db/id :ivan
                                       :name "Ivan 3rd"}]
-                                    [:crux.tx/cas :ivan
+                                    [:crux.tx/cas
                                      {:crux.db/id :ivan
                                       :name "Ivan 2nd"}
                                      {:crux.db/id :ivan
@@ -1268,7 +1268,7 @@
 
       (t/testing "normal put after CAS works"
         (let [{:crux.tx/keys [tx-time] :as submitted-tx}
-              (api/submit-tx *api* [[:crux.tx/put :ivan
+              (api/submit-tx *api* [[:crux.tx/put
                                      {:crux.db/id :ivan
                                       :name "Ivan 5th"}]])]
 
@@ -1305,13 +1305,13 @@
 
 (t/deftest test-bitemp-query-from-indexing-temporal-data-using-existing-b+-trees-paper
   ;; Day 0, represented as #inst "2018-12-31"
-  (api/submit-tx *api* [[:crux.tx/put :p2
+  (api/submit-tx *api* [[:crux.tx/put
                          {:crux.db/id :p2
                           :entry-pt :SFO
                           :arrival-time #inst "2018-12-31"
                           :departure-time :na}
                          #inst "2018-12-31"]
-                        [:crux.tx/put :p3
+                        [:crux.tx/put
                          {:crux.db/id :p3
                           :entry-pt :LA
                           :arrival-time #inst "2018-12-31"
@@ -1322,46 +1322,46 @@
   ;; Day 1, nothing happens.
   (api/submit-tx *api* [])
   ;; Day 2
-  (api/submit-tx *api* [[:crux.tx/put :p4
+  (api/submit-tx *api* [[:crux.tx/put
                          {:crux.db/id :p4
                           :entry-pt :NY
                           :arrival-time #inst "2019-01-02"
                           :departure-time :na}
                          #inst "2019-01-02"]])
   ;; Day 3
-  (let [third-day-submitted-tx (api/submit-tx *api* [[:crux.tx/put :p4
+  (let [third-day-submitted-tx (api/submit-tx *api* [[:crux.tx/put
                                                       {:crux.db/id :p4
                                                        :entry-pt :NY
                                                        :arrival-time #inst "2019-01-02"
                                                        :departure-time #inst "2019-01-03"}
                                                       #inst "2019-01-03"]])]
     ;; Day 4, correction, adding missing trip on new arrival.
-    (api/submit-tx *api* [[:crux.tx/put :p1
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p1
                             :entry-pt :NY
                             :arrival-time #inst "2018-12-31"
                             :departure-time :na}
                            #inst "2018-12-31"]
-                          [:crux.tx/put :p1
+                          [:crux.tx/put
                            {:crux.db/id :p1
                             :entry-pt :NY
                             :arrival-time #inst "2018-12-31"
                             :departure-time #inst "2019-01-03"}
                            #inst "2019-01-03"]
-                          [:crux.tx/put :p1
+                          [:crux.tx/put
                            {:crux.db/id :p1
                             :entry-pt :LA
                             :arrival-time #inst "2019-01-04"
                             :departure-time :na}
                            #inst "2019-01-04"]
-                          [:crux.tx/put :p3
+                          [:crux.tx/put
                            {:crux.db/id :p3
                             :entry-pt :LA
                             :arrival-time #inst "2018-12-31"
                             :departure-time #inst "2019-01-04"}
                            #inst "2019-01-04"]])
     ;; Day 5
-    (api/submit-tx *api* [[:crux.tx/put :p2
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p2
                             :entry-pt :SFO
                             :arrival-time #inst "2018-12-31"
@@ -1371,49 +1371,49 @@
     (api/submit-tx *api* [])
     ;; Day 7-12, correction of deletion/departure on day 4. Shows
     ;; how valid time cannot be the same as arrival time.
-    (api/submit-tx *api* [[:crux.tx/put :p3
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p3
                             :entry-pt :LA
                             :arrival-time #inst "2018-12-31"
                             :departure-time :na}
                            #inst "2019-01-04"]
-                          [:crux.tx/put :p3
+                          [:crux.tx/put
                            {:crux.db/id :p3
                             :entry-pt :LA
                             :arrival-time #inst "2018-12-31"
                             :departure-time #inst "2019-01-07"}
                            #inst "2019-01-07"]])
-    (api/submit-tx *api* [[:crux.tx/put :p3
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p3
                             :entry-pt :SFO
                             :arrival-time #inst "2019-01-08"
                             :departure-time :na}
                            #inst "2019-01-08"]
-                          [:crux.tx/put :p4
+                          [:crux.tx/put
                            {:crux.db/id :p4
                             :entry-pt :LA
                             :arrival-time #inst "2019-01-08"
                             :departure-time :na}
                            #inst "2019-01-08"]])
-    (api/submit-tx *api* [[:crux.tx/put :p3
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p3
                             :entry-pt :SFO
                             :arrival-time #inst "2019-01-08"
                             :departure-time #inst "2019-01-08"}
                            #inst "2019-01-09"]])
-    (api/submit-tx *api* [[:crux.tx/put :p5
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p5
                             :entry-pt :LA
                             :arrival-time #inst "2019-01-10"
                             :departure-time :na}
                            #inst "2019-01-10"]])
-    (api/submit-tx *api* [[:crux.tx/put :p7
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p7
                             :entry-pt :NY
                             :arrival-time #inst "2019-01-11"
                             :departure-time :na}
                            #inst "2019-01-11"]])
-    (api/submit-tx *api* [[:crux.tx/put :p6
+    (api/submit-tx *api* [[:crux.tx/put
                            {:crux.db/id :p6
                             :entry-pt :NY
                             :arrival-time #inst "2019-01-12"

--- a/test/crux/tx_test.clj
+++ b/test/crux/tx_test.clj
@@ -46,7 +46,7 @@
         valid-time #inst "2018-05-21"
         eid (c/new-id :http://dbpedia.org/resource/Pablo_Picasso)
         {:crux.tx/keys [tx-time tx-id]}
-        @(db/submit-tx tx-log [[:crux.tx/put :http://dbpedia.org/resource/Pablo_Picasso picasso valid-time]])
+        @(db/submit-tx tx-log [[:crux.tx/put picasso valid-time]])
         expected-entities [(c/map->EntityTx {:eid          eid
                                              :content-hash content-hash
                                              :vt           valid-time
@@ -85,7 +85,7 @@
             new-valid-time #inst "2018-05-20"
             {new-tx-time :crux.tx/tx-time
              new-tx-id   :crux.tx/tx-id}
-            @(db/submit-tx tx-log [[:crux.tx/put :http://dbpedia.org/resource/Pablo_Picasso new-picasso new-valid-time]])]
+            @(db/submit-tx tx-log [[:crux.tx/put new-picasso new-valid-time]])]
 
         (with-open [snapshot (kv/new-snapshot f/*kv*)]
           (t/is (= [(c/map->EntityTx {:eid          eid
@@ -108,7 +108,7 @@
             new-valid-time #inst "2018-05-22"
             {new-tx-time :crux.tx/tx-time
              new-tx-id   :crux.tx/tx-id}
-            @(db/submit-tx tx-log [[:crux.tx/put :http://dbpedia.org/resource/Pablo_Picasso new-picasso new-valid-time]])]
+            @(db/submit-tx tx-log [[:crux.tx/put new-picasso new-valid-time]])]
 
         (with-open [snapshot (kv/new-snapshot f/*kv*)]
           (t/is (= [(c/map->EntityTx {:eid          eid
@@ -137,7 +137,7 @@
                 new-valid-time #inst "2018-05-22"
                 {new-tx-time :crux.tx/tx-time
                  new-tx-id   :crux.tx/tx-id}
-                @(db/submit-tx tx-log [[:crux.tx/put :http://dbpedia.org/resource/Pablo_Picasso new-picasso new-valid-time]])]
+                @(db/submit-tx tx-log [[:crux.tx/put new-picasso new-valid-time]])]
 
             (with-open [snapshot (kv/new-snapshot f/*kv*)]
               (t/is (= [(c/map->EntityTx {:eid          eid
@@ -159,7 +159,7 @@
             (t/testing "compare and set does nothing with wrong content hash"
               (let [old-picasso (assoc picasso :baz :boz)
                     {cas-failure-tx-time :crux.tx/tx-time}
-                    @(db/submit-tx tx-log [[:crux.tx/cas :http://dbpedia.org/resource/Pablo_Picasso old-picasso new-picasso new-valid-time]])]
+                    @(db/submit-tx tx-log [[:crux.tx/cas old-picasso new-picasso new-valid-time]])]
                 (t/is (= cas-failure-tx-time (tx/await-tx-time indexer cas-failure-tx-time {:crux.tx-log/await-tx-timeout 1000})))
                 (with-open [snapshot (kv/new-snapshot f/*kv*)]
                   (t/is (= [(c/map->EntityTx {:eid          eid
@@ -175,7 +175,7 @@
                     new-content-hash (c/new-id new-picasso)
                     {new-tx-time :crux.tx/tx-time
                      new-tx-id   :crux.tx/tx-id}
-                    @(db/submit-tx tx-log [[:crux.tx/cas :http://dbpedia.org/resource/Pablo_Picasso old-picasso new-picasso new-valid-time]])]
+                    @(db/submit-tx tx-log [[:crux.tx/cas old-picasso new-picasso new-valid-time]])]
                 (t/is (= new-tx-time (tx/await-tx-time indexer new-tx-time {:crux.tx-log/await-tx-timeout 1000})))
                 (with-open [snapshot (kv/new-snapshot f/*kv*)]
                   (t/is (= [(c/map->EntityTx {:eid          eid
@@ -191,7 +191,7 @@
                     new-content-hash (c/new-id new-picasso)
                     {new-tx-time :crux.tx/tx-time
                      new-tx-id   :crux.tx/tx-id}
-                    @(db/submit-tx tx-log [[:crux.tx/cas :http://dbpedia.org/resource/Pablo2 nil new-picasso new-valid-time]])]
+                    @(db/submit-tx tx-log [[:crux.tx/cas nil new-picasso new-valid-time]])]
                 (t/is (= new-tx-time (tx/await-tx-time indexer new-tx-time {:crux.tx-log/await-tx-timeout 1000})))
                 (with-open [snapshot (kv/new-snapshot f/*kv*)]
                   (t/is (= [(c/map->EntityTx {:eid          new-eid
@@ -280,19 +280,19 @@
         v1-valid-time #inst "2018-11-26"
         {v1-tx-time :crux.tx/tx-time
          v1-tx-id :crux.tx/tx-id}
-        @(db/submit-tx tx-log [[:crux.tx/put :ivan v1-ivan v1-valid-time]])
+        @(db/submit-tx tx-log [[:crux.tx/put v1-ivan v1-valid-time]])
 
         v2-ivan (assoc ivan :version 2)
         v2-valid-time #inst "2018-11-27"
         {v2-tx-time :crux.tx/tx-time
          v2-tx-id :crux.tx/tx-id}
-        @(db/submit-tx tx-log [[:crux.tx/put :ivan v2-ivan v2-valid-time]])
+        @(db/submit-tx tx-log [[:crux.tx/put v2-ivan v2-valid-time]])
 
         v3-ivan (assoc ivan :version 3)
         v3-valid-time #inst "2018-11-28"
         {v3-tx-time :crux.tx/tx-time
          v3-tx-id :crux.tx/tx-id}
-        @(db/submit-tx tx-log [[:crux.tx/put :ivan v3-ivan v3-valid-time]])]
+        @(db/submit-tx tx-log [[:crux.tx/put v3-ivan v3-valid-time]])]
 
     (with-open [snapshot (kv/new-snapshot f/*kv*)]
       (t/testing "first version of entity is visible"
@@ -315,7 +315,7 @@
           corrected-end-valid-time #inst "2018-11-29"
           {corrected-tx-time :crux.tx/tx-time
            corrected-tx-id :crux.tx/tx-id}
-          @(db/submit-tx tx-log [[:crux.tx/put :ivan corrected-ivan corrected-start-valid-time corrected-end-valid-time]])]
+          @(db/submit-tx tx-log [[:crux.tx/put corrected-ivan corrected-start-valid-time corrected-end-valid-time]])]
 
       (with-open [snapshot (kv/new-snapshot f/*kv*)]
         (t/testing "first version of entity is still there"
@@ -381,7 +381,7 @@
         number-of-versions 1000]
 
     @(db/submit-tx tx-log (vec (for [n (range number-of-versions)]
-                                 [:crux.tx/put :ivan (assoc ivan :verison n) (Date. (+ (.getTime start-valid-time) (inc (long n))))])))
+                                 [:crux.tx/put (assoc ivan :verison n) (Date. (+ (.getTime start-valid-time) (inc (long n))))])))
 
     (with-open [snapshot (kv/new-snapshot f/*kv*)]
       (let [baseline-time (let [start-time (System/nanoTime)
@@ -411,15 +411,15 @@
         tx1-valid-time #inst "2018-11-26"
         {tx1-id :crux.tx/tx-id
          tx1-tx-time :crux.tx/tx-time}
-        @(db/submit-tx tx-log [[:crux.tx/put :ivan tx1-ivan tx1-valid-time]])
+        @(db/submit-tx tx-log [[:crux.tx/put tx1-ivan tx1-valid-time]])
 
         tx2-ivan (assoc ivan :version 2)
         tx2-petr {:crux.db/id :petr :name "Petr"}
         tx2-valid-time #inst "2018-11-27"
         {tx2-id :crux.tx/tx-id
          tx2-tx-time :crux.tx/tx-time}
-        @(db/submit-tx tx-log [[:crux.tx/put :ivan tx2-ivan tx2-valid-time]
-                               [:crux.tx/put :petr tx2-petr tx2-valid-time]])]
+        @(db/submit-tx tx-log [[:crux.tx/put tx2-ivan tx2-valid-time]
+                               [:crux.tx/put tx2-petr tx2-valid-time]])]
 
     (with-open [tx-log-context (db/new-tx-log-context tx-log)]
       (let [log (db/tx-log tx-log tx-log-context nil)]


### PR DESCRIPTION
I have also skimmed through the docs and removed mention of needing two instances of the ID.

Note that `put` and `cas` can no longer take an ID outside of the doc. `evict` and `delete` remain unchanged.