### PR TITLE
Batch index docs into the KV store

### DIFF
--- a/crux-bench/src/crux_bench/watdiv.clj
+++ b/crux-bench/src/crux_bench/watdiv.clj
@@ -30,7 +30,7 @@
   (cons
    {:db/ident (:crux.db/id e)}
    (for [[_ v] e
-         v (idx/normalize-value v)
+         v (idx/vectorize-value v)
          :when (keyword? v)]
      {:db/ident v})))
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -16,7 +16,7 @@
 
 ;; tag::Indexer[]
 (defprotocol Indexer
-  (index-doc [this content-hash doc])
+  (index-docs [this docs])
   (index-tx [this tx-events tx-time tx-id])
   (docs-exist? [this content-hashes])
   (store-index-meta [this k v])

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -532,7 +532,7 @@
         (let [value-buffer (get join-keys (.result-index binding))
               content-hash (.content-hash entity-tx)
               doc (db/get-single-object object-store snapshot content-hash)
-              values (idx/normalize-value (get doc (.attr binding)))
+              values (idx/vectorize-value (get doc (.attr binding)))
               value (if (or (nil? value-buffer)
                             (= (count values) 1))
                       (first values)
@@ -686,7 +686,7 @@
               args (vec (for [arg args]
                           (if (logic-var? arg)
                             arg
-                            (->> (map c/->value-buffer (idx/normalize-value arg))
+                            (->> (map c/->value-buffer (idx/vectorize-value arg))
                                  (into (sorted-set-by mem/buffer-comparator))))))]]
     (do (validate-existing-vars var->bindings clause unification-vars)
         {:join-depth unification-join-depth

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -275,7 +275,8 @@
                                     (mapcat (fn [[k doc]] (idx/doc-idx-keys k doc)))
                                     (idx/store-doc-idx-keys kv))
 
-                               (idx/doc-predicate-stats (vals upserted-docs) false))
+                               (->> (vals upserted-docs)
+                                    (map #(idx/doc-predicate-stats % false))))
 
                              (when (seq evicted-docs)
                                (with-open [snapshot (kv/new-snapshot kv)]
@@ -283,7 +284,9 @@
                                    (->> existing-docs
                                         (mapcat (fn [[k doc]] (idx/doc-idx-keys k doc)))
                                         (idx/delete-doc-idx-keys kv))
-                                   (idx/doc-predicate-stats upserted-docs true)))))]
+
+                                   (->> (vals existing-docs)
+                                        (map #(idx/doc-predicate-stats % true)))))))]
 
       (let [stats-fn ^Runnable #(idx/update-predicate-stats kv docs-stats)]
         (if stats-executor

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -212,8 +212,7 @@
                         ;; these nested docs never go to the doc topic,
                         ;; it's slightly less of an issue. It's done
                         ;; this way to support nested fns.
-                        (doseq [arg-doc arg-docs]
-                          (db/index-doc indexer (c/new-id arg-doc) arg-doc))
+                        (db/index-docs indexer (->> arg-docs (into {} (map (juxt c/new-id identity)))))
                         {:docs (vec docs)
                          :ops-result (vec (for [[op :as tx-event] (map tx-op->tx-event tx-ops)]
                                             (index-tx-event tx-event indexer kv object-store snapshot tx-log transact-time tx-id)))})
@@ -224,8 +223,7 @@
                           (log-tx-fn-error fn-result fn-id body args-id args)
                           false)}
         (let [{:keys [docs ops-result]} fn-result]
-          {:pre-commit-fn #(do (doseq [doc docs]
-                                 (db/index-doc indexer (c/new-id doc) doc))
+          {:pre-commit-fn #(do (db/index-docs indexer (->> docs (into {} (map (juxt c/new-id identity)))))
                                (every? true? (for [{:keys [pre-commit-fn]} ops-result
                                                    :when pre-commit-fn]
                                                (pre-commit-fn))))
@@ -263,28 +261,36 @@
         (.awaitTermination 60000 TimeUnit/MILLISECONDS))))
 
   db/Indexer
-  (index-doc [_ content-hash doc]
-    (log/debug "Indexing doc:" content-hash)
+  (index-docs [_ docs]
+    (log/debugf "Indexing %d docs" (count docs))
 
-    (when (not (contains? doc :crux.db/id))
+    (when-let [missing-ids (seq (remove :crux.db/id (vals docs)))]
       (throw (IllegalArgumentException.
-              (str "Missing required attribute :crux.db/id: " (cio/pr-edn-str doc)))))
+              (str "Missing required attribute :crux.db/id: " (cio/pr-edn-str missing-ids)))))
 
-    (let [content-hash (c/new-id content-hash)
-          evicted? (idx/evicted-doc? doc)]
-      (when-let [normalized-doc (if evicted?
-                                  (when-let [existing-doc (with-open [snapshot (kv/new-snapshot kv)]
-                                                            (db/get-single-object object-store snapshot content-hash))]
-                                    (idx/delete-doc-from-index kv content-hash existing-doc))
+    (let [{evicted-docs true, upserted-docs false} (group-by (comp boolean idx/evicted-doc? val) docs)
 
-                                  (idx/index-doc kv content-hash doc))]
+          docs-stats (concat (when (seq upserted-docs)
+                               (->> upserted-docs
+                                    (mapcat (fn [[k doc]] (idx/doc-idx-keys k doc)))
+                                    (idx/store-doc-idx-keys kv))
 
-        (let [stats-fn #(idx/update-predicate-stats kv evicted? normalized-doc)]
-          (if stats-executor
-            (.submit stats-executor ^Runnable stats-fn)
-            (stats-fn))))
+                               (idx/doc-predicate-stats (vals upserted-docs) false))
 
-      (db/put-objects object-store [[content-hash doc]])))
+                             (when (seq evicted-docs)
+                               (with-open [snapshot (kv/new-snapshot kv)]
+                                 (let [existing-docs (db/get-objects object-store snapshot (keys evicted-docs))]
+                                   (->> existing-docs
+                                        (mapcat (fn [[k doc]] (idx/doc-idx-keys k doc)))
+                                        (idx/delete-doc-idx-keys kv))
+                                   (idx/doc-predicate-stats upserted-docs true)))))]
+
+      (let [stats-fn ^Runnable #(idx/update-predicate-stats kv docs-stats)]
+        (if stats-executor
+          (.submit stats-executor stats-fn)
+          (stats-fn)))
+
+      (db/put-objects object-store docs)))
 
   (index-tx [this tx-events tx-time tx-id]
     (s/assert :crux.tx.event/tx-events tx-events)

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -21,7 +21,9 @@
                     (if-let [^Message last-message (reduce (fn [last-message ^Message m]
                                                              (case (get (.headers m) :crux.tx/sub-topic)
                                                                :docs
-                                                               (db/index-doc indexer (.key m) (.body m))
+                                                               ;; TODO we'll likely be able to make this more efficient
+                                                               ;; if it can insert multiple docs at once
+                                                               (db/index-docs indexer {(.key m) (.body m)})
                                                                :txs
                                                                (db/index-tx indexer
                                                                             (.body m)

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -17,24 +17,25 @@
                                                       :time nil}}))
   (while @running?
     (let [idle? (with-open [context (consumer/new-event-log-context event-log-consumer)]
-                  (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])]
-                    (if-let [^Message last-message (reduce (fn [last-message ^Message m]
-                                                             (case (get (.headers m) :crux.tx/sub-topic)
-                                                               :docs
-                                                               ;; TODO we'll likely be able to make this more efficient
-                                                               ;; if it can insert multiple docs at once
-                                                               (db/index-docs indexer {(.key m) (.body m)})
-                                                               :txs
-                                                               (db/index-tx indexer
-                                                                            (.body m)
-                                                                            (.message-time m)
-                                                                            (.message-id m)))
-                                                             m)
-                                                           nil
-                                                           (consumer/next-events event-log-consumer context next-offset))]
+                  (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
+                        msgs (consumer/next-events event-log-consumer context next-offset)
+                        {doc-msgs :docs, tx-msgs :txs} (->> msgs (group-by #(:crux.tx/sub-topic (.headers ^Message %))))]
+
+                    (when (seq doc-msgs)
+                      (db/index-docs indexer (->> doc-msgs
+                                                  (into {} (map (fn [^Message m]
+                                                                  [(.key m) (.body m)]))))))
+
+                    (doseq [^Message tx-msg tx-msgs]
+                      (db/index-tx indexer
+                                   (.body tx-msg)
+                                   (.message-time tx-msg)
+                                   (.message-id tx-msg)))
+
+                    (if-let [^Message last-msg (last msgs)]
                       (let [end-offset (consumer/end-offset event-log-consumer)
-                            tx-id (long (.message-id last-message))
-                            tx-time (.message-time last-message)
+                            tx-id (long (.message-id last-msg))
+                            tx-time (.message-time last-msg)
                             next-offset (inc tx-id)
                             lag (- end-offset next-offset)
                             _ (when (pos? lag)
@@ -47,6 +48,7 @@
                         (db/store-index-meta indexer :crux.tx/latest-completed-tx {:crux.tx/tx-time tx-time, :crux.tx/tx-id tx-id})
                         (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
                         false)
+
                       true)))]
       (when idle?
         (Thread/sleep idle-sleep-ms)))))

--- a/crux-dev/dev/dev.clj
+++ b/crux-dev/dev/dev.clj
@@ -109,7 +109,7 @@
        (finally
          (set-log-level! ~ns level#)))))
 
-(n/install-uncaught-exception-handler!)
+(cio/install-uncaught-exception-handler!)
 
 ;; Usage, create a dev/$USER.clj file like this, and add it to
 ;; .gitignore:

--- a/crux-test/test/crux/bitemporal_tale_test.clj
+++ b/crux-test/test/crux/bitemporal_tale_test.clj
@@ -150,11 +150,11 @@
     (t/is (= #{["Key from an unknown door"] ["Magic beans"]
                ["A used sword"] ["A Rather Cozy Mug"]
                ["A Tell DPS Laptop (what?)"]
-               ["Flintlock pistol"]})
-          (crux/q db
-                  '[:find ?name
-                    :where
-                    [_ :artefact/title ?name]]))
+               ["Flintlock pistol"]}
+             (crux/q db
+                     '[:find ?name
+                       :where
+                       [_ :artefact/title ?name]])))
     (crux/sync system (:crux.tx/tx-time (crux/submit-tx
                                          system
                                          [[:crux.tx/delete :ids.artefacts/forbidden-beans
@@ -361,24 +361,25 @@
 
     (crux/sync system (:crux.tx/tx-time (crux/submit-tx system (first-ownership-tx))) nil)
 
-    (t/is (= (crux/q
+    (t/is (= #{["Mary" "A used sword"]
+               ["Mary" "Flintlock pistol"]
+               ["Mary" "A Rather Cozy Mug"]}
+             (crux/q
               (crux/db system #inst "1715-05-18")
-              who-has-what-query))
-          #{["Mary" "A used sword"]
-            ["Mary" "Flintlock pistol"]
-            ["Mary" "A Rather Cozy Mug"]})
+              who-has-what-query)))
 
-    (t/is (= (crux/q
-              (crux/db system #inst "1740-06-19")
-              who-has-what-query)
-             #{["Mary" "A used sword"]
+    (t/is (= #{["Mary" "A used sword"]
                ["Mary" "Flintlock pistol"]
                ["Mary" "A Rather Cozy Mug"]
-               ["Charles" "Key from an unknown door"]}))
-    (t/is (= (crux/q
+               ["Charles" "Key from an unknown door"]}
+             (crux/q
+              (crux/db system #inst "1740-06-19")
+              who-has-what-query)))
+
+    (t/is (= #{["Mary" "A used sword"]
+               ["Mary" "Flintlock pistol"]}
+             (crux/q
               (crux/db system
                        #inst "1715-06-19"
                        (:crux.tx/tx-time first-ownership-tx-response))
-              who-has-what-query)
-             #{["Mary" "A used sword"]
-               ["Mary" "Flintlock pistol"]}))))
+              who-has-what-query)))))

--- a/crux-test/test/crux/rocksdb_microbench.clj
+++ b/crux-test/test/crux/rocksdb_microbench.clj
@@ -1,0 +1,28 @@
+(ns crux.rocksdb-microbench
+  (:require [crux.ts-weather-test :as ts-weather]
+            [clojure.test :as t]
+            [crux.fixtures.standalone :as fs]
+            [crux.fixtures.api :refer [*api*] :as fapi]
+            [crux.fixtures.kv :as fkv]
+            [crux.db :as db]
+            [crux.codec :as c]
+            [crux.kv :as kv]))
+
+(t/use-fixtures :each
+  fs/with-standalone-node
+  fkv/with-kv-dir
+  fkv/with-rocksdb
+  fapi/with-node)
+
+(t/deftest test-weather-ingest
+  (t/is :test-weather-ingest)
+
+  (when ts-weather/run-ts-weather-tests?
+    (ts-weather/with-condition-docs
+      (fn [[first-doc :as condition-docs]]
+        (time
+         (doseq [doc (take 10000 condition-docs)]
+           (db/index-doc (:indexer *api*) (c/new-id doc) doc)))
+
+        (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
+          (t/is (= first-doc (db/get-single-object (:object-store *api*) snapshot (c/new-id first-doc)))))))))

--- a/crux-test/test/crux/rocksdb_microbench.clj
+++ b/crux-test/test/crux/rocksdb_microbench.clj
@@ -21,8 +21,9 @@
     (ts-weather/with-condition-docs
       (fn [[first-doc :as condition-docs]]
         (time
-         (doseq [doc (take 10000 condition-docs)]
-           (db/index-doc (:indexer *api*) (c/new-id doc) doc)))
+         (doseq [doc-batch (->> (take 10000 condition-docs)
+                                (partition-all 100))]
+           (db/index-docs (:indexer *api*) (->> doc-batch (into {} (map (juxt c/new-id identity)))))))
 
         (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
           (t/is (= first-doc (db/get-single-object (:object-store *api*) snapshot (c/new-id first-doc)))))))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -281,8 +281,8 @@
         ivan1 (assoc ivan :value 1)
         ivan2 (assoc ivan :value 2)
         t #inst "2019-11-29"]
-    (db/index-doc (:indexer *api*) (c/new-id ivan1) ivan1)
-    (db/index-doc (:indexer *api*) (c/new-id ivan2) ivan2)
+    (db/index-docs (:indexer *api*) {(c/new-id ivan1) ivan1
+                                     (c/new-id ivan2) ivan2})
 
     (db/index-tx (:indexer *api*) [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]] t 1)
     (db/index-tx (:indexer *api*) [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]] t 2)

--- a/crux-test/test/crux/watdiv_test.clj
+++ b/crux-test/test/crux/watdiv_test.clj
@@ -116,7 +116,7 @@
   (cons
    {:db/ident (:crux.db/id e)}
    (for [[_ v] e
-         v (idx/normalize-value v)
+         v (idx/vectorize-value v)
          :when (keyword? v)]
      {:db/ident v})))
 

--- a/crux-uberjar/src/crux/cli.clj
+++ b/crux-uberjar/src/crux/cli.clj
@@ -5,7 +5,8 @@
             [clojure.tools.logging :as log]
             [crux.http-server :as srv]
             [crux.node :as n]
-            [crux.config :as cc])
+            [crux.config :as cc]
+            [crux.io :as cio])
   (:import java.io.Closeable))
 
 (def default-options
@@ -52,7 +53,7 @@
                       {:key k :value v}))))
 
 (defn start-node-from-command-line [args]
-  (n/install-uncaught-exception-handler!)
+  (cio/install-uncaught-exception-handler!)
   (let [{:keys [options
                 errors
                 summary]} (cli/parse-opts args cli-options)


### PR DESCRIPTION
Currently, we're indexing docs one-at-a-time into the KVIndexer - RocksDB, in particular, appreciates putting documents in sorted batches (see 'What's the fastest way to load data into RocksDB?' at https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ)

The microbench, on my laptop, takes ~11s to load 100k docs individually, but ~6.2s to load 100k docs in batches of 100 (batches of 1000 didn't make a significant difference)
