### PR TITLE
Two transactions in the same ms, touching the same entity, now returns the later of the two values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,27 @@
 
 ## 19.11-1.6.0-alpha
 
-### Changes
+### Breaking changes
 
-* [#428](https://github.com/juxt/crux/issues/428) Time ranges removed from 'evict' command, see [#PR438](https://github.com/juxt/crux/pull/438) for more details.
-* [#430](https://github.com/juxt/crux/issues/430) Add LMDB configuration example to docs + tests
+* [#428](https://github.com/juxt/crux/issues/428): Time ranges removed from 'evict' command, see [#PR438](https://github.com/juxt/crux/pull/438) for more details.
+* [#441](https://github.com/juxt/crux/issues/441): Fix two transactions updating the same entity in the same millisecond always returning the earlier of the two values - requires index rebuild.
 
 ### Bug fixes
 
-* [#PR363](https://github.com/juxt/crux/pull/363) Allow `full-results?` and other boolean flags in a vector-style query
-* [#365](https://github.com/juxt/crux/issues/365) Replace usages of 'pr-str' with 'pr-edn-str' under crux.io
-* [#367](https://github.com/juxt/crux/issues/367) Can query empty DB
-* [#377](https://github.com/juxt/crux/issues/377) Can use 'cons' within query predicates
-* [#351](https://github.com/juxt/crux/issues/351) Do not merge placeholders into unary results
-* [#368](https://github.com/juxt/crux/issues/368) Protect calls to modules when node is closed
-* [#372](https://github.com/juxt/crux/issues/372) Add support for Java collection types with submitTx
-* [#418](https://github.com/juxt/crux/issues/418) Adds exception when query with order-by doesn't return variable ordered on
-* [#419](https://github.com/juxt/crux/issues/419) Fix specification for ':timeout' within queries.
-* [#440](https://github.com/juxt/crux/issues/440) Fix return type of 'documents' in the API.
+* [#PR363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
+* [#365](https://github.com/juxt/crux/issues/365): Replace usages of 'pr-str' with 'pr-edn-str' under crux.io
+* [#367](https://github.com/juxt/crux/issues/367): Can query empty DB
+* [#377](https://github.com/juxt/crux/issues/377): Can use 'cons' within query predicates
+* [#351](https://github.com/juxt/crux/issues/351): Do not merge placeholders into unary results
+* [#368](https://github.com/juxt/crux/issues/368): Protect calls to modules when node is closed
+* [#372](https://github.com/juxt/crux/issues/372): Add support for Java collection types with submitTx
+* [#418](https://github.com/juxt/crux/issues/418): Adds exception when query with order-by doesn't return variable ordered on
+* [#419](https://github.com/juxt/crux/issues/419): Fix specification for ':timeout' within queries.
+* [#440](https://github.com/juxt/crux/issues/440): Fix return type of 'documents' in the API.
 
 ### New features
 * [#414](https://github.com/juxt/crux/issues/414): Developer tool for query tracing
+* [#430](https://github.com/juxt/crux/issues/430): Add LMDB configuration example to docs + tests
 
 ## 19.09-1.5.0-alpha
 

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -18,7 +18,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def ^:const index-version 4)
+(def ^:const index-version 5)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)
@@ -533,11 +533,14 @@
        (.putBytes index-id-size k 0 (.capacity k)))
      (+ index-id-size id-size))))
 
+(defn- descending-long ^long [^long l]
+  (bit-xor (bit-not l) Long/MIN_VALUE))
+
 (defn date->reverse-time-ms ^long [^Date date]
-  (bit-xor (bit-not (.getTime date)) Long/MIN_VALUE))
+  (descending-long (.getTime date)))
 
 (defn reverse-time-ms->date ^java.util.Date [^long reverse-time-ms]
-  (Date. (bit-xor (bit-not reverse-time-ms) Long/MIN_VALUE)))
+  (Date. (descending-long reverse-time-ms)))
 
 (defn- maybe-long-size ^long [x]
   (if x
@@ -565,7 +568,7 @@
      (when transact-time
        (.putLong b (+ index-id-size id-size Long/BYTES) (date->reverse-time-ms transact-time) ByteOrder/BIG_ENDIAN))
      (when tx-id
-       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) tx-id ByteOrder/BIG_ENDIAN))
+       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) (descending-long tx-id) ByteOrder/BIG_ENDIAN))
      (->> (+ index-id-size (.capacity entity)
              (maybe-long-size valid-time) (maybe-long-size transact-time) (maybe-long-size tx-id))
           (mem/limit-buffer b)))))
@@ -595,7 +598,7 @@
     (let [entity (Id. (mem/slice-buffer k index-id-size id-size) 0)
           valid-time (reverse-time-ms->date (.getLong k (+ index-id-size id-size) ByteOrder/BIG_ENDIAN))
           transact-time (reverse-time-ms->date (.getLong k (+ index-id-size id-size Long/BYTES) ByteOrder/BIG_ENDIAN))
-          tx-id (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN)]
+          tx-id (descending-long (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN))]
       (->EntityTx entity valid-time transact-time tx-id nil))))
 
 (defn encode-entity-tx-z-number [valid-time transaction-time]
@@ -623,7 +626,7 @@
        (.putLong b (+ index-id-size id-size) upper-morton ByteOrder/BIG_ENDIAN)
        (.putLong b (+ index-id-size id-size Long/BYTES) lower-morton ByteOrder/BIG_ENDIAN))
      (when tx-id
-       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) tx-id ByteOrder/BIG_ENDIAN))
+       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) (descending-long tx-id) ByteOrder/BIG_ENDIAN))
      (->> (+ index-id-size (.capacity entity) (if z (* 2 Long/BYTES) 0) (maybe-long-size tx-id))
           (mem/limit-buffer b)))))
 
@@ -641,7 +644,7 @@
     (assert (= entity+z+tx-id->content-hash-index-id index-id))
     (let [entity (Id. (mem/slice-buffer k index-id-size id-size) 0)
           [valid-time transaction-time] (morton/morton-number->longs (decode-entity+z+tx-id-key-as-z-number-from k))
-          tx-id (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN)]
+          tx-id (descending-long (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN))]
       (->EntityTx entity (reverse-time-ms->date valid-time) (reverse-time-ms->date transaction-time) tx-id nil))))
 
 (defn entity-tx->edn [^EntityTx entity-tx]
@@ -659,14 +662,14 @@
    (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (+ index-id-size (maybe-long-size tx-id))))]
      (.putByte b 0 failed-tx-id-index-id)
      (when tx-id
-       (.putLong b index-id-size tx-id ByteOrder/BIG_ENDIAN))
+       (.putLong b index-id-size (descending-long tx-id) ByteOrder/BIG_ENDIAN))
      (mem/limit-buffer b (+ index-id-size (maybe-long-size tx-id))))))
 
 (defn decode-failed-tx-id-key-from [^DirectBuffer k]
   (assert (= (+ index-id-size Long/BYTES) (.capacity k)) (mem/buffer->hex k))
   (let [index-id (.getByte k 0)]
     (assert (= failed-tx-id-index-id index-id))
-    (.getLong k index-id-size ByteOrder/BIG_ENDIAN)))
+    (descending-long (.getLong k index-id-size ByteOrder/BIG_ENDIAN))))
 
 (defn encode-index-version-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer index-id-size))]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -272,6 +272,7 @@
   status/Status
   (status-map [this]
     {:crux.index/index-version (idx/current-index-version kv)
+     :crux.tx/latest-completed-tx (db/read-index-meta this :crux.tx/latest-completed-tx)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (defmulti conform-tx-op first)
@@ -322,16 +323,8 @@
     (s/assert :crux.api/tx-ops tx-ops)
     tx-ops))
 
-(defn latest-completed-tx-time [consumer-state]
-  (let [consumer-states (->> consumer-state
-                             (vals)
-                             (sort-by :time))
-        consumer-states-without-lag (filter (comp zero? :lag) consumer-states)]
-    (if (= consumer-states consumer-states-without-lag)
-      (:time (last consumer-states))
-      (:time (first consumer-states)))))
-
-(defn await-no-consumer-lag [indexer timeout-ms]
+(defn ^:deprecated await-no-consumer-lag [indexer timeout-ms]
+  ;; this will likely be going away as part of #442
   (let [max-lag-fn #(some->> (db/read-index-meta indexer :crux.tx-log/consumer-state)
                              (vals)
                              (seq)
@@ -341,21 +334,19 @@
                            (pos? (long max-lag))
                            true)
                         timeout-ms)
-      (latest-completed-tx-time (db/read-index-meta indexer :crux.tx-log/consumer-state))
+      (db/read-index-meta indexer :crux.tx/latest-completed-tx)
       (throw (TimeoutException.
                (str "Timed out waiting for index to catch up, lag is: " (or (max-lag-fn)
                                                                             "unknown")))))))
 
 (defn await-tx-time [indexer transact-time timeout-ms]
-  (let [seen-tx-time (atom (Date. 0))]
-    (if (cio/wait-while #(pos? (compare transact-time
-                                        (let [completed-tx-time (or (latest-completed-tx-time
-                                                                     (db/read-index-meta indexer :crux.tx-log/consumer-state))
-                                                                    (Date. 0))]
-                                          (reset! seen-tx-time completed-tx-time)
-                                          completed-tx-time)))
+  (let [seen-tx (atom nil)]
+    (if (cio/wait-while #(let [latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)]
+                           (reset! seen-tx latest-completed-tx)
+                           (or (nil? latest-completed-tx)
+                               (pos? (compare transact-time (:crux.tx/tx-time latest-completed-tx)))))
                         timeout-ms)
-      @seen-tx-time
+      @seen-tx
       (throw (TimeoutException.
               (str "Timed out waiting for: " (cio/pr-edn-str transact-time)
-                   " index has: " (cio/pr-edn-str @seen-tx-time)))))))
+                   " index has: " (cio/pr-edn-str @seen-tx)))))))

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -212,7 +212,7 @@
         snapshot (.newSnapshot db)
         history (.historyAscending db snapshot (c/new-id eid))]
     (-> (streamed-edn-response snapshot history)
-        (add-last-modified (tx/latest-completed-tx-time (:crux.tx-log/consumer-state (.status crux-node)))))))
+        (add-last-modified (get-in (.status crux-node) [:crux.tx/latest-completed-tx :crux.tx/tx-time])))))
 
 (defn- history-descending [^ICruxAPI crux-node request]
   (let [{:keys [eid] :as body} (s/assert ::entity-map (body->edn request))
@@ -220,7 +220,7 @@
         snapshot (.newSnapshot db)
         history (.historyDescending db snapshot (c/new-id eid))]
     (-> (streamed-edn-response snapshot history)
-        (add-last-modified (tx/latest-completed-tx-time (:crux.tx-log/consumer-state (.status crux-node)))))))
+        (add-last-modified (get-in (.status crux-node) [:crux.tx/latest-completed-tx :crux.tx/tx-time])))))
 
 (defn- transact [^ICruxAPI crux-node request]
   (let [tx-ops (body->edn request)
@@ -237,7 +237,7 @@
         ctx (.newTxLogContext crux-node)
         result (.txLog crux-node ctx from-tx-id with-documents?)]
     (-> (streamed-edn-response ctx result)
-        (add-last-modified (tx/latest-completed-tx-time (:crux.tx-log/consumer-state (.status crux-node)))))))
+        (add-last-modified (get-in (.status crux-node) [:crux.tx/latest-completed-tx :crux.tx/tx-time])))))
 
 (defn- sync-handler [^ICruxAPI crux-node request]
   (let [timeout (some->> (get-in request [:query-params "timeout"])

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -73,7 +73,7 @@
 
 (t/deftest test-can-use-api-to-access-crux
   (t/testing "status"
-    (t/is (= (merge {:crux.index/index-version 4}
+    (t/is (= (merge {:crux.index/index-version 5}
                     (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                       {:crux.zk/zk-active? true}))
              (dissoc (.status *api*)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -76,13 +76,7 @@
     (t/is (= (merge {:crux.index/index-version 5}
                     (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                       {:crux.zk/zk-active? true}))
-             (dissoc (.status *api*)
-                     :crux.kv/kv-store
-                     :crux.kv/estimate-num-keys
-                     :crux.tx-log/consumer-state
-                     :crux.kv/size
-                     :crux.version/version
-                     :crux.version/revision))))
+             (select-keys (.status *api*) [:crux.index/index-version :crux.zk/zk-active?]))))
 
   (t/testing "empty db"
     (t/is (.db *api*)))
@@ -95,32 +89,12 @@
           {:keys [crux.tx/tx-time
                   crux.tx/tx-id]
            :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
-      (t/is (true? (.hasSubmittedTxUpdatedEntity *api* submitted-tx :ivan)))
       (t/is (= tx-time (.sync *api* (:crux.tx/tx-time submitted-tx) nil)))
+      (t/is (true? (.hasSubmittedTxUpdatedEntity *api* submitted-tx :ivan)))
 
       (let [status-map (.status *api*)]
         (t/is (pos? (:crux.kv/estimate-num-keys status-map)))
-        (cond
-          (instance? crux.moberg.MobergTxLog (:tx-log *api*))
-          (t/is (= {:crux.tx/event-log {:lag 0 :next-offset (inc tx-id) :time tx-time}}
-                   (:crux.tx-log/consumer-state status-map)))
-
-          (instance? crux.jdbc.JdbcTxLog (:tx-log *api*))
-          (t/is (= {:crux.tx/event-log {:lag 0 :next-offset (inc tx-id) :time tx-time}}
-                   (:crux.tx-log/consumer-state status-map)))
-
-          :else
-          (let [tx-topic-key (keyword "crux.kafka.topic-partition" (str fk/*tx-topic* "-0"))
-                doc-topic-key (keyword "crux.kafka.topic-partition" (str fk/*doc-topic* "-0"))]
-            (t/is (= {:lag 0
-                      :next-offset 1
-                      :time tx-time}
-                     (get-in status-map [:crux.tx-log/consumer-state tx-topic-key])))
-            (t/is (= {:lag 0
-                      :next-offset 1}
-                     (-> status-map
-                         (get-in [:crux.tx-log/consumer-state doc-topic-key])
-                         (dissoc :time)))))))
+        (t/is (= submitted-tx (:crux.tx/latest-completed-tx status-map))))
 
       (t/testing "query"
         (t/is (= #{[:ivan]} (.q (.db *api*)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -152,7 +152,7 @@
                     {cas-failure-tx-time :crux.tx/tx-time}
                     (api/submit-tx *api* [[:crux.tx/cas old-picasso new-picasso new-valid-time]])
                     _ (api/sync *api* cas-failure-tx-time nil)]
-                (t/is (= cas-failure-tx-time (tx/await-tx-time (:indexer *api*) cas-failure-tx-time 1000)))
+                (t/is (= cas-failure-tx-time (:crux.tx/tx-time (tx/await-tx-time (:indexer *api*) cas-failure-tx-time 1000))))
                 (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
                   (t/is (= [(c/map->EntityTx {:eid          picasso-eid
                                               :content-hash new-content-hash
@@ -168,7 +168,7 @@
                     {new-tx-time :crux.tx/tx-time
                      new-tx-id   :crux.tx/tx-id}
                     (api/submit-tx *api* [[:crux.tx/cas old-picasso new-picasso new-valid-time]])]
-                (t/is (= new-tx-time (tx/await-tx-time (:indexer *api*) new-tx-time 1000)))
+                (t/is (= new-tx-time (:crux.tx/tx-time (tx/await-tx-time (:indexer *api*) new-tx-time 1000))))
                 (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
                   (t/is (= [(c/map->EntityTx {:eid          picasso-eid
                                               :content-hash new-content-hash
@@ -185,7 +185,7 @@
                      new-tx-id   :crux.tx/tx-id}
                     (api/submit-tx *api* [[:crux.tx/cas nil new-picasso new-valid-time]])
                     _ (api/sync *api* new-tx-time nil)]
-                (t/is (= new-tx-time (tx/await-tx-time (:indexer *api*) new-tx-time 1000)))
+                (t/is (= new-tx-time (:crux.tx/tx-time (tx/await-tx-time (:indexer *api*) new-tx-time 1000))))
                 (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
                   (t/is (= [(c/map->EntityTx {:eid          new-eid
                                               :content-hash new-content-hash

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -71,14 +71,17 @@ curl -X GET $nodeURL/
 {:crux.kv/kv-store "crux.kv.rocksdb/kv",
  :crux.kv/estimate-num-keys 92,
  :crux.kv/size 72448,
+ :crux.tx/last-completed-tx
+   {:crux.tx/tx-id 19,
+    :crux.tx/tx-time #inst "2019-01-08T11:06:41.869-00:00"}
  :crux.zk/zk-active? true,
  :crux.tx-log/consumer-state
    {:crux.kafka.topic-partition/crux-docs-0
-      {:offset 25,
+      {:next-offset 25,
        :time #inst "2019-01-08T11:06:41.867-00:00",
        :lag 0},
     :crux.kafka.topic-partition/crux-transaction-log-0
-      {:offset 19,
+      {:next-offset 19,
        :time #inst "2019-01-08T11:06:41.869-00:00",
        :lag 0}}}
 ----


### PR DESCRIPTION
closes #441.

N.B. we don't get sub-ms resolution with this change, just that it returns the later-asserted of the two values (consistently with the rest of Crux)