### PR TITLE
Docs cleanup

### DIFF
--- a/docs/about.adoc
+++ b/docs/about.adoc
@@ -14,7 +14,7 @@ Crux ultimately aims to make the use of bitemporal modelling intuitive and acces
 [#about-team]
 == Team
 
-See: https://github.com/juxt/crux/graphs/contributors
+See our https://github.com/juxt/crux/graphs/contributors[contributors].
 
 [#about-support]
 == Support
@@ -50,4 +50,4 @@ include::contributing.adoc[leveloffset=+1]
 [#about-releases]
 === Releases
 
-For technical changes, see:https://github.com/juxt/crux/blob/master/CHANGELOG.md
+For technical changes, see the https://github.com/juxt/crux/blob/master/CHANGELOG.md[Changelog].

--- a/docs/about.adoc
+++ b/docs/about.adoc
@@ -51,3 +51,5 @@ include::contributing.adoc[leveloffset=+1]
 === Releases
 
 For technical changes, see the https://github.com/juxt/crux/blob/master/CHANGELOG.md[Changelog].
+
+include::faq.adoc[leveloffset=+1]

--- a/docs/bitemp.adoc
+++ b/docs/bitemp.adoc
@@ -187,6 +187,7 @@ and any subsequent laws that may be relevant and applied retrospectively
   information to aid predictions and understanding of motives across time
 - Criminal Investigations – efficiently organise analysis and evidence whilst
   enabling a simple retracing of investigative efforts
+
 [#bitemp-examples]
 == Example Queries
 
@@ -406,13 +407,14 @@ bitemporal queries.
 In summary, the Crux indexes as a whole could be described as a "partially
 persistent and fully retroactive data structure".
 
-https://courses.csail.mit.edu/6.851/fall17/lectures/L02.html
-https://erikdemaine.org/papers/Retroactive_TALG/paper.pdf
+.Further reading:
+* https://courses.csail.mit.edu/6.851/fall17/lectures/L02.html[Advanced Data Structures]
+* https://erikdemaine.org/papers/Retroactive_TALG/paper.pdf[Retroactive Data Structures]
 
 [#bitemp-references]
 == References
 
-* https://juxt.pro/blog/posts/value-of-bitemporality.html
+* https://juxt.pro/blog/posts/value-of-bitemporality.html[Value of Bitemporality]
 * https://en.wikipedia.org/wiki/Temporal_database[Temporal database]
 * https://martinfowler.com/eaaDev/timeNarrative.html[Temporal Patterns]
 * https://kx.com/blog/kx-insights-powering-business-decisions-bitemporal-data/[Kx Insights: Powering Business Decisions with Bitemporal Data]

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -292,7 +292,7 @@ include::./src/docs/examples.clj[tags=start-jdbc-node]
 ----
 
 [#config-http]
-== Http
+== HTTP
 
 Crux can be used programmatically as a library, but Crux also ships
 with an embedded HTTP server, that allows clients to use the API

--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -9,17 +9,15 @@ reflect our gratitude.
 == GitHub
 
 We currently use GitHub Issues to work on near-term changes to the Crux
-codebase and documentation. Please see the issues labelled with "good first
-issue" if you are looking for ideas to help push Crux forward:
-https://github.com/juxt/crux/labels/good%20first%20issue
+codebase and documentation. Please see the issues labelled with https://github.com/juxt/crux/labels/good%20first%20issue["good first issue"]
+if you are looking for ideas to help push Crux forward.
 
 PRs with fixes and improvements to these docs are very welcome.
 
 [#contributing-commits]
 == Commits
 
-Please strive to follow the best-practices for commit messages which are outlined here:
-https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+Please strive to follow the best-practices for commit messages which are outlined https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[here].
 
 [#contributing-cla]
 == CLA

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -196,9 +196,7 @@ Crux node independently. Being able to read your writes when using the HTTP
 interface requires stickiness to a particular node. For a cluster of nodes to
 be linearizable as a whole would require that every node always sees the result
 of every transaction immediately after it is written.  This could be achieved
-with the cost of non-trivial additional latency. Further reading:
-http://www.bailis.org/papers/hat-vldb2014.pdf,
-https://jepsen.io/consistency/models/sequential
+with the cost of non-trivial additional latency. Further reading: http://www.bailis.org/papers/hat-vldb2014.pdf[_Highly Available Transactions: Virtues and Limitations_], https://jepsen.io/consistency/models/sequential[_Sequential Consistency_].
 
 How is consistency provided by Crux?::
 

--- a/docs/get_started.adoc
+++ b/docs/get_started.adoc
@@ -81,4 +81,4 @@ include::./src/docs/examples.clj[tags=should-get-entity]
 
 === Next Steps
 
-Now you know the basics of how to interact with Crux you may want to dive into our <<#tutorials, tutorials>>. Otherwise, let's take a look at the kinds of things you are able to do with <<#queries,Queries>>.
+Now you know the basics of how to interact with Crux you may want to dive into our <<#tutorials, tutorials>> below. Otherwise, let's take a look at <<#configuration,setting up Crux>>.

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -31,8 +31,7 @@ other RDF features are available.
 
 The HTTP interface is provided as a Ring middleware in a Clojure namespace,
 located at `crux/crux-http-server/src/crux/http_server.clj`. There is an example of using this
-middleware in a full example HTTP server configuration:
-https://github.com/juxt/crux/tree/master/docs/example/standalone_webservice
+middleware in a https://github.com/juxt/crux/tree/master/docs/example/standalone_webservice[full example HTTP server configuration].
 
 Whilst CORS may be easily configured for use while prototyping a Single Page
 Application that uses Crux directly from a web browser, it is currently NOT


### PR DESCRIPTION
(See #468)

A pass over the docs, with some changes to hyperlinks and some minor re-organization. 
Further changes for re-organization need to be done within the website repository post these changes being merged (within `main.adoc`, removing the tutorial section and moving the tutorials section beneath 'Get Started').