### PR TITLE
Better locking around init of hash, avoids init more than once.

### DIFF
--- a/crux-core/src/crux/hash.clj
+++ b/crux-core/src/crux/hash.clj
@@ -34,23 +34,31 @@
     (catch ClassNotFoundException e
       false)))
 
-(defn id-hash [to buffer]
-  (locking id-hash
-    (if (and (= "SHA1" id-hash-algorithm)
-             byte-utils-sha1-enabled?)
-      (do (log/info "Using ByteUtils/sha1 for ID hashing.")
-          (def id-hash (fn [to from]
-                         (ByteUtils/sha1 to from))))
-      (if-let [openssl-id-hash-buffer (and openssl-enabled?
-                                           (jnr-available?)
-                                           (some-> 'crux.hash.jnr/openssl-id-hash-buffer requiring-resolve var-get))]
-        (do (log/info "Using libcrypto (OpenSSL) for ID hashing.")
-            (def id-hash openssl-id-hash-buffer))
-        (if-let [gcrypt-id-hash-buffer (and gcrypt-enabled?
-                                            (jnr-available?)
-                                            (some-> 'crux.hash.jnr/gcrypt-id-hash-buffer requiring-resolve var-get))]
-          (do (log/info "Using libgcrypt for ID hashing.")
-              (def id-hash gcrypt-id-hash-buffer))
-          (do (log/info "Using java.security.MessageDigest for ID hashing.")
-              (def id-hash message-digest-id-hash-buffer)))))
+(defn- init-id-hash []
+  (if (and (= "SHA1" id-hash-algorithm)
+           byte-utils-sha1-enabled?)
+    (do (log/info "Using ByteUtils/sha1 for ID hashing.")
+        (fn [to from]
+          (ByteUtils/sha1 to from)))
+    (if-let [openssl-id-hash-buffer (and openssl-enabled?
+                                         (jnr-available?)
+                                         (some-> 'crux.hash.jnr/openssl-id-hash-buffer requiring-resolve var-get))]
+      (do (log/info "Using libcrypto (OpenSSL) for ID hashing.")
+          openssl-id-hash-buffer)
+      (if-let [gcrypt-id-hash-buffer (and gcrypt-enabled?
+                                          (jnr-available?)
+                                          (some-> 'crux.hash.jnr/gcrypt-id-hash-buffer requiring-resolve var-get))]
+        (do (log/info "Using libgcrypt for ID hashing.")
+            gcrypt-id-hash-buffer)
+        (do (log/info "Using java.security.MessageDigest for ID hashing.")
+            message-digest-id-hash-buffer)))))
+
+(declare id-hash)
+
+(defn- lazy-id-hash [to buffer]
+  (locking #'lazy-id-hash
+    (when (= id-hash lazy-id-hash)
+      (alter-var-root #'id-hash (fn [_] (init-id-hash))))
     (id-hash to buffer)))
+
+(def id-hash lazy-id-hash)

--- a/crux-core/src/crux/hash.clj
+++ b/crux-core/src/crux/hash.clj
@@ -16,8 +16,6 @@
 (def ^:private ^MessageDigest id-digest-prototype (MessageDigest/getInstance id-hash-algorithm))
 (def ^:const id-hash-size (.getDigestLength id-digest-prototype))
 
-(declare id-hash)
-
 ;; NOTE: Allowing on-heap buffer here for now.
 (defn message-digest-id-hash-buffer ^org.agrona.DirectBuffer [^MutableDirectBuffer to ^DirectBuffer buffer]
   (let [^MessageDigest md (try
@@ -38,7 +36,7 @@
   (if (and (= "SHA1" id-hash-algorithm)
            byte-utils-sha1-enabled?)
     (do (log/info "Using ByteUtils/sha1 for ID hashing.")
-        (fn [to from]
+        (fn byte-utils-id-hash-buffer [to from]
           (ByteUtils/sha1 to from)))
     (if-let [openssl-id-hash-buffer (and openssl-enabled?
                                          (jnr-available?)


### PR DESCRIPTION
(Issue #486)

Earlier commit avoided races during initialising, this further enhances that to only init the hash implementation once.