### PR TITLE
Fixes #266 Make `event-log-dir` mandatory for standalone

### DIFF
--- a/dev/ivan.clj
+++ b/dev/ivan.clj
@@ -67,7 +67,8 @@
   (def system
     (crux.api/start-standalone-system
       {:kv-backend "crux.kv.memdb.MemKv"
-       :db-dir     "data/db-dir-1"}))
+       :db-dir     "data/db-dir-1"
+       :event-log-dir "data/eventlog-1"}))
 
   (binding [f/*api* system]
     (with-stocks-data println))

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -146,6 +146,7 @@ Set the following properties when configuring Crux systems:
 |Property|Value
 |`kv-backend`|`"crux.kv.rocksdb.RocksKv"`
 |`db-dir`|i.e. `"data/db-dir-1"`
+|`event-log-dir`|i.e. `"data/eventlog-1"`
 |===
 
 For example when constructing the standalone system:

--- a/docs/deps.edn
+++ b/docs/deps.edn
@@ -1,7 +1,7 @@
 {:deps
  {
   ;; tag::CruxDep[]
-  juxt/crux {:mvn/version "19.06-1.6.0-alpha"}
+  juxt/crux {:mvn/version "19.06-1.1.0-alpha"}
   ;; end::CruxDep[]
 
   ;; tag::KafkaDeps[]

--- a/docs/example_standalone_integrant_system.clj
+++ b/docs/example_standalone_integrant_system.clj
@@ -3,7 +3,8 @@
             [integrant.core :as ig]))
 
 (def config {:crux/standalone {:kv-backend "crux.kv.memdb.MemKv"
-                               :db-dir "data/db-dir-1"}})
+                               :db-dir "data/db-dir-1"
+                               :event-log-dir "data/eventlog-1"}})
 
 (defmethod ig/init-key :crux/standalone [_ opts]
   (api/start-standalone-system opts))

--- a/docs/examples.clj
+++ b/docs/examples.clj
@@ -6,7 +6,8 @@
 
 (def ^crux.api.ICruxAPI system
   (crux/start-standalone-system {:kv-backend "crux.kv.memdb.MemKv"
-                                 :db-dir "data/db-dir-1"}))
+                                 :db-dir "data/db-dir-1"
+                                 :event-log-dir "data/eventlog-1"}))
 ;; end::start-system[]
 
 ;; tag::close-system[]
@@ -16,13 +17,14 @@
 ;; tag::start-cluster-node-system[]
 (def ^crux.api.ICruxAPI system
   (crux/start-cluster-node {:kv-backend "crux.kv.memdb.MemKv"
-                           :bootstrap-servers "localhost:29092"}))
+                            :bootstrap-servers "localhost:29092"}))
 ;; end::start-cluster-node-system[]
 
 ;; tag::start-standalone-with-rocks[]
 (def ^crux.api.ICruxAPI system
   (crux/start-standalone-system {:kv-backend "crux.kv.rocksdb.RocksKv"
-                                :db-dir "data/db-dir-1"}))
+                                 :db-dir "data/db-dir-1"
+                                 :event-log-dir "data/eventlog-1"}))
 ;; end::start-standalone-with-rocks[]
 
 ;; tag::submit-tx[]

--- a/example/standalone_webservice/project.clj
+++ b/example/standalone_webservice/project.clj
@@ -14,7 +14,7 @@
                  [org.eclipse.rdf4j/rdf4j-rio-ntriples "2.4.5"]
                  [org.eclipse.rdf4j/rdf4j-queryparser-sparql "2.4.5"]
 
-                 [juxt/crux "19.04-1.0.3-alpha"]
+                 [juxt/crux "19.06-1.1.0-alpha"]
                  [yada "1.3.0-alpha7"]
                  [hiccup "2.0.0-alpha2"]
                  [org.rocksdb/rocksdbjni "5.17.2"]

--- a/src/crux/bootstrap/standalone.clj
+++ b/src/crux/bootstrap/standalone.clj
@@ -76,8 +76,8 @@
     (doseq [c [event-log-consumer tx-log kv-store]]
       (cio/try-close c))))
 
-(s/def ::standalone-options (s/keys :req-un [:crux.kv/db-dir :crux.kv/kv-backend]
-                                    :opt-un [:crux.kv/sync? :crux.tx/event-log-dir :crux.db/object-store :crux.lru/doc-cache-size]
+(s/def ::standalone-options (s/keys :req-un [:crux.kv/db-dir :crux.tx/event-log-dir :crux.kv/kv-backend]
+                                    :opt-un [:crux.kv/sync? :crux.db/object-store :crux.lru/doc-cache-size]
                                     :opt [:crux.tx/event-log-sync-interval-ms
                                           :crux.tx/event-log-kv-backend]))
 


### PR DESCRIPTION
`:event-log-dir` mandatory for standalone, reflected this in docs. Also fixed version number typo in docs.