### PR TITLE
Remove sync to no lag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,8 @@ jobs:
       - run:
           name: Install datasets for ts-weather-test and ts-devices-test
           command: |
-            cd crux-test/
-            cd resources
-            mkdir ts
-            cd ts
-            mkdir data
-            cd data
+            mkdir -p crux-test/resources/ts/data
+            cd crux-test/resource/ts/data/
             wget https://timescaledata.blob.core.windows.net/datasets/weather_small.tar.gz
             tar -xzf weather_small.tar.gz
             wget https://timescaledata.blob.core.windows.net/datasets/devices_small.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ target
 /docs/javadoc
 /crux-test/test/watdiv/data
 /crux-test/test/ts/data
+/crux-test/resources/ts/data
 /crux-test/data
 /crux-test/dev-storage*
 /crux-*/cruxtest*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.01-1.7.0-alpha
+
+### Breaking changes
+* [#466](https://github.com/juxt/crux/issues/466): Remove `sync` without a supplied transaction time.
+
 ## 19.12-1.6.1-alpha
 
 ### Bug fixes

--- a/crux-bench/src/crux_bench/watdiv.clj
+++ b/crux-bench/src/crux_bench/watdiv.clj
@@ -394,10 +394,9 @@
   (ingest-watdiv-data [this resource]
     (when-not (:done? (crux/entity (crux/db crux) ::watdiv-ingestion-status))
       (let [time-before (Date.)
-            submit-future (future
-                            (with-open [in (io/input-stream (io/resource resource))]
-                              (rdf/submit-ntriples (:tx-log crux) in 1000)))]
-        (assert (= 521585 @submit-future))
+            {:keys [entity-count]} (with-open [in (io/input-stream (io/resource resource))]
+                                     (rdf/submit-ntriples (:tx-log crux) in 1000))]
+        (assert (= 521585 entity-count))
         (let [kafka-ingest-done (Date.)
               {:keys [crux.tx/tx-time]}
               (crux/submit-tx

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -115,16 +115,12 @@
   eid is an object that can be coerced into an entity id.
   Returns true if the entity was updated in this transaction.")
 
-  (sync
-    [node ^Duration timeout]
-    [node ^Date transaction-time ^Duration timeout]
-    "If the transaction-time is supplied, blocks until indexing has
-  processed a tx with a greater-than transaction-time, otherwise
-  blocks until the node has caught up indexing the tx-log
-  backlog. Will throw an exception on timeout. The returned date is
-  the latest index time when this node has caught up as of this
-  call. This can be used as the second parameter in (db valid-time,
-  transaction-time) for consistent reads.
+  (sync [node ^Date transaction-time ^Duration timeout]
+    "Blocks until indexing has processed a tx at or after the provided
+  transaction-time. Will throw an exception on timeout. The returned date is the
+  latest index time when this node has caught up as of this call. This can be
+  used as the second parameter in (db valid-time, transaction-time) for
+  consistent reads.
 
   timeout – max time to wait, can be nil for the default.
   Returns the latest known transaction time.")
@@ -190,11 +186,8 @@
   (submitted-tx-corrected-entity? [this submitted-tx ^Date valid-time eid]
     (.hasSubmittedTxCorrectedEntity this submitted-tx valid-time eid))
 
-  (sync
-    ([this timeout]
-     (.sync this timeout))
-    ([this transaction-time timeout]
-     (.sync this transaction-time timeout)))
+  (sync [this transaction-time timeout]
+    (.sync this transaction-time timeout))
 
   (attribute-stats [this]
     (.attributeStats this)))

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -121,19 +121,7 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
     public boolean hasSubmittedTxCorrectedEntity(Map<Keyword,?> submittedTx, Date validTime, Object eid);
 
     /**
-     * Blocks until the node has caught up indexing. Will throw an
-     * exception on timeout. The returned date is the latest index
-     * time when this node has caught up as of this call. This can be
-     * used as the second parameter in {@link #db(Date validTime,
-     * Date transactionTime)} for consistent reads.
-     *
-     * @param timeout max time to wait, can be null for the default.
-     * @return        the latest known transaction time.
-     */
-    public Date sync(Duration timeout);
-
-    /**
-     * Blocks until the node has indexed a transaction that is past
+     * Blocks until the node has indexed a transaction at or after
      * the supplied transactionTime. Will throw a timeout. The
      * returned date is the latest index time when this node has
      * caught up as of this call.

--- a/crux-core/src/crux/api/alpha/CruxNode.java
+++ b/crux-core/src/crux/api/alpha/CruxNode.java
@@ -104,15 +104,6 @@ public class CruxNode implements AutoCloseable {
             .collect(Collectors.toList());
     }
 
-    /**
-     * Blocks until the node has caught up indexing. Will throw an exception on timeout
-     * @param timeout Max time to wait, can be null for the default
-     * @return Date representing the latest index time when this node has caught up as of this call
-     */
-    public Date sync(Duration timeout) {
-        return node.sync(timeout);
-    }
-
     @Override
     public void close() throws IOException {
         node.close();

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -132,13 +132,6 @@
                             (mapv #(tx/tx-event->tx-op % snapshot object-store))))))
           tx-log-entry))))
 
-  (sync [this timeout]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (-> (tx/await-no-consumer-lag indexer (or (and timeout (.toMillis timeout))
-                                                (:crux.tx-log/await-tx-timeout options)))
-          :crux.tx/tx-time)))
-
   (sync [this tx-time timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -210,14 +210,11 @@
       (register-stream-with-remote-stream! tx-log-context in)
       (edn-list->lazy-seq in)))
 
-  (sync [_ timeout]
-    (api-request-sync (cond-> (str url "/sync")
-                        timeout (str "?timeout=" (.toMillis timeout))) nil {:method :get}))
-
   (sync [_ transaction-time timeout]
-    (api-request-sync (cond-> (str url "/sync")
-                        transaction-time (str "?transactionTime=" (cio/format-rfc3339-date transaction-time))
-                        timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
+    (api-request-sync (cond-> (str url "/sync?transactionTime=" (cio/format-rfc3339-date transaction-time))
+                        timeout (str "&timeout=" (cio/format-duration-millis timeout)))
+                      nil
+                      {:method :get}))
 
   Closeable
   (close [_]))

--- a/crux-rdf/src/crux/rdf.clj
+++ b/crux-rdf/src/crux/rdf.clj
@@ -208,14 +208,15 @@
        (statements->maps)
        (map #(use-default-language % *default-language*))
        (partition-all tx-size)
-       (reduce (fn [^long n entities]
-                 (when (zero? (long (mod n *ntriples-log-size*)))
-                   (log/debug "submitted" n))
+       (reduce (fn [{:keys [^long entity-count last-tx]} entities]
+                 (when (zero? (long (mod entity-count *ntriples-log-size*)))
+                   (log/debug "submitted" entity-count))
                  (let [tx-ops (vec (for [entity entities]
                                      [:crux.tx/put entity]))]
-                   (db/submit-tx tx-log tx-ops))
-                 (+ n (count entities)))
-               0)))
+                   {:entity-count (+ entity-count (count entities))
+                    :last-tx (db/submit-tx tx-log tx-ops)}))
+
+               {:entity-count 0})))
 
 (def ^:dynamic *default-prefixes* {:rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                                    :rdfs "http://www.w3.org/2000/01/rdf-schema#"

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -81,9 +81,6 @@
   (t/testing "empty db"
     (t/is (.db *api*)))
 
-  (t/testing "syncing empty db"
-    (t/is (nil? (.sync *api* (Duration/ofSeconds 10)))))
-
   (t/testing "transaction"
     (let [valid-time (Date.)
           {:keys [crux.tx/tx-time
@@ -206,8 +203,7 @@
                         crux.tx/tx-id]
                  :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
             (t/is (true? (.hasSubmittedTxUpdatedEntity *api* submitted-tx :ivan)))
-            (t/is (= tx-time (.sync *api* (:crux.tx/tx-time submitted-tx) nil)))
-            (t/is (= tx-time (.sync *api* nil))))
+            (t/is (= tx-time (.sync *api* (:crux.tx/tx-time submitted-tx) nil))))
 
           (let [stats (.attributeStats *api*)]
             (t/is (= 2 (:name stats)))))

--- a/crux-test/test/crux/fixtures/lubm.clj
+++ b/crux-test/test/crux/fixtures/lubm.clj
@@ -10,8 +10,12 @@
   (let [tx-ops (->> (concat (rdf/->tx-ops (rdf/ntriples "lubm/univ-bench.ntriples"))
                             (rdf/->tx-ops (rdf/ntriples lubm-triples-resource-8k)))
                     (rdf/->default-language)
-                    vec)]
-    (doseq [tx-ops (partition-all 1000 tx-ops)]
-      (api/submit-tx *api* (vec tx-ops)))
-    (api/sync *api* nil)
+                    vec)
+
+        last-tx (->> (partition-all 1000 tx-ops)
+                     (reduce (fn [_ tx-ops]
+                               (api/submit-tx *api* (vec tx-ops)))
+                             nil))]
+
+    (api/sync *api* (:crux.tx/tx-time last-tx) nil)
     (f)))

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -296,7 +296,7 @@
             (future
               (time
                (with-open [in (io/input-stream mappingbased-properties-file)]
-                 (reset! n-transacted (rdf/submit-ntriples tx-log in tx-size)))))
+                 (reset! n-transacted (:entity-count (rdf/submit-ntriples tx-log in tx-size))))))
             (time
              (loop [{:keys [docs]} (k/consume-and-index-entities indexer fk/*consumer* 100)
                     n 0]

--- a/crux-test/test/crux/lubm_test.clj
+++ b/crux-test/test/crux/lubm_test.clj
@@ -33,7 +33,6 @@
 ;; individual tests.
 (t/use-fixtures :once
   fk/with-embedded-kafka-cluster
-  fk/with-kafka-client
   fk/with-cluster-node-opts
   kvf/with-kv-dir
   apif/with-node

--- a/crux-test/test/crux/ts_devices_test.clj
+++ b/crux-test/test/crux/ts_devices_test.clj
@@ -4,9 +4,9 @@
             [clojure.string :as str]
             [clojure.test :as t]
             [crux.api :as api]
-            [crux.fixtures.api :refer [*api*]]
+            [crux.fixtures.api :as fapi :refer [*api*]]
             [crux.fixtures.kafka :as fk]
-            [crux.fixtures.kv-only :as fkv :refer [*kv*]]
+            [crux.fixtures.kv :as fkv]
             [crux.io :as cio])
   (:import java.time.temporal.ChronoUnit
            java.util.Date))
@@ -17,9 +17,10 @@
 (def ^:const devices-device-info-csv-resource "ts/data/devices_small_device_info.csv")
 (def ^:const devices-readings-csv-resource "ts/data/devices_small_readings.csv")
 
-(def run-ts-devices-tests? (boolean (and (io/resource devices-device-info-csv-resource)
-                                         (io/resource devices-readings-csv-resource)
-                                         (Boolean/parseBoolean (System/getenv "CRUX_TS_DEVICES")))))
+(def run-ts-devices-tests?
+  (boolean (and (io/resource devices-device-info-csv-resource)
+                (io/resource devices-readings-csv-resource)
+                (Boolean/parseBoolean (System/getenv "CRUX_TS_DEVICES")))))
 
 (def ^:const readings-chunk-size 1000)
 
@@ -27,9 +28,9 @@
 (defn submit-ts-devices-data
   ([node]
    (submit-ts-devices-data
-     node
-     (io/resource devices-device-info-csv-resource)
-     (io/resource devices-readings-csv-resource)))
+    node
+    (io/resource devices-device-info-csv-resource)
+    (io/resource devices-readings-csv-resource)))
   ([node info-resource readings-resource]
    (with-open [info-in (io/reader info-resource)
                readings-in (io/reader readings-resource)]
@@ -47,54 +48,54 @@
        (->> (line-seq readings-in)
             (partition readings-chunk-size)
             (reduce
-             (fn [n chunk]
-               (api/submit-tx
-                node
-                (vec (for [reading chunk
-                           :let [[time device-id battery-level battery-status
-                                  battery-temperature bssid
-                                  cpu-avg-1min cpu-avg-5min cpu-avg-15min
-                                  mem-free mem-used rssi ssid] (str/split reading #",")
-                                 time (inst/read-instant-date
-                                       (-> time
-                                           (str/replace " " "T")
-                                           (str/replace #"-(\d\d)$" ".000-$1:00")))
-                                 reading-id (keyword "reading" device-id)
-                                 device-id (keyword "device-info" device-id)]]
-                       [:crux.tx/put
-                        {:crux.db/id reading-id
-                         :reading/time time
-                         :reading/device-id device-id
-                         :reading/battery-level (Double/parseDouble battery-level)
-                         :reading/battery-status (keyword battery-status)
-                         :reading/battery-temperature (Double/parseDouble battery-temperature)
-                         :reading/bssid bssid
-                         :reading/cpu-avg-1min (Double/parseDouble cpu-avg-1min)
-                         :reading/cpu-avg-5min (Double/parseDouble cpu-avg-5min)
-                         :reading/cpu-avg-15min (Double/parseDouble cpu-avg-15min)
-                         :reading/mem-free (Double/parseDouble mem-free)
-                         :reading/mem-used (Double/parseDouble mem-used)
-                         :reading/rssi (Double/parseDouble rssi)
-                         :reading/ssid ssid}
-                        time])))
-               (+ n (count chunk)))
-             (count info-tx-ops)))))))
+             (fn [{:keys [op-count last-tx]} chunk]
+               {:op-count (+ op-count (count chunk))
+                :last-tx (api/submit-tx
+                          node
+                          (vec (for [reading chunk
+                                     :let [[time device-id battery-level battery-status
+                                            battery-temperature bssid
+                                            cpu-avg-1min cpu-avg-5min cpu-avg-15min
+                                            mem-free mem-used rssi ssid] (str/split reading #",")
+                                           time (inst/read-instant-date
+                                                 (-> time
+                                                     (str/replace " " "T")
+                                                     (str/replace #"-(\d\d)$" ".000-$1:00")))
+                                           reading-id (keyword "reading" device-id)
+                                           device-id (keyword "device-info" device-id)]]
+                                 [:crux.tx/put
+                                  {:crux.db/id reading-id
+                                   :reading/time time
+                                   :reading/device-id device-id
+                                   :reading/battery-level (Double/parseDouble battery-level)
+                                   :reading/battery-status (keyword battery-status)
+                                   :reading/battery-temperature (Double/parseDouble battery-temperature)
+                                   :reading/bssid bssid
+                                   :reading/cpu-avg-1min (Double/parseDouble cpu-avg-1min)
+                                   :reading/cpu-avg-5min (Double/parseDouble cpu-avg-5min)
+                                   :reading/cpu-avg-15min (Double/parseDouble cpu-avg-15min)
+                                   :reading/mem-free (Double/parseDouble mem-free)
+                                   :reading/mem-used (Double/parseDouble mem-used)
+                                   :reading/rssi (Double/parseDouble rssi)
+                                   :reading/ssid ssid}
+                                  time])))})
+             {:op-count (count info-tx-ops)}))))))
 
 (defn with-ts-devices-data [f]
   (if run-ts-devices-tests?
-    (let [submit-future (future (submit-ts-devices-data *api*))]
-      (api/sync *api* (java.time.Duration/ofMinutes 20))
-      (t/is (= 1001000 @submit-future))
+    (let [{:keys [op-count last-tx]} (submit-ts-devices-data *api*)]
+      (assert (= op-count 1001000) (str "actual op-count: " op-count))
+      (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
       (f))
+
     (f)))
 
 (t/use-fixtures :once
-                fk/with-embedded-kafka-cluster
-                fk/with-kafka-client
-                fk/with-cluster-node-opts
-                ; perhaps should use with-node as well. if this config fails try uncommenting the line below
-                ; f-api/with-node
-                with-ts-devices-data)
+  fk/with-embedded-kafka-cluster
+  fk/with-cluster-node-opts
+  fkv/with-kv-dir
+  fapi/with-node
+  with-ts-devices-data)
 
 ;; 10 most recent battery temperature readings for charging devices
 ;; SELECT time, device_id, battery_temperature
@@ -116,7 +117,7 @@
 ;; 2016-11-15 23:39:30-05 | demo004729 |                99.6
 ;; (10 rows)
 
-(t/deftest test-10-most-recent-battery-readeings-for-charging-devices
+(t/deftest test-10-most-recent-battery-readings-for-charging-devices
   (if run-ts-devices-tests?
     (t/is (= [[#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000999 88.7]
               [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000998 93.1]
@@ -157,7 +158,7 @@
 
 ;; TODO: This test doesn't only does current time slice, which isn't
 ;; valid for this example.
-(t/deftest test-busiest-devices-1-min-avg-whoste-battery-evel-is-below-33-percent-and-is-not-charging
+(t/deftest test-busiest-devices-1-min-avg-whose-battery-level-is-below-33-percent-and-is-not-charging
   (if run-ts-devices-tests?
     (t/is (= [[#inst "2016-11-15T20:19:30.000-00:00"
                :device-info/demo000818
@@ -239,8 +240,7 @@
               [#inst "2016-11-15T18:00:00.000-00:00" 6.0 100.0]
               [#inst "2016-11-15T19:00:00.000-00:00" 6.0 100.0]
               [#inst "2016-11-15T20:00:00.000-00:00" 6.0 100.0]]
-             (let [kv *kv*
-                   reading-ids (->> (api/q (api/db *api*)
+             (let [reading-ids (->> (api/q (api/db *api*)
                                         '{:find [r]
                                           :where [[r :reading/device-id device-id]
                                                   (or [device-id :device-info/model "pinto"]

--- a/crux-test/test/crux/ts_weather_test.clj
+++ b/crux-test/test/crux/ts_weather_test.clj
@@ -4,8 +4,9 @@
             [clojure.string :as str]
             [clojure.test :as t]
             [crux.api :as api]
-            [crux.fixtures.api :refer [*api*]]
+            [crux.fixtures.api :as fapi :refer [*api*]]
             [crux.fixtures.kafka :as fk]
+            [crux.fixtures.kv :as fkv]
             [crux.io :as cio])
   (:import java.math.RoundingMode
            java.time.temporal.ChronoUnit
@@ -20,18 +21,19 @@
 (def ^:const weather-locations-csv-resource "ts/data/weather_small_locations.csv")
 (def ^:const weather-conditions-csv-resource "ts/data/weather_small_conditions.csv")
 
-(def run-ts-weather-tests? (boolean (and (io/resource weather-locations-csv-resource)
-                                         (io/resource weather-conditions-csv-resource)
-                                         (Boolean/parseBoolean (System/getenv "CRUX_TS_WEATHER")))))
+(def run-ts-weather-tests?
+  (boolean (and (io/resource weather-locations-csv-resource)
+                (io/resource weather-conditions-csv-resource)
+                (Boolean/parseBoolean (System/getenv "CRUX_TS_WEATHER")))))
 
 (def ^:const conditions-chunk-size 1000)
 
 (defn submit-ts-weather-data
   ([node]
-   (submit-ts-weather-data
-     node
-     (io/resource weather-locations-csv-resource)
-     (io/resource weather-conditions-csv-resource)))
+   (submit-ts-weather-data node
+                           (io/resource weather-locations-csv-resource)
+                           (io/resource weather-conditions-csv-resource)))
+
   ([node locations-resource conditions-resource]
    (with-open [locations-in (io/reader locations-resource)
                conditions-in (io/reader conditions-resource)]
@@ -47,42 +49,42 @@
        (api/submit-tx node location-tx-ops)
        (->> (line-seq conditions-in)
             (partition conditions-chunk-size)
-            (reduce
-             (fn [n chunk]
-               (api/submit-tx
-                node
-                (vec (for [condition chunk
-                           :let [[time device-id temperature humidity] (str/split condition #",")
-                                 time (inst/read-instant-date
-                                       (-> time
-                                           (str/replace " " "T")
-                                           (str/replace #"-(\d\d)$" ".000-$1:00")))
-                                 condition-id (keyword "condition" device-id)
-                                 location-device-id (keyword "location" device-id)]]
-                       [:crux.tx/put
-                        {:crux.db/id condition-id
-                         :condition/time time
-                         :condition/device-id location-device-id
-                         :condition/temperature (Double/parseDouble temperature)
-                         :condition/humidity (Double/parseDouble humidity)}
-                        time])))
-               (+ n (count chunk)))
-             (count location-tx-ops)))))))
+            (reduce (fn [{:keys [op-count last-tx]} chunk]
+                      {:op-count (+ op-count (count chunk))
+                       :last-tx (api/submit-tx node
+                                               (vec (for [condition chunk
+                                                          :let [[time device-id temperature humidity] (str/split condition #",")
+                                                                time (inst/read-instant-date
+                                                                      (-> time
+                                                                          (str/replace " " "T")
+                                                                          (str/replace #"-(\d\d)$" ".000-$1:00")))
+                                                                condition-id (keyword "condition" device-id)
+                                                                location-device-id (keyword "location" device-id)]]
+                                                      [:crux.tx/put
+                                                       {:crux.db/id condition-id
+                                                        :condition/time time
+                                                        :condition/device-id location-device-id
+                                                        :condition/temperature (Double/parseDouble temperature)
+                                                        :condition/humidity (Double/parseDouble humidity)}
+                                                       time])))})
+                    {:op-count (count location-tx-ops)
+                     :last-tx nil}))))))
 
 
 (defn with-ts-weather-data [f]
   (if run-ts-weather-tests?
-    (let [submit-future (future (submit-ts-weather-data *api*))]
-      (api/sync *api* (java.time.Duration/ofMinutes 20))
-      (t/is (= 1001000 @submit-future))
+    (let [{:keys [last-tx op-count]} (submit-ts-weather-data *api*)]
+      (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
+      (assert (= 1001000 op-count) (str "actual op-count: " op-count))
       (f))
     (f)))
 
 (t/use-fixtures :once
-                fk/with-embedded-kafka-cluster
-                fk/with-kafka-client
-                fk/with-cluster-node-opts
-                with-ts-weather-data)
+  fk/with-embedded-kafka-cluster
+  fk/with-cluster-node-opts
+  fkv/with-kv-dir
+  fapi/with-node
+  with-ts-weather-data)
 
 ;; NOTE: Does not work with range, takes latest values.
 

--- a/crux-test/test/crux/watdiv_test.clj
+++ b/crux-test/test/crux/watdiv_test.clj
@@ -325,12 +325,11 @@
 ;; Crux
 
 (defn load-rdf-into-crux [resource]
-  (let [submit-future (future
-                        (with-open [in (io/input-stream (io/resource resource))]
-                          (rdf/submit-ntriples (:tx-log *api*) in 1000)))]
+  (let [{:keys [last-tx entity-count]} (with-open [in (io/input-stream (io/resource resource))]
+                                         (rdf/submit-ntriples (:tx-log *api*) in 1000))]
     (println "Loaded into kafka awaiting Crux to catch up indexing...")
-    (api/sync *api* (java.time.Duration/ofMinutes 20))
-    (t/is (= 521585 @submit-future))))
+    (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
+    (t/is (= 521585 entity-count))))
 
 (defn with-watdiv-data [f]
   (if run-watdiv-tests?

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -112,15 +112,13 @@ toc::[]
 [source,clj]
 ----
   (sync
-    [node ^Duration timeout]
     [node ^Date transaction-time ^Duration timeout]
-    "If the transaction-time is supplied, blocks until indexing has
-    processed a tx with a greater-than transaction-time, otherwise
-    blocks until the node has caught up indexing the tx-log
-    backlog. Will throw an exception on timeout. The returned date is
-    the latest index time when this node has caught up as of this
-    call. This can be used as the second parameter in (db valid-time,
-    transaction-time) for consistent reads.
+    "Blocks until indexing has processed a tx at or after the provided
+    transaction-time. Will throw an exception on timeout. The returned
+    date is the latest index time when this node has caught up as of
+    this call. This can be used as the second parameter in (db
+    valid-time, transaction-time) for consistent reads.
+
     timeout – max time to wait, can be null for the default.
     Returns the latest known transaction time.")
 ----

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -202,22 +202,21 @@ https://jepsen.io/consistency/models/sequential
 
 How is consistency provided by Crux?::
 
-  Crux does not try to enforce consistency among nodes, which all
-consume the log in the same order, but nodes may be at different points. A
-client using the same node will have a consistent view. Reading your own
-writes can be achieved by providing the transaction time Kafka assigned
-to the submitted transaction, which is returned in a promise from
-`crux.api/submit-tx`, in the call to `crux.api/sync`. This will block
-until this transaction time has been seen by the cluster node.
+  Crux does not try to enforce consistency among nodes, which all consume the
+log in the same order, but nodes may be at different points. A client using the
+same node will have a consistent view. Reading your own writes can be achieved
+by providing the transaction time Kafka assigned to the submitted transaction,
+which is returned from `crux.api/submit-tx`, in the call to `crux.api/sync`.
+This will block until this transaction time has been seen by the cluster node.
 +
-Write consistency across nodes is provided via the `:crux.db/cas`
-operation. The user needs to attempt to perform a CAS, then wait for the
-transaction time (as above), and check that the entity got updated. More
-advanced algorithms can be built on top of this. As mentioned above, all
-CAS operations in a transaction must pass their pre-condition check for
-the transaction to proceed and get indexed, which enables one to enforce
-consistency across documents. There is currently no way to check if a
-transaction got aborted, apart from checking if the write succeeded.
+Write consistency across nodes is provided via the `:crux.db/cas` operation. The
+user needs to attempt to perform a CAS, then wait for the transaction time (as
+above), and check that the entity got updated. More advanced algorithms can be
+built on top of this. As mentioned above, all CAS operations in a transaction
+must pass their pre-condition check for the transaction to proceed and get
+indexed, which enables one to enforce consistency across documents. There is
+currently no way to check if a transaction got aborted, apart from checking if
+the write succeeded.
 
 Will a lack of schema lead to confusion?::
 

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -52,7 +52,7 @@ otherwise restrict the execution of queries.
 |<<#rest-history, `/history/[:key]`>>|GET OR POST|Returns the transaction history of a key
 |<<#rest-query, `/query`>>|POST|Takes a datalog query and returns its results
 |<<#rest-query-stream, `/query-stream`>>|POST| Same as `/query` but the results are streamed
-|<<#rest-sync, `/sync`>>|GET| Wait until the Kafka consumer's lag is back to 0
+|<<#rest-sync, `/sync`>>|GET| Wait until the indexer's indexed a transaction at or after the given transaction time
 |<<#rest-tx-log, `/tx-log`>>|GET| Returns a list of all transactions
 |<<#rest-tx-log-post, `/tx-log`>>|POST|The "write" endpoint, to post transactions.
 |===
@@ -234,11 +234,11 @@ Same as `/query` but the results are streamed.
 [#rest-sync]
 === GET `/sync`
 
-Wait until the Kafka consumer's lag is back to 0 (i.e. when it no longer has pending transactions to write). Timeout is 10 seconds by default, but can be specified as a parameter in milliseconds. Returns the transaction time of the most recent transaction.
+Wait until the indexer's indexed a transaction at or after the given transaction time. Timeout is 10 seconds by default, but can be specified as a parameter in milliseconds. Returns the transaction time of the most recent transaction.
 
 [source,bash]
 ----
-curl -X GET $nodeURL/sync?timeout=500
+curl -X GET $nodeURL/sync?transactionTime=2019-12-23T12:01:10.053Z&timeout=500
 ----
 
 [source,clj]


### PR DESCRIPTION
First part of #466, removing sync-to-no-lag (i.e. without a provided tx-time)

* Removed from public API/docs
* Removed from HTTP server/remote client
* Updated tests that used it to pass the last submitted tx through, and sync to that instead.

Intention is to hold off on merging this til we've had chance to discuss it after Christmas - in the meantime, though, I'll base my multi-threaded Kafka branch on it, so that I don't have to make it backward compatible for this function.

There were a couple of bench tests that used `future` but then seemed to immediately deref them, I've removed the futures - shout if there was a reason for this that I haven't thought of?
