### PR TITLE
Put/delete range semantics, #326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#428](https://github.com/juxt/crux/issues/428): Time ranges removed from 'evict' command, see [#PR438](https://github.com/juxt/crux/pull/438) for more details.
 * [#441](https://github.com/juxt/crux/issues/441): Fix two transactions updating the same entity in the same millisecond always returning the earlier of the two values - requires index rebuild.
+* [#326](https://github.com/juxt/crux/issues/326): Put/delete with start/end valid-time semantics made consistent
 
 ### Bug fixes
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1182,11 +1182,11 @@
     (crux.query/q this snapshot q))
 
   (historyAscending [this snapshot eid]
-    (for [^EntityTx entity-tx (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid valid-time transact-time)]
+    (for [^EntityTx entity-tx (idx/entity-history-seq-ascending snapshot eid valid-time transact-time)]
       (assoc (c/entity-tx->edn entity-tx) :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
 
   (historyDescending [this snapshot eid]
-    (for [^EntityTx entity-tx (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid valid-time transact-time)]
+    (for [^EntityTx entity-tx (idx/entity-history-seq-descending snapshot eid valid-time transact-time)]
       (assoc (c/entity-tx->edn entity-tx) :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
 
   (validTime [_]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -49,9 +49,12 @@
                                   (into (sorted-set)))]
 
         {:kvs (->> (concat (when end-valid-time
-                             [[end-valid-time (if-let [entity-to-restore (first entity-history)]
-                                                (c/->id-buffer (.content-hash ^EntityTx entity-to-restore))
-                                                (c/nil-id-buffer))]])
+                             (let [entity-to-restore ^EntityTx (first entity-history)]
+                               (cond
+                                 (nil? entity-to-restore) [[end-valid-time (c/nil-id-buffer)]]
+                                 (= end-valid-time (.vt entity-to-restore)) nil
+                                 :else [[end-valid-time (c/->id-buffer (.content-hash ^EntityTx entity-to-restore))]])))
+
                            (map vector dates-to-correct (repeat content-hash)))
 
                    (mapcat (fn [[valid-time content-hash]]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -66,6 +66,9 @@
 
 (defn tx-command-put [indexer kv object-store snapshot tx-log [op k v start-valid-time end-valid-time] transact-time tx-id]
   (assoc (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/->id-buffer (c/new-id v)))
+
+         ;; This check shouldn't be required, under normal operation - the ingester checks for this before indexing
+         ;; keeping this around _just in case_ - e.g. if we're refactoring the ingest code
          :pre-commit-fn #(let [content-hash (c/new-id v)
                                correct-state? (db/known-keys? object-store snapshot [content-hash])]
                            (when-not correct-state?

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -66,52 +66,51 @@
 
                               (map ->new-entity-tx)))]
 
-    {:kvs (->> new-entity-txs
-               (mapcat (fn [^EntityTx etx]
-                         [[(c/encode-entity+vt+tt+tx-id-key-to
-                            nil
-                            (c/->id-buffer (.eid etx))
-                            (.vt etx)
-                            (.tt etx)
-                            (.tx-id etx))
-                           (c/->id-buffer (.content-hash etx))]
-                          [(c/encode-entity+z+tx-id-key-to
-                            nil
-                            (c/->id-buffer (.eid etx))
-                            (c/encode-entity-tx-z-number (.vt etx) (.tt etx))
-                            (.tx-id etx))
-                           (c/->id-buffer (.content-hash etx))]]))
-               (into []))}))
+    (->> new-entity-txs
+         (mapcat (fn [^EntityTx etx]
+                   [[(c/encode-entity+vt+tt+tx-id-key-to
+                      nil
+                      (c/->id-buffer (.eid etx))
+                      (.vt etx)
+                      (.tt etx)
+                      (.tx-id etx))
+                     (c/->id-buffer (.content-hash etx))]
+                    [(c/encode-entity+z+tx-id-key-to
+                      nil
+                      (c/->id-buffer (.eid etx))
+                      (c/encode-entity-tx-z-number (.vt etx) (.tt etx))
+                      (.tx-id etx))
+                     (c/->id-buffer (.content-hash etx))]]))
+         (into []))))
 
 (defn tx-command-put [indexer kv object-store snapshot tx-log [op k v start-valid-time end-valid-time] transact-time tx-id]
-  (assoc (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/new-id v))
-
-         ;; This check shouldn't be required, under normal operation - the ingester checks for this before indexing
-         ;; keeping this around _just in case_ - e.g. if we're refactoring the ingest code
-         :pre-commit-fn #(let [content-hash (c/new-id v)
-                               correct-state? (db/known-keys? object-store snapshot [content-hash])]
-                           (when-not correct-state?
-                             (log/error "Put, incorrect doc state for:" content-hash "tx id:" tx-id))
-                           correct-state?)))
+  ;; This check shouldn't be required, under normal operation - the ingester checks for this before indexing
+  ;; keeping this around _just in case_ - e.g. if we're refactoring the ingest code
+  {:pre-commit-fn #(let [content-hash (c/new-id v)
+                         correct-state? (db/known-keys? object-store snapshot [content-hash])]
+                     (when-not correct-state?
+                       (log/error "Put, incorrect doc state for:" content-hash "tx id:" tx-id))
+                     correct-state?)
+   :kvs (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/new-id v))})
 
 (defn tx-command-delete [indexer kv object-store snapshot tx-log [op k start-valid-time end-valid-time] transact-time tx-id]
-  (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id nil))
+  {:kvs (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id nil)})
 
 (defn tx-command-cas [indexer kv object-store snapshot tx-log [op k old-v new-v at-valid-time :as cas-op] transact-time tx-id]
   (let [eid (c/new-id k)
         valid-time (or at-valid-time transact-time)]
 
-    (assoc (put-delete-kvs object-store snapshot eid valid-time nil transact-time tx-id (c/new-id new-v))
+    {:pre-commit-fn #(let [{:keys [content-hash] :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
+                       (if (= (c/new-id content-hash)
+                              (c/new-id old-v))
+                         (let [correct-state? (not (nil? (db/get-single-object object-store snapshot (c/new-id new-v))))]
+                           (when-not correct-state?
+                             (log/error "CAS, incorrect doc state for:" (c/new-id new-v) "tx id:" tx-id))
+                           correct-state?)
+                         (do (log/warn "CAS failure:" (cio/pr-edn-str cas-op) "was:" (c/new-id content-hash))
+                             false)))
 
-           :pre-commit-fn #(let [{:keys [content-hash] :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
-                             (if (= (c/new-id content-hash)
-                                    (c/new-id old-v))
-                               (let [correct-state? (not (nil? (db/get-single-object object-store snapshot (c/new-id new-v))))]
-                                 (when-not correct-state?
-                                   (log/error "CAS, incorrect doc state for:" (c/new-id new-v) "tx id:" tx-id))
-                                 correct-state?)
-                               (do (log/warn "CAS failure:" (cio/pr-edn-str cas-op) "was:" (c/new-id content-hash))
-                                   false))))))
+     :kvs (put-delete-kvs object-store snapshot eid valid-time nil transact-time tx-id (c/new-id new-v))}))
 
 (def evict-time-ranges-env-var "CRUX_EVICT_TIME_RANGES")
 (def ^:dynamic *evict-all-on-legacy-time-ranges?* (= (System/getenv evict-time-ranges-env-var) "EVICT_ALL"))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -52,8 +52,7 @@
 
                                      [(if-let [entity-to-restore ^EntityTx (first entity-history)]
                                         (-> entity-to-restore
-                                            (assoc :vt end-valid-time)
-                                            (update :content-hash c/->id-buffer))
+                                            (assoc :vt end-valid-time))
 
                                         (c/->EntityTx eid end-valid-time transact-time tx-id (c/nil-id-buffer)))])))
 
@@ -75,17 +74,17 @@
                             (.vt etx)
                             (.tt etx)
                             (.tx-id etx))
-                           (.content-hash etx)]
+                           (c/->id-buffer (.content-hash etx))]
                           [(c/encode-entity+z+tx-id-key-to
                             nil
                             (c/->id-buffer (.eid etx))
                             (c/encode-entity-tx-z-number (.vt etx) (.tt etx))
                             (.tx-id etx))
-                           (.content-hash etx)]]))
+                           (c/->id-buffer (.content-hash etx))]]))
                (into []))}))
 
 (defn tx-command-put [indexer kv object-store snapshot tx-log [op k v start-valid-time end-valid-time] transact-time tx-id]
-  (assoc (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/->id-buffer (c/new-id v)))
+  (assoc (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/new-id v))
 
          ;; This check shouldn't be required, under normal operation - the ingester checks for this before indexing
          ;; keeping this around _just in case_ - e.g. if we're refactoring the ingest code
@@ -96,13 +95,13 @@
                            correct-state?)))
 
 (defn tx-command-delete [indexer kv object-store snapshot tx-log [op k start-valid-time end-valid-time] transact-time tx-id]
-  (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id (c/nil-id-buffer)))
+  (put-delete-kvs object-store snapshot k start-valid-time end-valid-time transact-time tx-id nil))
 
 (defn tx-command-cas [indexer kv object-store snapshot tx-log [op k old-v new-v at-valid-time :as cas-op] transact-time tx-id]
   (let [eid (c/new-id k)
         valid-time (or at-valid-time transact-time)]
 
-    (assoc (put-delete-kvs object-store snapshot eid valid-time nil transact-time tx-id (c/->id-buffer (c/new-id new-v)))
+    (assoc (put-delete-kvs object-store snapshot eid valid-time nil transact-time tx-id (c/new-id new-v))
 
            :pre-commit-fn #(let [{:keys [content-hash] :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
                              (if (= (c/new-id content-hash)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -100,30 +100,19 @@
 
 (defn tx-command-cas [indexer kv object-store snapshot tx-log [op k old-v new-v at-valid-time :as cas-op] transact-time tx-id]
   (let [eid (c/new-id k)
-        valid-time (or at-valid-time transact-time)
-        {:keys [content-hash]
-         :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
-    {:pre-commit-fn #(if (= (c/new-id content-hash)
-                            (c/new-id old-v))
-                       (let [correct-state? (not (nil? (db/get-single-object object-store snapshot (c/new-id new-v))))]
-                         (when-not correct-state?
-                           (log/error "CAS, incorrect doc state for:" (c/new-id new-v) "tx id:" tx-id))
-                         correct-state?)
-                       (do (log/warn "CAS failure:" (cio/pr-edn-str cas-op) "was:" (c/new-id content-hash))
-                           false))
-     :kvs [[(c/encode-entity+vt+tt+tx-id-key-to
-             nil
-             (c/->id-buffer eid)
-             valid-time
-             transact-time
-             tx-id)
-            (c/->id-buffer new-v)]
-           [(c/encode-entity+z+tx-id-key-to
-             nil
-             (c/->id-buffer eid)
-             (c/encode-entity-tx-z-number valid-time transact-time)
-             tx-id)
-            (c/->id-buffer new-v)]]}))
+        valid-time (or at-valid-time transact-time)]
+
+    (assoc (put-delete-kvs object-store snapshot eid valid-time nil transact-time tx-id (c/->id-buffer (c/new-id new-v)))
+
+           :pre-commit-fn #(let [{:keys [content-hash] :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
+                             (if (= (c/new-id content-hash)
+                                    (c/new-id old-v))
+                               (let [correct-state? (not (nil? (db/get-single-object object-store snapshot (c/new-id new-v))))]
+                                 (when-not correct-state?
+                                   (log/error "CAS, incorrect doc state for:" (c/new-id new-v) "tx id:" tx-id))
+                                 correct-state?)
+                               (do (log/warn "CAS failure:" (cio/pr-edn-str cas-op) "was:" (c/new-id content-hash))
+                                   false))))))
 
 (def evict-time-ranges-env-var "CRUX_EVICT_TIME_RANGES")
 (def ^:dynamic *evict-all-on-legacy-time-ranges?* (= (System/getenv evict-time-ranges-env-var) "EVICT_ALL"))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -285,17 +285,15 @@
     (db/index-tx (:indexer *api*) [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]] t 2)
 
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
-      ;; TODO (JH) iterator goes when we merge the put/delete branch
-      (let [i (kv/new-iterator snapshot)]
-        (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))
-                  (c/->EntityTx (c/new-id :ivan) t t 1 (c/new-id ivan1))]
-                 (idx/entity-history snapshot (c/new-id :ivan))))
+      (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))
+                (c/->EntityTx (c/new-id :ivan) t t 1 (c/new-id ivan1))]
+               (idx/entity-history snapshot (c/new-id :ivan))))
 
-        (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
-                 (idx/entity-history-seq-descending i (c/new-id :ivan) t t)))
+      (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
+               (idx/entity-history-seq-descending snapshot (c/new-id :ivan) t t)))
 
-        (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
-                 (idx/entity-history-seq-ascending i (c/new-id :ivan) t t)))))))
+      (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
+               (idx/entity-history-seq-ascending snapshot (c/new-id :ivan) t t))))))
 
 (t/deftest test-can-store-doc
   (let [content-hash (c/new-id picasso)]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -350,6 +350,13 @@
      [#inst "2019-11-26" 1 12]
      [#inst "2019-11-29" 0 10]]
 
+    ;; delete a range
+    [[10 #inst "2019-11-25"]
+     [nil #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 10]
+     [#inst "2019-11-26" 1 nil]
+     [#inst "2019-11-29" 0 10]]
+
     ;; shouldn't override the value at end-vt if there's one there
     [[10 #inst "2019-11-25"]
      [20 #inst "2019-11-29"]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -348,7 +348,7 @@
      [12 #inst "2019-11-26" #inst "2019-11-29"]]
     [[#inst "2019-11-25" 0 10]
      [#inst "2019-11-26" 1 12]
-     [#inst "2019-11-29" 1 10]]
+     [#inst "2019-11-29" 0 10]]
 
     ;; shouldn't override the value at end-vt if there's one there
     [[10 #inst "2019-11-25"]
@@ -356,7 +356,16 @@
      [12 #inst "2019-11-26" #inst "2019-11-29"]]
     [[#inst "2019-11-25" 0 10]
      [#inst "2019-11-26" 2 12]
-     [#inst "2019-11-29" 1 20]]))
+     [#inst "2019-11-29" 1 20]]
+
+    ;; should re-instate 15 at the end of the range
+    [[10 #inst "2019-11-25"]
+     [15 #inst "2019-11-28"]
+     [12 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 10]
+     [#inst "2019-11-26" 2 12]
+     [#inst "2019-11-28" 2 12]
+     [#inst "2019-11-29" 1 15]]))
 
 ;; TODO: This test just shows that this is an issue, if we fix the
 ;; underlying issue this test should start failing. We can then change

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -338,13 +338,25 @@
                                     (->> (idx/entity-history-seq-ascending snapshot eid first-vt last-tx-time)
                                          (map (juxt :vt :tx-id :content-hash)))))))
 
+
+    [[12 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-26" 0 12]
+     [#inst "2019-11-29" 0 nil]]
+
+    ;; re-instates the previous value at the end of the range
     [[10 #inst "2019-11-25"]
-     [20 #inst "2019-11-30"]
+     [12 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 10]
+     [#inst "2019-11-26" 1 12]
+     [#inst "2019-11-29" 1 10]]
+
+    ;; shouldn't override the value at end-vt if there's one there
+    [[10 #inst "2019-11-25"]
+     [20 #inst "2019-11-29"]
      [12 #inst "2019-11-26" #inst "2019-11-29"]]
     [[#inst "2019-11-25" 0 10]
      [#inst "2019-11-26" 2 12]
-     [#inst "2019-11-29" 2 10]
-     [#inst "2019-11-30" 1 20]]))
+     [#inst "2019-11-29" 1 20]]))
 
 ;; TODO: This test just shows that this is an issue, if we fix the
 ;; underlying issue this test should start failing. We can then change

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -338,41 +338,72 @@
                                     (->> (idx/entity-history-seq-ascending snapshot eid first-vt last-tx-time)
                                          (map (juxt :vt :tx-id :content-hash)))))))
 
+    ;; pairs
+    ;; [[value vt ?end-vt] ...]
+    ;; [[vt tx-idx value] ...]
 
-    [[12 #inst "2019-11-26" #inst "2019-11-29"]]
-    [[#inst "2019-11-26" 0 12]
+    [[26 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-26" 0 26]
      [#inst "2019-11-29" 0 nil]]
 
     ;; re-instates the previous value at the end of the range
-    [[10 #inst "2019-11-25"]
-     [12 #inst "2019-11-26" #inst "2019-11-29"]]
-    [[#inst "2019-11-25" 0 10]
-     [#inst "2019-11-26" 1 12]
-     [#inst "2019-11-29" 0 10]]
+    [[25 #inst "2019-11-25"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 25]
+     [#inst "2019-11-26" 1 26]
+     [#inst "2019-11-29" 0 25]]
 
     ;; delete a range
-    [[10 #inst "2019-11-25"]
+    [[25 #inst "2019-11-25"]
      [nil #inst "2019-11-26" #inst "2019-11-29"]]
-    [[#inst "2019-11-25" 0 10]
+    [[#inst "2019-11-25" 0 25]
      [#inst "2019-11-26" 1 nil]
-     [#inst "2019-11-29" 0 10]]
+     [#inst "2019-11-29" 0 25]]
 
     ;; shouldn't override the value at end-vt if there's one there
-    [[10 #inst "2019-11-25"]
-     [20 #inst "2019-11-29"]
-     [12 #inst "2019-11-26" #inst "2019-11-29"]]
-    [[#inst "2019-11-25" 0 10]
-     [#inst "2019-11-26" 2 12]
-     [#inst "2019-11-29" 1 20]]
+    [[25 #inst "2019-11-25"]
+     [29 #inst "2019-11-29"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 25]
+     [#inst "2019-11-26" 2 26]
+     [#inst "2019-11-29" 1 29]]
 
-    ;; should re-instate 15 at the end of the range
-    [[10 #inst "2019-11-25"]
-     [15 #inst "2019-11-28"]
-     [12 #inst "2019-11-26" #inst "2019-11-29"]]
-    [[#inst "2019-11-25" 0 10]
-     [#inst "2019-11-26" 2 12]
-     [#inst "2019-11-28" 2 12]
-     [#inst "2019-11-29" 1 15]]))
+    ;; should re-instate 28 at the end of the range
+    [[25 #inst "2019-11-25"]
+     [28 #inst "2019-11-28"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]]
+    [[#inst "2019-11-25" 0 25]
+     [#inst "2019-11-26" 2 26]
+     [#inst "2019-11-28" 2 26]
+     [#inst "2019-11-29" 1 28]]
+
+    ;; 26.1 should overwrite the full range
+    [[28 #inst "2019-11-28"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]
+     [26.1 #inst "2019-11-26"]]
+    [[#inst "2019-11-26" 2 26.1]
+     [#inst "2019-11-28" 2 26.1]
+     [#inst "2019-11-29" 0 28]]
+
+    ;; 27 should override the latter half of the range
+    [[25 #inst "2019-11-25"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]
+     [27 #inst "2019-11-27"]]
+    [[#inst "2019-11-25" 0 25]
+     [#inst "2019-11-26" 1 26]
+     [#inst "2019-11-27" 2 27]
+     [#inst "2019-11-29" 0 25]]
+
+    ;; 27 should still override the latter half of the range
+    [[25 #inst "2019-11-25"]
+     [28 #inst "2019-11-28"]
+     [26 #inst "2019-11-26" #inst "2019-11-29"]
+     [27 #inst "2019-11-27"]]
+    [[#inst "2019-11-25" 0 25]
+     [#inst "2019-11-26" 2 26]
+     [#inst "2019-11-27" 3 27]
+     [#inst "2019-11-28" 3 27]
+     [#inst "2019-11-29" 1 28]]))
 
 ;; TODO: This test just shows that this is an issue, if we fix the
 ;; underlying issue this test should start failing. We can then change


### PR DESCRIPTION
closes #326 

To get an idea of what the semantics have changed to, best to start with the `tx_test.clj` file, particularly `test-put-delete-range-semantics`.

Implementation-wise, we've changed the way the put/delete kvs are calculated - this now switches on whether the put/delete is 'from a vt', or 'for a vt range'.

For a vt range, we may have many existing documents between the start and end valid times - we need to overwrite each of these valid times with the new value. We also need to reinstate the previously visible value at the end of the range, so that the put stops taking effect at the end valid-time. There're a couple of cases here:
* If our previous value was at vt=28, we put vt between 25 and 30, we want to reinstate the value at vt=28 at the end of the range, vt=30.
* If the previous value was at vt=23, we still want to reinstate that value - we say that the implicit range for the previous one was from vt=23 until further notice; the range put then briefly interrupts that value, and then the vt=23 range continues afterwards.

'From a vt', we'd like the semantics to be that the put value holds until the next change. Importantly, though, with the above range change, we might well have added a number of otherwise invisible entries which aren't 'changes', but exist to overwrite previous values. 

As part of this change, we therefore have to read forward in the entity history for single-vt puts, overwriting values until we see a 'real change'.

TODO
- [x] CaS should behave like a compare then a put (with new put semantics)

