### PR TITLE
Fix overlapping time ranges within a single transaction, #434

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -17,7 +17,7 @@
 ;; tag::Indexer[]
 (defprotocol Indexer
   (index-docs [this docs])
-  (index-tx [this tx])
+  (index-tx [this tx tx-events])
   (docs-exist? [this content-hashes])
   (store-index-meta [this k v])
   (read-index-meta [this k]))

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -17,7 +17,7 @@
 ;; tag::Indexer[]
 (defprotocol Indexer
   (index-docs [this docs])
-  (index-tx [this tx-events tx-time tx-id])
+  (index-tx [this tx])
   (docs-exist? [this content-hashes])
   (store-index-meta [this k v])
   (read-index-meta [this k]))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -167,9 +167,8 @@
       (when (and (not @closed?) close-fn) (close-fn))
       (reset! closed? true))))
 
-(defn- start-kv-indexer [{::keys [kv-store tx-log object-store]} _]
-  (tx/->KvIndexer kv-store tx-log object-store
-                  (Executors/newSingleThreadExecutor (cio/thread-factory "crux.tx.update-stats-thread"))))
+(defn- start-kv-indexer [deps _]
+  (tx/->KvIndexer deps (Executors/newSingleThreadExecutor (cio/thread-factory "crux.tx.update-stats-thread"))))
 
 (s/def ::topology-id
   (fn [id]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -167,9 +167,6 @@
       (when (and (not @closed?) close-fn) (close-fn))
       (reset! closed? true))))
 
-(defn- start-kv-indexer [deps _]
-  (tx/->KvIndexer deps (Executors/newSingleThreadExecutor (cio/thread-factory "crux.tx.update-stats-thread"))))
-
 (s/def ::topology-id
   (fn [id]
     (and (or (string? id) (keyword? id) (symbol? id))
@@ -252,10 +249,10 @@
                                :when (instance? Closeable m)]
                          (cio/try-close m)))]))
 
-(def base-topology {::kv-store 'crux.kv.rocksdb/kv
-                    ::object-store 'crux.object-store/kv-object-store
-                    ::indexer {:start-fn start-kv-indexer
-                               :deps [::kv-store ::tx-log ::object-store]}})
+(def base-topology
+  {::kv-store 'crux.kv.rocksdb/kv
+   ::object-store 'crux.object-store/kv-object-store
+   ::indexer 'crux.tx/kv-indexer})
 
 (defn options->topology [{:keys [crux.node/topology] :as options}]
   (when-not topology

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -392,6 +392,11 @@
      :crux.tx/latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)
      :crux.tx-log/consumer-state (db/read-index-meta indexer :crux.tx-log/consumer-state)}))
 
+(def kv-indexer
+  {:start-fn (fn [deps args]
+               (->KvIndexer deps (Executors/newSingleThreadExecutor (cio/thread-factory "crux.tx.update-stats-thread"))))
+   :deps [:crux.node/kv-store :crux.node/tx-log :crux.node/object-store]})
+
 (defn ^:deprecated await-no-consumer-lag [indexer timeout-ms]
   ;; this will likely be going away as part of #442
   (let [max-lag-fn #(some->> (db/read-index-meta indexer :crux.tx-log/consumer-state)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -344,7 +344,7 @@
 
       (db/put-objects object-store docs)))
 
-  (index-tx [this {:crux.tx/keys [tx-time tx-id], :crux.tx.event/keys [tx-events], :as tx}]
+  (index-tx [this {:crux.tx/keys [tx-time tx-id] :as tx} tx-events]
     (s/assert :crux.tx.event/tx-events tx-events)
 
     (log/debug "Indexing tx-id:" tx-id "tx-events:" (count tx-events))

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -27,25 +27,23 @@
                                                                   [(.key m) (.body m)]))))))
 
                     (doseq [^Message tx-msg tx-msgs]
-                      (db/index-tx indexer
-                                   {:crux.tx/tx-time (.message-time tx-msg)
-                                    :crux.tx/tx-id (.message-id tx-msg)}
-                                   (.body tx-msg)))
+                      (let [tx {:crux.tx/tx-time (.message-time tx-msg)
+                                :crux.tx/tx-id (.message-id tx-msg)}]
+                        (db/index-tx indexer tx (.body tx-msg))
+                        (db/store-index-meta indexer :crux.tx/latest-completed-tx tx)))
 
                     (if-let [^Message last-msg (last msgs)]
                       (let [end-offset (consumer/end-offset event-log-consumer)
-                            tx-id (long (.message-id last-msg))
-                            tx-time (.message-time last-msg)
-                            next-offset (inc tx-id)
+                            next-offset (inc (long (.message-id last-msg)))
+                            time (.message-time last-msg)
                             lag (- end-offset next-offset)
                             _ (when (pos? lag)
                                 (log/debug "Falling behind" ::event-log "at:" next-offset "end:" end-offset))
                             consumer-state {:crux.tx/event-log
                                             {:lag lag
                                              :next-offset next-offset
-                                             :time tx-time}}]
+                                             :time time}}]
                         (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
-                        (db/store-index-meta indexer :crux.tx/latest-completed-tx {:crux.tx/tx-time tx-time, :crux.tx/tx-id tx-id})
                         (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
                         false)
 

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -28,9 +28,9 @@
 
                     (doseq [^Message tx-msg tx-msgs]
                       (db/index-tx indexer
-                                   (.body tx-msg)
-                                   (.message-time tx-msg)
-                                   (.message-id tx-msg)))
+                                   {:crux.tx.event/tx-events (.body tx-msg)
+                                    :crux.tx/tx-time (.message-time tx-msg)
+                                    :crux.tx/tx-id (.message-id tx-msg)}))
 
                     (if-let [^Message last-msg (last msgs)]
                       (let [end-offset (consumer/end-offset event-log-consumer)

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -28,9 +28,9 @@
 
                     (doseq [^Message tx-msg tx-msgs]
                       (db/index-tx indexer
-                                   {:crux.tx.event/tx-events (.body tx-msg)
-                                    :crux.tx/tx-time (.message-time tx-msg)
-                                    :crux.tx/tx-id (.message-id tx-msg)}))
+                                   {:crux.tx/tx-time (.message-time tx-msg)
+                                    :crux.tx/tx-id (.message-id tx-msg)}
+                                   (.body tx-msg)))
 
                     (if-let [^Message last-msg (last msgs)]
                       (let [end-offset (consumer/end-offset event-log-consumer)

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -196,7 +196,7 @@
 
 (defn- index-tx-record [indexer ^ConsumerRecord record]
   (let [{:keys [crux.tx.event/tx-events] :as record} (tx-record->tx-log-entry record)]
-    (db/index-tx indexer record)
+    (db/index-tx indexer (select-keys record [:crux.tx/tx-time :crux.tx/tx-id]) tx-events)
     tx-events))
 
 (defn consume-and-index-entities

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -195,11 +195,8 @@
                                               [(.key record) (.value record)]))))))
 
 (defn- index-tx-record [indexer ^ConsumerRecord record]
-  (let [record (tx-record->tx-log-entry record)
-        {:crux.tx/keys [tx-time
-                        tx-id]} record
-        {:crux.tx.event/keys [tx-events]} record]
-    (db/index-tx indexer tx-events tx-time tx-id)
+  (let [{:keys [crux.tx.event/tx-events] :as record} (tx-record->tx-log-entry record)]
+    (db/index-tx indexer record)
     tx-events))
 
 (defn consume-and-index-entities

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -47,7 +47,7 @@
         doc-topic "test-can-transact-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/example-data-artists.nt"))
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {})
-        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)]
+        indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
     (k/create-topic fk/*admin-client* doc-topic 1 1 k/doc-topic-config)
@@ -70,7 +70,7 @@
         doc-topic "test-can-transact-and-query-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/picasso.nt"))
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
-        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)
+        indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
         node (reify crux.api.ICruxAPI
                (db [this]
@@ -128,7 +128,7 @@
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
 
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
-        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)
+        indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)
 
         node (reify crux.api.ICruxAPI
                (db [this]
@@ -179,7 +179,7 @@
                 (fkv/with-kv-store
                   (fn []
                     (let [object-store (os/->KvObjectStore *kv*)
-                          indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store object-store} nil)
+                          indexer (tx/->KvIndexer object-store *kv* tx-log nil)
                           consume-opts {:indexer indexer
                                         :consumer fk/*consumer*
                                         :pending-txs-state (atom [])

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -47,7 +47,7 @@
         doc-topic "test-can-transact-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/example-data-artists.nt"))
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {})
-        indexer (tx/->KvIndexer *kv* tx-log (os/->KvObjectStore *kv*) nil)]
+        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
     (k/create-topic fk/*admin-client* doc-topic 1 1 k/doc-topic-config)
@@ -70,7 +70,7 @@
         doc-topic "test-can-transact-and-query-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/picasso.nt"))
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
-        indexer (tx/->KvIndexer *kv* tx-log (os/->KvObjectStore *kv*) nil)
+        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
         node (reify crux.api.ICruxAPI
                (db [this]
@@ -128,7 +128,7 @@
         tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
 
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
-        indexer (tx/->KvIndexer *kv* tx-log (os/->KvObjectStore *kv*) nil)
+        indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store (os/->KvObjectStore *kv*)} nil)
 
         node (reify crux.api.ICruxAPI
                (db [this]
@@ -179,7 +179,7 @@
                 (fkv/with-kv-store
                   (fn []
                     (let [object-store (os/->KvObjectStore *kv*)
-                          indexer (tx/->KvIndexer *kv* tx-log object-store nil)
+                          indexer (tx/->KvIndexer #:crux.node{:kv-store *kv*, :tx-log tx-log, :object-store object-store} nil)
                           consume-opts {:indexer indexer
                                         :consumer fk/*consumer*
                                         :pending-txs-state (atom [])

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1421,7 +1421,7 @@
                                       :name "Ivan 3rd"}]
                                     [:crux.tx/cas
                                      {:crux.db/id :ivan
-                                      :name "Ivan 2nd"}
+                                      :name "Ivan 3rd"}
                                      {:crux.db/id :ivan
                                       :name "Ivan 4th"}]])
               updated? (api/submitted-tx-updated-entity? *api* submitted-tx :ivan)]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -665,42 +665,44 @@
                                                [child :joins parent]]}))))))
 
 (t/deftest overlapping-valid-time-ranges-434
-  (sync-submit-tx *api*
-                  [[:crux.tx/put {:crux.db/id :foo, :v 10} #inst "2020-01-10"]
-                   [:crux.tx/put {:crux.db/id :bar, :v 5} #inst "2020-01-05"]
-                   [:crux.tx/put {:crux.db/id :bar, :v 10} #inst "2020-01-10"]
+  (let [_ (sync-submit-tx *api*
+                          [[:crux.tx/put {:crux.db/id :foo, :v 10} #inst "2020-01-10"]
+                           [:crux.tx/put {:crux.db/id :bar, :v 5} #inst "2020-01-05"]
+                           [:crux.tx/put {:crux.db/id :bar, :v 10} #inst "2020-01-10"]
 
-                   [:crux.tx/put {:crux.db/id :baz, :v 10} #inst "2020-01-10"]])
+                           [:crux.tx/put {:crux.db/id :baz, :v 10} #inst "2020-01-10"]])
 
-  (sync-submit-tx *api*
-                  [[:crux.tx/put {:crux.db/id :bar, :v 7} #inst "2020-01-07"]
-                   ;; mixing foo and bar shouldn't matter
-                   [:crux.tx/put {:crux.db/id :foo, :v 8} #inst "2020-01-08" #inst "2020-01-12"] ; reverts to 10 afterwards
-                   [:crux.tx/put {:crux.db/id :foo, :v 9} #inst "2020-01-09" #inst "2020-01-11"] ; reverts to 8 afterwards, then 10
-                   [:crux.tx/put {:crux.db/id :bar, :v 8} #inst "2020-01-08" #inst "2020-01-09"] ; reverts to 7 afterwards
-                   [:crux.tx/put {:crux.db/id :bar, :v 11} #inst "2020-01-11" #inst "2020-01-12"] ; reverts to 10 afterwards
-                   ])
+        last-tx (sync-submit-tx *api*
+                                [[:crux.tx/put {:crux.db/id :bar, :v 7} #inst "2020-01-07"]
+                                 ;; mixing foo and bar shouldn't matter
+                                 [:crux.tx/put {:crux.db/id :foo, :v 8} #inst "2020-01-08" #inst "2020-01-12"] ; reverts to 10 afterwards
+                                 [:crux.tx/put {:crux.db/id :foo, :v 9} #inst "2020-01-09" #inst "2020-01-11"] ; reverts to 8 afterwards, then 10
+                                 [:crux.tx/put {:crux.db/id :bar, :v 8} #inst "2020-01-08" #inst "2020-01-09"] ; reverts to 7 afterwards
+                                 [:crux.tx/put {:crux.db/id :bar, :v 11} #inst "2020-01-11" #inst "2020-01-12"] ; reverts to 10 afterwards
+                                 ])
 
-  (let [db (api/db *api*)]
+        db (api/db *api*)]
+
     (with-open [snapshot (api/new-snapshot db)]
       (let [eid->history (fn [eid]
-                           (->> (idx/entity-history snapshot (c/new-id eid))
+                           (->> (idx/entity-history-seq-ascending snapshot (c/new-id eid)
+                                                                  #inst "2020-01-01"
+                                                                  (:crux.tx/tx-time last-tx))
                                 (map (fn [{:keys [content-hash vt]}]
                                        [vt (:v (db/get-single-object (:object-store *api*) snapshot content-hash))]))))]
         ;; transaction functions, asserts both still apply at the start of the transaction
-
-        (t/is (= [[#inst "2020-01-12" 10]
-                  [#inst "2020-01-11" 8]
-                  [#inst "2020-01-10" 9]
+        (t/is (= [[#inst "2020-01-08" 8]
                   [#inst "2020-01-09" 9]
-                  [#inst "2020-01-08" 8]]
+                  [#inst "2020-01-10" 9]
+                  [#inst "2020-01-11" 8]
+                  [#inst "2020-01-12" 10]]
                  (eid->history :foo)))
 
-        (t/is (= [[#inst "2020-01-12" 10]
-                  [#inst "2020-01-11" 11]
-                  [#inst "2020-01-10" 10]
-                  [#inst "2020-01-09" 7]
-                  [#inst "2020-01-08" 8]
+        (t/is (= [[#inst "2020-01-05" 5]
                   [#inst "2020-01-07" 7]
-                  [#inst "2020-01-05" 5]]
+                  [#inst "2020-01-08" 8]
+                  [#inst "2020-01-09" 7]
+                  [#inst "2020-01-10" 10]
+                  [#inst "2020-01-11" 11]
+                  [#inst "2020-01-12" 10]]
                  (eid->history :bar)))))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -247,9 +247,9 @@
         evict-tx-id (inc put-tx-id)
 
         index-evict! #(db/index-tx (:indexer *api*)
-                                   [[:crux.tx/evict picasso-id #inst "2018-05-23"]]
-                                   evict-tx-time
-                                   evict-tx-id)]
+                                   {:crux.tx.event/tx-events [[:crux.tx/evict picasso-id #inst "2018-05-23"]]
+                                    :crux.tx/tx-time evict-tx-time
+                                    :crux.tx/tx-id evict-tx-id})]
 
     ;; we have to index these manually because the new evict API won't allow docs
     ;; with the legacy valid-time range
@@ -284,8 +284,8 @@
     (db/index-docs (:indexer *api*) {(c/new-id ivan1) ivan1
                                      (c/new-id ivan2) ivan2})
 
-    (db/index-tx (:indexer *api*) [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]] t 1)
-    (db/index-tx (:indexer *api*) [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]] t 2)
+    (db/index-tx (:indexer *api*) {:crux.tx.event/tx-events [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]], :crux.tx/tx-time t, :crux.tx/tx-id 1})
+    (db/index-tx (:indexer *api*) {:crux.tx.event/tx-events [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]], :crux.tx/tx-time t, :crux.tx/tx-id 2})
 
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -663,3 +663,44 @@
                (api/q (api/db *api*) '{:find [parent child]
                                        :where [[parent :crux.db/id _]
                                                [child :joins parent]]}))))))
+
+(t/deftest overlapping-valid-time-ranges-434
+  (sync-submit-tx *api*
+                  [[:crux.tx/put {:crux.db/id :foo, :v 10} #inst "2020-01-10"]
+                   [:crux.tx/put {:crux.db/id :bar, :v 5} #inst "2020-01-05"]
+                   [:crux.tx/put {:crux.db/id :bar, :v 10} #inst "2020-01-10"]
+
+                   [:crux.tx/put {:crux.db/id :baz, :v 10} #inst "2020-01-10"]])
+
+  (sync-submit-tx *api*
+                  [[:crux.tx/put {:crux.db/id :bar, :v 7} #inst "2020-01-07"]
+                   ;; mixing foo and bar shouldn't matter
+                   [:crux.tx/put {:crux.db/id :foo, :v 8} #inst "2020-01-08" #inst "2020-01-12"] ; reverts to 10 afterwards
+                   [:crux.tx/put {:crux.db/id :foo, :v 9} #inst "2020-01-09" #inst "2020-01-11"] ; reverts to 8 afterwards, then 10
+                   [:crux.tx/put {:crux.db/id :bar, :v 8} #inst "2020-01-08" #inst "2020-01-09"] ; reverts to 7 afterwards
+                   [:crux.tx/put {:crux.db/id :bar, :v 11} #inst "2020-01-11" #inst "2020-01-12"] ; reverts to 10 afterwards
+                   ])
+
+  (let [db (api/db *api*)]
+    (with-open [snapshot (api/new-snapshot db)]
+      (let [eid->history (fn [eid]
+                           (->> (idx/entity-history snapshot (c/new-id eid))
+                                (map (fn [{:keys [content-hash vt]}]
+                                       [vt (:v (db/get-single-object (:object-store *api*) snapshot content-hash))]))))]
+        ;; transaction functions, asserts both still apply at the start of the transaction
+
+        (t/is (= [[#inst "2020-01-12" 10]
+                  [#inst "2020-01-11" 8]
+                  [#inst "2020-01-10" 9]
+                  [#inst "2020-01-09" 9]
+                  [#inst "2020-01-08" 8]]
+                 (eid->history :foo)))
+
+        (t/is (= [[#inst "2020-01-12" 10]
+                  [#inst "2020-01-11" 11]
+                  [#inst "2020-01-10" 10]
+                  [#inst "2020-01-09" 7]
+                  [#inst "2020-01-08" 8]
+                  [#inst "2020-01-07" 7]
+                  [#inst "2020-01-05" 5]]
+                 (eid->history :bar)))))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -247,9 +247,9 @@
         evict-tx-id (inc put-tx-id)
 
         index-evict! #(db/index-tx (:indexer *api*)
-                                   {:crux.tx.event/tx-events [[:crux.tx/evict picasso-id #inst "2018-05-23"]]
-                                    :crux.tx/tx-time evict-tx-time
-                                    :crux.tx/tx-id evict-tx-id})]
+                                   {:crux.tx/tx-time evict-tx-time
+                                    :crux.tx/tx-id evict-tx-id}
+                                   [[:crux.tx/evict picasso-id #inst "2018-05-23"]])]
 
     ;; we have to index these manually because the new evict API won't allow docs
     ;; with the legacy valid-time range
@@ -284,8 +284,8 @@
     (db/index-docs (:indexer *api*) {(c/new-id ivan1) ivan1
                                      (c/new-id ivan2) ivan2})
 
-    (db/index-tx (:indexer *api*) {:crux.tx.event/tx-events [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]], :crux.tx/tx-time t, :crux.tx/tx-id 1})
-    (db/index-tx (:indexer *api*) {:crux.tx.event/tx-events [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]], :crux.tx/tx-time t, :crux.tx/tx-id 2})
+    (db/index-tx (:indexer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 1} [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]])
+    (db/index-tx (:indexer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 2} [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]])
 
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))


### PR DESCRIPTION
fixes #434 

Currently, if a user specifies overlapping time ranges for the same entity within a transaction, each operation only sees the database as at the start of the transaction - later operations do not correctly overwrite earlier operations within the transaction. Likewise, CaS/transaction functions currently compare against the start of the transaction.

This change ensures that operations can see (and hence correctly overwrite) earlier operations within the transaction, but without persisting those operations to the DB until the transaction commits.

N.B.:
* Might help to start with the [new test](https://github.com/juxt/crux/pull/529/files#diff-e9248c848b198b5586ceb964d0f2ede7R667)
* This [old test](https://github.com/juxt/crux/pull/529/files#diff-8d0564fb1283009c592ba069490c0f15R1424) shows that the CaS behaviour has changed for two CaS operations on the same entity in the same tx
* Related: in an isolated commit, I've also refactored the KVIndexer to pass around maps of values that commonly travel together (the 'Parameter Object' pattern), and given the keys/destructured locals names consistent with the rest of Crux. particularly, settling on `kv-store` (rather than `kv`) and `tx-time` (rather than `transact-time`) because of the keywords `:crux.node/kv-store` and `:crux.tx/tx-time` respectively. This also helps when there are more than ~4-5 positional args - don't have to explicitly pass all of these through, in a consistent order (or otherwise), every time. RFC!