### PR TITLE
Fix CaS when the doc's provided in a different order, #362

### DIFF
--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -632,3 +632,10 @@
 
       (t/is (= {:crux.db/id :foo, :bar :baz}
                (api/entity (api/db *api*) :foo))))))
+
+(t/deftest cas-map-ordering-362
+  (sync-submit-tx *api* [[:crux.tx/put {:crux.db/id :foo, :foo :bar}]])
+  (sync-submit-tx *api* [[:crux.tx/cas {:foo :bar, :crux.db/id :foo} {:crux.db/id :foo, :foo :baz}]])
+
+  (t/is (= {:crux.db/id :foo, :foo :baz}
+           (api/entity (api/db *api*) :foo))))


### PR DESCRIPTION
Currently, CaS operations turn their arguments into content-hashes when they're submitted; the CaS indexer then compares the content hash against the current content-hash in the KV store. Because of #362, a difference in the order of keys within maps yield different content-hashes, and so the CaS operation doesn't match against the current document value.

This PR temporarily updates the CaS indexer to compare the underlying documents for equality rather than just the content-hashes - this can be reverted when we've fixed the main issue.