### PR TITLE
Fix performance issue caused by not releasing KV iterators in put/delete ops

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -500,9 +500,13 @@
                 (recur (kv/next i)))))))))
 
   (db/next-values [this]
-    (throw (UnsupportedOperationException.))))
+    (throw (UnsupportedOperationException.)))
 
-(defn new-entity-as-of-index [snapshot valid-time transaction-time]
+  Closeable
+  (close [this]
+    (.close ^Closeable i)))
+
+(defn new-entity-as-of-index ^crux.index.EntityAsOfIndex [snapshot valid-time transaction-time]
   (->EntityAsOfIndex (kv/new-iterator snapshot) (or valid-time min-date) (or transaction-time min-date)))
 
 (defn entity-at [entity-as-of-idx eid]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -269,9 +269,7 @@
                      (pre-commit-fn))
                    (doall)
                    (every? true?))
-            (do (->> (map :kvs tx-command-results)
-                     (reduce into (sorted-map-by mem/buffer-comparator))
-                     (kv/store kv))
+            (do (kv/store kv (into (sorted-map-by mem/buffer-comparator) (mapcat :kvs) tx-command-results))
                 (doseq [{:keys [post-commit-fn]} tx-command-results
                         :when post-commit-fn]
                   (post-commit-fn)))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -57,7 +57,7 @@
                                         (c/->EntityTx eid end-valid-time transact-time tx-id (c/nil-id-buffer)))])))
 
                          (->> (cons start-valid-time
-                                    (when-let [visible-entity (some-> (first (idx/entity-history-seq-descending snapshot eid start-valid-time transact-time))
+                                    (when-let [visible-entity (some-> (first (idx/entities-at snapshot [eid] start-valid-time transact-time))
                                                                       (select-keys [:tx-time :tx-id :content-hash]))]
                                       (->> (idx/entity-history-seq-ascending snapshot eid start-valid-time transact-time)
                                            (remove #{start-valid-time})

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -57,12 +57,13 @@
                                         (c/->EntityTx eid end-valid-time transact-time tx-id (c/nil-id-buffer)))])))
 
                          (->> (cons start-valid-time
-                                    (when-let [visible-entity (some-> (first (idx/entities-at snapshot [eid] start-valid-time transact-time))
-                                                                      (select-keys [:tx-time :tx-id :content-hash]))]
-                                      (->> (idx/entity-history-seq-ascending snapshot eid start-valid-time transact-time)
-                                           (remove #{start-valid-time})
-                                           (take-while #(= visible-entity (select-keys % [:tx-time :tx-id :content-hash])))
-                                           (map #(.vt ^EntityTx %)))))
+                                    (with-open [entity-as-of-idx (idx/new-entity-as-of-index snapshot start-valid-time transact-time)]
+                                      (when-let [visible-entity (some-> (idx/entity-at entity-as-of-idx eid)
+                                                                        (select-keys [:tx-time :tx-id :content-hash]))]
+                                        (->> (idx/entity-history-seq-ascending snapshot eid start-valid-time transact-time)
+                                             (remove #{start-valid-time})
+                                             (take-while #(= visible-entity (select-keys % [:tx-time :tx-id :content-hash])))
+                                             (map #(.vt ^EntityTx %))))))
 
                               (map ->new-entity-tx)))]
 


### PR DESCRIPTION
We weren't releasing KV iterators back to the snapshot's pool after put/delete ops, so each put/delete in a transaction was creating a new iterator, which is expensive.

This became more of an issue after the put/delete semantics were changed - previously, puts/deletes (incorrectly) didn't read any of the indices before putting their KVs into the store.