### PR TITLE
Change default :group-id to use HOSTNAME environment variables (or a UUID)

### DIFF
--- a/crux-core/src/crux/bootstrap.clj
+++ b/crux-core/src/crux/bootstrap.clj
@@ -14,7 +14,7 @@
             [crux.status :as status]
             [crux.tx :as tx])
   (:import java.io.Closeable
-           java.net.InetAddress
+           java.util.UUID
            crux.api.ICruxAPI))
 
 (s/check-asserts (if-let [check-asserts (System/getProperty "clojure.spec.compile-asserts")]
@@ -22,7 +22,9 @@
                    true))
 
 (def default-options {:bootstrap-servers "localhost:9092"
-                      :group-id (.trim ^String (:out (clojure.java.shell/sh "hostname")))
+                      :group-id (.trim ^String (or (System/getenv "HOSTNAME")
+                                                   (System/getenv "COMPUTERNAME")
+                                                   (.toString (java.util.UUID/randomUUID))))
                       :tx-topic "crux-transaction-log"
                       :doc-topic "crux-docs"
                       :create-topics true


### PR DESCRIPTION
Shelling out to 'hostname' doesn't seem to be possible inside of a typical Docker container. This seems to be okay as a workaround but I may be missing something.

Related change and context: https://github.com/juxt/crux/commit/e728410e1b62a19c9f2f110f1291e37937db4165

And context on why `hostname` doesn't work in Docker: https://github.com/moby/moby/issues/8902

A more extensive attempt to combine approaches may be preferable: https://stackoverflow.com/a/52440261