### PR TITLE
Ensuring we don't accidentally re-tag a previously pushed version of crux-http

### DIFF
--- a/crux-docker/README.md
+++ b/crux-docker/README.md
@@ -73,4 +73,4 @@ Within the main directory, a logging configuration file `logback.xml`, is includ
 
 ### Updating / Redeploying the docker image
 
-To rebuild / redeploy the docker image, ensure you are logged into docker and have access to the **juxt** docker account, and run the `./bin/build.sh`/`./bin/push.sh` scripts. Updating Crux to a new version requires updating the versions within `deps.edn`, and changing the tag version within `build.sh`.
+To rebuild / redeploy the docker image, ensure you are logged into docker and have access to the **juxt** docker account, and run the `./bin/build.sh`/`./bin/tag.sh`/`./bin/push.sh` scripts. Updating Crux to a new version requires updating the versions within `deps.edn`, and changing the tag version within `tag.sh`/`push.sh`.

--- a/crux-docker/bin/build.sh
+++ b/crux-docker/bin/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-docker build -t juxt/crux-http:latest -t juxt/crux-http:19.12-1.6.1-alpha .
+#!/bin/bash -xe
+docker build -t juxt/crux-http:latest .

--- a/crux-docker/bin/push.sh
+++ b/crux-docker/bin/push.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-docker push juxt/crux-http
+#!/bin/bash -xe
+docker push juxt/crux-http:19.12-1.6.1-alpha

--- a/crux-docker/bin/tag.sh
+++ b/crux-docker/bin/tag.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -xe
+docker tag juxt/crux-http:19.12-1.6.1-alpha juxt/crux-http:latest


### PR DESCRIPTION
* `build.sh` currently tags the most recently built docker image with the tag from the most recent release (which is likely not what we want when we're developing)
* `push.sh` pushes all the user's tags for `juxt/crux-http`, which may well override previous versions if they've been re-built

Separated out into an explicit `tag.sh` script, and only pushing the most recent tag.