### PR TITLE
Factor in range-clauses attr frequencies for join order #384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Refactoring: Modularize configuration options defaults and documentation
 * Refactoring: Test fixtures more composable
 * [#352](https://github.com/juxt/crux/issues/352): fix Kotlin multhreaded node-start issues
+* [#348](https://github.com/juxt/crux/issues/348); Increase range constraints var-frequency for join order
 
 ## 19.09-1.4.0-alpha
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -273,9 +273,10 @@
         (log/debug :join-order :aev e (pr-str v) (pr-str clause))
         (idx/update-binary-join-order! binary-idx e-doc-idx v-idx)))))
 
-(defn- triple-joins [triple-clauses var->joins arg-vars stats]
+(defn- triple-joins [triple-clauses range-clauses var->joins arg-vars stats]
   (let [var->frequency (->> (concat (map :e triple-clauses)
-                                    (map :v triple-clauses))
+                                    (map :v triple-clauses)
+                                    (map :sym range-clauses))
                             (filter logic-var?)
                             (frequencies))
         triple-clauses (sort-by (fn [{:keys [a]}]
@@ -867,6 +868,7 @@
         v-var->range-constraints (build-v-var-range-constraints e-vars range-clauses)
         v-range-vars (set (keys v-var->range-constraints))
         [triple-join-deps var->joins] (triple-joins triple-clauses
+                                                    range-clauses
                                                     var->joins
                                                     arg-vars
                                                     stats)


### PR DESCRIPTION
Bumped up `var->frequency` to factor in vars in range searches.

A deeper fix may want to be considered in future to prioritize range-searches in the precalculated join-order. 