### PR TITLE
Update doc with memory-only standalone config

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -110,6 +110,15 @@ You can later stop the node if you wish:
 include::./src/docs/examples.clj[tags=close-node]
 ----
 
+If you want to run a memory-only node (_e.g._ for testing purpose), you can use the following code:
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=include-crux-api]
+
+include::./src/docs/examples.clj[tags=start-in-memory-standalone-node]
+----
+
+
 [#config-rocksdb]
 == RocksDB
 

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -20,6 +20,15 @@
 ;; end::start-standalone-node[]
   node)
 
+(defn example-start-in-memory-standalone []
+;; tag::start-in-memory-standalone-node[]
+(def ^crux.api.ICruxAPI node
+  (crux/start-node {:crux.node/topology :crux.standalone/topology
+                    :crux.node/kv-store "crux.kv.memdb/kv"
+                    :crux.standalone/event-log-kv "crux.kv.memdb/kv"}))
+;; end::start-in-memory-standalone-node[]
+  node)
+
 (defn example-close-node [^java.io.Closeable node]
 ;; tag::close-node[]
 (.close node)


### PR DESCRIPTION
The current configuration shown in the documentation forces the write on local storage. This update would help to set up memory-only nodes.