### PR TITLE
fix `#crux/id` reader issues in http-server and remote-api-client

### DIFF
--- a/dev/ivan.clj
+++ b/dev/ivan.clj
@@ -72,6 +72,8 @@
        :db-dir     "data/db-dir-1"
        :event-log-dir "data/eventlog-1"}))
 
+  (def s #crux/id :https://thing)
+
   (binding [fb/*api* system]
     (with-stocks-data println))
 
@@ -84,27 +86,27 @@
     :limit 1000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-10000
   '[:find stock-id currency-id
     :limit 10000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-100000
   '[:find stock-id currency-id
     :limit 100000
     :where
     [currency-id :currency/name currency-name]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-2
   '[:find stock-id currency-id
     :where
     [currency-id :currency/name "Euro"]
-    [stock-id :stock/currency-id currency-id] ])
+    [stock-id :stock/currency-id currency-id]])
 
 (def query-3
   '[:find stock-id currency-name

--- a/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -709,7 +709,7 @@
                             (api/start-standalone-system options))
               api-server (srv/start-http-server
                            crux-system
-                           {:server-port http-port 
+                           {:server-port http-port
                             :cors-access-control
                             [:access-control-allow-origin [#".*"]
                              :access-control-allow-headers ["X-Requested-With"
@@ -746,11 +746,15 @@
     (catch Exception e
       (log/error e "what happened" (ex-data e)))))
 
+(defn start-from-repl []
+  (def s
+   (future
+     (run-system
+       crux-options
+       (fn [_]
+         (def crux)
+         (Thread/sleep Long/MAX_VALUE))))))
+
 (comment
-  (def s (future
-           (run-system
-            crux-options
-            (fn [_]
-              (def crux)
-              (Thread/sleep Long/MAX_VALUE)))))
+  (start-from-repl)
   (future-cancel s))

--- a/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -709,7 +709,7 @@
                             (api/start-standalone-system options))
               api-server (srv/start-http-server
                            crux-system
-                           {:server-port http-port
+                           {:server-port http-port 
                             :cors-access-control
                             [:access-control-allow-origin [#".*"]
                              :access-control-allow-headers ["X-Requested-With"
@@ -746,15 +746,11 @@
     (catch Exception e
       (log/error e "what happened" (ex-data e)))))
 
-(defn start-from-repl []
-  (def s
-   (future
-     (run-system
-       crux-options
-       (fn [_]
-         (def crux)
-         (Thread/sleep Long/MAX_VALUE))))))
-
 (comment
-  (start-from-repl)
+  (def s (future
+           (run-system
+            crux-options
+            (fn [_]
+              (def crux)
+              (Thread/sleep Long/MAX_VALUE)))))
   (future-cancel s))

--- a/src/crux/bootstrap/remote_api_client.clj
+++ b/src/crux/bootstrap/remote_api_client.clj
@@ -74,7 +74,6 @@
                                                         {"Content-Type" "application/edn"})
                                              :body (some-> body pr-str)}
                                             opts))]
-     (prn "body resp " body)
      (cond
        (= 404 status)
        nil

--- a/src/crux/bootstrap/remote_api_client.clj
+++ b/src/crux/bootstrap/remote_api_client.clj
@@ -2,6 +2,7 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [crux.io :as cio]
+            [crux.codec :as c]
             [crux.query :as q])
   (:import [java.io Closeable InputStreamReader IOException PushbackReader]
            java.time.Duration
@@ -73,6 +74,7 @@
                                                         {"Content-Type" "application/edn"})
                                              :body (some-> body pr-str)}
                                             opts))]
+     (prn "body resp " body)
      (cond
        (= 404 status)
        nil
@@ -80,7 +82,7 @@
        (and (<= 200 status) (< status 400)
             (= "application/edn" (:content-type headers)))
        (if (string? body)
-         (edn/read-string body)
+         (edn/read-string {:readers {'crux/id c/id-edn-reader}} body)
          body)
 
        :else

--- a/src/crux/bootstrap/standalone.clj
+++ b/src/crux/bootstrap/standalone.clj
@@ -122,4 +122,4 @@
       (catch Throwable t
         (doseq [c (reverse @started)]
           (cio/try-close c))
-        (throw t))))  )
+        (throw t)))))

--- a/src/crux/codec.clj
+++ b/src/crux/codec.clj
@@ -312,11 +312,11 @@
 
 (defmethod print-method Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (str id)))
+  (.write w (pr-str (str id))))
 
 (defmethod print-dup Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (str id)))
+  (.write w (pr-str (str id))))
 
 (extend-protocol IdOrBuffer
   Id
@@ -389,11 +389,11 @@
 
 (defmethod print-method EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (str (or (.original-id id) (.hex id)))))
+  (.write w (pr-str (str (or (.original-id id) (.hex id))))))
 
 (defmethod print-dup EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (str (or (.original-id id) (.hex id)))))
+  (.write w (pr-str (str (or (.original-id id) (.hex id))))))
 
 (nippy/extend-freeze
  EDNId

--- a/src/crux/http_server.clj
+++ b/src/crux/http_server.clj
@@ -36,9 +36,9 @@
 ;; Utils
 
 (defn- body->edn [request]
-  (-> request
+  (->> request
       req/body-string
-      edn/read-string))
+      (edn/read-string {:readers {'crux/id c/id-edn-reader}})))
 
 (defn- check-path [[path-pattern valid-methods] request]
   (let [path (req/path-info request)
@@ -304,7 +304,7 @@
     (transact crux-system request)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
-             sparql-available? )
+             sparql-available?)
       ((resolve 'crux.sparql.protocol/sparql-query) crux-system request)
       {:status 400
        :headers {"Content-Type" "text/plain"}

--- a/test/crux/api_test.clj
+++ b/test/crux/api_test.clj
@@ -33,6 +33,13 @@
     (.sync fb/*api* (:crux.tx/tx-time submitted-tx) nil)
     (t/is (.entity (.db fb/*api*) {:user "Xwop1A7Xog4nD6AfhZaPgg"}))))
 
+(t/deftest test-can-use-crux-ids
+  (let [id #crux/id :https://adam.com
+        doc {:crux.db/id id, :name "Adam"}
+        submitted-tx (.submitTx f/*api* [[:crux.tx/put doc]])]
+    (.sync f/*api* (:crux.tx/tx-time submitted-tx) nil)
+    (t/is (.entity (.db f/*api*) id))))
+
 (t/deftest test-single-id
   (let [valid-time (Date.)
         content-ivan {:crux.db/id :ivan :name "Ivan"}]


### PR DESCRIPTION
This adds tag->reader mapping to `remote-api-client` and `http-server`.  
Adds a test for reading and writing `#crux/id` into `api-test`. 
Adds proper quoting for `#crux/id` printing.