### PR TITLE
Greater than range bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#506](https://github.com/juxt/crux/issues/506): Fix lifetime of EntityAsOfIdx within put/delete, was being closed too soon.
 * [#512](https://github.com/juxt/crux/issues/512): Fix race condition initialising id-hashing
+* [#545](https://github.com/juxt/crux/issues/545): Fix greater than range predicate bug on empty db
 
 ## 19.12-1.6.0-alpha
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -71,11 +71,11 @@
       (attribute-value+placeholder k peek-state)))
 
   (next-values [this]
-    (let [last-k (.last-k peek-state)
-          prefix-size (- (mem/capacity last-k) c/id-size c/id-size)]
-      (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer last-k prefix-size (.get seek-buffer-tl)) prefix-size))
-                            (kv/seek i))]
-        (attribute-value+placeholder k peek-state)))))
+    (when-let [last-k (.last-k peek-state)]
+      (let [prefix-size (- (mem/capacity last-k) c/id-size c/id-size)]
+        (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer last-k prefix-size (.get seek-buffer-tl)) prefix-size))
+                              (kv/seek i))]
+          (attribute-value+placeholder k peek-state))))))
 
 (defn new-doc-attribute-value-entity-value-index [snapshot attr]
   (let [attr (c/->id-buffer attr)
@@ -163,14 +163,14 @@
             placeholder)))))
 
   (next-values [this]
-    (let [last-k (.last-k peek-state)
-          prefix-size (+ c/index-id-size c/id-size c/id-size)]
-      (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer last-k prefix-size (.get seek-buffer-tl)) prefix-size))
-                            (kv/seek i))]
-        (let [placeholder (attribute-entity+placeholder k attr entity-as-of-idx peek-state)]
-          (if (= ::deleted-entity placeholder)
-            (recur)
-            placeholder))))))
+    (when-let [last-k (.last-k peek-state)]
+      (let [prefix-size (+ c/index-id-size c/id-size c/id-size)]
+        (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer last-k prefix-size (.get seek-buffer-tl)) prefix-size))
+                              (kv/seek i))]
+          (let [placeholder (attribute-entity+placeholder k attr entity-as-of-idx peek-state)]
+            (if (= ::deleted-entity placeholder)
+              (recur)
+              placeholder)))))))
 
 (defn new-doc-attribute-entity-value-entity-index [snapshot attr entity-as-of-idx]
   (let [attr (c/->id-buffer attr)

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -270,6 +270,14 @@
                                                   min-v)))]
     (->GreaterThanVirtualIndex idx)))
 
+(defn new-equals-virtual-index [idx v]
+  (let [v (c/->value-buffer v)
+        pred (value-comparsion-predicate zero? v)]
+    (->PredicateVirtualIndex idx pred (fn [k]
+                                        (if (pred k)
+                                          k
+                                          v)))))
+
 (defn new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
   (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (mem/capacity prefix-v))
         pred (value-comparsion-predicate zero? prefix-v (mem/capacity prefix-v))]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -244,8 +244,7 @@
            [var (->> (for [{:keys [op val sym]} clauses
                            :let [type-prefix (c/value-buffer-type-id (c/->value-buffer val))]]
                        (case op
-                         = #(-> (idx/new-greater-than-equal-virtual-index % val)
-                                (idx/new-less-than-equal-virtual-index val)
+                         = #(-> (idx/new-equals-virtual-index % val)
                                 (idx/new-prefix-equal-virtual-index type-prefix))
                          < #(-> (idx/new-less-than-virtual-index % val)
                                 (idx/new-prefix-equal-virtual-index type-prefix))

--- a/crux-test/test/crux/index_test.clj
+++ b/crux-test/test/crux/index_test.clj
@@ -340,6 +340,13 @@
              (->> (idx/idx->seq (idx/new-greater-than-equal-virtual-index r 2))
                   (map second))))
 
+    (t/is (= [2]
+             (->> (idx/idx->seq (idx/new-equals-virtual-index r 2))
+                  (map second))))
+
+    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r 0))))
+    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r 6))))
+
     (t/testing "seek skips to lower range"
       (t/is (= 2 (second (db/seek-values (idx/new-greater-than-equal-virtual-index r 2) (c/->value-buffer nil)))))
       (t/is (= 3 (second (db/seek-values (idx/new-greater-than-virtual-index r 2) (c/->value-buffer 1))))))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2689,12 +2689,13 @@
          (api/q (api/db *api*)
                 '{:find [offset]
                   :where [[e :offset offset]
-                          [(> offset -9223372036854775808)]] ;; Long/MAX_VALUE
+                          [(> offset -9223372036854775808)]] ;; Long/MIN_VALUE
                   :limit 1})))
 
-  (t/is (empty?
-         (api/q (api/db *api*)
-                '{:find [offset]
-                  :where [[e :offset offset]
-                          [(= e :foo)]]
-                  :limit 1}))))
+  (t/testing "checking that entity ranges don't have same bug"
+    (t/is (empty?
+           (api/q (api/db *api*)
+                  '{:find [offset]
+                    :where [[e :offset offset]
+                            [(= e :foo)]]
+                    :limit 1})))))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2683,3 +2683,18 @@
                                            snapshot-hit-ns)))))
                          (repeatedly n))]
         (t/is (>= (/ (reduce + factors) n) acceptable-snapshot-speedup))))))
+
+(t/deftest test-greater-than-range-predicate-545
+  (t/is (empty?
+         (api/q (api/db *api*)
+                '{:find [offset]
+                  :where [[e :offset offset]
+                          [(> offset -9223372036854775808)]] ;; Long/MAX_VALUE
+                  :limit 1})))
+
+  (t/is (empty?
+         (api/q (api/db *api*)
+                '{:find [offset]
+                  :where [[e :offset offset]
+                          [(= e :foo)]]
+                  :limit 1}))))


### PR DESCRIPTION
Reproduces and fixes issue occurring when using `>` queries against an empty database. Also includes a small refactoring to the `=` range predicate.