### PR TITLE
Update 'standalone webservice' example

### DIFF
--- a/docs/example/standalone_webservice/project.clj
+++ b/docs/example/standalone_webservice/project.clj
@@ -20,5 +20,6 @@
                  [cljsjs/vega-lite "3.0.0-rc10-0"]
                  [cljsjs/vega-embed "3.26.0-0"]
                  [cljsjs/codemirror "5.44.0-1"]]
-  :global-vars {*warn-on-reflection* true}
-  :main example-standalone-webservice.main)
+  :global-vars {*warn-on-reflection* false}
+  :main example-standalone-webservice.main
+  :jvm-opts ["--illegal-access=deny"])

--- a/docs/example/standalone_webservice/project.clj
+++ b/docs/example/standalone_webservice/project.clj
@@ -9,9 +9,10 @@
 ;                 [ring/ring-jetty-adapter "1.7.1"]
                  [ring-cors "0.1.13"]
 
-                 [juxt/crux-core "19.09-1.4.0-alpha"]
-                 [juxt/crux-rocksdb "19.09-1.4.0-alpha"]
-                 [juxt/crux-http-server "19.09-1.4.0-alpha"]
+                 [juxt/crux-core "19.09-1.5.0-alpha"]
+                 [juxt/crux-kafka "19.09-1.5.0-alpha"]
+                 [juxt/crux-rocksdb "19.09-1.5.0-alpha"]
+                 [juxt/crux-http-server "19.09-1.5.0-alpha"]
                  [ch.qos.logback/logback-classic "1.2.3"]
                  [yada "1.3.0-alpha7"]
                  [hiccup "2.0.0-alpha2"]

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -688,8 +688,7 @@
 (def log-dir "data/eventlog-1")
 
 (def crux-options
-  {:crux.node/topology :crux.kafka/topology
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+  {:crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.kafka/bootstrap-servers "kafka-cluster-kafka-brokers.crux.svc.cluster.local:9092"
    :crux.standalone/event-log-dir log-dir
    :crux.kv/db-dir index-dir
@@ -703,7 +702,11 @@
    ::backup/sh-restore-script "bin/restore.sh"})
 
 (defn run-node [{:keys [server-port http-port] :as options} with-node-fn]
-  (with-open [crux-node (api/start-node options)
+  (with-open [crux-node (case (System/getenv "CRUX_MODE")
+                          "CLUSTER_NODE" (api/start-node (assoc options
+                                                                :crux.node/topology :crux.kafka/topology))
+                          (api/start-node (assoc options
+                                                 :crux.node/topology :crux.standalone/topology)))
               api-server (srv/start-http-server
                            crux-node
                            {:server-port http-port


### PR DESCRIPTION
Minor updates and fixes to the standalone webservice example:

- Ignores reflection/illegal reflective warnings within the `project.clj` file.
- Update the Crux dependencies to **19.09-1.5.0-alpha**.
- Add **crux-kafka** to the dependencies.
- Fix issues with `crux-options` (introduced with the topology changes).