### PR TITLE
Making IndexVersionOutOfSyncException an unchecked exception

### DIFF
--- a/crux-bench/src/crux_bench/main.clj
+++ b/crux-bench/src/crux_bench/main.clj
@@ -258,10 +258,7 @@
                           :free-memory (.freeMemory (Runtime/getRuntime))})))
           (log/info
             (with-out-str
-              (pp/pprint (some-> node :benchmark-runner :status deref)))))))
-    (catch IndexVersionOutOfSyncException e
-      (crux-io/delete-dir index-dir)
-      (-main)))
+              (pp/pprint (some-> node :benchmark-runner :status deref))))))))
   (log/info "bench runner exiting"))
 
 (comment

--- a/crux-core/src/crux/api/IndexVersionOutOfSyncException.java
+++ b/crux-core/src/crux/api/IndexVersionOutOfSyncException.java
@@ -1,6 +1,6 @@
 package crux.api;
 
-public class IndexVersionOutOfSyncException extends Exception {
+public class IndexVersionOutOfSyncException extends RuntimeException {
     private static final long serialVersionUID = 6124848552293819498L;
 
     public IndexVersionOutOfSyncException(String message) {

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -737,9 +737,6 @@
         (while (not (.isInterrupted (Thread/currentThread)))
           (Thread/sleep (* 1000 60 60 1)) ;; every hour
           (backup/backup-current-version crux-options crux-node))))
-    (catch IndexVersionOutOfSyncException e
-      (crux-io/delete-dir index-dir)
-      (-main))
     (catch Exception e
       (log/error e "what happened" (ex-data e)))))
 


### PR DESCRIPTION
As discussed with @hraberg - not much that a caller can reasonably do without human intervention.