### PR TITLE
Allow full-results? flag in a vector-style query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 19.10-1.5.1-alpha
+
+### Bug fixes
+
+* [#PR363](https://github.com/juxt/crux/pull/363) Allow `full-results?` and other boolean flags in a vector-style query
+
 ## 19.09-1.5.0-alpha
 
 ### Changes

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1021,7 +1021,8 @@
   (cond
     (vector? q) (into {} (for [[[k] v] (->> (partition-by keyword? q)
                                             (partition-all 2))]
-                           [k (if (and (nat-int? (first v))
+                           [k (if (and (or (nat-int? (first v))
+                                           (boolean? (first v)))
                                        (= 1 (count v)))
                                 (first v)
                                 (vec v))]))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -73,6 +73,13 @@
                                       :where [[e :name first-name]]
                                       :full-results? true})))))
 
+  (t/testing "Can retrieve full for a vector-style query"
+    (t/is (= [{:crux.db/id :ivan :name "Ivan" :last-name "Ivanov"}
+              "Ivan"] (first (api/q (api/db *api*)
+                                    '[:find e first-name
+                                      :where [e :name first-name]
+                                      :full-results? true])))))
+
   (t/testing "Can retrieve full results in or-join"
     (t/is (= [{:crux.db/id :ivan :name "Ivan" :last-name "Ivanov"}
               "Ivan"] (first (api/q (api/db *api*)
@@ -1000,7 +1007,7 @@
                                                         [(>= 20 age)]]})))))
 
 (t/deftest test-mutiple-values
-  (f/transact! *api* (f/people [{:crux.db/id :ivan :name "Ivan" }
+  (f/transact! *api* (f/people [{:crux.db/id :ivan :name "Ivan"}
                                 {:crux.db/id :oleg :name "Oleg"}
                                 {:crux.db/id :petr :name "Petr" :follows #{:ivan :oleg}}]))
 
@@ -1555,7 +1562,7 @@
                       {:crux.db/id :3 :name "Oleg" :age 10}
                       {:crux.db/id :4 :name "Oleg" :age 20}
                       {:crux.db/id :5 :name "Ivan" :age 10}
-                      {:crux.db/id :6 :name "Ivan" :age 20} ]))
+                      {:crux.db/id :6 :name "Ivan" :age 20}]))
 
 (t/deftest datascript-test-not
   (populate-datascript-test-db)


### PR DESCRIPTION
So the case is that for vector queries plain values (except for nat-ints) are wrongly wrapped into vectors. Like
[:find [...] :where [...] :key1 1 :key2 true :key3 "se"]
gets converted into
{:key1 1 :key2 [true] :key3 ["se"]}
This fix allows boolean values.