### PR TITLE
Use thread-safe requiring-resolve instead of require

### DIFF
--- a/crux-core/src/crux/hash.clj
+++ b/crux-core/src/crux/hash.clj
@@ -42,14 +42,12 @@
                        (ByteUtils/sha1 to from))))
     (if-let [openssl-id-hash-buffer (and openssl-enabled?
                                          (jnr-available?)
-                                         (do (require 'crux.hash.jnr)
-                                             (some-> (resolve 'crux.hash.jnr/openssl-id-hash-buffer) (deref))))]
+                                         (some-> 'crux.hash.jnr/openssl-id-hash-buffer requiring-resolve var-get))]
       (do (log/info "Using libcrypto (OpenSSL) for ID hashing.")
           (def id-hash openssl-id-hash-buffer))
       (if-let [gcrypt-id-hash-buffer (and gcrypt-enabled?
                                           (jnr-available?)
-                                          (do (require 'crux.hash.jnr)
-                                              (some-> (resolve 'crux.hash.jnr/gcrypt-id-hash-buffer) (deref))))]
+                                          (some-> 'crux.hash.jnr/gcrypt-id-hash-buffer requiring-resolve var-get))]
         (do (log/info "Using libgcrypt for ID hashing.")
             (def id-hash gcrypt-id-hash-buffer))
         (do (log/info "Using java.security.MessageDigest for ID hashing.")

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -46,14 +46,12 @@
      (constantly
       (binding [*warn-on-reflection* false]
         (or (try
-              (require 'clj-http.client)
-              (let [f (resolve 'clj-http.client/request)]
+              (let [f (requiring-resolve 'clj-http.client/request)]
                 (fn [opts]
                   (f (merge {:as "UTF-8" :throw-exceptions false} opts))))
               (catch IOException not-found))
             (try
-              (require 'org.httpkit.client)
-              (let [f (resolve 'org.httpkit.client/request)]
+              (let [f (requiring-resolve 'org.httpkit.client/request)]
                 (fn [opts]
                   (let [{:keys [error] :as result} @(f (merge {:as :text} opts))]
                     (if error

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -254,8 +254,8 @@
 (defn- attribute-stats [^ICruxAPI crux-node]
   (success-response (.attributeStats crux-node)))
 
-(def ^:private sparql-available? (try
-                                   (require 'crux.sparql.protocol)
+(def ^:private sparql-available? (try ; you can change it back to require when clojure.core fixes it to be thread-safe
+                                   (requiring-resolve 'crux.sparql.protocol/sparql-query)
                                    true
                                    (catch IOException _
                                      false)))

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -161,9 +161,12 @@
                 (filter (fn [[k]] (= "crux.jdbc" (namespace k))))
                 (map (fn [[k v]] [(keyword (name k)) v])))))
 
+(def ^:private require-lock 'lock)
+
 (defn- start-jdbc-ds [_ options]
   (let [{:keys [dbtype] :as options} (conform-next-jdbc-properties options)]
-    (require (symbol (str "crux.jdbc." (name (dbtype->crux-jdbc-dialect dbtype)))))
+    (locking require-lock
+      (require (symbol (str "crux.jdbc." (name (dbtype->crux-jdbc-dialect dbtype))))))
     (let [ds (jdbcc/->pool HikariDataSource (->pool-options dbtype options))]
       (setup-schema! dbtype ds)
       ds)))

--- a/crux-uberjar/src/crux/main.clj
+++ b/crux-uberjar/src/crux/main.clj
@@ -2,5 +2,4 @@
   (:gen-class))
 
 (defn -main [& args]
-  (require 'crux.cli)
-  ((resolve 'crux.cli/start-node-from-command-line) args))
+  ((requiring-resolve 'crux.cli/start-node-from-command-line) args))


### PR DESCRIPTION
This updates a few more places in our codebase to use thread-safe `requiring-resolve` rather than `require`. A couple of usages of `require` are still left and marked with a comment.