### PR TITLE
Add proc:none to javac opts to "fix" warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,8 @@
   :javac-options ["-source" "8" "-target" "8"
                   "-XDignore.symbol.file"
                   "-Xlint:all,-options,-path"
-                  "-Werror"]
+                  "-Werror"
+                  "-proc:none"]
   :aot [crux.main]
   :main crux.main
   :global-vars {*warn-on-reflection* true}


### PR DESCRIPTION
This fixes the following warning: `warning: Supported source version 'RELEASE_6' from annotation processor 'org.sonatype.guice.bean.scanners.index.SisuIndexAPT6' less than -source '1.8'`

I was getting the above warning on a clean pull when running `lein test` on both Java 8 and Java 10. I am not sure if other people see this on a clean pull or if there is some local issue, I am committing in order to record and discuss. Note. This warning does cause compilation to fail. 

```
Compiling 24 source files to /home/markwoodhall/src/mark/crux/target/classes
warning: Supported source version 'RELEASE_6' from annotation processor 'org.sonatype.guice.bean.scanners.index.SisuIndexAPT6' less than -source '1.8'
error: warnings found and -Werror specified
1 error
1 warning
Compilation of Java sources(lein javac) failed.
```

> javac enables annotation processors by default. If you are not using them, and wish to suppress warnings, you need to pass the -proc:none command line flag to javac when you compile your code.

Obviously this change could have more impact than just resolving the above warning. Having said that if this isn't an issue isolated to my environment it makes sense to try and resolve it.

Perhaps there could be some dependency that needs upgrading?

_Edit: Switching back to master after submitting this PR made me realise that if compilation has succeeded once then you never get this error again, unless you `lein clean` or `rm -rf target`._