### PR TITLE
introducing await-tx/await-tx-time (#466 pt 1)

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -117,18 +117,31 @@
   Returns true if the entity was updated in this transaction.")
 
   (sync
+    [node]
     [node ^Duration timeout]
-    [node ^Date transaction-time ^Duration timeout]
-    "If the transaction-time is supplied, blocks until indexing has
-  processed a tx with a greater-than transaction-time, otherwise
-  blocks until the node has caught up indexing the tx-log
-  backlog. Will throw an exception on timeout. The returned date is
-  the latest index time when this node has caught up as of this
-  call. This can be used as the second parameter in (db valid-time,
-  transaction-time) for consistent reads.
+    ^:deprecated [node ^Date transaction-time ^Duration timeout]
+    "Blocks until the node has caught up indexing to the latest tx available at
+  the time this method is called. Will throw an exception on timeout. The
+  returned date is the latest transaction time indexed by this node. This can be
+  used as the second parameter in (db valid-time, transaction-time) for
+  consistent reads.
 
   timeout – max time to wait, can be nil for the default.
   Returns the latest known transaction time.")
+
+  (await-tx-time
+    [node ^Date tx-time]
+    [node ^Date tx-time ^Duration timeout]
+    "Blocks until the node has indexed a transaction that is past the supplied
+  txTime. Will throw on timeout. The returned date is the latest index time when
+  this node has caught up as of this call.")
+
+  (await-tx
+    [node tx]
+    [node tx ^Duration timeout]
+    "Blocks until the node has indexed a transaction that is at or past the
+  supplied tx. Will throw on timeout. Returns the most recent tx indexed by the
+  node.")
 
   (attribute-stats [node]
     "Returns frequencies map for indexed attributes"))
@@ -192,10 +205,26 @@
     (.hasSubmittedTxCorrectedEntity this submitted-tx valid-time eid))
 
   (sync
+    ([this]
+     (.sync this nil))
     ([this timeout]
      (.sync this timeout))
+
+    ;; TODO deprecated
     ([this transaction-time timeout]
-     (.sync this transaction-time timeout)))
+     (.awaitTxTime this transaction-time timeout)))
+
+  (await-tx
+    ([this tx]
+     (await-tx this tx nil))
+    ([this tx timeout]
+     (.awaitTx this tx timeout)))
+
+  (await-tx-time
+    ([this tx-time]
+     (await-tx-time this tx-time nil))
+    ([this tx-time timeout]
+     (.awaitTxTime this tx-time timeout)))
 
   (attribute-stats [this]
     (.attributeStats this)))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -2,7 +2,8 @@
   "Public API of Crux."
   (:refer-clojure :exclude [sync])
   (:require [clojure.spec.alpha :as s]
-            [crux.codec :as c])
+            [crux.codec :as c]
+            [clojure.tools.logging :as log])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
             ICruxAsyncIngestAPI ICruxDatasource]
            java.io.Closeable
@@ -210,9 +211,10 @@
     ([this timeout]
      (.sync this timeout))
 
-    ;; TODO deprecated
-    ([this transaction-time timeout]
-     (.awaitTxTime this transaction-time timeout)))
+    ([this tx-time timeout]
+     (defonce warn-on-deprecated-sync
+       (log/warn "(sync tx-time <timeout?>) is deprecated, replace with either (await-tx-time tx-time <timeout?>) or, preferably, (await-tx tx <timeout?>)"))
+     (.awaitTxTime this tx-time timeout)))
 
   (await-tx
     ([this tx]

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -217,10 +217,10 @@
      (.awaitTxTime this tx-time timeout)))
 
   (await-tx
-    ([this tx]
-     (await-tx this tx nil))
-    ([this tx timeout]
-     (.awaitTx this tx timeout)))
+    ([this submitted-tx]
+     (await-tx this submitted-tx nil))
+    ([this submitted-tx timeout]
+     (.awaitTx this submitted-tx timeout)))
 
   (await-tx-time
     ([this tx-time]

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -96,7 +96,7 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      * @return the status map.
      */
     public Map<Keyword,?> status();
-    // todo elaborate
+    // TODO elaborate
 
     /**
      * Checks if a submitted tx did update an entity.
@@ -121,28 +121,44 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
     public boolean hasSubmittedTxCorrectedEntity(Map<Keyword,?> submittedTx, Date validTime, Object eid);
 
     /**
-     * Blocks until the node has caught up indexing. Will throw an
-     * exception on timeout. The returned date is the latest index
-     * time when this node has caught up as of this call. This can be
-     * used as the second parameter in {@link #db(Date validTime,
-     * Date transactionTime)} for consistent reads.
+     * Blocks until the node has caught up indexing to the latest tx available
+     * at the time this method is called. Will throw an exception on timeout.
+     * The returned date is the latest transaction time indexed by this node.
+     * This can be used as the second parameter in {@link #db(Date validTime, Date transactionTime)}
+     * for consistent reads.
      *
      * @param timeout max time to wait, can be null for the default.
-     * @return        the latest known transaction time.
+     * @return the latest known transaction time.
      */
     public Date sync(Duration timeout);
 
     /**
-     * Blocks until the node has indexed a transaction that is past
-     * the supplied transactionTime. Will throw a timeout. The
-     * returned date is the latest index time when this node has
-     * caught up as of this call.
-     *
-     * @param transactionTime transaction time to sync past.
-     * @param timeout max time to wait, can be null for the default.
-     * @return        the latest known transaction time.
+     * @deprecated see {@link #awaitTxTime}
      */
-    public Date sync(Date transactionTime, Duration timeout);
+    @Deprecated
+    public Date sync(Date txTime, Duration timeout);
+
+    /**
+     * Blocks until the node has indexed a transaction that is past the supplied
+     * txTime. Will throw on timeout. The returned date is the latest index time
+     * when this node has caught up as of this call.
+     *
+     * @param txTime transaction time to await.
+     * @param timeout max time to wait, can be null for the default.
+     * @return the latest known transaction time.
+     */
+    public Date awaitTxTime(Date txTime, Duration timeout);
+
+    /**
+     * Blocks until the node has indexed a transaction that is at or past the
+     * supplied tx. Will throw on timeout. Returns the most recent tx indexed by
+     * the node.
+     *
+     * @param tx Transaction to await, as returned from submitTx.
+     * @param timeout max time to wait, can be null for the default.
+     * @return the latest known transaction.
+     */
+    public Map<Keyword, ?> awaitTx(Map<Keyword,?> tx, Duration timeout);
 
     /**
      * Return frequencies of indexed attributes.

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -28,7 +28,8 @@
   (submit-doc [this content-hash doc])
   (submit-tx [this tx-ops])
   (new-tx-log-context ^java.io.Closeable [this])
-  (tx-log [this tx-log-context from-tx-id]))
+  (tx-log [this tx-log-context from-tx-id])
+  (latest-submitted-tx [this]))
 ;; end::TxLog[]
 
 ;; NOTE: The snapshot parameter here is an optimisation to avoid keep

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -293,9 +293,12 @@
 
 ;; Meta
 
+(defn meta-kv [k v]
+  [(c/encode-meta-key-to (.get seek-buffer-tl) (c/->id-buffer k))
+   (mem/->off-heap (nippy/fast-freeze v))])
+
 (defn store-meta [kv k v]
-  (kv/store kv [[(c/encode-meta-key-to (.get seek-buffer-tl) (c/->id-buffer k))
-                 (mem/->off-heap (nippy/fast-freeze v))]]))
+  (kv/store kv [(meta-kv k v)]))
 
 (defn read-meta [kv k]
   (let [seek-k (c/encode-meta-key-to (.get seek-buffer-tl) (c/->id-buffer k))]

--- a/crux-core/src/crux/moberg.clj
+++ b/crux-core/src/crux/moberg.clj
@@ -234,6 +234,11 @@
            :crux.tx/tx-id (.message-id m)
            :crux.tx/tx-time (.message-time m)}))))
 
+  (latest-submitted-tx [_]
+    (let [end-offset (end-message-id-offset event-log-kv ::event-log)]
+      (when (> end-offset 1)
+        {:crux.tx/tx-id (dec end-offset)})))
+
   backup/INodeBackup
   (write-checkpoint [this {:keys [crux.backup/checkpoint-directory]}]
     (kv/backup event-log-kv (io/file checkpoint-directory "event-log-kv-store"))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -137,10 +137,8 @@
           tx-log-entry))))
 
   (sync [this timeout]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (-> (tx/await-no-consumer-lag indexer (or (and timeout (.toMillis timeout))
-                                                (:crux.tx-log/await-tx-timeout options)))
+    (when-let [tx (db/latest-submitted-tx (:tx-log this))]
+      (-> (api/await-tx this tx nil)
           :crux.tx/tx-time)))
 
   (awaitTxTime [this tx-time timeout]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -148,11 +148,11 @@
                                                 (:crux.tx-log/await-tx-timeout options)))
           :crux.tx/tx-time)))
 
-  (awaitTx [this tx timeout]
+  (awaitTx [this submitted-tx timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (tx/await-tx indexer tx (or (and timeout (.toMillis timeout))
-                                  (:crux.tx-log/await-tx-timeout options)))))
+      (tx/await-tx indexer submitted-tx (or (and timeout (.toMillis timeout))
+                                            (:crux.tx-log/await-tx-timeout options)))))
 
   ICruxAsyncIngestAPI
   (submitTxAsync [this tx-ops]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -379,7 +379,10 @@
                   (post-commit-fn)))
 
             (do (log/warn "Transaction aborted:" (cio/pr-edn-str tx-events) (cio/pr-edn-str tx-time) tx-id)
-                (kv/store kv-store [[(c/encode-failed-tx-id-key-to nil tx-id) c/empty-buffer]])))))))
+                (kv/store kv-store [[(c/encode-failed-tx-id-key-to nil tx-id) c/empty-buffer]])))
+
+          (db/store-index-meta this :crux.tx/latest-completed-tx tx)
+          tx))))
 
   (docs-exist? [_ content-hashes]
     (with-open [snapshot (kv/new-snapshot kv-store)]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -419,7 +419,6 @@
                (str "Timed out waiting for index to catch up, lag is: " (or (max-lag-fn)
                                                                             "unknown")))))))
 
-;;; TODO need to expose this as node/await-tx when 'sync' goes
 (defn await-tx [indexer {::keys [tx-id] :as tx} timeout-ms]
   (let [seen-tx (atom nil)]
     (if (cio/wait-while #(let [latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)]
@@ -432,8 +431,7 @@
               (str "Timed out waiting for: " (cio/pr-edn-str tx)
                    " index has: " (cio/pr-edn-str @seen-tx)))))))
 
-;;; will remove this when 'sync' goes
-(defn ^:deprecated await-tx-time [indexer transact-time timeout-ms]
+(defn await-tx-time [indexer transact-time timeout-ms]
   (let [seen-tx (atom nil)]
     (if (cio/wait-while #(let [latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)]
                            (reset! seen-tx latest-completed-tx)

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -29,8 +29,7 @@
                     (doseq [^Message tx-msg tx-msgs]
                       (let [tx {:crux.tx/tx-time (.message-time tx-msg)
                                 :crux.tx/tx-id (.message-id tx-msg)}]
-                        (db/index-tx indexer tx (.body tx-msg))
-                        (db/store-index-meta indexer :crux.tx/latest-completed-tx tx)))
+                        (db/index-tx indexer tx (.body tx-msg))))
 
                     (if-let [^Message last-msg (last msgs)]
                       (let [end-offset (consumer/end-offset event-log-consumer)

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -12,9 +12,7 @@
   (when-not (db/read-index-meta indexer :crux.tx-log/consumer-state)
     (db/store-index-meta
      indexer
-     :crux.tx-log/consumer-state {:crux.tx/event-log {:lag 0
-                                                      :next-offset 0
-                                                      :time nil}}))
+     :crux.tx-log/consumer-state {:crux.tx/event-log {:next-offset 0}}))
   (while @running?
     (let [idle? (with-open [context (consumer/new-event-log-context event-log-consumer)]
                   (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
@@ -32,16 +30,8 @@
                         (db/index-tx indexer tx (.body tx-msg))))
 
                     (if-let [^Message last-msg (last msgs)]
-                      (let [end-offset (consumer/end-offset event-log-consumer)
-                            next-offset (inc (long (.message-id last-msg)))
-                            time (.message-time last-msg)
-                            lag (- end-offset next-offset)
-                            _ (when (pos? lag)
-                                (log/debug "Falling behind" ::event-log "at:" next-offset "end:" end-offset))
-                            consumer-state {:crux.tx/event-log
-                                            {:lag lag
-                                             :next-offset next-offset
-                                             :time time}}]
+                      (let [next-offset (inc (long (.message-id last-msg)))
+                            consumer-state {:crux.tx/event-log {:next-offset next-offset}}]
                         (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
                         (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
                         false)

--- a/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
+++ b/crux-dev/dev/crux_microbench/cached_entities_index_in_vivo.clj
@@ -80,7 +80,7 @@
                         (range history-days))]
     (println "Txes submitted, synchronizing...")
     (let [sync-time (crux.bench/duration-millis
-                     (api/sync crux-node (:crux.tx/tx-time last-tx) (Duration/ofMinutes 20)))]
+                     (api/await-tx crux-node last-tx (Duration/ofMinutes 20)))]
       (swap! sync-times assoc [stocks-count history-days] sync-time)
       (println "Sync takes: " sync-time))))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -246,7 +246,7 @@
         transaction-time (some->> (get-in request [:query-params "transactionTime"])
                                   (cio/parse-rfc3339-or-millis-date))]
     (let [last-modified (if transaction-time
-                          (.sync crux-node transaction-time timeout)
+                          (.awaitTxTime crux-node transaction-time timeout)
                           (.sync crux-node timeout))]
       (-> (success-response last-modified)
           (add-last-modified last-modified)))))

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -130,7 +130,13 @@
          (lazy-seq
           (when-let [x (.poll q 5000 TimeUnit/MILLISECONDS)]
             (when (not= -1 x)
-              (cons x (step))))))))))
+              (cons x (step)))))))))
+
+  (latest-submitted-tx [this]
+    (when-let [max-offset (-> (jdbc/execute-one! ds ["SELECT max(EVENT_OFFSET) AS max_offset FROM tx_events"]
+                                                 {:builder-fn jdbcr/as-unqualified-lower-maps})
+                              :max_offset)]
+      {:crux.tx/tx-id max-offset})))
 
 (defn- event-result->message [dbtype result]
   (Message. (->v dbtype (:v result))

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -140,7 +140,14 @@
          (lazy-seq
           (when-let [records (seq (.poll tx-topic-consumer (Duration/ofMillis 1000)))]
             (concat (map tx-record->tx-log-entry records)
-                    (step)))))))))
+                    (step))))))))
+
+  (latest-submitted-tx [this]
+    (with-open [consumer (create-consumer kafka-config)]
+      (let [tx-tp (TopicPartition. tx-topic 0)
+            end-offset (-> (.endOffsets consumer [tx-tp]) (get tx-tp))]
+        (when (pos? end-offset)
+          {:crux.tx/tx-id (dec end-offset)})))))
 
 ;;; Indexing Consumer
 
@@ -152,33 +159,23 @@
                                        (TopicPartition. (.topic r)
                                                         (.partition r))) records)
         partitions (vec (keys partition->records))
-        end-offsets (.endOffsets consumer partitions)
         stored-consumer-state (or (db/read-index-meta indexer :crux.tx-log/consumer-state) {})
         consumer-state (->> (for [^TopicPartition partition partitions
                                   :let [^ConsumerRecord last-record-in-batch (->> (get partition->records partition)
                                                                                   (sort-by #(.offset ^ConsumerRecord %))
                                                                                   (last))
-                                        next-offset (inc (.offset last-record-in-batch))
-                                        end-offset (get end-offsets partition)
-                                        lag (- end-offset next-offset)]]
-                              (do (when-not (zero? lag)
-                                    (log/debug "Falling behind" (str partition) "at:" next-offset "end:" end-offset))
-                                  [(topic-partition-meta-key partition)
-                                   {:next-offset next-offset
-                                    :time (Date. (.timestamp last-record-in-batch))
-                                    :lag lag}]))
+                                        next-offset (inc (.offset last-record-in-batch))]]
+                              [(topic-partition-meta-key partition)
+                               {:next-offset next-offset}])
                             (into stored-consumer-state))]
     (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)))
 
 (defn- prune-consumer-state [indexer ^KafkaConsumer consumer partitions]
-  (let [consumer-state (db/read-index-meta indexer :crux.tx-log/consumer-state)
-        end-offsets (.endOffsets consumer (vec partitions))]
+  (let [consumer-state (db/read-index-meta indexer :crux.tx-log/consumer-state)]
     (->> (for [^TopicPartition partition partitions
                :let [partition-key (topic-partition-meta-key partition)
                      next-offset (or (get-in consumer-state [partition-key :next-offset]) 0)]]
-           [partition-key {:next-offset next-offset
-                           :lag (- (dec (get end-offsets partition)) next-offset)
-                           :time (get-in consumer-state [partition-key :time])}])
+           [partition-key {:next-offset next-offset}])
          (into {})
          (db/store-index-meta indexer :crux.tx-log/consumer-state))))
 

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -234,10 +234,7 @@
                         (vec))]
 
     (doseq [record tx-records]
-      (index-tx-record indexer record)
-      (db/store-index-meta indexer :crux.tx/latest-completed-tx (-> record
-                                                                    tx-record->tx-log-entry
-                                                                    (select-keys [:crux.tx/tx-id :crux.tx/tx-time]))))
+      (index-tx-record indexer record))
 
     (when-let [records (seq (concat doc-records tx-records))]
       (update-stored-consumer-state indexer consumer records)

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -28,7 +28,8 @@
 (def topology {:crux.node/tx-log k/tx-log
                :crux.kafka/admin-client k/admin-client
                :crux.kafka/admin-wrapper k/admin-wrapper
-               :crux.kafka/producer k/producer})
+               :crux.kafka/producer k/producer
+               :crux.kafka/latest-submitted-tx-consumer k/latest-submitted-tx-consumer})
 
 (defn new-ingest-client ^ICruxAsyncIngestAPI [options]
   (let [[{:keys [crux.node/tx-log]} close-fn] (n/start-modules topology options)]

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -4,7 +4,7 @@
             [crux.fixtures.standalone :as fs]
             [crux.moberg]
             [crux.codec :as c]
-            [crux.fixtures.api :refer [*api*] :as apif]
+            [crux.fixtures.api :refer [*api*] :as fapi]
             [crux.fixtures.kv :as kvf]
             [crux.fixtures.kafka :as fk :refer [*ingest-client*]]
             crux.jdbc
@@ -13,7 +13,7 @@
             [crux.fixtures.kafka :as kf]
             [crux.rdf :as rdf]
             [crux.api :as api]
-            [crux.fixtures.api :as apif]
+            [crux.fixtures.api :as fapi]
             [crux.db :as db]
             [crux.query :as q])
   (:import crux.api.NodeOutOfSyncException
@@ -38,7 +38,7 @@
         fs/with-standalone-node))))
 
 (t/use-fixtures :once fk/with-embedded-kafka-cluster)
-(t/use-fixtures :each with-each-api-implementation kvf/with-kv-dir apif/with-node)
+(t/use-fixtures :each with-each-api-implementation kvf/with-kv-dir fapi/with-node)
 
 (declare execute-sparql)
 
@@ -364,8 +364,7 @@
                     (lazy-seq (step)))))))))
 
 (t/deftest test-db-throws-if-future-tx-time-provided
-  (let [{:keys [^Date crux.tx/tx-time]} (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]])
-        _ (api/sync *api* tx-time nil)
+  (let [{:keys [^Date crux.tx/tx-time]} (fapi/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
         the-future (Date. (+ (.getTime tx-time) 10000))]
     (t/is (thrown? NodeOutOfSyncException (api/db *api* the-future the-future)))))
 

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -14,7 +14,8 @@
             [crux.rdf :as rdf]
             [crux.api :as api]
             [crux.fixtures.api :as apif]
-            [crux.db :as db])
+            [crux.db :as db]
+            [crux.query :as q])
   (:import crux.api.NodeOutOfSyncException
            clojure.lang.LazySeq
            java.util.Date
@@ -371,6 +372,10 @@
 (t/deftest test-latest-submitted-tx
   (t/is (nil? (db/latest-submitted-tx (:tx-log *api*))))
 
-  (let [{:keys [crux.tx/tx-id]} (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]])]
+  (let [{:keys [crux.tx/tx-id] :as tx} (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]])]
     (t/is (= {:crux.tx/tx-id tx-id}
-             (db/latest-submitted-tx (:tx-log *api*))))))
+             (db/latest-submitted-tx (:tx-log *api*)))))
+
+  (api/sync *api*)
+
+  (t/is (= {:crux.db/id :foo} (api/entity (api/db *api*) :foo))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -50,14 +50,14 @@
 (t/deftest test-can-write-entity-using-map-as-id
   (let [doc {:crux.db/id {:user "Xwop1A7Xog4nD6AfhZaPgg"} :name "Adam"}
         submitted-tx (.submitTx *api* [[:crux.tx/put doc]])]
-    (.sync *api* (:crux.tx/tx-time submitted-tx) nil)
+    (.awaitTx *api* submitted-tx nil)
     (t/is (.entity (.db *api*) {:user "Xwop1A7Xog4nD6AfhZaPgg"}))))
 
 (t/deftest test-can-use-crux-ids
   (let [id #crux/id :https://adam.com
         doc {:crux.db/id id, :name "Adam"}
         submitted-tx (.submitTx *api* [[:crux.tx/put doc]])]
-    (.sync *api* (:crux.tx/tx-time submitted-tx) nil)
+    (.awaitTx *api* submitted-tx nil)
     (t/is (.entity (.db *api*) id))))
 
 (t/deftest test-single-id
@@ -66,8 +66,8 @@
 
     (t/testing "put works with no id"
       (t/is
-       (let [{:keys [crux.tx/tx-time]} (.submitTx *api* [[:crux.tx/put content-ivan valid-time]])]
-         (.sync *api* tx-time nil)
+       (let [{:crux.tx/keys [tx-time] :as tx} (.submitTx *api* [[:crux.tx/put content-ivan valid-time]])]
+         (.awaitTx *api* tx nil)
          (.db *api* valid-time tx-time))))
 
     (t/testing "Delete works with id"
@@ -88,10 +88,8 @@
 
   (t/testing "transaction"
     (let [valid-time (Date.)
-          {:keys [crux.tx/tx-time
-                  crux.tx/tx-id]
-           :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
-      (t/is (= tx-time (.sync *api* (:crux.tx/tx-time submitted-tx) nil)))
+          {:crux.tx/keys [tx-time tx-id] :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+      (t/is (= submitted-tx (.awaitTx *api* submitted-tx nil)))
       (t/is (true? (.hasSubmittedTxUpdatedEntity *api* submitted-tx :ivan)))
 
       (let [status-map (.status *api*)]
@@ -165,7 +163,7 @@
           (t/is (= ivan (.document *api* (:crux.db/content-hash entity-tx))))
           (t/is (= {ivan-crux-id ivan} (.documents *api* #{(:crux.db/content-hash entity-tx)})))
           (t/is (= [entity-tx] (.history *api* :ivan)))
-          (t/is (= [entity-tx] (.historyRange *api* :ivan #inst "1990" #inst "1990" (:crux.tx/tx-time submitted-tx) (:crux.tx/tx-time submitted-tx))))
+          (t/is (= [entity-tx] (.historyRange *api* :ivan #inst "1990" #inst "1990" tx-time tx-time)))
 
           (t/is (nil? (.document *api* (c/new-id :does-not-exist))))
           (t/is (nil? (.entityTx (.db *api* #inst "1999") :ivan)))))
@@ -204,21 +202,17 @@
 
         (t/testing "updated"
           (let [valid-time (Date.)
-                {:keys [crux.tx/tx-time
-                        crux.tx/tx-id]
-                 :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
+                submitted-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
             (t/is (true? (.hasSubmittedTxUpdatedEntity *api* submitted-tx :ivan)))
-            (t/is (= tx-time (.sync *api* (:crux.tx/tx-time submitted-tx) nil))))
+            (t/is (= submitted-tx (.awaitTx *api* submitted-tx nil))))
 
           (let [stats (.attributeStats *api*)]
             (t/is (= 2 (:name stats)))))
 
         (t/testing "reflect evicted documents"
           (let [valid-time (Date.)
-                {:keys [crux.tx/tx-time
-                        crux.tx/tx-id]
-                 :as submitted-tx} (.submitTx *api* [[:crux.tx/evict :ivan]])]
-            (t/is (.sync *api* tx-time nil))
+                submitted-tx (.submitTx *api* [[:crux.tx/evict :ivan]])]
+            (t/is (.awaitTx *api* submitted-tx nil))
 
             ;; actual removal of the document happens asynchronously after
             ;; the transaction has been processed so waiting on the
@@ -233,9 +227,8 @@
         (t/testing "Add back evicted document"
           (assert (not (.entity (.db *api*) :ivan)))
           (let [valid-time (Date.)
-                {:keys [crux.tx/tx-time]
-                 :as submitted-tx} (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
-            (t/is (.sync *api* tx-time nil))
+                submitted-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+            (t/is (.awaitTx *api* submitted-tx nil))
             (t/is (.entity (.db *api*) :ivan))))))))
 
 (t/deftest test-document-bug-123
@@ -271,10 +264,14 @@
             (t/is (= 2 (count result)))))))))
 
 (t/deftest test-db-history-api
-  (let [version-1-submitted-tx-time (.sync *api* (:crux.tx/tx-time (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1} #inst "2019-02-01"]])) nil)
-        version-2-submitted-tx-time (.sync *api* (:crux.tx/tx-time (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2} #inst "2019-02-02"]])) nil)
-        version-3-submitted-tx-time (.sync *api* (:crux.tx/tx-time (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 3} #inst "2019-02-03"]])) nil)
-        version-2-corrected-submitted-tx-time (.sync *api* (:crux.tx/tx-time (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true} #inst "2019-02-02"]])) nil)]
+  (let [version-1-submitted-tx-time (-> (.awaitTx *api* (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1} #inst "2019-02-01"]]) nil)
+                                        :crux.tx/tx-time)
+        version-2-submitted-tx-time (-> (.awaitTx *api* (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2} #inst "2019-02-02"]]) nil)
+                                        :crux.tx/tx-time)
+        version-3-submitted-tx-time (-> (.awaitTx *api* (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 3} #inst "2019-02-03"]]) nil)
+                                        :crux.tx/tx-time)
+        version-2-corrected-submitted-tx-time (-> (.awaitTx *api* (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true} #inst "2019-02-02"]]) nil)
+                                                  :crux.tx/tx-time)]
 
     (let [history (.history *api* :ivan)]
       (t/is (= 4 (count history))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -13,7 +13,8 @@
             [crux.fixtures.kafka :as kf]
             [crux.rdf :as rdf]
             [crux.api :as api]
-            [crux.fixtures.api :as apif])
+            [crux.fixtures.api :as apif]
+            [crux.db :as db])
   (:import crux.api.NodeOutOfSyncException
            clojure.lang.LazySeq
            java.util.Date
@@ -366,3 +367,10 @@
         _ (api/sync *api* tx-time nil)
         the-future (Date. (+ (.getTime tx-time) 10000))]
     (t/is (thrown? NodeOutOfSyncException (api/db *api* the-future the-future)))))
+
+(t/deftest test-latest-submitted-tx
+  (t/is (nil? (db/latest-submitted-tx (:tx-log *api*))))
+
+  (let [{:keys [crux.tx/tx-id]} (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]])]
+    (t/is (= {:crux.tx/tx-id tx-id}
+             (db/latest-submitted-tx (:tx-log *api*))))))

--- a/crux-test/test/crux/bitemporal_tale_test.clj
+++ b/crux-test/test/crux/bitemporal_tale_test.clj
@@ -23,103 +23,94 @@
 
     (t/is system)
 
-    (crux/sync system (:crux.tx/tx-time
-                       (crux/submit-tx
-                        system
-                        [[:crux.tx/put
-                          {:crux.db/id :ids.people/Charles
-                           :person/name "Charles"
-                           :person/born #inst "1700-05-18"
-                           :person/location :ids.places/rarities-shop
-                           :person/str  40
-                           :person/int  40
-                           :person/dex  40
-                           :person/hp   40
-                           :person/gold 10000}
-                          #inst "1700-05-18"]]))
-               nil)
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/put
+                             {:crux.db/id :ids.people/Charles
+                              :person/name "Charles"
+                              :person/born #inst "1700-05-18"
+                              :person/location :ids.places/rarities-shop
+                              :person/str  40
+                              :person/int  40
+                              :person/dex  40
+                              :person/hp   40
+                              :person/gold 10000}
+                             #inst "1700-05-18"]]))
 
-    (crux/sync system (:crux.tx/tx-time
-                       (crux/submit-tx
-                        system
-                        [[:crux.tx/put
-                          {:crux.db/id :ids.people/Mary
-                           :person/name "Mary"
-                           :person/born #inst "1710-05-18"
-                           :person/location :ids.places/carribean
-                           :person/str  40
-                           :person/int  50
-                           :person/dex  50
-                           :person/hp   50}
-                          #inst "1710-05-18"]
-                         [:crux.tx/put
-                          {:crux.db/id :ids.people/Joe
-                           :person/name "Joe"
-                           :person/born #inst "1715-05-18"
-                           :person/location :ids.places/city
-                           :person/str  39
-                           :person/int  40
-                           :person/dex  60
-                           :person/hp   60
-                           :person/gold 70}
-                          #inst "1715-05-18"]]))
-               nil)
-    (crux/sync system (:crux.tx/tx-time
-                       (crux/submit-tx
-                        system
-                        [[:crux.tx/put
-                          {:crux.db/id :ids.artefacts/cozy-mug
-                           :artefact/title "A Rather Cozy Mug"
-                           :artefact.perks/int 3}
-                          #inst "1625-05-18"]
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/put
+                             {:crux.db/id :ids.people/Mary
+                              :person/name "Mary"
+                              :person/born #inst "1710-05-18"
+                              :person/location :ids.places/carribean
+                              :person/str  40
+                              :person/int  50
+                              :person/dex  50
+                              :person/hp   50}
+                             #inst "1710-05-18"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.people/Joe
+                              :person/name "Joe"
+                              :person/born #inst "1715-05-18"
+                              :person/location :ids.places/city
+                              :person/str  39
+                              :person/int  40
+                              :person/dex  60
+                              :person/hp   60
+                              :person/gold 70}
+                             #inst "1715-05-18"]]))
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/put
+                             {:crux.db/id :ids.artefacts/cozy-mug
+                              :artefact/title "A Rather Cozy Mug"
+                              :artefact.perks/int 3}
+                             #inst "1625-05-18"]
 
-                         [:crux.tx/put
-                          {:crux.db/id :ids.artefacts/forbidden-beans
-                           :artefact/title "Magic beans"
-                           :artefact.perks/int 30
-                           :artefact.perks/hp -20}
-                          #inst "1500-05-18"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.artefacts/forbidden-beans
+                              :artefact/title "Magic beans"
+                              :artefact.perks/int 30
+                              :artefact.perks/hp -20}
+                             #inst "1500-05-18"]
 
-                         [:crux.tx/put
-                          {:crux.db/id :ids.artefacts/pirate-sword
-                           :artefact/title "A used sword"}
-                          #inst "1710-05-18"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.artefacts/pirate-sword
+                              :artefact/title "A used sword"}
+                             #inst "1710-05-18"]
 
-                         [:crux.tx/put
-                          {:crux.db/id :ids.artefacts/flintlock-pistol
-                           :artefact/title "Flintlock pistol"}
-                          #inst "1710-05-18"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.artefacts/flintlock-pistol
+                              :artefact/title "Flintlock pistol"}
+                             #inst "1710-05-18"]
 
-                         [:crux.tx/put
-                          {:crux.db/id :ids.artefacts/unknown-key
-                           :artefact/title "Key from an unknown door"}
-                          #inst "1700-05-18"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.artefacts/unknown-key
+                              :artefact/title "Key from an unknown door"}
+                             #inst "1700-05-18"]
 
-                         [:crux.tx/put
-                          {:crux.db/id :ids.artefacts/laptop
-                           :artefact/title "A Tell DPS Laptop (what?)"}
-                          #inst "2016-05-18"]]))
-               nil)
+                            [:crux.tx/put
+                             {:crux.db/id :ids.artefacts/laptop
+                              :artefact/title "A Tell DPS Laptop (what?)"}
+                             #inst "2016-05-18"]]))
 
-    (crux/sync system (:crux.tx/tx-time
-                       (crux/submit-tx
-                        system
-                        [[:crux.tx/put
-                          {:crux.db/id :ids.places/continent
-                           :place/title "Ah The Continent"}
-                          #inst "1000-01-01"]
-                         [:crux.tx/put
-                          {:crux.db/id :ids.places/carribean
-                           :place/title "Ah The Good Ol Carribean Sea"
-                           :place/location :ids.places/carribean}
-                          #inst "1000-01-01"]
-                         [:crux.tx/put
-                          {:crux.db/id :ids.places/coconut-island
-                           :place/title "Coconut Island"
-                           :place/location :ids.places/carribean}
-                          #inst "1000-01-01"]]))
-               nil)
-
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/put
+                             {:crux.db/id :ids.places/continent
+                              :place/title "Ah The Continent"}
+                             #inst "1000-01-01"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.places/carribean
+                              :place/title "Ah The Good Ol Carribean Sea"
+                              :place/location :ids.places/carribean}
+                             #inst "1000-01-01"]
+                            [:crux.tx/put
+                             {:crux.db/id :ids.places/coconut-island
+                              :place/title "Coconut Island"
+                              :place/location :ids.places/carribean}
+                             #inst "1000-01-01"]]))
     (def db (crux/db system))
     (t/is (= {:crux.db/id :ids.people/Charles,
               :person/str 40,
@@ -155,16 +146,14 @@
                      '[:find ?name
                        :where
                        [_ :artefact/title ?name]])))
-    (crux/sync system (:crux.tx/tx-time (crux/submit-tx
-                                         system
-                                         [[:crux.tx/delete :ids.artefacts/forbidden-beans
-                                           #inst "1690-05-18"]]))
-               nil)
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/delete :ids.artefacts/forbidden-beans
+                             #inst "1690-05-18"]]))
 
-    (crux/sync system (:crux.tx/tx-time (crux/submit-tx
-                                         system
-                                         [[:crux.tx/evict :ids.artefacts/laptop]]))
-               nil)
+    (crux/await-tx system (crux/submit-tx
+                           system
+                           [[:crux.tx/evict :ids.artefacts/laptop]]))
 
     (t/is (= #{["Key from an unknown door"] ["A used sword"] ["A Rather Cozy Mug"] ["Flintlock pistol"]}
              (crux/q (crux/db system)
@@ -205,7 +194,7 @@
     (def first-ownership-tx-response
       (crux/submit-tx system (first-ownership-tx)))
 
-    (crux/sync system (:crux.tx/tx-time first-ownership-tx-response) nil)
+    (crux/await-tx system first-ownership-tx-response)
 
     (def who-has-what-query
       '[:find ?name ?atitle
@@ -274,10 +263,9 @@
          (crux/entity db entity-id)
          keys-to-pull)))
 
-    (crux/sync system (:crux.tx/tx-time (entity-update :ids.people/Charles
-                                                       {:person/int  50}
-                                                       #inst "1730-05-18"))
-               nil)
+    (crux/await-tx system (entity-update :ids.people/Charles
+                                         {:person/int  50}
+                                         #inst "1730-05-18"))
     (t/is (= (entity :ids.people/Charles)
              {:person/str 40,
               :person/dex 40,
@@ -307,59 +295,53 @@
               :person/gold 10000,
               :person/born #inst "1700-05-18T00:00:00.000-00:00"}))
 
-    (crux/sync system (:crux.tx/tx-time
-                       (let [theft-date #inst "1740-06-18"]
-                         (crux/submit-tx
-                          system
-                          [[:crux.tx/put
-                            (update (entity-at :ids.people/Charles theft-date)
-                                    :person/has
-                                    disj
-                                    :ids.artefacts/cozy-mug)
-                            theft-date]
-                           [:crux.tx/put
-                            (update (entity-at :ids.people/Mary theft-date)
-                                    :person/has
-                                    (comp set conj)
-                                    :ids.artefacts/cozy-mug)
-                            theft-date]])))
-               nil)
+    (crux/await-tx system (let [theft-date #inst "1740-06-18"]
+                            (crux/submit-tx
+                             system
+                             [[:crux.tx/put
+                               (update (entity-at :ids.people/Charles theft-date)
+                                       :person/has
+                                       disj
+                                       :ids.artefacts/cozy-mug)
+                               theft-date]
+                              [:crux.tx/put
+                               (update (entity-at :ids.people/Mary theft-date)
+                                       :person/has
+                                       (comp set conj)
+                                       :ids.artefacts/cozy-mug)
+                               theft-date]])))
     (t/is (= #{["Mary" "A used sword"]
                ["Mary" "Flintlock pistol"]
                ["Mary" "A Rather Cozy Mug"]
                ["Charles" "Key from an unknown door"]}
              (crux/q (crux/db system #inst "1740-06-18") who-has-what-query)))
 
-    (crux/sync system (:crux.tx/tx-time
-                       (let [marys-birth-inst #inst "1710-05-18"
-                             db (crux/db system marys-birth-inst)
-                             baby-mary (crux/entity db :ids.people/Mary)]
-                         (crux/submit-tx
-                          system
-                          [[:crux.tx/cas
-                            baby-mary
-                            (update baby-mary :person/has (comp set conj) :ids.artefacts/cozy-mug)
-                            marys-birth-inst]])))
-               nil)
+    (crux/await-tx system (let [marys-birth-inst #inst "1710-05-18"
+                                db (crux/db system marys-birth-inst)
+                                baby-mary (crux/entity db :ids.people/Mary)]
+                            (crux/submit-tx
+                             system
+                             [[:crux.tx/cas
+                               baby-mary
+                               (update baby-mary :person/has (comp set conj) :ids.artefacts/cozy-mug)
+                               marys-birth-inst]])))
 
 
-    (crux/sync system (:crux.tx/tx-time
-                       (let [mug-lost-date  #inst "1723-01-09"
-                             db (crux/db system mug-lost-date)
-                             mary (crux/entity db :ids.people/Mary)]
-                         (crux/submit-tx
-                          system
-                          [[:crux.tx/cas
-                            mary
-                            (update mary :person/has (comp set disj) :ids.artefacts/cozy-mug)
-                            mug-lost-date]])))
-               nil)
+    (crux/await-tx system (let [mug-lost-date  #inst "1723-01-09"
+                                db (crux/db system mug-lost-date)
+                                mary (crux/entity db :ids.people/Mary)]
+                            (crux/submit-tx
+                             system
+                             [[:crux.tx/cas
+                               mary
+                               (update mary :person/has (comp set disj) :ids.artefacts/cozy-mug)
+                               mug-lost-date]])))
     (t/is (= #{["Mary" "A used sword"] ["Mary" "Flintlock pistol"]}
              (crux/q
               (crux/db system #inst "1715-05-18")
               who-has-what-query)))
 
-    (crux/sync system (:crux.tx/tx-time (crux/submit-tx system (first-ownership-tx))) nil)
+    (crux/await-tx system (crux/submit-tx system (first-ownership-tx)))
 
     (t/is (= #{["Mary" "A used sword"]
                ["Mary" "Flintlock pistol"]

--- a/crux-test/test/crux/compaction_test.clj
+++ b/crux-test/test/crux/compaction_test.clj
@@ -24,13 +24,13 @@
               :crux.kv/kv-store "crux.kv.memdb/kv"}]
     (try
       (let [api (Crux/startNode opts)
-            {:keys [crux.tx/tx-time]} (api/submit-tx api [[:crux.tx/put {:crux.db/id :foo}]])]
-        (api/sync api tx-time nil)
+            tx (api/submit-tx api [[:crux.tx/put {:crux.db/id :foo}]])]
+        (api/await-tx api tx)
         (f/transact! api [{:crux.db/id :foo}])
         (.close api)
 
         (with-open [api2 (Crux/startNode opts)]
-          (api/sync api2 tx-time nil)
+          (api/await-tx api2 tx nil)
           (t/is (= 2 (count (api/history api2 :foo))))))
       (finally
         (cio/delete-dir db-dir)))))

--- a/crux-test/test/crux/dbpedia_test.clj
+++ b/crux-test/test/crux/dbpedia_test.clj
@@ -13,11 +13,9 @@
 (t/use-fixtures :each fk/with-cluster-node-opts fkv/with-kv-dir apif/with-node)
 
 (t/deftest test-can-transact-and-query-dbpedia-entities
-  (let [tx (crux/submit-tx *api* (->> (concat (rdf/->tx-ops (rdf/ntriples "crux/Pablo_Picasso.ntriples"))
-                                              (rdf/->tx-ops (rdf/ntriples "crux/Guernica_(Picasso).ntriples")))
-                                      (rdf/->default-language)))]
-
-    (crux/sync *api* (:crux.tx/tx-time tx) nil))
+  (fapi/submit+await-tx (->> (concat (rdf/->tx-ops (rdf/ntriples "crux/Pablo_Picasso.ntriples"))
+                                     (rdf/->tx-ops (rdf/ntriples "crux/Guernica_(Picasso).ntriples")))
+                             (rdf/->default-language)))
 
   (t/is (= #{[:http://dbpedia.org/resource/Pablo_Picasso]}
            (crux/q (crux/db *api*)
@@ -74,7 +72,7 @@
                                   (partition-all 1000)
                                   (reduce (fn [_ ops]
                                             (crux/submit-tx *api* ops))))]
-                 (crux/sync *api* (:crux.tx/tx-time last-tx) nil))))))
+                 (crux/await-tx *api* last-tx))))))
 
         (t/testing "querying transacted data"
           (t/is (= (rdf/with-prefix {:dbr "http://dbpedia.org/resource/"}

--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -21,7 +21,7 @@
     (t/is (not= nil node))
     ;; Testing example submit-tx works properly (and wait for it to complete)
     (t/is (not= nil submitted))
-    (crux/sync node (:crux.tx/tx-time submitted) nil)
+    (crux/await-tx node submitted nil)
 
     ;; Testing 'getting started' example queries
     (t/is (= {:crux.db/id :dbpedia.resource/Pablo-Picasso
@@ -64,7 +64,7 @@
 
 (t/deftest test-example-basic-queries
   (with-open [^crux.api.ICruxAPI node (ex/example-start-standalone)]
-    (crux/sync node (:crux.tx/tx-time (ex/query-example-setup node)) nil)
+    (crux/await-tx node (ex/query-example-setup node) nil)
     (t/is (= #{[:smith]} (ex/query-example-basic-query node)))
     (t/is (= #{["Ivan"]} (ex/query-example-with-arguments-1 node)))
     (t/is (= #{[:petr] [:ivan]} (ex/query-example-with-arguments-2 node)))
@@ -75,13 +75,13 @@
 
 (t/deftest test-example-time-queries
   (with-open [^crux.api.ICruxAPI node (ex/example-start-standalone)]
-    (crux/sync node (:crux.tx/tx-time (ex/query-example-at-time-setup node)) nil)
+    (crux/await-tx node (ex/query-example-at-time-setup node) nil)
     (t/is (= #{} (ex/query-example-at-time-q1 node)))
     (t/is (= #{[:malcolm]} (ex/query-example-at-time-q2 node)))))
 
 (t/deftest test-example-join-queries
   (with-open [^crux.api.ICruxAPI node (ex/example-start-standalone)]
-    (crux/sync node (:crux.tx/tx-time (ex/query-example-join-q1-setup node)) nil)
+    (crux/await-tx node (ex/query-example-join-q1-setup node) nil)
     (t/is (= #{[:ivan :ivan]
                [:petr :petr]
                [:sergei :sergei]
@@ -90,6 +90,6 @@
                [:denis-a :denis-b]
                [:denis-b :denis-a]}
              (ex/query-example-join-q1 node)))
-    (crux/sync node (:crux.tx/tx-time (ex/query-example-join-q2-setup node)) nil)
+    (crux/await-tx node (ex/query-example-join-q2-setup node) nil)
     (t/is (= #{[:petr]}
              (ex/query-example-join-q2 node)))))

--- a/crux-test/test/crux/fixtures.clj
+++ b/crux-test/test/crux/fixtures.clj
@@ -23,9 +23,8 @@
   ([api entities]
    (transact! api entities (cio/next-monotonic-date)))
   ([^ICruxAPI api entities ts]
-   (let [submitted-tx (api/submit-tx api (maps->tx-ops entities ts))]
-     ;; TODO when 'sync' gets replaced by 'await-tx', this should use the higher-level protocol again
-     (tx/await-tx (:indexer api) submitted-tx 10000))
+   (doto (api/submit-tx api (maps->tx-ops entities ts))
+     (->> (api/await-tx api)))
    entities))
 
 (defn entities->delete-tx-ops [entities ts]

--- a/crux-test/test/crux/fixtures.clj
+++ b/crux-test/test/crux/fixtures.clj
@@ -36,7 +36,7 @@
    (delete-entities! api entities (cio/next-monotonic-date)))
   ([api entities ts]
    (let [submitted-tx (api/submit-tx api (entities->delete-tx-ops entities ts))]
-     (api/sync api (:crux.tx/tx-time submitted-tx) nil))
+     (api/await-tx api submitted-tx))
    entities))
 
 (defn random-person [] {:crux.db/id (UUID/randomUUID)

--- a/crux-test/test/crux/fixtures/api.clj
+++ b/crux-test/test/crux/fixtures/api.clj
@@ -1,4 +1,5 @@
 (ns crux.fixtures.api
+  (:require [crux.api :as crux])
   (:import [crux.api Crux ICruxAPI]
            [java.util ArrayList List]))
 
@@ -13,6 +14,11 @@
   (with-open [node (Crux/startNode *opts*)]
     (binding [*api* node]
       (f))))
+
+(defn submit+await-tx [tx-ops]
+  (let [tx (crux/submit-tx *api* tx-ops)]
+    (crux/await-tx *api* tx)
+    tx))
 
 ;; Literal vectors aren't type hinted as List in Clojure, and cannot
 ;; be type hinted without via a var.

--- a/crux-test/test/crux/fixtures/lubm.clj
+++ b/crux-test/test/crux/fixtures/lubm.clj
@@ -15,5 +15,5 @@
                                (api/submit-tx *api* (vec tx-ops)))
                              nil))]
 
-    (api/sync *api* (:crux.tx/tx-time last-tx) nil)
+    (api/await-tx *api* last-tx)
     (f)))

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -34,7 +34,7 @@
 (t/deftest test-happy-path-jdbc-event-log
   (let [doc {:crux.db/id :origin-man :name "Adam"}
         submitted-tx (.submitTx *api* [[:crux.tx/put doc]])]
-    (.sync *api* (:crux.tx/tx-time submitted-tx) nil)
+    (.awaitTx *api* submitted-tx nil)
     (t/is (.entity (.db *api*) :origin-man))
     (t/testing "Tx log"
       (with-open [tx-log-context (.newTxLogContext *api*)]
@@ -87,7 +87,7 @@
          (reset! last-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id (keyword (str n))}]]))))
 
       (time
-       (.sync *api* (:crux.tx/tx-time last-tx) nil))))
+       (.awaitTx *api* last-tx nil))))
   (t/is true))
 
 (t/deftest test-ingest-bench

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -46,7 +46,7 @@
   (let [tx-topic "test-can-transact-entities-tx"
         doc-topic "test-can-transact-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/example-data-artists.nt"))
-        tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {})
+        tx-log (k/->KafkaTxLog fk/*producer* fk/*consumer* tx-topic doc-topic {})
         indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
@@ -69,7 +69,7 @@
   (let [tx-topic "test-can-transact-and-query-entities-tx"
         doc-topic "test-can-transact-and-query-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/picasso.nt"))
-        tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
+        tx-log (k/->KafkaTxLog fk/*producer* fk/*consumer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
         indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
         node (reify crux.api.ICruxAPI
@@ -125,7 +125,7 @@
 
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/picasso.nt"))
 
-        tx-log (k/->KafkaTxLog fk/*producer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
+        tx-log (k/->KafkaTxLog fk/*producer* fk/*consumer* tx-topic doc-topic {"bootstrap.servers" fk/*kafka-bootstrap-servers*})
 
         object-store  (os/->CachedObjectStore (lru/new-cache os/default-doc-cache-size) (os/->KvObjectStore *kv*))
         indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log nil)

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -179,10 +179,8 @@
         (t/is n)
 
         (let [valid-time (Date.)
-              {:keys [crux.tx/tx-time
-                      crux.tx/tx-id]
-               :as submitted-tx} (.submitTx n [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
-          (t/is (= tx-time (.sync n (:crux.tx/tx-time submitted-tx) nil)))
+              submitted-tx (.submitTx n [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+          (t/is (= submitted-tx (.awaitTx n submitted-tx nil)))
           (t/is (= #{[:ivan]} (.q (.db n)
                                   '{:find [e]
                                     :where [[e :name "Ivan"]]}))))
@@ -201,10 +199,8 @@
                              :where [[e :name "Ivan"]]})))
 
           (let [valid-time (Date.)
-                {:keys [crux.tx/tx-time
-                        crux.tx/tx-id]
-                 :as submitted-tx} (.submitTx n2 [[:crux.tx/put {:crux.db/id :ivan :name "Iva"} valid-time]])]
-            (t/is (= tx-time (.sync n2 (:crux.tx/tx-time submitted-tx) nil)))
+                submitted-tx (.submitTx n2 [[:crux.tx/put {:crux.db/id :ivan :name "Iva"} valid-time]])]
+            (t/is (= submitted-tx (.awaitTx n2 submitted-tx nil)))
             (t/is (= #{[:ivan]} (.q (.db n2)
                                     '{:find [e]
                                       :where [[e :name "Iva"]]}))))

--- a/crux-test/test/crux/repl_walkthrough_test.clj
+++ b/crux-test/test/crux/repl_walkthrough_test.clj
@@ -55,11 +55,9 @@
   (def node (crux/start-node crux-options))
   (t/is node)
 
-  (crux/sync node (:crux.tx/tx-time
-                   (crux/submit-tx
-                    node
-                    (mapv (fn [n] [:crux.tx/put n]) nodes)))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       (mapv (fn [n] [:crux.tx/put n]) nodes)))
 
   (def db (crux/db node))
 
@@ -108,45 +106,39 @@
 
   (t/is node)
 
-  (crux/sync node (:crux.tx/tx-time
-                   (crux/submit-tx
-                    node
-                    [[:crux.tx/put
-                      {:crux.db/id :dbpedia.resource/Pablo-Picasso
-                       :name "Pablo"
-                       :last-name "Picasso"
-                       :location "Spain"}
-                      #inst "1881-10-25T09:20:27.966-00:00"]
-                     [:crux.tx/put
-                      {:crux.db/id :dbpedia.resource/Pablo-Picasso
-                       :name "Pablo"
-                       :last-name "Picasso"
-                       :location "Sain2"}
-                      #inst "1881-10-25T09:20:27.966-00:00"]]))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       [[:crux.tx/put
+                         {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                          :name "Pablo"
+                          :last-name "Picasso"
+                          :location "Spain"}
+                         #inst "1881-10-25T09:20:27.966-00:00"]
+                        [:crux.tx/put
+                         {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                          :name "Pablo"
+                          :last-name "Picasso"
+                          :location "Sain2"}
+                         #inst "1881-10-25T09:20:27.966-00:00"]]))
 
-  (crux/sync node (:crux.tx/tx-time
-                   (crux/submit-tx
-                    node
-                    [[:crux.tx/cas
-                      {:crux.db/id :dbpedia.resource/Pablo-Picasso
-                       :name "Pablo"
-                       :last-name "Picasso"
-                       :location "Spain"}
-                      {:crux.db/id :dbpedia.resource/Pablo-Picasso
-                       :name "Pablo"
-                       :last-name "Picasso"
-                       :height 1.63
-                       :location "France"}
-                      #inst "1973-04-08T09:20:27.966-00:00"]]))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       [[:crux.tx/cas
+                         {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                          :name "Pablo"
+                          :last-name "Picasso"
+                          :location "Spain"}
+                         {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                          :name "Pablo"
+                          :last-name "Picasso"
+                          :height 1.63
+                          :location "France"}
+                         #inst "1973-04-08T09:20:27.966-00:00"]]))
 
-  (crux/sync node (:crux.tx/tx-time
-                   (crux/submit-tx
-                    node
-                    [[:crux.tx/delete :dbpedia.resource/Pablo-Picasso
-                      #inst "1973-04-08T09:20:27.966-00:00"]]))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       [[:crux.tx/delete :dbpedia.resource/Pablo-Picasso
+                         #inst "1973-04-08T09:20:27.966-00:00"]]))
 
   (t/is (= #{[{:crux.db/id :dbpedia.resource/Pablo-Picasso, :name "Pablo", :last-name "Picasso", :location "Sain2"}]}
            (crux/q
@@ -155,11 +147,9 @@
               :where [[e :name "Pablo"]]
               :full-results? true})))
 
-  (crux/sync node (:crux.tx/tx-time
-                   (crux/submit-tx
-                    node
-                    [[:crux.tx/evict :dbpedia.resource/Pablo-Picasso]]))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       [[:crux.tx/evict :dbpedia.resource/Pablo-Picasso]]))
 
   (t/is (empty? (crux/q
                  (crux/db node)
@@ -167,16 +157,15 @@
                    :where [[e :name "Pablo"]]
                    :full-results? true})))
 
-  (crux/sync node (:crux.tx/tx-time (crux/submit-tx
-                                     node
-                                     [[:crux.tx/put
-                                       {:crux.db/id :dbpedia.resource/Pablo-Picasso
-                                        :name "Pablo"
-                                        :last-name "Picasso"
-                                        :height 1.63
-                                        :location "France"}
-                                       #inst "1973-04-08T09:20:27.966-00:00"]]))
-             nil)
+  (crux/await-tx node (crux/submit-tx
+                       node
+                       [[:crux.tx/put
+                         {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                          :name "Pablo"
+                          :last-name "Picasso"
+                          :height 1.63
+                          :location "France"}
+                         #inst "1973-04-08T09:20:27.966-00:00"]]))
 
   (t/is (= #{[{:crux.db/id :dbpedia.resource/Pablo-Picasso, :name "Pablo", :last-name "Picasso", :height 1.63, :location "France"}]}
            (crux/q

--- a/crux-test/test/crux/space_tutorial_test.clj
+++ b/crux-test/test/crux/space_tutorial_test.clj
@@ -72,7 +72,7 @@
 
   (t/deftest earth-test
     (t/is crux)
-    (crux/sync crux (:crux.tx/tx-time (crux/submit-tx crux [[:crux.tx/put manifest]])) nil)
+    (crux/await-tx crux (crux/submit-tx crux [[:crux.tx/put manifest]]))
 
     (t/is (= {:crux.db/id :manifest,
               :pilot-name "Johanna",
@@ -89,90 +89,84 @@
                       :args [{'belongings "secret note"}]}))))
 
   (t/deftest pluto-tests
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx crux
-                                     [[:crux.tx/put
-                                       {:crux.db/id :commodity/Pu
-                                        :common-name "Plutonium"
-                                        :type :element/metal
-                                        :density 19.816
-                                        :radioactive true}]
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/put
+                                          {:crux.db/id :commodity/Pu
+                                           :common-name "Plutonium"
+                                           :type :element/metal
+                                           :density 19.816
+                                           :radioactive true}]
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :commodity/N
-                                        :common-name "Nitrogen"
-                                        :type :element/gas
-                                        :density 1.2506
-                                        :radioactive false}]
+                                         [:crux.tx/put
+                                          {:crux.db/id :commodity/N
+                                           :common-name "Nitrogen"
+                                           :type :element/gas
+                                           :density 1.2506
+                                           :radioactive false}]
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :commodity/CH4
-                                        :common-name "Methane"
-                                        :type :molecule/gas
-                                        :density 0.717
-                                        :radioactive false}]]))
-               nil)
+                                         [:crux.tx/put
+                                          {:crux.db/id :commodity/CH4
+                                           :common-name "Methane"
+                                           :type :molecule/gas
+                                           :density 0.717
+                                           :radioactive false}]]))
 
 
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx crux
-                                     [[:crux.tx/put
-                                       {:crux.db/id :stock/Pu
-                                        :commod :commodity/Pu
-                                        :weight-ton 21 }
-                                       #inst "2115-02-13T18"] ;; valid-time
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/put
+                                          {:crux.db/id :stock/Pu
+                                           :commod :commodity/Pu
+                                           :weight-ton 21 }
+                                          #inst "2115-02-13T18"] ;; valid-time
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :stock/Pu
-                                        :commod :commodity/Pu
-                                        :weight-ton 23 }
-                                       #inst "2115-02-14T18"]
+                                         [:crux.tx/put
+                                          {:crux.db/id :stock/Pu
+                                           :commod :commodity/Pu
+                                           :weight-ton 23 }
+                                          #inst "2115-02-14T18"]
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :stock/Pu
-                                        :commod :commodity/Pu
-                                        :weight-ton 22.2 }
-                                       #inst "2115-02-15T18"]
+                                         [:crux.tx/put
+                                          {:crux.db/id :stock/Pu
+                                           :commod :commodity/Pu
+                                           :weight-ton 22.2 }
+                                          #inst "2115-02-15T18"]
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :stock/Pu
-                                        :commod :commodity/Pu
-                                        :weight-ton 24 }
-                                       #inst "2115-02-18T18"]
+                                         [:crux.tx/put
+                                          {:crux.db/id :stock/Pu
+                                           :commod :commodity/Pu
+                                           :weight-ton 24 }
+                                          #inst "2115-02-18T18"]
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :stock/Pu
-                                        :commod :commodity/Pu
-                                        :weight-ton 24.9 }
-                                       #inst "2115-02-19T18"]]))
-               nil)
+                                         [:crux.tx/put
+                                          {:crux.db/id :stock/Pu
+                                           :commod :commodity/Pu
+                                           :weight-ton 24.9 }
+                                          #inst "2115-02-19T18"]]))
 
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx crux
-                                     [[:crux.tx/put
-                                       {:crux.db/id :stock/N
-                                        :commod :commodity/N
-                                        :weight-ton 3 }
-                                       #inst "2115-02-13T18" ;; start valid-time
-                                       #inst "2115-02-19T18"] ;; end valid-time
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/put
+                                          {:crux.db/id :stock/N
+                                           :commod :commodity/N
+                                           :weight-ton 3 }
+                                          #inst "2115-02-13T18" ;; start valid-time
+                                          #inst "2115-02-19T18"] ;; end valid-time
 
-                                      [:crux.tx/put
-                                       {:crux.db/id :stock/CH4
-                                        :commod :commodity/CH4
-                                        :weight-ton 92 }
-                                       #inst "2115-02-15T18"
-                                       #inst "2115-02-19T18"]]))
-               nil)
+                                         [:crux.tx/put
+                                          {:crux.db/id :stock/CH4
+                                           :commod :commodity/CH4
+                                           :weight-ton 92 }
+                                          #inst "2115-02-15T18"
+                                          #inst "2115-02-19T18"]]))
 
     (t/is (= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 21}
              (crux/entity (crux/db crux #inst "2115-02-14") :stock/Pu)))
     (t/is (= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 22.2}
              (crux/entity (crux/db crux #inst "2115-02-18") :stock/Pu)))
 
-    (crux/sync crux (:crux.tx/tx-time (crux/submit-tx
-                                       crux
-                                       [[:crux.tx/put
-                                         (assoc manifest :badges ["SETUP" "PUT"])]])) nil)
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put
+                           (assoc manifest :badges ["SETUP" "PUT"])]]))
 
     (t/is (= {:crux.db/id :manifest,
               :pilot-name "Johanna",
@@ -225,7 +219,7 @@
         :density 1.73
         :radioactive false}])
 
-    (crux/sync crux (:crux.tx/tx-time (easy-ingest crux data)) nil)
+    (crux/await-tx crux (easy-ingest crux data))
 
     (t/is (={:crux.db/id :commodity/borax
              :common-name "Borax"
@@ -286,10 +280,10 @@
              #{["Borax" "Sodium tetraborate decahydrate"]}
              ))
 
-    (crux/sync crux (:crux.tx/tx-time (crux/submit-tx
-                                       crux
-                                       [[:crux.tx/put
-                                         (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"])]])) nil)
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put
+                           (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"])]]))
 
 
     (t/is (= {:crux.db/id :manifest,
@@ -301,60 +295,56 @@
              (crux/entity (crux/db crux) :manifest))))
 
   (t/deftest neptune-test
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx
-                      crux
-                      [[:crux.tx/put
-                        {:crux.db/id :consumer/RJ29sUU
-                         :consumer-id :RJ29sUU
-                         :first-name "Jay"
-                         :last-name "Rose"
-                         :cover? true
-                         :cover-type :Full}
-                        #inst "2114-12-03"]]))
-               nil)
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx
-                      crux
-                      [[:crux.tx/put ;; <1>
-                        {:crux.db/id :consumer/RJ29sUU
-                         :consumer-id :RJ29sUU
-                         :first-name "Jay"
-                         :last-name "Rose"
-                         :cover? true
-                         :cover-type :Full}
-                        #inst "2113-12-03" ;; Valid time start
-                        #inst "2114-12-03"] ;; Valid time end
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put
+                           {:crux.db/id :consumer/RJ29sUU
+                            :consumer-id :RJ29sUU
+                            :first-name "Jay"
+                            :last-name "Rose"
+                            :cover? true
+                            :cover-type :Full}
+                           #inst "2114-12-03"]]))
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put ;; <1>
+                           {:crux.db/id :consumer/RJ29sUU
+                            :consumer-id :RJ29sUU
+                            :first-name "Jay"
+                            :last-name "Rose"
+                            :cover? true
+                            :cover-type :Full}
+                           #inst "2113-12-03" ;; Valid time start
+                           #inst "2114-12-03"] ;; Valid time end
 
-                       [:crux.tx/put ;; <2>
-                        {:crux.db/id :consumer/RJ29sUU
-                         :consumer-id :RJ29sUU
-                         :first-name "Jay"
-                         :last-name "Rose"
-                         :cover? true
-                         :cover-type :Full}
-                        #inst "2112-12-03"
-                        #inst "2113-12-03"]
+                          [:crux.tx/put ;; <2>
+                           {:crux.db/id :consumer/RJ29sUU
+                            :consumer-id :RJ29sUU
+                            :first-name "Jay"
+                            :last-name "Rose"
+                            :cover? true
+                            :cover-type :Full}
+                           #inst "2112-12-03"
+                           #inst "2113-12-03"]
 
-                       [:crux.tx/put ;; <3>
-                        {:crux.db/id :consumer/RJ29sUU
-                         :consumer-id :RJ29sUU
-                         :first-name "Jay"
-                         :last-name "Rose"
-                         :cover? false}
-                        #inst "2112-06-03"
-                        #inst "2112-12-02"]
+                          [:crux.tx/put ;; <3>
+                           {:crux.db/id :consumer/RJ29sUU
+                            :consumer-id :RJ29sUU
+                            :first-name "Jay"
+                            :last-name "Rose"
+                            :cover? false}
+                           #inst "2112-06-03"
+                           #inst "2112-12-02"]
 
-                       [:crux.tx/put ;; <4>
-                        {:crux.db/id :consumer/RJ29sUU
-                         :consumer-id :RJ29sUU
-                         :first-name "Jay"
-                         :last-name "Rose"
-                         :cover? true
-                         :cover-type :Promotional}
-                        #inst "2111-06-03"
-                        #inst "2112-06-03"]]))
-               nil)
+                          [:crux.tx/put ;; <4>
+                           {:crux.db/id :consumer/RJ29sUU
+                            :consumer-id :RJ29sUU
+                            :first-name "Jay"
+                            :last-name "Rose"
+                            :cover? true
+                            :cover-type :Promotional}
+                           #inst "2111-06-03"
+                           #inst "2112-06-03"]]))
 
     (t/is (= #{[true :Full]}
              (crux/q (crux/db crux #inst "2115-07-03")
@@ -376,11 +366,11 @@
                        :where [[e :consumer-id :RJ29sUU]
                                [e :cover? cover]
                                [e :cover-type type]]})))
-    (crux/sync crux (:crux.tx/tx-time (crux/submit-tx
-                                       crux
-                                       [[:crux.tx/put
-                                         (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"
-                                                                  "BITEMP"])]])) nil)
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put
+                           (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"
+                                                    "BITEMP"])]]))
 
     (t/is (= {:crux.db/id :manifest,
               :pilot-name "Johanna",
@@ -423,92 +413,89 @@
         :company-name "Blue Energy"
         :credits 1000}])
 
-    (crux/sync crux (:crux.tx/tx-time (easy-ingest crux data-saturn)) nil)
+    (crux/await-tx crux (easy-ingest crux data-saturn))
 
-    (crux/sync crux
-               (:crux.tx/tx-time
-                (crux/submit-tx
-                 crux
-                 [[:crux.tx/cas
-                   ;; Old doc
-                   {:crux.db/id :blue-energy
-                    :seller? false
-                    :buyer? true
-                    :company-name "Blue Energy"
-                    :credits 1000}
-                   ;; New doc
+    (crux/await-tx crux
+                   (crux/submit-tx
+                    crux
+                    [[:crux.tx/cas
+                      ;; Old doc
+                      {:crux.db/id :blue-energy
+                       :seller? false
+                       :buyer? true
+                       :company-name "Blue Energy"
+                       :credits 1000}
+                      ;; New doc
 
-                   {:crux.db/id :blue-energy
-                    :seller? false
-                    :buyer? true
-                    :company-name "Blue Energy"
-                    :credits 900
-                    :units/CH4 10}]
+                      {:crux.db/id :blue-energy
+                       :seller? false
+                       :buyer? true
+                       :company-name "Blue Energy"
+                       :credits 900
+                       :units/CH4 10}]
 
-                  [:crux.tx/cas
-                   ;; Old doc
-                   {:crux.db/id :tombaugh-resources
-                    :company-name "Tombaugh Resources Ltd."
-                    :seller? true
-                    :buyer? false
-                    :units/Pu 50
-                    :units/N 3
-                    :units/CH4 92
-                    :credits 51}
-                   ;; New doc
-                   {:crux.db/id :tombaugh-resources
-                    :company-name "Tombaugh Resources Ltd."
-                    :seller? true
-                    :buyer? false
-                    :units/Pu 50
-                    :units/N 3
-                    :units/CH4 82
-                    :credits 151}]]))
-               nil)
+                     [:crux.tx/cas
+                      ;; Old doc
+                      {:crux.db/id :tombaugh-resources
+                       :company-name "Tombaugh Resources Ltd."
+                       :seller? true
+                       :buyer? false
+                       :units/Pu 50
+                       :units/N 3
+                       :units/CH4 92
+                       :credits 51}
+                      ;; New doc
+                      {:crux.db/id :tombaugh-resources
+                       :company-name "Tombaugh Resources Ltd."
+                       :seller? true
+                       :buyer? false
+                       :units/Pu 50
+                       :units/N 3
+                       :units/CH4 82
+                       :credits 151}]]))
     (t/is (= '("Name: Tombaugh Resources Ltd., Funds: 151, :units/CH4 82")
              (format-stock-check (stock-check :tombaugh-resources :units/CH4))))
 
     (t/is (= '("Name: Blue Energy, Funds: 900, :units/CH4 10")
              (format-stock-check (stock-check :blue-energy :units/CH4))))
-    (crux/sync crux
-               (:crux.tx/tx-time (crux/submit-tx
-                                  crux
-                                  [[:crux.tx/cas
-                                    ;; Old doc
-                                    {:crux.db/id :gold-harmony
-                                     :company-name "Gold Harmony"
-                                     :seller? true
-                                     :buyer? false
-                                     :units/Au 10211
-                                     :credits 51}
-                                    ;; New doc
-                                    {:crux.db/id :gold-harmony
-                                     :company-name "Gold Harmony"
-                                     :seller? true
-                                     :buyer? false
-                                     :units/Au 211
-                                     :credits 51}]
+    (crux/await-tx crux
+                   (crux/submit-tx
+                    crux
+                    [[:crux.tx/cas
+                      ;; Old doc
+                      {:crux.db/id :gold-harmony
+                       :company-name "Gold Harmony"
+                       :seller? true
+                       :buyer? false
+                       :units/Au 10211
+                       :credits 51}
+                      ;; New doc
+                      {:crux.db/id :gold-harmony
+                       :company-name "Gold Harmony"
+                       :seller? true
+                       :buyer? false
+                       :units/Au 211
+                       :credits 51}]
 
-                                   [:crux.tx/cas
-                                    ;; Old doc
-                                    {:crux.db/id :encompass-trade
-                                     :company-name "Encompass Trade"
-                                     :seller? true
-                                     :buyer? true
-                                     :units/Au 10
-                                     :units/Pu 5
-                                     :units/CH4 211
-                                     :credits 100002}
-                                    ;; New doc
-                                    {:crux.db/id :encompass-trade
-                                     :company-name "Encompass Trade"
-                                     :seller? true
-                                     :buyer? true
-                                     :units/Au 10010
-                                     :units/Pu 5
-                                     :units/CH4 211
-                                     :credits 1002}]]))
-               nil)
+                     [:crux.tx/cas
+                      ;; Old doc
+                      {:crux.db/id :encompass-trade
+                       :company-name "Encompass Trade"
+                       :seller? true
+                       :buyer? true
+                       :units/Au 10
+                       :units/Pu 5
+                       :units/CH4 211
+                       :credits 100002}
+                      ;; New doc
+                      {:crux.db/id :encompass-trade
+                       :company-name "Encompass Trade"
+                       :seller? true
+                       :buyer? true
+                       :units/Au 10010
+                       :units/Pu 5
+                       :units/CH4 211
+                       :credits 1002}]]))
 
     (t/is (= '("Name: Gold Harmony, Funds: 51, :units/Au 10211")
              (format-stock-check (stock-check :gold-harmony :units/Au))))
@@ -516,11 +503,11 @@
     (t/is (= '("Name: Encompass Trade, Funds: 1002, :units/Au 10")
              (format-stock-check (stock-check :encompass-trade :units/Au))))
 
-    (crux/sync crux (:crux.tx/tx-time (crux/submit-tx
-                                       crux
-                                       [[:crux.tx/put
-                                         (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"
-                                                                  "BITEMP" "CAS"])]])) nil)
+    (crux/await-tx crux (crux/submit-tx
+                         crux
+                         [[:crux.tx/put
+                           (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"
+                                                    "BITEMP" "CAS"])]]))
     (t/is (= {:crux.db/id :manifest,
               :pilot-name "Johanna",
               :id/rocket "SB002-sol",
@@ -530,28 +517,26 @@
              (crux/entity (crux/db crux) :manifest))))
 
   (t/deftest jupiter-tests
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx crux
-                                     [[:crux.tx/put {:crux.db/id :kaarlang/clients
-                                                     :clients [:encompass-trade]}
-                                       #inst "2110-01-01T09"
-                                       #inst "2111-01-01T09"]
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/put {:crux.db/id :kaarlang/clients
+                                                        :clients [:encompass-trade]}
+                                          #inst "2110-01-01T09"
+                                          #inst "2111-01-01T09"]
 
-                                      [:crux.tx/put {:crux.db/id :kaarlang/clients
-                                                     :clients [:encompass-trade :blue-energy]}
-                                       #inst "2111-01-01T09"
-                                       #inst "2113-01-01T09"]
+                                         [:crux.tx/put {:crux.db/id :kaarlang/clients
+                                                        :clients [:encompass-trade :blue-energy]}
+                                          #inst "2111-01-01T09"
+                                          #inst "2113-01-01T09"]
 
-                                      [:crux.tx/put {:crux.db/id :kaarlang/clients
-                                                     :clients [:blue-energy]}
-                                       #inst "2113-01-01T09"
-                                       #inst "2114-01-01T09"]
+                                         [:crux.tx/put {:crux.db/id :kaarlang/clients
+                                                        :clients [:blue-energy]}
+                                          #inst "2113-01-01T09"
+                                          #inst "2114-01-01T09"]
 
-                                      [:crux.tx/put {:crux.db/id :kaarlang/clients
-                                                     :clients [:blue-energy :gold-harmony :tombaugh-resources]}
-                                       #inst "2114-01-01T09"
-                                       #inst "2115-01-01T09"]]))
-               nil)
+                                         [:crux.tx/put {:crux.db/id :kaarlang/clients
+                                                        :clients [:blue-energy :gold-harmony :tombaugh-resources]}
+                                          #inst "2114-01-01T09"
+                                          #inst "2115-01-01T09"]]))
 
     (t/is (= {:crux.db/id :kaarlang/clients
               :clients [:blue-energy :gold-harmony :tombaugh-resources]}
@@ -563,10 +548,8 @@
            (crux/new-snapshot (crux/db crux #inst "2116-01-01T09")) ;; <1>
            :kaarlang/clients))
 
-    (crux/sync crux (:crux.tx/tx-time
-                     (crux/submit-tx crux
-                                     [[:crux.tx/delete :kaarlang/clients #inst "2110-01-01" #inst "2116-01-01"]]))
-               nil)
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/delete :kaarlang/clients #inst "2110-01-01" #inst "2116-01-01"]]))
 
     (t/is nil? (crux/entity (crux/db crux #inst "2114-01-01T09") :kaarlang/clients))
 
@@ -590,36 +573,34 @@
 
     (t/is crux)
 
-    (crux/sync crux (:crux.tx/tx-time
-                      (crux/submit-tx crux
-                                      [[:crux.tx/put
-                                        {:crux.db/id :person/kaarlang
-                                         :full-name "Kaarlang"
-                                         :origin-planet "Mars"
-                                         :identity-tag :KA01299242093
-                                         :DOB #inst "2040-11-23"}]
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/put
+                                          {:crux.db/id :person/kaarlang
+                                           :full-name "Kaarlang"
+                                           :origin-planet "Mars"
+                                           :identity-tag :KA01299242093
+                                           :DOB #inst "2040-11-23"}]
 
-                                       [:crux.tx/put
-                                        {:crux.db/id :person/ilex
-                                         :full-name "Ilex Jefferson"
-                                         :origin-planet "Venus"
-                                         :identity-tag :IJ01222212454
-                                         :DOB #inst "2061-02-17"}]
+                                         [:crux.tx/put
+                                          {:crux.db/id :person/ilex
+                                           :full-name "Ilex Jefferson"
+                                           :origin-planet "Venus"
+                                           :identity-tag :IJ01222212454
+                                           :DOB #inst "2061-02-17"}]
 
-                                       [:crux.tx/put
-                                        {:crux.db/id :person/thadd
-                                         :full-name "Thad Christover"
-                                         :origin-moon "Titan"
-                                         :identity-tag :IJ01222212454
-                                         :DOB #inst "2101-01-01"}]
+                                         [:crux.tx/put
+                                          {:crux.db/id :person/thadd
+                                           :full-name "Thad Christover"
+                                           :origin-moon "Titan"
+                                           :identity-tag :IJ01222212454
+                                           :DOB #inst "2101-01-01"}]
 
-                                       [:crux.tx/put
-                                        {:crux.db/id :person/johanna
-                                         :full-name "Johanna"
-                                         :origin-planet "Earth"
-                                         :identity-tag :JA012992129120
-                                         :DOB #inst "2090-12-07"}]]))
-               nil)
+                                         [:crux.tx/put
+                                          {:crux.db/id :person/johanna
+                                           :full-name "Johanna"
+                                           :origin-planet "Earth"
+                                           :identity-tag :JA012992129120
+                                           :DOB #inst "2090-12-07"}]]))
 
     (t/is (= #{[{:crux.db/id :person/ilex,
                  :full-name "Ilex Jefferson",
@@ -643,12 +624,10 @@
                  :DOB #inst "2090-12-07T00:00:00.000-00:00"}]}
              (full-query crux)))
 
-    (crux/sync crux (:crux.tx/tx-time
-                      (crux/submit-tx crux
-                                      [[:crux.tx/evict
-                                        :person/kaarlang] ;; <1>
-                                       ]))
-               nil)
+    (crux/await-tx crux (crux/submit-tx crux
+                                        [[:crux.tx/evict
+                                          :person/kaarlang] ;; <1>
+                                         ]))
     (t/is empty? (full-query crux))
 
     ;; Check not nil, history constantly changing so it is hard to check otherwise

--- a/crux-test/test/crux/sparql_test.clj
+++ b/crux-test/test/crux/sparql_test.clj
@@ -13,8 +13,7 @@
 
 ;; https://jena.apache.org/tutorials/sparql.html
 (t/deftest test-can-transact-and-query-using-sparql
-  (let [tx (crux/submit-tx *api* (->> (rdf/ntriples "crux/vc-db-1.nt") (rdf/->tx-ops) (rdf/->default-language)))]
-    (crux/sync *api* (:crux.tx/tx-time tx) nil))
+  (fapi/submit+await-tx (->> (rdf/ntriples "crux/vc-db-1.nt") (rdf/->tx-ops) (rdf/->default-language)))
 
   (t/testing "querying transacted data"
     (t/is (= #{[(keyword "http://somewhere/JohnSmith/")]}

--- a/crux-test/test/crux/ts_devices_test.clj
+++ b/crux-test/test/crux/ts_devices_test.clj
@@ -81,7 +81,7 @@
   (if run-ts-devices-tests?
     (let [{:keys [op-count last-tx]} (submit-ts-devices-data *api*)]
       (assert (= op-count 1001000) (str "actual op-count: " op-count))
-      (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
+      (api/await-tx *api* last-tx (java.time.Duration/ofMinutes 20))
       (f))
 
     (f)))

--- a/crux-test/test/crux/ts_weather_test.clj
+++ b/crux-test/test/crux/ts_weather_test.clj
@@ -73,7 +73,7 @@
 (defn with-ts-weather-data [f]
   (if run-ts-weather-tests?
     (let [{:keys [last-tx op-count]} (submit-ts-weather-data *api*)]
-      (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
+      (api/await-tx *api* last-tx (java.time.Duration/ofMinutes 20))
       (assert (= 1001000 op-count) (str "actual op-count: " op-count))
       (f))
     (f)))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -416,10 +416,9 @@
   (let [ivan {:crux.db/id :ivan :name "Ivan"}
         start-valid-time #inst "2019"
         number-of-versions 1000
-        tx (api/submit-tx *api* (vec (for [n (range number-of-versions)]
-                                       [:crux.tx/put (assoc ivan :version n) (Date. (+ (.getTime start-valid-time) (inc (long n))))])))
-        ;; HACK using internal tx/await-tx til we properly deprecate 'sync'
-        _ (tx/await-tx (:indexer *api*) tx 10000)]
+        tx (doto (api/submit-tx *api* (vec (for [n (range number-of-versions)]
+                                             [:crux.tx/put (assoc ivan :version n) (Date. (+ (.getTime start-valid-time) (inc (long n))))])))
+             (->> (api/await-tx *api*)))]
 
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
       (let [baseline-time (let [start-time (System/nanoTime)

--- a/crux-test/test/crux/watdiv_test.clj
+++ b/crux-test/test/crux/watdiv_test.clj
@@ -5,7 +5,7 @@
             [clojure.tools.logging :as log]
             [crux.api :as api]
             [crux.fixtures :as f]
-            [crux.fixtures.api :as apif :refer [*api*]]
+            [crux.fixtures.api :as fapi :refer [*api*]]
             [crux.fixtures.kafka :as fk]
             [crux.fixtures.kv :as fkv]
             [crux.index :as idx]
@@ -329,7 +329,7 @@
   (let [{:keys [last-tx entity-count]} (with-open [in (io/input-stream (io/resource resource))]
                                          (rdf/submit-ntriples (:tx-log *api*) in 1000))]
     (println "Loaded into kafka awaiting Crux to catch up indexing...")
-    (api/sync *api* (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
+    (fapi/submit+await-tx (:crux.tx/tx-time last-tx) (java.time.Duration/ofMinutes 20))
     (t/is (= 521585 entity-count))))
 
 (defn with-watdiv-data [f]
@@ -378,7 +378,7 @@
   with-neo4j
   fk/with-cluster-node-opts
   fkv/with-kv-dir
-  apif/with-node
+  fapi/with-node
   with-watdiv-data)
 
 ;; TODO: What do the numbers in the .desc file represent? They all


### PR DESCRIPTION
This is the non-breaking part of #466, adding in `await-tx`/`await-tx-time` - would like to merge this in advance of the breaking changes so that we can start to use this in tests, etc.

* adds `await-tx`/`await-tx-time` (non-breaking - keeping existing `(sync node tx-time)` for now)
* `sync` (with no args) awaits the latest submitted tx rather than trying to chase zero-lag
* internally, adds a `latest-submitted-tx` to TxLog protocol so that `sync` can find out what tx to await
* updated all the tests that used `(sync node tx-time)` to use `(await-tx node tx)` instead
* I deliberately haven't touched the HTTP sync endpoints (beyond preserving existing behaviour) because of #527 

coming up in part 2 (see #466) for more details:
* remove deprecated functionality
* update docs/tutorials
* timeout default change

