### PR TITLE
 DISCUSS ONLY. tests : add a standalone system bootstrap test

### DIFF
--- a/dev/ivan.clj
+++ b/dev/ivan.clj
@@ -1,9 +1,8 @@
 (ns ivan
-  (:require [clojure.test :as t]
-            [crux.bench :as bench]
-            [crux.fixtures :as f]
-            [crux.api :as api]
-            [crux.codec :as c]))
+  (:require [crux.api :as api]
+            [crux.codec :as c]
+            [crux.bootstrap.standalone :as bs]
+            [clojure.spec.alpha :as s]))
 
 ;;;;; This is not a benchmark
 ;;;;; Rather a sanity check tool for internal changes
@@ -32,6 +31,8 @@
 (def id-buffer->id
   (let [ks (keys currencies-by-id)]
     (zipmap (map c/->id-buffer ks) ks)))
+
+(s/assert ::bs/standalone-options {:db-dir "ee" :kv-backend "ee"})
 
 (defn gen-stock [i]
   (let [id (keyword "stock.id" (str "company-" i))]
@@ -65,7 +66,7 @@
 (comment
 
   (def system
-    (crux.api/start-standalone-system
+    (api/start-standalone-system
       {:kv-backend "crux.kv.memdb.MemKv"
        :db-dir     "data/db-dir-1"}))
 
@@ -81,27 +82,27 @@
     :limit 1000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-10000
   '[:find stock-id currency-id
     :limit 10000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-100000
   '[:find stock-id currency-id
     :limit 100000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-2
   '[:find stock-id currency-id
     :where
     [currency-id :currency/name "Euro"]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-3
   '[:find stock-id currency-name

--- a/src/crux/bootstrap/standalone.clj
+++ b/src/crux/bootstrap/standalone.clj
@@ -122,4 +122,4 @@
       (catch Throwable t
         (doseq [c (reverse @started)]
           (cio/try-close c))
-        (throw t))))  )
+        (throw t)))))

--- a/test/crux/bootstrap_standalone_test.clj
+++ b/test/crux/bootstrap_standalone_test.clj
@@ -1,0 +1,16 @@
+(ns crux.bootstrap-standalone-test
+  (:require [clojure.test :as t]
+            [crux.api :as api]))
+
+(t/deftest test-api-standalone-system
+  (t/testing "System starts with just :kv-backend, :event-log-dir and :db-dir"
+    (t/is (api/start-standalone-system
+              {:kv-backend "crux.kv.memdb.MemKv"
+               :event-log-dir  "data/evt-dir-1"
+               :db-dir "data/db-dir-1"})))
+  (t/testing "System starts with just kv-backend and db-dir"
+    (t/is (api/start-standalone-system
+            {:kv-backend "crux.kv.memdb.MemKv"
+             :db-dir "data/db-dir-1"}))))
+
+; (t/run-tests 'crux.standalone-bootstrap-test)


### PR DESCRIPTION
This adds two tests for the standalone system init.
First of them passes, second fails with a weird error
```
ERROR in (test-api-standalone-system) (alpha.clj:1966)
expected: (api/start-standalone-system {:kv-backend "crux.kv.memdb.MemKv", :db-dir "data/db-dir-1"})
  actual: clojure.lang.ExceptionInfo: Spec assertion failed
nil - failed: string? in: [:db-dir] at: [:db-dir] spec: :crux.kv/db-dir
```
