### PR TITLE
Fix for TxLog spec assertion failures post evictions.

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -308,24 +308,17 @@
     (s/assert :crux.tx.event/tx-events tx-events)
     tx-events))
 
-(defn- create-tx-op-docs [id docs]
-   (map
-    #(if (string? %)
-       {:crux.db/id (c/new-id id)}
-       %)
-    docs))
-
 (defn tx-events->tx-ops [snapshot object-store tx-events]
   (let [tx-ops (vec (for [[op id & args] tx-events]
                       (cond->> (for [arg args]
                                  (or (when (satisfies? c/IdToBuffer arg)
-                                       (db/get-single-object object-store snapshot arg))
+                                       (or (db/get-single-object object-store snapshot arg)
+                                           {:crux.db/id (c/new-id id)
+                                            :crux.db/evicted? true}))
                                      arg))
                         (contains? #{:crux.tx/delete
                                      :crux.tx/evict
                                      :crux.tx/fn} op) (cons (c/new-id id))
-                        (contains? #{:crux.tx/put
-                                     :crux.tx/cas} op) (create-tx-op-docs id)
                         true (cons op)
                         true (vec))))]
     (s/assert :crux.api/tx-ops tx-ops)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -308,6 +308,13 @@
     (s/assert :crux.tx.event/tx-events tx-events)
     tx-events))
 
+(defn create-tx-op-docs [id docs]
+  (concat '() (map
+               #(if (string? %)
+                  {:crux.db/id (c/new-id id)}
+                  %)
+               docs)))
+
 (defn tx-events->tx-ops [snapshot object-store tx-events]
   (let [tx-ops (vec (for [[op id & args] tx-events]
                       (cond->> (for [arg args]
@@ -317,6 +324,8 @@
                         (contains? #{:crux.tx/delete
                                      :crux.tx/evict
                                      :crux.tx/fn} op) (cons (c/new-id id))
+                        (contains? #{:crux.tx/put
+                                     :crux.tx/cas} op) (create-tx-op-docs id)
                         true (cons op)
                         true (vec))))]
     (s/assert :crux.api/tx-ops tx-ops)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -308,12 +308,12 @@
     (s/assert :crux.tx.event/tx-events tx-events)
     tx-events))
 
-(defn create-tx-op-docs [id docs]
-  (concat '() (map
-               #(if (string? %)
-                  {:crux.db/id (c/new-id id)}
-                  %)
-               docs)))
+(defn- create-tx-op-docs [id docs]
+   (map
+    #(if (string? %)
+       {:crux.db/id (c/new-id id)}
+       %)
+    docs))
 
 (defn tx-events->tx-ops [snapshot object-store tx-events]
   (let [tx-ops (vec (for [[op id & args] tx-events]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -597,3 +597,10 @@
                 (t/is (= {:crux.db/id :tx-metadata
                           :crux.tx/current-tx (assoc submitted-tx :crux.tx.event/tx-events [[:crux.tx/fn (str (c/new-id :tx-metadata-fn))]])}
                          (api/entity (api/db *api*) :tx-metadata)))))))))))
+
+(t/deftest tx-log-evict []
+  (sync-submit-tx *api* [[:crux.tx/put {:crux.db/id :to-evict}]])
+  (sync-submit-tx *api* [[:crux.tx/cas {:crux.db/id :to-evict} {:crux.db/id :to-evict :test "test"}]])
+  (sync-submit-tx *api* [[:crux.tx/evict :to-evict]])
+  (with-open [tx-log-context (api/new-tx-log-context *api*)]
+    (t/is (api/tx-log *api* tx-log-context nil true))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -598,9 +598,22 @@
                           :crux.tx/current-tx (assoc submitted-tx :crux.tx.event/tx-events [[:crux.tx/fn (str (c/new-id :tx-metadata-fn))]])}
                          (api/entity (api/db *api*) :tx-metadata)))))))))))
 
-(t/deftest tx-log-evict []
+(t/deftest tx-log-evict-454 []
   (sync-submit-tx *api* [[:crux.tx/put {:crux.db/id :to-evict}]])
   (sync-submit-tx *api* [[:crux.tx/cas {:crux.db/id :to-evict} {:crux.db/id :to-evict :test "test"}]])
   (sync-submit-tx *api* [[:crux.tx/evict :to-evict]])
+
   (with-open [tx-log-context (api/new-tx-log-context *api*)]
-    (t/is (api/tx-log *api* tx-log-context nil true))))
+    (t/is (= (->> (api/tx-log *api* tx-log-context nil true)
+                  (map :crux.api/tx-ops))
+             [[[:crux.tx/put
+                #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
+                          :evicted? true}]]
+              [[:crux.tx/cas
+                #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
+                          :evicted? true}
+                #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
+                          :evicted? true}]]
+              [[:crux.tx/evict
+                #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0"]]])))
+  )


### PR DESCRIPTION
Summary: After an evict, calling tx-log (with the `with-ops?` flag set to true) causes a spec fail within **tx-events->tx-ops**  (as can be seen in #454). This is because the puts (and similarly, the cas operations) that are returned look like this (rather than a **document** map as is expected by the `doc` spec):

`[[:crux.tx/put "fb512c5da4eaa0b945f3823944a6a093eb5c42a3"]]`

I also suspect this to be the cause of the issue reported within #364, though this requires some further investigation.

Based off of the handling of **deletes, evictions** and **tx** operations (using their *id*) within **tx-events->tx-ops**, I have added a case for **put** and *cas* operations, where if a document map is not returned it instead returns a document with their *id* of the form:

`{:crux.db/id id}`

For example, pre-eviction, a tx-log would look like this:
```clojure
 {:crux.tx/tx-id 9,
  :crux.tx/tx-time #inst "2019-12-11T13:57:39.212-00:00",
  :crux.api/tx-ops
  [[:crux.tx/put {:hello :a 1}]]}
 {:crux.tx/tx-id 10,
  :crux.tx/tx-time #inst "2019-12-11T14:02:28.525-00:00",
  :crux.api/tx-ops
  [[:crux.tx/cas {:hello :a 1} {:hello :a 2}]]}
```
With these changes, post an eviction on `:hello`, the tx-log will look like this:

```clojure
 {:crux.tx/tx-id 9,
  :crux.tx/tx-time #inst "2019-12-11T13:57:39.212-00:00",
  :crux.api/tx-ops
  [[:crux.tx/put
    #:crux.db{:id
              #crux/id "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"}]]}
 {:crux.tx/tx-id 10,
  :crux.tx/tx-time #inst "2019-12-11T14:02:28.525-00:00",
  :crux.api/tx-ops
  [[:crux.tx/cas
    #:crux.db{:id
              #crux/id "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"}
    #:crux.db{:id
              #crux/id "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"}]]}
 {:crux.tx/tx-id 11,
  :crux.tx/tx-time #inst "2019-12-11T14:03:02.567-00:00",
  :crux.api/tx-ops
  [[:crux.tx/evict
    #crux/id "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"]]}
```