### PR TITLE
Adding equals as a range predicate and showing intended literal range behaviour

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -55,7 +55,7 @@
 (s/def ::rule (s/and list? (s/cat :name (s/and symbol? (complement built-ins))
                                   :args (s/+ any?))))
 
-(s/def ::range-op '#{< <= >= >})
+(s/def ::range-op '#{< <= >= > =})
 (s/def ::range (s/tuple (s/and list?
                                (s/or :sym-val (s/cat :op ::range-op
                                                      :sym logic-var?
@@ -146,7 +146,8 @@
 (def ^:private range->inverse-range '{< >=
                                       <= >
                                       > <=
-                                      >= <})
+                                      >= <
+                                      = =})
 
 (defn- rewrite-self-join-triple-clause [{:keys [e v] :as triple}]
   (let [v-var (gensym (str "self-join_" v "_"))]
@@ -230,48 +231,54 @@
                                   arg))
                            or-join-vars)}))
 
-(defn- build-v-var-range-constraints [e-vars range-clauses]
-  (let [v-var->range-clauses (->> (for [{:keys [sym] :as clause} range-clauses]
-                                    (if (contains? e-vars sym)
-                                      (throw (IllegalArgumentException.
-                                              (str "Cannot add range constraints on entity variable: "
-                                                   (cio/pr-edn-str clause))))
-                                      clause))
-                                  (group-by :sym))]
-    (->> (for [[v-var clauses] v-var->range-clauses]
-           [v-var (->> (for [{:keys [op val]} clauses
-                             :let [type-prefix (c/value-buffer-type-id (c/->value-buffer val))]]
-                         (case op
-                           < #(-> (idx/new-less-than-virtual-index % val)
-                                  (idx/new-prefix-equal-virtual-index type-prefix))
-                           <= #(-> (idx/new-less-than-equal-virtual-index % val)
-                                   (idx/new-prefix-equal-virtual-index type-prefix))
-                           > #(-> (idx/new-greater-than-virtual-index % val)
-                                  (idx/new-prefix-equal-virtual-index type-prefix))
-                           >= #(-> (idx/new-greater-than-equal-virtual-index % val)
-                                   (idx/new-prefix-equal-virtual-index type-prefix))))
-                       (apply comp))])
+(defn- build-var-range-constraints [e-vars range-clauses]
+  (let [var->range-clauses (->> (for [{:keys [op sym] :as clause} range-clauses]
+                                  (if (and (contains? e-vars sym)
+                                           (not= '= op))
+                                    (throw (IllegalArgumentException.
+                                            (str "Cannot add range constraints on entity variable: "
+                                                 (cio/pr-edn-str clause))))
+                                    clause))
+                                (group-by :sym))]
+    (->> (for [[var clauses] var->range-clauses]
+           [var (->> (for [{:keys [op val sym]} clauses
+                           :let [type-prefix (c/value-buffer-type-id (c/->value-buffer val))]]
+                       (case op
+                         = #(-> (idx/new-greater-than-equal-virtual-index % val)
+                                (idx/new-less-than-equal-virtual-index val)
+                                (idx/new-prefix-equal-virtual-index type-prefix))
+                         < #(-> (idx/new-less-than-virtual-index % val)
+                                (idx/new-prefix-equal-virtual-index type-prefix))
+                         <= #(-> (idx/new-less-than-equal-virtual-index % val)
+                                 (idx/new-prefix-equal-virtual-index type-prefix))
+                         > #(-> (idx/new-greater-than-virtual-index % val)
+                                (idx/new-prefix-equal-virtual-index type-prefix))
+                         >= #(-> (idx/new-greater-than-equal-virtual-index % val)
+                                 (idx/new-prefix-equal-virtual-index type-prefix))))
+                     (apply comp))])
          (into {}))))
 
 (defn- arg-for-var [arg var]
   (or (get arg (symbol (name var)))
       (get arg (keyword (name var)))))
 
-(defn- update-binary-index! [snapshot {:keys [entity-as-of-idx]} binary-idx vars-in-join-order v-var->range-constraints]
+(defn- update-binary-index! [snapshot {:keys [entity-as-of-idx]} binary-idx vars-in-join-order var->range-constraints]
   (let [{:keys [clause names]} (meta binary-idx)
         {:keys [e a v]} clause
         order (filter (set (vals names)) vars-in-join-order)
-        v-range-constraints (get v-var->range-constraints v)]
+        v-range-constraints (get var->range-constraints v)
+        e-range-constraints (get var->range-constraints e)]
     (if (= (:v names) (first order))
       (let [v-doc-idx (idx/new-doc-attribute-value-entity-value-index snapshot a)
-            e-idx (idx/new-doc-attribute-value-entity-entity-index snapshot a v-doc-idx entity-as-of-idx)]
+            e-idx (-> (idx/new-doc-attribute-value-entity-entity-index snapshot a v-doc-idx entity-as-of-idx)
+                      (idx/wrap-with-range-constraints e-range-constraints))]
         (log/debug :join-order :ave (cio/pr-edn-str v) e (cio/pr-edn-str clause))
         (idx/update-binary-join-order! binary-idx (idx/wrap-with-range-constraints v-doc-idx v-range-constraints) e-idx))
       (let [e-doc-idx (idx/new-doc-attribute-entity-value-entity-index snapshot a entity-as-of-idx)
             v-idx (-> (idx/new-doc-attribute-entity-value-value-index snapshot a e-doc-idx)
                       (idx/wrap-with-range-constraints v-range-constraints))]
         (log/debug :join-order :aev e (cio/pr-edn-str v) (cio/pr-edn-str clause))
-        (idx/update-binary-join-order! binary-idx e-doc-idx v-idx)))))
+        (idx/update-binary-join-order! binary-idx (idx/wrap-with-range-constraints e-doc-idx e-range-constraints) v-idx)))))
 
 (defn- triple-joins [triple-clauses range-clauses var->joins arg-vars stats]
   (let [var->frequency (->> (concat (map :e triple-clauses)
@@ -377,7 +384,7 @@
              var->joins))])
     [nil var->joins]))
 
-(defn- pred-joins [pred-clauses v-var->range-constraints var->joins]
+(defn- pred-joins [pred-clauses var->range-constraints var->joins]
   (->> pred-clauses
        (reduce
         (fn [[pred-clause+idx-ids var->joins] {:keys [return] :as pred-clause}]
@@ -387,7 +394,7 @@
                         :idx-fn #(idx/new-relation-virtual-index idx-id
                                                                  []
                                                                  1
-                                                                 [(get v-var->range-constraints return)])
+                                                                 [(get var->range-constraints return)])
                         :name (symbol "crux.query.value" (name return))}]
               [(conj pred-clause+idx-ids [pred-clause idx-id])
                (merge-with into var->joins {return [join]})])
@@ -612,7 +619,7 @@
 ;; sequence and reuse it, somehow detecting if it loops.
 (defn- build-or-constraints
   [rule-name->rules or-clause+idx-id+or-branches
-   var->bindings vars-in-join-order v-var->range-constraints stats]
+   var->bindings vars-in-join-order var->range-constraints stats]
   (for [[clause idx-id [{:keys [free-vars bound-vars]} :as or-branches]] or-clause+idx-id+or-branches
         :let [or-join-depth (calculate-constraint-join-depth var->bindings bound-vars)
               free-vars-in-join-order (filter (set free-vars) vars-in-join-order)
@@ -664,7 +671,7 @@
                                          (apply concat)
                                          (distinct)
                                          (vec))]
-                   (idx/update-relation-virtual-index! (get idx-id->idx idx-id) free-results (map v-var->range-constraints free-vars-in-join-order))))
+                   (idx/update-relation-virtual-index! (get idx-id->idx idx-id) free-results (map var->range-constraints free-vars-in-join-order))))
                join-results)))})))
 
 ;; TODO: Unification could be improved by using dynamic relations
@@ -865,8 +872,7 @@
                 pred-vars
                 pred-return-vars]} (collect-vars type->clauses)
         var->joins {}
-        v-var->range-constraints (build-v-var-range-constraints e-vars range-clauses)
-        v-range-vars (set (keys v-var->range-constraints))
+        var->range-constraints (build-var-range-constraints e-vars range-clauses)
         [triple-join-deps var->joins] (triple-joins triple-clauses
                                                     range-clauses
                                                     var->joins
@@ -875,7 +881,7 @@
         [args-idx-id var->joins] (arg-joins arg-vars
                                             e-vars
                                             var->joins)
-        [pred-clause+idx-ids var->joins] (pred-joins pred-clauses v-var->range-constraints var->joins)
+        [pred-clause+idx-ids var->joins] (pred-joins pred-clauses var->range-constraints var->joins)
         known-vars (set/union e-vars v-vars arg-vars)
         known-vars (add-pred-returns-bound-at-top-level known-vars pred-clauses)
         [or-clause+idx-id+or-branches known-vars var->joins] (or-joins rule-name->rules
@@ -917,7 +923,7 @@
         not-join-constraints (build-not-constraints rule-name->rules :not-join not-join-clauses var->bindings stats)
         pred-constraints (build-pred-constraints pred-clause+idx-ids var->bindings)
         or-constraints (build-or-constraints rule-name->rules or-clause+idx-id+or-branches
-                                             var->bindings vars-in-join-order v-var->range-constraints stats)
+                                             var->bindings vars-in-join-order var->range-constraints stats)
         depth->constraints (->> (concat unification-constraints
                                         pred-constraints
                                         not-constraints
@@ -928,7 +934,7 @@
                                    (update acc join-depth (fnil conj []) constraint-fn))
                                  (vec (repeat join-depth nil))))]
     {:depth->constraints depth->constraints
-     :v-var->range-constraints v-var->range-constraints
+     :var->range-constraints var->range-constraints
      :vars-in-join-order vars-in-join-order
      :var->joins var->joins
      :var->bindings var->bindings
@@ -954,7 +960,7 @@
   (let [arg-vars (arg-vars args)
         {:keys [depth->constraints
                 vars-in-join-order
-                v-var->range-constraints
+                var->range-constraints
                 var->joins
                 var->bindings
                 arg-vars-in-join-order
@@ -973,13 +979,13 @@
                                     (assoc (or (get idx-id->idx id) (idx-fn)) :name name)))]
     (doseq [[_ idx] idx-id->idx
             :when (instance? BinaryJoinLayeredVirtualIndex idx)]
-      (update-binary-index! snapshot db idx vars-in-join-order v-var->range-constraints))
+      (update-binary-index! snapshot db idx vars-in-join-order var->range-constraints))
     (when (and (seq args) args-idx-id)
       (idx/update-relation-virtual-index!
        (get idx-id->idx args-idx-id)
        (vec (for [arg (distinct args)]
               (mapv #(arg-for-var arg %) arg-vars-in-join-order)))
-       (mapv v-var->range-constraints arg-vars-in-join-order)))
+       (mapv var->range-constraints arg-vars-in-join-order)))
     (log/debug :where (cio/pr-edn-str where))
     (log/debug :vars-in-join-order vars-in-join-order)
     (log/debug :attr-stats (cio/pr-edn-str attr-stats))


### PR DESCRIPTION
(Issue #505)

Initial report likely used arguments to supply the range constraints, which would always result in using predicates, which will do the filtering purely in Clojure and have no way of knowing how to skip parts of the index. Test added showing it works as expected with literal constraints.

As a bonus, finally added `=` as a kind of range predicate. This predicate, unlike the ones depending on order, is also allowed on entity vars.