### PR TITLE
Replacing usages of 'pr-str' with a helper function in crux.io #365

### DIFF
--- a/crux-bench/src/crux_bench/watdiv.clj
+++ b/crux-bench/src/crux_bench/watdiv.clj
@@ -6,7 +6,8 @@
             [crux.index :as idx]
             [crux.rdf :as rdf]
             [crux.sparql :as sparql]
-            [datomic.api :as d])
+            [datomic.api :as d]
+            [crux.io :as cio])
   (:import com.amazonaws.services.s3.model.CannedAccessControlList
            [java.io Closeable File]
            java.time.Duration
@@ -459,10 +460,10 @@
                         (fn write-result-thread []
                           (with-open [out (io/writer out-file)]
                             (.write out "{\n")
-                            (.write out (str ":test-time " (pr-str (System/currentTimeMillis)) "\n"))
-                            (.write out (str ":backend-info " (pr-str (backend-info backend)) "\n"))
-                            (.write out (str ":num-tests " (pr-str num-tests) "\n"))
-                            (.write out (str ":num-threads " (pr-str num-threads) "\n"))
+                            (.write out (str ":test-time " (cio/prn-edn (System/currentTimeMillis)) "\n"))
+                            (.write out (str ":backend-info " (cio/prn-edn (backend-info backend)) "\n"))
+                            (.write out (str ":num-tests " (cio/prn-edn num-tests) "\n"))
+                            (.write out (str ":num-threads " (cio/prn-edn num-threads) "\n"))
                             (.write out (str ":tests " "\n"))
                             (.write out "[\n")
                             (loop []
@@ -470,12 +471,12 @@
                                                                               (.poll completed-queue)
                                                                               (.take completed-queue))]
                                 (.write out "{")
-                                (.write out (str ":idx " (pr-str idx) "\n"))
-                                (.write out (str ":query " (pr-str q) "\n"))
+                                (.write out (str ":idx " (cio/prn-edn idx) "\n"))
+                                (.write out (str ":query " (cio/prn-edn q) "\n"))
                                 (if error
-                                  (.write out (str ":error " (pr-str (str error)) "\n"))
+                                  (.write out (str ":error " (cio/prn-edn (str error)) "\n"))
                                   (.write out (str ":backend-results " results "\n")))
-                                (.write out (str ":time " (pr-str time)))
+                                (.write out (str ":time " (cio/prn-edn time)))
                                 (.write out "}\n")
                                 (.flush out)
                                 (recur)))

--- a/crux-bench/src/crux_bench/watdiv.clj
+++ b/crux-bench/src/crux_bench/watdiv.clj
@@ -460,10 +460,10 @@
                         (fn write-result-thread []
                           (with-open [out (io/writer out-file)]
                             (.write out "{\n")
-                            (.write out (str ":test-time " (cio/prn-edn (System/currentTimeMillis)) "\n"))
-                            (.write out (str ":backend-info " (cio/prn-edn (backend-info backend)) "\n"))
-                            (.write out (str ":num-tests " (cio/prn-edn num-tests) "\n"))
-                            (.write out (str ":num-threads " (cio/prn-edn num-threads) "\n"))
+                            (.write out (str ":test-time " (cio/pr-edn-str (System/currentTimeMillis)) "\n"))
+                            (.write out (str ":backend-info " (cio/pr-edn-str (backend-info backend)) "\n"))
+                            (.write out (str ":num-tests " (cio/pr-edn-str num-tests) "\n"))
+                            (.write out (str ":num-threads " (cio/pr-edn-str num-threads) "\n"))
                             (.write out (str ":tests " "\n"))
                             (.write out "[\n")
                             (loop []
@@ -471,12 +471,12 @@
                                                                               (.poll completed-queue)
                                                                               (.take completed-queue))]
                                 (.write out "{")
-                                (.write out (str ":idx " (cio/prn-edn idx) "\n"))
-                                (.write out (str ":query " (cio/prn-edn q) "\n"))
+                                (.write out (str ":idx " (cio/pr-edn-str idx) "\n"))
+                                (.write out (str ":query " (cio/pr-edn-str q) "\n"))
                                 (if error
-                                  (.write out (str ":error " (cio/prn-edn (str error)) "\n"))
+                                  (.write out (str ":error " (cio/pr-edn-str (str error)) "\n"))
                                   (.write out (str ":backend-results " results "\n")))
-                                (.write out (str ":time " (cio/prn-edn time)))
+                                (.write out (str ":time " (cio/pr-edn-str time)))
                                 (.write out "}\n")
                                 (.flush out)
                                 (recur)))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -314,11 +314,11 @@
 
 (defmethod print-method Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (cio/prn-edn (str id))))
+  (.write w (cio/pr-edn-str (str id))))
 
 (defmethod print-dup Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (cio/prn-edn (str id))))
+  (.write w (cio/pr-edn-str (str id))))
 
 (extend-protocol IdOrBuffer
   Id
@@ -397,11 +397,11 @@
 
 (defmethod print-method EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (cio/prn-edn (edn-id->original-id id))))
+  (.write w (cio/pr-edn-str (edn-id->original-id id))))
 
 (defmethod print-dup EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (cio/prn-edn (edn-id->original-id id))))
+  (.write w (cio/pr-edn-str (edn-id->original-id id))))
 
 (nippy/extend-freeze
  EDNId

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -3,7 +3,8 @@
             [crux.hash :as hash]
             [crux.memory :as mem]
             [crux.morton :as morton]
-            [taoensso.nippy :as nippy])
+            [taoensso.nippy :as nippy]
+            [crux.io :as cio])
   (:import [clojure.lang IHashEq IPersistentMap Keyword]
            [java.io Closeable Writer]
            [java.net MalformedURLException URI URL]
@@ -313,11 +314,11 @@
 
 (defmethod print-method Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (pr-str (str id))))
+  (.write w (cio/prn-edn (str id))))
 
 (defmethod print-dup Id [id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (pr-str (str id))))
+  (.write w (cio/prn-edn (str id))))
 
 (extend-protocol IdOrBuffer
   Id
@@ -396,11 +397,11 @@
 
 (defmethod print-method EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (pr-str (edn-id->original-id id))))
+  (.write w (cio/prn-edn (edn-id->original-id id))))
 
 (defmethod print-dup EDNId [^EDNId id ^Writer w]
   (.write w "#crux/id ")
-  (.write w (pr-str (edn-id->original-id id))))
+  (.write w (cio/prn-edn (edn-id->original-id id))))
 
 (nippy/extend-freeze
  EDNId

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -221,10 +221,7 @@
          (.unlock lock# stamp#)))))
 
 (defn prn-edn [xs]
-  (binding [*print-length* *print-length*
-            *print-level* *print-level*
-            *print-namespace-maps* *print-namespace-maps*]
-    (set! *print-length* nil)
-    (set! *print-level* nil)
-    (set! *print-namespace-maps* false)
+  (binding [*print-length* nil
+            *print-level* nil
+            *print-namespace-maps* false]
     (pr-str xs)))

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -220,7 +220,7 @@
        (finally
          (.unlock lock# stamp#)))))
 
-(defn prn-edn [xs]
+(defn pr-edn-str [xs]
   (binding [*print-length* nil
             *print-level* nil
             *print-namespace-maps* false]

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -219,3 +219,12 @@
        ~@body
        (finally
          (.unlock lock# stamp#)))))
+
+(defn prn-edn [xs]
+  (binding [*print-length* *print-length*
+            *print-level* *print-level*
+            *print-namespace-maps* *print-namespace-maps*]
+    (set! *print-length* nil)
+    (set! *print-level* nil)
+    (set! *print-namespace-maps* false)
+    (pr-str xs)))

--- a/crux-core/src/crux/moberg.clj
+++ b/crux-core/src/crux/moberg.clj
@@ -12,7 +12,8 @@
             [crux.tx.polling :as p]
             [clojure.tools.logging :as log]
             [crux.moberg.types]
-            [crux.tx.consumer])
+            [crux.tx.consumer]
+            [crux.io :as cio])
   (:import [org.agrona DirectBuffer ExpandableDirectByteBuffer MutableDirectBuffer]
            org.agrona.io.DirectBufferInputStream
            crux.api.NonMonotonicTimeException
@@ -118,9 +119,9 @@
       (and detect-clock-drift? (< message-id (long end-message-id)))
       (throw (NonMonotonicTimeException.
               (str "Clock has moved backwards in time, message id: " message-id
-                   " was generated using " (pr-str message-time)
+                   " was generated using " (cio/prn-edn message-time)
                    " lowest valid next id: " end-message-id
-                   " was generated using " (pr-str (message-id->message-time end-message-id)))))
+                   " was generated using " (cio/prn-edn (message-id->message-time end-message-id)))))
 
       (> seq max-seq-id)
       (recur kv topic)
@@ -256,7 +257,7 @@
         (reduce [_ f init]
           (if-let [m (seek-message i ::event-log next-offset)]
             (do
-              (log/debug "Consuming message:" (pr-str (message->edn m)))
+              (log/debug "Consuming message:" (cio/prn-edn (message->edn m)))
               (loop [init' init m m n 1]
                 (let [result (f init' m)]
                   (if (reduced? result)

--- a/crux-core/src/crux/moberg.clj
+++ b/crux-core/src/crux/moberg.clj
@@ -119,9 +119,9 @@
       (and detect-clock-drift? (< message-id (long end-message-id)))
       (throw (NonMonotonicTimeException.
               (str "Clock has moved backwards in time, message id: " message-id
-                   " was generated using " (cio/prn-edn message-time)
+                   " was generated using " (cio/pr-edn-str message-time)
                    " lowest valid next id: " end-message-id
-                   " was generated using " (cio/prn-edn (message-id->message-time end-message-id)))))
+                   " was generated using " (cio/pr-edn-str (message-id->message-time end-message-id)))))
 
       (> seq max-seq-id)
       (recur kv topic)
@@ -257,7 +257,7 @@
         (reduce [_ f init]
           (if-let [m (seek-message i ::event-log next-offset)]
             (do
-              (log/debug "Consuming message:" (cio/prn-edn (message->edn m)))
+              (log/debug "Consuming message:" (cio/pr-edn-str (message->edn m)))
               (loop [init' init m m n 1]
                 (let [result (f init' m)]
                   (if (reduced? result)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -234,7 +234,7 @@
                                     (if (contains? e-vars sym)
                                       (throw (IllegalArgumentException.
                                               (str "Cannot add range constraints on entity variable: "
-                                                   (cio/prn-edn clause))))
+                                                   (cio/pr-edn-str clause))))
                                       clause))
                                   (group-by :sym))]
     (->> (for [[v-var clauses] v-var->range-clauses]
@@ -264,12 +264,12 @@
     (if (= (:v names) (first order))
       (let [v-doc-idx (idx/new-doc-attribute-value-entity-value-index snapshot a)
             e-idx (idx/new-doc-attribute-value-entity-entity-index snapshot a v-doc-idx entity-as-of-idx)]
-        (log/debug :join-order :ave (cio/prn-edn v) e (cio/prn-edn clause))
+        (log/debug :join-order :ave (cio/pr-edn-str v) e (cio/pr-edn-str clause))
         (idx/update-binary-join-order! binary-idx (idx/wrap-with-range-constraints v-doc-idx v-range-constraints) e-idx))
       (let [e-doc-idx (idx/new-doc-attribute-entity-value-entity-index snapshot a entity-as-of-idx)
             v-idx (-> (idx/new-doc-attribute-entity-value-value-index snapshot a e-doc-idx)
                       (idx/wrap-with-range-constraints v-range-constraints))]
-        (log/debug :join-order :aev e (cio/prn-edn v) (cio/prn-edn clause))
+        (log/debug :join-order :aev e (cio/pr-edn-str v) (cio/pr-edn-str clause))
         (idx/update-binary-join-order! binary-idx e-doc-idx v-idx)))))
 
 (defn- triple-joins [triple-clauses range-clauses var->joins arg-vars stats]
@@ -397,7 +397,7 @@
 ;; TODO: This is a naive, but not totally irrelevant measure. Aims to
 ;; bind variables as early and cheaply as possible.
 (defn- clause-complexity [clause]
-  (count (cio/prn-edn clause)))
+  (count (cio/pr-edn-str clause)))
 
 (defn- single-e-var-triple? [vars where]
   (and (= 1 (count where))
@@ -430,7 +430,7 @@
                                     (doseq [var or-vars
                                             :when (not (contains? body-vars var))]
                                       (throw (IllegalArgumentException.
-                                              (str "Or join variable never used: " var " " (cio/prn-edn clause))))))
+                                              (str "Or join variable never used: " var " " (cio/pr-edn-str clause))))))
                                   {:or-vars or-vars
                                    :free-vars free-vars
                                    :bound-vars bound-vars
@@ -445,7 +445,7 @@
                                                                  (count free-vars))})]
             (when (not (apply = (map :or-vars or-branches)))
               (throw (IllegalArgumentException.
-                      (str "Or requires same logic variables: " (cio/prn-edn clause)))))
+                      (str "Or requires same logic variables: " (cio/pr-edn-str clause)))))
             [(conj or-clause+idx-id+or-branches [clause idx-id or-branches])
              (into known-vars free-vars)
              (apply merge-with into var->joins (for [v free-vars]
@@ -552,7 +552,7 @@
           :when (not (contains? var->bindings var))]
     (throw (IllegalArgumentException.
             (str "Clause refers to unknown variable: "
-                 var " " (cio/prn-edn clause))))))
+                 var " " (cio/pr-edn-str clause))))))
 
 (defn- build-pred-constraints [pred-clause+idx-ids var->bindings]
   (for [[{:keys [pred return] :as clause} idx-id] pred-clause+idx-ids
@@ -775,7 +775,7 @@
                  rules (get rule-name->rules rule-name)]
              (when-not rules
                (throw (IllegalArgumentException.
-                       (str "Unknown rule: " (cio/prn-edn sub-clause)))))
+                       (str "Unknown rule: " (cio/pr-edn-str sub-clause)))))
              (let [rule-args+body (for [{:keys [head body]} rules]
                                     [(vec (concat (:bound-args head)
                                                   (:args head)))
@@ -784,10 +784,10 @@
                                             (map (comp count first))
                                             (distinct))]
                (when-not (= 1 (count arities))
-                 (throw (IllegalArgumentException. (str "Rule definitions require same arity: " (cio/prn-edn rules)))))
+                 (throw (IllegalArgumentException. (str "Rule definitions require same arity: " (cio/pr-edn-str rules)))))
                (when-not (= arity (count (:args clause)))
                  (throw (IllegalArgumentException.
-                         (str "Rule invocation has wrong arity, expected: " arity " " (cio/prn-edn sub-clause)))))
+                         (str "Rule invocation has wrong arity, expected: " arity " " (cio/pr-edn-str sub-clause)))))
                ;; TODO: the caches and expansion here needs
                ;; revisiting.
                (let [expanded-rules (for [[branch-index [rule-args body]] (map-indexed vector rule-args+body)
@@ -979,10 +979,10 @@
        (vec (for [arg (distinct args)]
               (mapv #(arg-for-var arg %) arg-vars-in-join-order)))
        (mapv v-var->range-constraints arg-vars-in-join-order)))
-    (log/debug :where (cio/prn-edn where))
+    (log/debug :where (cio/pr-edn-str where))
     (log/debug :vars-in-join-order vars-in-join-order)
-    (log/debug :attr-stats (cio/prn-edn attr-stats))
-    (log/debug :var->bindings (cio/prn-edn var->bindings))
+    (log/debug :attr-stats (cio/pr-edn-str attr-stats))
+    (log/debug :var->bindings (cio/pr-edn-str var->bindings))
     (constrain-result-fn [] [])
     {:n-ary-join (-> (mapv idx/new-unary-join-virtual-index unary-join-index-groups)
                      (idx/new-n-ary-join-layered-virtual-index)
@@ -1119,7 +1119,7 @@
          q-conformed (.q-conformed conformed-query)
          {:keys [find where args rules offset limit order-by full-results?]} q-conformed
          stats (idx/read-meta kv :crux.kv/stats)]
-     (log/debug :query (cio/prn-edn q))
+     (log/debug :query (cio/pr-edn-str q))
      (validate-args args)
      (let [rule-name->rules (rule-name->rules rules)
            entity-as-of-idx (idx/new-entity-as-of-index snapshot valid-time transact-time)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -80,7 +80,7 @@
                          (when-not correct-state?
                            (log/error "CAS, incorrect doc state for:" (c/new-id new-v) "tx id:" tx-id))
                          correct-state?)
-                       (do (log/warn "CAS failure:" (cio/prn-edn cas-op) "was:" (c/new-id content-hash))
+                       (do (log/warn "CAS failure:" (cio/pr-edn-str cas-op) "was:" (c/new-id content-hash))
                            false))
      :kvs [[(c/encode-entity+vt+tt+tx-id-key-to
              nil
@@ -130,13 +130,13 @@
 (def ^:private tx-fn-eval-cache (memoize eval))
 
 (defn log-tx-fn-error [fn-result fn-id body args-id args]
-  (log/warn fn-result "Transaction function failure:" fn-id (cio/prn-edn body) args-id (cio/prn-edn args)))
+  (log/warn fn-result "Transaction function failure:" fn-id (cio/pr-edn-str body) args-id (cio/pr-edn-str args)))
 
 (def tx-fns-enabled? (Boolean/parseBoolean (System/getenv "CRUX_ENABLE_TX_FNS")))
 
 (defn tx-command-fn [indexer kv object-store snapshot tx-log [op k args-v :as tx-op] transact-time tx-id]
   (if-not tx-fns-enabled?
-    (throw (IllegalArgumentException. (str "Transaction functions not enabled: " (cio/prn-edn tx-op))))
+    (throw (IllegalArgumentException. (str "Transaction functions not enabled: " (cio/pr-edn-str tx-op))))
     (let [fn-id (c/new-id k)
           db (q/db kv object-store transact-time transact-time)
           {:crux.db.fn/keys [body] :as fn-doc} (q/entity db fn-id)
@@ -216,7 +216,7 @@
 
     (when (not (contains? doc :crux.db/id))
       (throw (IllegalArgumentException.
-              (str "Missing required attribute :crux.db/id: " (cio/prn-edn doc)))))
+              (str "Missing required attribute :crux.db/id: " (cio/pr-edn-str doc)))))
 
     (let [content-hash (c/new-id content-hash)
           evicted? (idx/evicted-doc? doc)]
@@ -256,7 +256,7 @@
                 (doseq [{:keys [post-commit-fn]} tx-command-results
                         :when post-commit-fn]
                   (post-commit-fn)))
-            (do (log/warn "Transaction aborted:" (cio/prn-edn tx-events) (cio/prn-edn tx-time) tx-id)
+            (do (log/warn "Transaction aborted:" (cio/pr-edn-str tx-events) (cio/pr-edn-str tx-time) tx-id)
                 (kv/store kv [[(c/encode-failed-tx-id-key-to nil tx-id) c/empty-buffer]])))))))
 
   (docs-exist? [_ content-hashes]
@@ -357,5 +357,5 @@
                         timeout-ms)
       @seen-tx-time
       (throw (TimeoutException.
-              (str "Timed out waiting for: " (cio/prn-edn transact-time)
-                   " index has: " (cio/prn-edn @seen-tx-time)))))))
+              (str "Timed out waiting for: " (cio/pr-edn-str transact-time)
+                   " index has: " (cio/pr-edn-str @seen-tx-time)))))))

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -1,5 +1,6 @@
 (ns crux.tx.polling
   (:require [crux.db :as db]
+            [crux.io :as cio]
             [clojure.tools.logging :as log]
             [crux.tx.consumer :as consumer])
   (:import java.util.Date
@@ -38,7 +39,7 @@
                                             {:lag lag
                                              :next-offset next-offset
                                              :time (.message-time last-message)}}]
-                        (log/debug "Event log consumer state:" (pr-str consumer-state))
+                        (log/debug "Event log consumer state:" (cio/prn-edn consumer-state))
                         (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
                         false)
                       true)))]

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -39,7 +39,7 @@
                                             {:lag lag
                                              :next-offset next-offset
                                              :time (.message-time last-message)}}]
-                        (log/debug "Event log consumer state:" (cio/prn-edn consumer-state))
+                        (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
                         (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
                         false)
                       true)))]

--- a/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
+++ b/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
@@ -13,7 +13,8 @@
             [crux.fixtures.standalone :as fs]
             [crux.fixtures.api :as f-api]
             [clojure.java.io :as io]
-            [clojure.pprint :as pp])
+            [clojure.pprint :as pp]
+            [crux.io :as cio])
   (:import (java.sql Date)
            (java.time Duration)))
 
@@ -31,8 +32,8 @@
   (reset! sync-times (or (slurp-edn "sync-times.edn") {})))
 
 (defn- spit-test-times! []
-  (spit "sync-times.edn" (pr-str @sync-times))
-  (spit "test-times.edn" (pr-str @query-perf-times)))
+  (spit "sync-times.edn" (cio/prn-edn @sync-times))
+  (spit "test-times.edn" (cio/prn-edn @query-perf-times)))
 
 (defn avg [nums]
   (/ (reduce + nums) (count nums)))
@@ -184,4 +185,3 @@
   (def q2 (::q2 s))
   (def q2-data (:data q2))
   (clojure.pprint/pprint q2-data))
-

--- a/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
+++ b/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
@@ -32,8 +32,8 @@
   (reset! sync-times (or (slurp-edn "sync-times.edn") {})))
 
 (defn- spit-test-times! []
-  (spit "sync-times.edn" (cio/prn-edn @sync-times))
-  (spit "test-times.edn" (cio/prn-edn @query-perf-times)))
+  (spit "sync-times.edn" (cio/pr-edn-str @sync-times))
+  (spit "test-times.edn" (cio/pr-edn-str @query-perf-times)))
 
 (defn avg [nums]
   (/ (reduce + nums) (count nums)))

--- a/crux-dev/dev/matrix.clj
+++ b/crux-dev/dev/matrix.clj
@@ -815,7 +815,7 @@
                         (try
                           (let [result (count (matrix/query wg (crux.sparql/sparql->datalog query)))]
                             (assert (= crux-results result)
-                                    (pr-str [idx crux-results result])))
+                                    (cio/prn-edn [idx crux-results result])))
                           (catch Throwable t
                             (prn idx t)))
                         (- (System/currentTimeMillis) start)))

--- a/crux-dev/dev/matrix.clj
+++ b/crux-dev/dev/matrix.clj
@@ -815,7 +815,7 @@
                         (try
                           (let [result (count (matrix/query wg (crux.sparql/sparql->datalog query)))]
                             (assert (= crux-results result)
-                                    (cio/prn-edn [idx crux-results result])))
+                                    (cio/pr-edn-str [idx crux-results result])))
                           (catch Throwable t
                             (prn idx t)))
                         (- (System/currentTimeMillis) start)))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -71,7 +71,7 @@
                                              :method :post
                                              :headers (when body
                                                         {"Content-Type" "application/edn"})
-                                             :body (some-> body cio/prn-edn)}
+                                             :body (some-> body cio/pr-edn-str)}
                                             opts))]
      (cond
        (= 404 status)

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -71,7 +71,7 @@
                                              :method :post
                                              :headers (when body
                                                         {"Content-Type" "application/edn"})
-                                             :body (some-> body pr-str)}
+                                             :body (some-> body cio/prn-edn)}
                                             opts))]
      (cond
        (= 404 status)

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -48,7 +48,7 @@
               200
               404)
             {"Content-Type" "application/edn"}
-            (cio/prn-edn m)))
+            (cio/pr-edn-str m)))
 
 (defn- exception-response [status ^Exception e]
   (response status
@@ -65,7 +65,7 @@
           (if (and (.getMessage e)
                    (str/starts-with? (.getMessage e) "Spec assertion failed"))
             (exception-response 400 e) ;; Valid edn, invalid content
-            (do (log/error e "Exception while handling request:" (cio/prn-edn request))
+            (do (log/error e "Exception while handling request:" (cio/pr-edn-str request))
                 (exception-response 500 e))))) ;; Valid content; something internal failed, or content validity is not properly checked
       (catch Exception e
         (exception-response 400 e))))) ;;Invalid edn
@@ -86,7 +86,7 @@
       (success-response status-map)
       (response 500
                 {"Content-Type" "application/edn"}
-                (cio/prn-edn status-map)))))
+                (cio/pr-edn-str status-map)))))
 
 (defn- document [^ICruxAPI crux-node request]
   (let [[_ content-hash] (re-find #"^/document/(.+)$" (req/path-info request))]
@@ -152,7 +152,7 @@
                         out (io/writer out)]
               (.write out "(")
               (doseq [x edn]
-                (.write out (cio/prn-edn x)))
+                (.write out (cio/pr-edn-str x)))
               (.write out ")"))))
          (response 200 {"Content-Type" "application/edn"}))
     (catch Throwable t

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -48,7 +48,7 @@
               200
               404)
             {"Content-Type" "application/edn"}
-            (pr-str m)))
+            (cio/prn-edn m)))
 
 (defn- exception-response [status ^Exception e]
   (response status
@@ -65,7 +65,7 @@
           (if (and (.getMessage e)
                    (str/starts-with? (.getMessage e) "Spec assertion failed"))
             (exception-response 400 e) ;; Valid edn, invalid content
-            (do (log/error e "Exception while handling request:" (pr-str request))
+            (do (log/error e "Exception while handling request:" (cio/prn-edn request))
                 (exception-response 500 e))))) ;; Valid content; something internal failed, or content validity is not properly checked
       (catch Exception e
         (exception-response 400 e))))) ;;Invalid edn
@@ -86,7 +86,7 @@
       (success-response status-map)
       (response 500
                 {"Content-Type" "application/edn"}
-                (pr-str status-map)))))
+                (cio/prn-edn status-map)))))
 
 (defn- document [^ICruxAPI crux-node request]
   (let [[_ content-hash] (re-find #"^/document/(.+)$" (req/path-info request))]
@@ -152,7 +152,7 @@
                         out (io/writer out)]
               (.write out "(")
               (doseq [x edn]
-                (.write out (pr-str x)))
+                (.write out (cio/prn-edn x)))
               (.write out ")"))))
          (response 200 {"Content-Type" "application/edn"}))
     (catch Throwable t

--- a/crux-kafka-connect/src/crux/kafka/connect.clj
+++ b/crux-kafka-connect/src/crux/kafka/connect.clj
@@ -201,7 +201,7 @@
           batch-size (get props CruxSourceConnector/TASK_BATCH_SIZE_CONFIG)
           source-partition {"url" url}
           formatter (case format
-                      "edn" cio/prn-edn
+                      "edn" cio/pr-edn-str
                       "json" json/generate-string
                       "transit" write-transit)
           tx-log-entry->source-records (case mode

--- a/crux-kafka-connect/src/crux/kafka/connect.clj
+++ b/crux-kafka-connect/src/crux/kafka/connect.clj
@@ -3,6 +3,7 @@
             [cheshire.generate]
             [clojure.tools.logging :as log]
             [crux.codec :as c]
+            [crux.io :as cio]
             [cognitect.transit :as transit])
   (:import [org.apache.kafka.connect.data Schema Schema$Type Struct Field]
            org.apache.kafka.connect.sink.SinkRecord
@@ -200,7 +201,7 @@
           batch-size (get props CruxSourceConnector/TASK_BATCH_SIZE_CONFIG)
           source-partition {"url" url}
           formatter (case format
-                      "edn" pr-str
+                      "edn" cio/prn-edn
                       "json" json/generate-string
                       "transit" write-transit)
           tx-log-entry->source-records (case mode

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -233,11 +233,11 @@
                                  {:crux.tx/keys [tx-time
                                                  tx-id]} (tx-record->tx-log-entry tx-record)]
                              (if ready?
-                               (log/info "Ready for indexing of tx" tx-id (cio/prn-edn tx-time))
+                               (log/info "Ready for indexing of tx" tx-id (cio/pr-edn-str tx-time))
                                (do (when-not (.contains (.paused consumer) tx-topic-partition)
                                      (log/debug "Pausing" tx-topic)
                                      (.pause consumer [tx-topic-partition]))
-                                   (log/info "Delaying indexing of tx" tx-id (cio/prn-edn tx-time) "pending:" (count pending-tx-records))))
+                                   (log/info "Delaying indexing of tx" tx-id (cio/pr-edn-str tx-time) "pending:" (count pending-tx-records))))
                              ready?)))
                         (vec))]
     (doseq [record tx-records]

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -233,11 +233,11 @@
                                  {:crux.tx/keys [tx-time
                                                  tx-id]} (tx-record->tx-log-entry tx-record)]
                              (if ready?
-                               (log/info "Ready for indexing of tx" tx-id (pr-str tx-time))
+                               (log/info "Ready for indexing of tx" tx-id (cio/prn-edn tx-time))
                                (do (when-not (.contains (.paused consumer) tx-topic-partition)
                                      (log/debug "Pausing" tx-topic)
                                      (.pause consumer [tx-topic-partition]))
-                                   (log/info "Delaying indexing of tx" tx-id (pr-str tx-time) "pending:" (count pending-tx-records))))
+                                   (log/info "Delaying indexing of tx" tx-id (cio/prn-edn tx-time) "pending:" (count pending-tx-records))))
                              ready?)))
                         (vec))]
     (doseq [record tx-records]

--- a/crux-kafka/src/crux/kafka/edn/EdnSerializer.java
+++ b/crux-kafka/src/crux/kafka/edn/EdnSerializer.java
@@ -15,7 +15,7 @@ public class EdnSerializer implements Serializer<Object> {
     }
 
     static {
-        prStr = resolve("crux.io/prn-edn");
+        prStr = resolve("crux.io/pr-edn-str");
     }
 
     public void close() {

--- a/crux-kafka/src/crux/kafka/edn/EdnSerializer.java
+++ b/crux-kafka/src/crux/kafka/edn/EdnSerializer.java
@@ -8,9 +8,14 @@ import org.apache.kafka.common.serialization.Serializer;
 
 public class EdnSerializer implements Serializer<Object> {
     private static final IFn prStr;
+     private static IFn requiringResolve = Clojure.var("clojure.core/requiring-resolve");
+
+    private static IFn resolve(String symbolName) {
+        return (IFn) requiringResolve.invoke(Clojure.read(symbolName));
+    }
 
     static {
-        prStr = Clojure.var("clojure.core/pr-str");
+        prStr = resolve("crux.io/prn-edn");
     }
 
     public void close() {

--- a/crux-rdf/src/crux/sparql/protocol.clj
+++ b/crux-rdf/src/crux/sparql/protocol.clj
@@ -53,7 +53,7 @@
        "</sparql>"))
 
 (defn- sparql-json-response [vars results]
-  (str "{\"head\": {\"vars\": [" (str/join ", " (map (comp cio/prn-edn strip-qmark str) vars)) "]}, "
+  (str "{\"head\": {\"vars\": [" (str/join ", " (map (comp cio/pr-edn-str strip-qmark str) vars)) "]}, "
        "\"results\": { \"bindings\": ["
        (->> (for [result results]
               (str "{"

--- a/crux-rdf/src/crux/sparql/protocol.clj
+++ b/crux-rdf/src/crux/sparql/protocol.clj
@@ -5,7 +5,8 @@
             [crux.rdf :as rdf]
             [crux.sparql :as sparql]
             [ring.util.request :as req]
-            [ring.util.time :as rt])
+            [ring.util.time :as rt]
+            [crux.io :as cio])
   (:import [org.eclipse.rdf4j.model BNode IRI Literal]
            crux.api.ICruxAPI))
 
@@ -52,7 +53,7 @@
        "</sparql>"))
 
 (defn- sparql-json-response [vars results]
-  (str "{\"head\": {\"vars\": [" (str/join ", " (map (comp pr-str strip-qmark str) vars)) "]}, "
+  (str "{\"head\": {\"vars\": [" (str/join ", " (map (comp cio/prn-edn strip-qmark str) vars)) "]}, "
        "\"results\": { \"bindings\": ["
        (->> (for [result results]
               (str "{"

--- a/crux-rdf/test/crux/sparql_test.clj
+++ b/crux-rdf/test/crux/sparql_test.clj
@@ -27,11 +27,11 @@ WHERE
     ?y  <http://www.w3.org/2001/vcard-rdf/3.0#Given>  ?givenName .
   }")))
 
-    (t/is (= (cio/prn-edn (rdf/with-prefix {:vcard "http://www.w3.org/2001/vcard-rdf/3.0#"}
+    (t/is (= (cio/pr-edn-str (rdf/with-prefix {:vcard "http://www.w3.org/2001/vcard-rdf/3.0#"}
                        '{:find [?g]
                          :where [[?y :vcard/Given ?g]
                                  [(re-find #"(?i)r" ?g)]]}))
-             (cio/prn-edn (sparql/sparql->datalog
+             (cio/pr-edn-str (sparql/sparql->datalog
                       "
 PREFIX vcard: <http://www.w3.org/2001/vcard-rdf/3.0#>
 
@@ -172,11 +172,11 @@ SELECT ( CONCAT(?G, \" \", ?S) AS ?name )
 WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S }
 ")))
 
-    (t/is (= (cio/prn-edn '{:find [?title],
+    (t/is (= (cio/pr-edn-str '{:find [?title],
                        :where
                        [[?x :http://purl.org/dc/elements/1.1/title ?title]
                         [(re-find #"^SPARQL" ?title)]]})
-             (cio/prn-edn (sparql/sparql->datalog
+             (cio/pr-edn-str (sparql/sparql->datalog
                       "
 PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
 SELECT  ?title
@@ -184,11 +184,11 @@ WHERE   { ?x dc:title ?title
           FILTER regex(?title, \"^SPARQL\")
         }"))))
 
-    (t/is (= (cio/prn-edn '{:find [?title],
+    (t/is (= (cio/pr-edn-str '{:find [?title],
                        :where
                        [[?x :http://purl.org/dc/elements/1.1/title ?title]
                         [(re-find #"(?i)web" ?title)]]})
-             (cio/prn-edn (sparql/sparql->datalog
+             (cio/pr-edn-str (sparql/sparql->datalog
                       "
 PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
 SELECT  ?title

--- a/crux-rdf/test/crux/sparql_test.clj
+++ b/crux-rdf/test/crux/sparql_test.clj
@@ -1,6 +1,7 @@
 (ns crux.sparql-test
   (:require [clojure.test :as t]
             [clojure.java.io :as io]
+            [crux.io :as cio]
             [crux.rdf :as rdf]
             [crux.sparql :as sparql]))
 
@@ -26,11 +27,11 @@ WHERE
     ?y  <http://www.w3.org/2001/vcard-rdf/3.0#Given>  ?givenName .
   }")))
 
-    (t/is (= (pr-str (rdf/with-prefix {:vcard "http://www.w3.org/2001/vcard-rdf/3.0#"}
+    (t/is (= (cio/prn-edn (rdf/with-prefix {:vcard "http://www.w3.org/2001/vcard-rdf/3.0#"}
                        '{:find [?g]
                          :where [[?y :vcard/Given ?g]
                                  [(re-find #"(?i)r" ?g)]]}))
-             (pr-str (sparql/sparql->datalog
+             (cio/prn-edn (sparql/sparql->datalog
                       "
 PREFIX vcard: <http://www.w3.org/2001/vcard-rdf/3.0#>
 
@@ -171,11 +172,11 @@ SELECT ( CONCAT(?G, \" \", ?S) AS ?name )
 WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S }
 ")))
 
-    (t/is (= (pr-str '{:find [?title],
+    (t/is (= (cio/prn-edn '{:find [?title],
                        :where
                        [[?x :http://purl.org/dc/elements/1.1/title ?title]
                         [(re-find #"^SPARQL" ?title)]]})
-             (pr-str (sparql/sparql->datalog
+             (cio/prn-edn (sparql/sparql->datalog
                       "
 PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
 SELECT  ?title
@@ -183,11 +184,11 @@ WHERE   { ?x dc:title ?title
           FILTER regex(?title, \"^SPARQL\")
         }"))))
 
-    (t/is (= (pr-str '{:find [?title],
+    (t/is (= (cio/prn-edn '{:find [?title],
                        :where
                        [[?x :http://purl.org/dc/elements/1.1/title ?title]
                         [(re-find #"(?i)web" ?title)]]})
-             (pr-str (sparql/sparql->datalog
+             (cio/prn-edn (sparql/sparql->datalog
                       "
 PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
 SELECT  ?title

--- a/crux-test/test/crux/moberg_test.clj
+++ b/crux-test/test/crux/moberg_test.clj
@@ -40,10 +40,10 @@
              NonMonotonicTimeException
              (re-pattern (str "Clock has moved backwards in time, message id: "
                               1583412019200001
-                              " was generated using " (cio/prn-edn #inst "2019")
+                              " was generated using " (cio/pr-edn-str #inst "2019")
                               " lowest valid next id: "
                               (inc message-id)
-                              " was generated using " (cio/prn-edn message-time)))
+                              " was generated using " (cio/pr-edn-str message-time)))
              (moberg/sent-message->edn (moberg/send-message *kv* :my-topic "Hello World")))))))
 
 (t/deftest test-can-send-and-receive-message-on-two-topics

--- a/crux-test/test/crux/moberg_test.clj
+++ b/crux-test/test/crux/moberg_test.clj
@@ -8,7 +8,8 @@
             [crux.fixtures.kv-only :as fkv :refer [*kv* *kv-module*]]
             [crux.kv :as kv]
             [crux.moberg :as moberg]
-            [crux.status :as status])
+            [crux.status :as status]
+            [crux.io :as cio])
   (:import crux.api.NonMonotonicTimeException))
 
 (t/use-fixtures :each fkv/with-each-kv-store-implementation fkv/without-kv-index-version fkv/with-kv-store f/with-silent-test-check)
@@ -39,10 +40,10 @@
              NonMonotonicTimeException
              (re-pattern (str "Clock has moved backwards in time, message id: "
                               1583412019200001
-                              " was generated using " (pr-str #inst "2019")
+                              " was generated using " (cio/prn-edn #inst "2019")
                               " lowest valid next id: "
                               (inc message-id)
-                              " was generated using " (pr-str message-time)))
+                              " was generated using " (cio/prn-edn message-time)))
              (moberg/sent-message->edn (moberg/send-message *kv* :my-topic "Hello World")))))))
 
 (t/deftest test-can-send-and-receive-message-on-two-topics

--- a/crux-test/test/crux/watdiv_test.clj
+++ b/crux-test/test/crux/watdiv_test.clj
@@ -402,8 +402,8 @@
                :when (or (nil? watdiv-indexes)
                          (contains? watdiv-indexes idx))]
          (.write out "{")
-         (.write out (str ":idx " (pr-str idx) "\n"))
-         (.write out (str ":query " (pr-str q) "\n"))
+         (.write out (str ":idx " (cio/prn-edn idx) "\n"))
+         (.write out (str ":query " (cio/prn-edn q) "\n"))
          (when crux-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
@@ -411,48 +411,48 @@
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":crux-error " (pr-str (str t)) "\n"))
+                       (.write out (str ":crux-error " (cio/prn-edn (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":crux-time " (pr-str (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":crux-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
 
          (when sail-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":sail-results " (pr-str (count (execute-sparql *sail-conn* q)))
+                     (.write out (str ":sail-results " (cio/prn-edn (count (execute-sparql *sail-conn* q)))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":sail-error " (pr-str (str t)) "\n"))
+                       (.write out (str ":sail-error " (cio/prn-edn (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":sail-time " (pr-str (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":sail-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
 
          (when neo4j-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":neo4j-results " (pr-str (count (execute-cypher *neo4j-db* (sparql->cypher *neo4j-db* q))))
+                     (.write out (str ":neo4j-results " (cio/prn-edn (count (execute-cypher *neo4j-db* (sparql->cypher *neo4j-db* q))))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":neo4j-error " (pr-str (str t)) "\n"))
+                       (.write out (str ":neo4j-error " (cio/prn-edn (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":neo4j-time " (pr-str (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":neo4j-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
 
          (when datomic-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":datomic-results " (pr-str (count (d/query {:query (sparql/sparql->datalog q)
+                     (.write out (str ":datomic-results " (cio/prn-edn (count (d/query {:query (sparql/sparql->datalog q)
                                                                                    :timeout query-timeout-ms
                                                                                    :args [(d/db *datomic-conn*)]})))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":datomic-error " (pr-str (str t)) "\n"))
+                       (.write out (str ":datomic-error " (cio/prn-edn (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":datomic-time " (pr-str (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":datomic-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
 
          (.write out "}\n")
          (.flush out))

--- a/crux-test/test/crux/watdiv_test.clj
+++ b/crux-test/test/crux/watdiv_test.clj
@@ -402,8 +402,8 @@
                :when (or (nil? watdiv-indexes)
                          (contains? watdiv-indexes idx))]
          (.write out "{")
-         (.write out (str ":idx " (cio/prn-edn idx) "\n"))
-         (.write out (str ":query " (cio/prn-edn q) "\n"))
+         (.write out (str ":idx " (cio/pr-edn-str idx) "\n"))
+         (.write out (str ":query " (cio/pr-edn-str q) "\n"))
          (when crux-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
@@ -411,48 +411,48 @@
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":crux-error " (cio/prn-edn (str t)) "\n"))
+                       (.write out (str ":crux-error " (cio/pr-edn-str (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":crux-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":crux-time " (cio/pr-edn-str (-  (System/currentTimeMillis) start-time))))))
 
          (when sail-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":sail-results " (cio/prn-edn (count (execute-sparql *sail-conn* q)))
+                     (.write out (str ":sail-results " (cio/pr-edn-str (count (execute-sparql *sail-conn* q)))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":sail-error " (cio/prn-edn (str t)) "\n"))
+                       (.write out (str ":sail-error " (cio/pr-edn-str (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":sail-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":sail-time " (cio/pr-edn-str (-  (System/currentTimeMillis) start-time))))))
 
          (when neo4j-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":neo4j-results " (cio/prn-edn (count (execute-cypher *neo4j-db* (sparql->cypher *neo4j-db* q))))
+                     (.write out (str ":neo4j-results " (cio/pr-edn-str (count (execute-cypher *neo4j-db* (sparql->cypher *neo4j-db* q))))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":neo4j-error " (cio/prn-edn (str t)) "\n"))
+                       (.write out (str ":neo4j-error " (cio/pr-edn-str (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":neo4j-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":neo4j-time " (cio/pr-edn-str (-  (System/currentTimeMillis) start-time))))))
 
          (when datomic-tests?
            (let [start-time (System/currentTimeMillis)]
              (t/is (try
-                     (.write out (str ":datomic-results " (cio/prn-edn (count (d/query {:query (sparql/sparql->datalog q)
+                     (.write out (str ":datomic-results " (cio/pr-edn-str (count (d/query {:query (sparql/sparql->datalog q)
                                                                                    :timeout query-timeout-ms
                                                                                    :args [(d/db *datomic-conn*)]})))
                                       "\n"))
                      true
                      (catch Throwable t
-                       (.write out (str ":datomic-error " (cio/prn-edn (str t)) "\n"))
+                       (.write out (str ":datomic-error " (cio/pr-edn-str (str t)) "\n"))
                        (throw t)))
                    idx)
-             (.write out (str ":datomic-time " (cio/prn-edn (-  (System/currentTimeMillis) start-time))))))
+             (.write out (str ":datomic-time " (cio/pr-edn-str (-  (System/currentTimeMillis) start-time))))))
 
          (.write out "}\n")
          (.flush out))

--- a/crux-uberjar/src/crux/main/graal.clj
+++ b/crux-uberjar/src/crux/main/graal.clj
@@ -11,4 +11,4 @@
   (with-open [node (n/start sa/topology {:crux.kv/db-dir "graal-data"
                                          :crux.standalone/event-log-dir "graal-event-log"
                                          :crux.node/kv-store "crux.kv.rocksdb/kv"})]
-    (log/info "Starting Crux native image" (cio/prn-edn (.status node)))))
+    (log/info "Starting Crux native image" (cio/pr-edn-str (.status node)))))

--- a/crux-uberjar/src/crux/main/graal.clj
+++ b/crux-uberjar/src/crux/main/graal.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [crux.standalone :as sa]
             [crux.node :as n]
+            [crux.io :as cio]
             [crux.kv.memdb]
             [crux.kv.rocksdb])
   (:gen-class))
@@ -10,4 +11,4 @@
   (with-open [node (n/start sa/topology {:crux.kv/db-dir "graal-data"
                                          :crux.standalone/event-log-dir "graal-event-log"
                                          :crux.node/kv-store "crux.kv.rocksdb/kv"})]
-    (log/info "Starting Crux native image" (pr-str (.status node)))))
+    (log/info "Starting Crux native image" (cio/prn-edn (.status node)))))

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -505,7 +505,7 @@
               [:table
                [:thead
                 (for [v (:find conformed-query)]
-                  [:th (pr-str v)])]
+                  [:th (crux-io/prn-edn v)])]
                [:tbody
                 (for [tuple result]
                   [:tr

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -505,7 +505,7 @@
               [:table
                [:thead
                 (for [v (:find conformed-query)]
-                  [:th (crux-io/prn-edn v)])]
+                  [:th (crux-io/pr-edn-str v)])]
                [:tbody
                 (for [tuple result]
                   [:tr


### PR DESCRIPTION
There has been some amount of discussion on the EDN serialization card. Though the default bindings appear to be sufficient, I decided to replace the usages of `pr-str` with a function under `crux.io` called `prn-edn` and use explicit bindings for it. Happy to discuss whether or not you think this is necessary/would do it differently :) 