### PR TITLE
Update docs to use symbols in :args, relates to #247

### DIFF
--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -339,12 +339,12 @@ control the result order.
 
 [source,clj]
 ----
-{:find [time device-id temperature humidity]
- :where [[c :condition/time time]
-         [c :condition/device-id device-id]
-         [c :condition/temperature temperature]
-         [c :condition/humidity humidity]]
- :order-by [[time :desc] [device-id :asc]]}
+'{:find [time device-id temperature humidity]
+  :where [[c :condition/time time]
+          [c :condition/device-id device-id]
+          [c :condition/temperature temperature]
+          [c :condition/humidity humidity]]
+  :order-by [[time :desc] [device-id :asc]]}
 ----
 
 Use of `:order-by` will typically require that results are fully-realised by
@@ -357,14 +357,14 @@ naively scroll through the initial result set each time.
 
 [source,clj]
 ----
-{:find [time device-id temperature humidity]
- :where [[c :condition/time time]
-         [c :condition/device-id device-id]
-         [c :condition/temperature temperature]
-         [c :condition/humidity humidity]]
- :order-by [[device-id :asc]]
- :limit 10
- :offset 90}
+'{:find [time device-id temperature humidity]
+  :where [[c :condition/time time]
+          [c :condition/device-id device-id]
+          [c :condition/temperature temperature]
+          [c :condition/humidity humidity]]
+  :order-by [[device-id :asc]]
+  :limit 10
+  :offset 90}
 ----
 
 Pagination relies on efficient retrieval of explicitly ordered documents and
@@ -374,15 +374,15 @@ queries to apply range filters using predicates.
 
 [source,clj]
 ----
-{:find [time device-id temperature humidity]
- :where [[c :condition/time time]
-         [c :condition/device-id device-id]
-         [(>= device-id my-offset)]
-         [c :condition/temperature temperature]
-         [c :condition/humidity humidity]]
- :order-by [[device-id :asc]]
+{:find '[time device-id temperature humidity]
+ :where '[[c :condition/time time]
+          [c :condition/device-id device-id]
+          [(>= device-id my-offset)]
+          [c :condition/temperature temperature]
+          [c :condition/humidity humidity]]
+ :order-by '[[device-id :asc]]
  :limit 10
- :args [{:my-offset 990}]}
+ :args [{'my-offset 990}]}
 ----
 
 Additionally, since Crux stores documents and can traverse arbitrary keys as
@@ -399,14 +399,14 @@ connected to a given entity via the `:follow` attribute.
 
 [source,clj]
 ----
-{:find [?e2]
- :where [(follow ?e1 ?e2)]
- :args [{:?e1 :1}]
- :rules [[(follow ?e1 ?e2)
-          [?e1 :follow ?e2]]
-         [(follow ?e1 ?e2)
-          [?e1 :follow ?t]
-          (follow ?t ?e2)]]})
+'{:find [?e2]
+  :where [(follow ?e1 ?e2)]
+  :args [{?e1 :1}]
+  :rules [[(follow ?e1 ?e2)
+           [?e1 :follow ?e2]]
+          [(follow ?e1 ?e2)
+           [?e1 :follow ?t]
+           (follow ?t ?e2)]]})
 ----
 
 == Lazy Queries
@@ -422,11 +422,11 @@ be retrieved from a `kv` instance via `crux.api/new-snapshot`.
 === Quoting
 
 Logic variables used in queries must always be quoted in the `:find` and
-`:where` clauses, which in the most minimal case could look like the following: 
+`:where` clauses, which in the most minimal case could look like the following:
 
 [source,clj]
 ----
-(crux/q db 
+(crux/q db
   {:find ['?e]
    :where [['?e :event/employee-code '?code]]}))
 ----
@@ -436,7 +436,7 @@ map rather than each individual use of every logical variable, for instance:
 
 [source,clj]
 ----
-(crux/q db 
+(crux/q db
   '{:find [?e]
     :where [[?e :event/employee-code ?code]]}))
 ----
@@ -444,7 +444,7 @@ map rather than each individual use of every logical variable, for instance:
 Confusion may arise when you later attempt to introduce references to Clojure
 variables within your query map, such as when using `:args`. This can be
 resolved by introducing more granular quoting for specific parts of the query
-map: 
+map:
 
 [source,clj]
 ----
@@ -452,7 +452,7 @@ map:
   (crux/q db
     {:find '[?e]
      :where '[[?e :event/employee-code ?code]]
-     :args [{:?code my-code}]}))
+     :args [{'?code my-code}]}))
 ----
 
 == DataScript Differences

--- a/docs/query_examples.clj
+++ b/docs/query_examples.clj
@@ -55,14 +55,15 @@
                          [:crux.tx/put m]))))
 
 
-(api/q (api/db system) (quote
-;; tag::basic-query[]
-{:find [p1]
- :where [[p1 :name n]
-         [p1 :last-name n]
-         [p1 :name "Smith"]]}
-;; end::basic-query[]
-))
+(api/q
+ (api/db system)
+ ;; tag::basic-query[]
+ '{:find [p1]
+   :where [[p1 :name n]
+           [p1 :last-name n]
+           [p1 :name "Smith"]]}
+ ;; end::basic-query[]
+ )
 
 ;; tag::basic-query-r[]
 #{[:smith]}
@@ -70,14 +71,13 @@
 
 (api/q
  (api/db system)
- (quote
   ;; tag::query-with-arguments1[]
-  {:find [n]
-   :where [[e :name n]]
-   :args [{:e :ivan
-           :n "Ivan"}]}
+ {:find '[n]
+  :where '[[e :name n]]
+  :args [{'e :ivan
+          'n "Ivan"}]}
   ;; end::query-with-arguments1[]
-  ))
+  )
 
 ;; tag::query-with-arguments1-r[]
 #{["Ivan"]}
@@ -85,14 +85,13 @@
 
 (api/q
  (api/db system)
- (quote
   ;; tag::query-with-arguments2[]
-  {:find [e]
-   :where [[e :name n]]
-   :args [{:n "Ivan"}
-          {:n "Petr"}]}
+ {:find '[e]
+  :where '[[e :name n]]
+  :args [{'n "Ivan"}
+         {'n "Petr"}]}
   ;; end::query-with-arguments2[]
-  ))
+  )
 
 ;; tag::query-with-arguments2-r[]
 #{[:petr] [:ivan]}
@@ -100,15 +99,15 @@
 
 (api/q
  (api/db system)
- (quote
-  ;; tag::query-with-arguments3[]
-  {:find [e]
-   :where [[e :name n]
+ ;; tag::query-with-arguments3[]
+ {:find '[e]
+  :where '[[e :name n]
            [e :last-name l]]
-   :args [{:n "Ivan" :l "Ivanov"}
-          {:n "Petr" :l "Petrov"}]}
-  ;; end::query-with-arguments3[]
-  ))
+  :args [{'n "Ivan" 'l "Ivanov"}
+         {'n "Petr" 'l "Petrov"
+          }]}
+ ;; end::query-with-arguments3[]
+ )
 
 ;; tag::query-with-arguments3-r[]
 #{[:petr] [:ivan]}
@@ -116,15 +115,14 @@
 
 (api/q
  (api/db system)
- (quote
-  ;; tag::query-with-arguments4[]
-  {:find [n]
-   :where [[(re-find #"I" n)]
+ ;; tag::query-with-arguments4[]
+ {:find '[n]
+  :where '[[(re-find #"I" n)]
            [(= l "Ivanov")]]
-   :args [{:n "Ivan" :l "Ivanov"}
-          {:n "Petr" :l "Petrov"}]}
-  ;; end::query-with-arguments4[]
-  ))
+  :args [{'n "Ivan" 'l "Ivanov"}
+         {'n "Petr" 'l "Petrov"}]}
+ ;; end::query-with-arguments4[]
+ )
 
 ;; tag::query-with-arguments4-r[]
 #{["Ivan"]}
@@ -132,13 +130,12 @@
 
 (api/q
  (api/db system)
- (quote
-  ;; tag::query-with-arguments5[]
-  {:find [age]
-   :where [[(>= age 21)]]
-   :args [{:age 22}]}
-  ;; end::query-with-arguments5[]
-  ))
+ ;; tag::query-with-arguments5[]
+ {:find '[age]
+  :where '[[(>= age 21)]]
+  :args [{'age 22}]}
+ ;; end::query-with-arguments5[]
+ )
 
 ;; tag::query-with-arguments5-r[]
 #{[22]}
@@ -165,13 +162,12 @@
 (api/q
  (api/db
   system #inst "1986-10-23")
- (quote
-  ;; tag::query-at-t-q1[]
-  {:find [e]
+ ;; tag::query-at-t-q1[]
+ '{:find [e]
    :where [[e :name "Malcolma"]
            [e :last-name "Sparks"]]}
-  ;; end::query-at-t-q1[]
-  ))
+ ;; end::query-at-t-q1[]
+ )
 
 ;; tag::query-at-t-q1-q[]
 ; Using Clojure: `(api/q (api/db my-crux-system #inst "1986-10-23") q)`
@@ -281,13 +277,12 @@
 
 (api/q
  (api/db system)
- (quote
-  ;; tag::join-q[]
-  {:find [p1 p2]
+ ;; tag::join-q[]
+ '{:find [p1 p2]
    :where [[p1 :name n]
            [p2 :name n]]}
-  ;; end::join-q[]
-  ))
+ ;; end::join-q[]
+ )
 
 (let [maps
       ;; tag::join2-d[]
@@ -305,14 +300,13 @@
 
 (api/q
  (api/db system)
- (quote
-  ;; tag::join2-q[]
-  {:find [e2]
+ ;; tag::join2-q[]
+ '{:find [e2]
    :where [[e :last-name l]
            [e2 :follows l]
            [e :name "Ivan"]]}
-  ;; end::join2-q[]
-  ))
+ ;; end::join2-q[]
+ )
 
 (comment
 


### PR DESCRIPTION
Updated the docs examples to use symbol instead of keywords in the interest of clearer examples.