### PR TITLE
Consistent map hashing, fixes #362

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These changes bump the index version to version 5 - a re-index of Crux nodes is 
 
 ### Bug fixes
 
+* [#362](https://github.com/juxt/crux/issues/362): Fixes 362 where hashes of small maps were dependent on order
 * [#PR363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
 * [#365](https://github.com/juxt/crux/issues/365): Replace usages of 'pr-str' with 'pr-edn-str' under crux.io
 * [#367](https://github.com/juxt/crux/issues/367): Can query empty DB
@@ -35,7 +36,7 @@ These changes bump the index version to version 5 - a re-index of Crux nodes is 
 
 ### Changes
 
-* [#340](https://github.com/juxt/crux/pull/340): Improve node configuration API, introduce topologies *Breaking*
+* [#340](https://github.com/juxt/crux/pull/340): *Breaking* Improve node configuration API, introduce topologies
 * [#341](https://github.com/juxt/crux/issues/341): Various documentation improvements
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,27 +10,27 @@ These changes bump the index version to version 5 - a re-index of Crux nodes is 
 * [#441](https://github.com/juxt/crux/issues/441): Fix two transactions updating the same entity in the same millisecond always returning the earlier of the two values - requires index rebuild.
 * [#326](https://github.com/juxt/crux/issues/326): Put/delete with start/end valid-time semantics made consistent
 
+### New features
+* [#PR363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
+* [#372](https://github.com/juxt/crux/issues/372): Add support for Java collection types with submitTx
+* [#377](https://github.com/juxt/crux/issues/377): Can use 'cons' within query predicates
+* [#414](https://github.com/juxt/crux/issues/414): Developer tool for query tracing
+* [#430](https://github.com/juxt/crux/issues/430): Add LMDB configuration example to docs + tests
+* [#457](https://github.com/juxt/crux/issues/457): Allowing nil to be returned from tx-fns
+
 ### Bug fixes
 
 * [#362](https://github.com/juxt/crux/issues/362): Fixes 362 where hashes of small maps were dependent on order
-* [#PR363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
 * [#365](https://github.com/juxt/crux/issues/365): Replace usages of 'pr-str' with 'pr-edn-str' under crux.io
 * [#367](https://github.com/juxt/crux/issues/367): Can query empty DB
-* [#377](https://github.com/juxt/crux/issues/377): Can use 'cons' within query predicates
 * [#351](https://github.com/juxt/crux/issues/351): Do not merge placeholders into unary results
 * [#368](https://github.com/juxt/crux/issues/368): Protect calls to modules when node is closed
-* [#372](https://github.com/juxt/crux/issues/372): Add support for Java collection types with submitTx
 * [#418](https://github.com/juxt/crux/issues/418): Adds exception when query with order-by doesn't return variable ordered on
 * [#419](https://github.com/juxt/crux/issues/419): Fix specification for ':timeout' within queries.
 * [#440](https://github.com/juxt/crux/issues/440): Fix return type of 'documents' in the API.
 * [#453](https://github.com/juxt/crux/issues/453): Add nil check for queries in spec.
 * [#454](https://github.com/juxt/crux/issues/454): Add fix for tx-log breaking in spec after an eviction
-* [#457](https://github.com/juxt/crux/issues/457): Allowing nil to be returned from tx-fns
 * [#482](https://github.com/juxt/crux/issues/482): Bringing README up to date.
-
-### New features
-* [#414](https://github.com/juxt/crux/issues/414): Developer tool for query tracing
-* [#430](https://github.com/juxt/crux/issues/430): Add LMDB configuration example to docs + tests
 
 ## 19.09-1.5.0-alpha
 

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -102,8 +102,8 @@
         valid-time (or at-valid-time transact-time)]
 
     {:pre-commit-fn #(let [{:keys [content-hash] :as entity} (first (idx/entities-at snapshot [eid] valid-time transact-time))]
-                       ;; see juxt/crux#473 - we shouldn't need to compare the underlying documents
-                       ;; once the content-hashes are consistent
+                       ;; see juxt/crux#362 - we'd like to just compare content hashes here, but
+                       ;; can't rely on the old content-hashing returning the same hash for the same document
                        (if (= (db/get-single-object object-store snapshot (c/new-id content-hash))
                               (db/get-single-object object-store snapshot (c/new-id old-v)))
                          (let [correct-state? (not (nil? (db/get-single-object object-store snapshot (c/new-id new-v))))]

--- a/docs/transactions.adoc
+++ b/docs/transactions.adoc
@@ -57,6 +57,7 @@ The following types of `:crux.db/id` are allowed:
 * UUID (e.g. `{:crux.db/id #uuid "6f0232d0-f3f9-4020-a75f-17b067f41203"}` or `{:crux.db/id #crux/id "6f0232d0-f3f9-4020-a75f-17b067f41203"}`)
 * URI (e.g. `{:crux.db/id #crux/id "mailto:crux@juxt.pro"}`)
 * URL (e.g. `{:crux.db/id #crux/id "https://github.com/juxt/crux"}`), including `http`, `https`, `ftp` and `file` protocols
+* Maps (e.g. `{:crux.db/id #crux/id {:this :id-field}}`) (Note: see https://github.com/juxt/crux/issues/362[issue #362]).
 
 The `#crux/id` reader literal will take any string and attempt to coerce it
 into a valid ID. Use of `#crux/id` with a valid ID type will also work


### PR DESCRIPTION
A couple of changes from the reqmts in #362:
* SHA1 hashing maps without sorting them turned out to require hashing each value separately, rather than sorting-then-hashing, where you can just hash the whole map.
* because of how we actually use these hashes in practice, I don't think we need the backwards compatibility, nor the Kafka migration, nor the tool (although it'd no doubt be useful)

right. first, where do we use these hashes, and what properties do we need of them?

1. In the Kafka consumer, each message on the transaction log has a set of content-hashes, each message on the document log is keyed by the content-hash. The consumer waits for all the documents of a transaction to be in the object store before indexing the transaction
2/ In the KV indices, we look up AV and get EC (content-hash). we look up the content hash in the bitemp (EVtTtC) index to check whether it's current, and in the object store to get the underlying document - these three need to be consistent, and also consistent with the hashes in incoming queries/entity reqs. 

importantly, while the indexer does calculate the hashes of the eids/values, to insert into the indices, I don't think it re-calculates the document content-hash - it trusts the one that it gets in from Kafka.so, 

given we've got an index version bump going in anyway, we can assume that users are going to have to reindex their KV stores - which means that the new KV stores can be indexed using the consistent map-hashing. this means that the eid/value hashes in the updated AVEC/EVtTtC indices will match each other, and the query parameters. there'll be some old-style content-hashes in the 'C' fields, and some new-style, but old and new will both match with what's in the object store.

on Kafka, content-hashes don't need to match between transactions - so it's fine that we have old transactions with new in the same Kafka instance.

upshot is that we just need to ensure that, whenever we need to hash an object, we post-walk and sort all of the maps, so that they serialise consistently, and hence hash consistently. success :smile: 