### PR TITLE
Fixes #261 Undo event-log-dir change for standalone mode

### DIFF
--- a/src/crux/bootstrap/standalone.clj
+++ b/src/crux/bootstrap/standalone.clj
@@ -76,8 +76,8 @@
     (doseq [c [event-log-consumer tx-log kv-store]]
       (cio/try-close c))))
 
-(s/def ::standalone-options (s/keys :req-un [:crux.kv/db-dir :crux.kv/kv-backend :crux.tx/event-log-dir]
-                                    :opt-un [:crux.kv/sync? :crux.db/object-store :crux.lru/doc-cache-size]
+(s/def ::standalone-options (s/keys :req-un [:crux.kv/db-dir :crux.kv/kv-backend]
+                                    :opt-un [:crux.kv/sync? :crux.tx/event-log-dir :crux.db/object-store :crux.lru/doc-cache-size]
                                     :opt [:crux.tx/event-log-sync-interval-ms
                                           :crux.tx/event-log-kv-backend]))
 


### PR DESCRIPTION
Made `:event-log-dir` optional again for standalone mode.