### PR TITLE
Cleanup queries section, minor edits and additions

### DIFF
--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -48,7 +48,6 @@
 
 (t/deftest test-example-rocks-node
   (let [node (ex/example-start-rocks)]
-
     ;; Testing example node with RocksDB is created properly
     (t/is (not= nil node))
     ;; Testing example node with RocksDB is closed properly
@@ -70,7 +69,8 @@
     (t/is (= #{[:petr] [:ivan]} (ex/query-example-with-arguments-2 node)))
     (t/is (= #{[:petr] [:ivan]} (ex/query-example-with-arguments-3 node)))
     (t/is (= #{["Ivan"]} (ex/query-example-with-arguments-4 node)))
-    (t/is (= #{[22]} (ex/query-example-with-arguments-5 node))))
+    (t/is (= #{[22]} (ex/query-example-with-arguments-5 node)))
+    (t/is (= #{[21]} (ex/query-example-with-predicate-1 node))))
   (cio/delete-dir "data"))
 
 (t/deftest test-example-time-queries

--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -70,7 +70,8 @@
     (t/is (= #{[:petr] [:ivan]} (ex/query-example-with-arguments-3 node)))
     (t/is (= #{["Ivan"]} (ex/query-example-with-arguments-4 node)))
     (t/is (= #{[22]} (ex/query-example-with-arguments-5 node)))
-    (t/is (= #{[21]} (ex/query-example-with-predicate-1 node))))
+    (t/is (= #{[21]} (ex/query-example-with-predicate-1 node)))
+    (t/is (= [:smith]) (first (ex/query-example-lazy node))))
   (cio/delete-dir "data"))
 
 (t/deftest test-example-time-queries

--- a/docs/get_started.adoc
+++ b/docs/get_started.adoc
@@ -53,6 +53,7 @@ For the purposes of this Hello World, we are using the simplest configuration of
 include::./src/docs/examples.clj[tags=submit-tx]
 ----
 
+[#get-started-query]
 === Querying
 
 [source,clj]

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -192,7 +192,7 @@ include::./src/docs/examples.clj[tags=query-with-arguments5-r]
 ----
 
 [#queries_valid_time_travel]
-=== Valid time travel
+== Valid time travel
 
 Congratulations! You already know enough about queries to build a simple CRUD application with Crux. However, your manager has just told you that the new CRUD application you have been designing needs to backfill the historical document versions from the legacy CRUD application. Luckily Crux makes it easy for your application to both insert and retrieve these old versions.
 
@@ -247,31 +247,6 @@ Result Set:
 include::./src/docs/examples.clj[tags=query-at-t-q2-r]
 ----
 
-[#queries_history_api]
-== History API
-
-[#history_full_document_history]
-=== Full Document History
-Crux allows you to retrieve all versions of a document:
-[source,clj]
-----
-include::./src/docs/examples.clj[tags=history-full]
-----
-
-[#history_document_history_range]
-=== Document History Range
-Retrievable document versions can be bounded by four time coordinates:
-
-* valid-time-start
-* tx-time-start
-* valid-time-end
-* tx-time-end
-
-All coordinates are inclusive. All coordinates can be null.
-[source,clj]
-----
-include::./src/docs/examples.clj[tags=history-range]
-----
 
 [#queries_joins]
 == Joins
@@ -404,7 +379,6 @@ connected to a given entity via the `:follow` attribute.
            (follow ?t ?e2)]]})
 ----
 
-
 [#queries_lazy_queries]
 == Lazy Queries
 
@@ -413,6 +387,32 @@ optionally a `snapshot` which is already opened and managed by the caller
 (using `with-open` for example). This version of the call returns a lazy
 sequence of the results, while the other version provides a set. A snapshot can
 be retrieved from a `kv` instance via `crux.api/new-snapshot`.
+
+[#queries_history_api]
+== History API
+
+[#history_full_document_history]
+=== Full Document History
+Crux allows you to retrieve all versions of a document:
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=history-full]
+----
+
+[#history_document_history_range]
+=== Document History Range
+Retrievable document versions can be bounded by four time coordinates:
+
+* valid-time-start
+* tx-time-start
+* valid-time-end
+* tx-time-end
+
+All coordinates are inclusive. All coordinates can be null.
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=history-range]
+----
 
 [#queries_clojure_tips]
 == Clojure Tips

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -100,7 +100,7 @@ be returned, which in this case is simply `:smith` (the keyword database ID for
 the document relating to our protagonist "Smith Smith"). Results are returned
 as an edn set, which means duplicate results will not appear.
 
-The edn result set only contains the value `:smith`
+Passing the query into `crux.api/q` (see how to <<#get-started-query,submit a query>> in 'Get Started'), you get an edn result set containing the value `:smith`
 
 [source,clj]
 ----

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -401,7 +401,18 @@ The function `crux.api/q` takes 2 or 3 arguments, `db` and `q` but also
 optionally a `snapshot` which is already opened and managed by the caller
 (using `with-open` for example). This version of the call returns a lazy
 sequence of the results, while the other version provides a set. A snapshot can
-be retrieved from a `kv` instance via `crux.api/new-snapshot`.
+be retrieved from a `kv` instance via `crux.api/new-snapshot`. For example, a lazy version of a basic query from the top of this section:
+
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=lazy-query]
+----
+
+This will lazily return:
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=lazy-query-r]
+----
 
 [#queries_history_api]
 == History API

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -401,7 +401,7 @@ The function `crux.api/q` takes 2 or 3 arguments, `db` and `q` but also
 optionally a `snapshot` which is already opened and managed by the caller
 (using `with-open` for example). This version of the call returns a lazy
 sequence of the results, while the other version provides a set. A snapshot can
-be retrieved from a `kv` instance via `crux.api/new-snapshot`. For example, a lazy version of a basic query from the top of this section:
+be retrieved from a `kv` instance via `crux.api/new-snapshot`. For example, a lazy version of a basic query from the top of this section (using `with-open` to ensure that the snapshot is closed):
 
 [source,clj]
 ----

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -162,15 +162,6 @@ Result Set:
 include::./src/docs/examples.clj[tags=query-with-arguments3-r]
 ----
 
-=== Query: "Use predicates with arguments"
-
-[source,clj]
-----
-include::./src/docs/examples.clj[tags=query-with-arguments4]
-----
-
-Something else we can do with arguments is apply predicates to them directly within the clauses. Predicates return either `true` or `false` but all predicates used in clauses must return `true` in order for the given combination of field values to be part of the valid result set. In this case only `:name "Ivan"` satisfies `[(re-find #"I" n)]` (which returns true for any values that begin with "I").
-
 [source,clj]
 ----
 include::./src/docs/examples.clj[tags=query-with-arguments4-r]
@@ -190,6 +181,30 @@ Result Set:
 ----
 include::./src/docs/examples.clj[tags=query-with-arguments5-r]
 ----
+
+[#queries_predicates]
+== Predicates
+
+Something else we can do with arguments is apply *predicates* to them directly within the clauses. Predicates return either `true` or `false` but all predicates used in clauses must return `true` in order for the given combination of field values to be part of the valid result set:
+
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=query-with-arguments4]
+----
+
+In this case only `:name "Ivan"` satisfies `[(re-find #"I" n)]` (which returns true for any values that begin with "I"). Any *fully qualified* Clojure function function that returns a boolean can be used in place of `re-find`, for example:
+
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=query-with-pred-1]
+----
+
+Result:
+[source,clj]
+----
+include::./src/docs/examples.clj[tags=query-with-pred-1-r]
+----
+
 
 [#queries_valid_time_travel]
 == Valid time travel

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -275,13 +275,14 @@ node)
 
 (defn query-example-lazy [node]
   ;; tag::lazy-query[]
+(with-open [snapshot (crux.api/new-snapshot (crux/db node))]
   (crux/q
    (crux/db node)
-   (crux.api/new-snapshot (crux/db node))
+   snapshot
    '{:find [p1]
      :where [[p1 :name n]
              [p1 :last-name n]
-             [p1 :name "Smith"]]})
+             [p1 :name "Smith"]]}))
   ;; end::lazy-query[]
   )
 

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -257,6 +257,22 @@ node)
 ;; end::query-with-arguments5-r[]
 )
 
+(defn query-example-with-predicate-1 [node]
+  (crux/q
+   (crux/db node)
+   ;; tag::query-with-pred-1[]
+   {:find '[age]
+    :where '[[(odd? age)]]
+    :args [{'age 22} {'age 21}]}
+   ;; end::query-with-pred-1[]
+ ))
+
+#_(comment
+;; tag::query-with-pred-1-r[]
+#{[21]}
+;; end::query-with-pred-1-r[]
+)
+
 (defn query-example-at-time-setup [node]
  (crux/submit-tx
   node

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -273,6 +273,24 @@ node)
 ;; end::query-with-pred-1-r[]
 )
 
+(defn query-example-lazy [node]
+  ;; tag::lazy-query[]
+  (crux/q
+   (crux/db node)
+   (crux.api/new-snapshot (crux/db node))
+   '{:find [p1]
+     :where [[p1 :name n]
+             [p1 :last-name n]
+             [p1 :name "Smith"]]})
+  ;; end::lazy-query[]
+  )
+
+#_(comment
+;; tag::lazy-query-r[]
+([:smith])
+;; end::lazy-query-r[]
+)
+
 (defn query-example-at-time-setup [node]
  (crux/submit-tx
   node


### PR DESCRIPTION
(Fixes #470)

Some minor organization changes, addition of a small 'predicates' section (to be a bit more explicit in which functions can be used as predicates), and addition of examples to both this section and 'lazy queries' (inc. tests added for all the examples). 