### PR TITLE
Extract out Kafka Consumer

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -19,7 +19,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def ^:const index-version 5)
+(def ^:const index-version 6)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -417,7 +417,7 @@
   (status-map [this]
     {:crux.index/index-version (idx/current-index-version kv-store)
      :crux.tx/latest-completed-tx (db/read-index-meta this :crux.tx/latest-completed-tx)
-     ;; TODO there is another consumer state of doc-doc
+     :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (def kv-indexer

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -417,6 +417,7 @@
   (status-map [this]
     {:crux.index/index-version (idx/current-index-version kv-store)
      :crux.tx/latest-completed-tx (db/read-index-meta this :crux.tx/latest-completed-tx)
+     ;; TODO there is another consumer state of doc-doc
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (def kv-indexer

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -96,7 +96,7 @@
 
 ;;; Transacting Producer
 
-(defrecord KafkaTxLog [^KafkaProducer producer, ^KafkaConsumer latest-submitted-tx-consumer, tx-topic doc-topic kafka-config]
+(defrecord KafkaTxLog [^KafkaProducer producer, ^KafkaConsumer latest-submitted-tx-consumer, tx-topic, doc-topic, kafka-config]
   Closeable
   (close [_])
 
@@ -148,17 +148,29 @@
       (when (pos? end-offset)
         {:crux.tx/tx-id (dec end-offset)}))))
 
+(defprotocol Offsets
+  (read-offsets [this])
+  (store-offsets [this offsets]))
+
+(defrecord IndexedOffsets [indexer k]
+  Offsets
+  (read-offsets [this]
+    (db/read-index-meta indexer k))
+  (store-offsets [this offsets]
+    (println "Put offsets" offsets k)
+    (db/store-index-meta indexer k offsets)))
+
 ;;; Indexing Consumer
 
 (defn- topic-partition-meta-key [^TopicPartition partition]
   (keyword "crux.kafka.topic-partition" (str partition)))
 
-(defn- update-stored-consumer-state [indexer ^KafkaConsumer consumer records]
+(defn- update-stored-consumer-state [offsets ^KafkaConsumer consumer records]
   (let [partition->records (group-by (fn [^ConsumerRecord r]
                                        (TopicPartition. (.topic r)
                                                         (.partition r))) records)
         partitions (vec (keys partition->records))
-        stored-consumer-state (or (db/read-index-meta indexer :crux.tx-log/consumer-state) {})
+        stored-consumer-state (or (read-offsets offsets) {})
         consumer-state (->> (for [^TopicPartition partition partitions
                                   :let [^ConsumerRecord last-record-in-batch (->> (get partition->records partition)
                                                                                   (sort-by #(.offset ^ConsumerRecord %))
@@ -167,49 +179,40 @@
                               [(topic-partition-meta-key partition)
                                {:next-offset next-offset}])
                             (into stored-consumer-state))]
-    (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)))
+    (store-offsets offsets consumer-state)))
 
-(defn- prune-consumer-state [indexer ^KafkaConsumer consumer partitions]
-  (let [consumer-state (db/read-index-meta indexer :crux.tx-log/consumer-state)]
+(defn- prune-consumer-state [offsets ^KafkaConsumer consumer partitions]
+  (let [consumer-state (read-offsets offsets)]
     (->> (for [^TopicPartition partition partitions
                :let [partition-key (topic-partition-meta-key partition)
                      next-offset (or (get-in consumer-state [partition-key :next-offset]) 0)]]
            [partition-key {:next-offset next-offset}])
          (into {})
-         (db/store-index-meta indexer :crux.tx-log/consumer-state))))
+         (store-offsets offsets))))
 
-(defn seek-to-stored-offsets [indexer ^KafkaConsumer consumer partitions]
-  (let [consumer-state (db/read-index-meta indexer :crux.tx-log/consumer-state)]
+(defn seek-to-stored-offsets [offsets ^KafkaConsumer consumer partitions]
+  (let [consumer-state (read-offsets offsets)]
     (doseq [^TopicPartition partition partitions]
       (if-let [offset (get-in consumer-state [(topic-partition-meta-key partition) :next-offset])]
         (.seek consumer partition (long offset))
         (.seekToBeginning consumer [partition])))))
 
-(defn- index-doc-records [indexer doc-records]
-  (db/index-docs indexer (->> doc-records
-                              (into {} (map (fn [^ConsumerRecord record]
-                                              [(c/new-id (.key record)) (.value record)]))))))
+(defn- ensure-tx-topic-has-single-partition [^AdminClient admin-client tx-topic]
+  (let [name->description @(.all (.describeTopics admin-client [tx-topic]))]
+    (assert (= 1 (count (.partitions ^TopicDescription (get name->description tx-topic)))))))
 
-(defn- index-tx-record [indexer ^ConsumerRecord record]
-  (let [{:keys [crux.tx.event/tx-events] :as record} (tx-record->tx-log-entry record)]
-    (db/index-tx indexer (select-keys record [:crux.tx/tx-time :crux.tx/tx-id]) tx-events)
-    tx-events))
-
-(defn consume-and-index-entities
-  [{:keys [indexer ^KafkaConsumer consumer pending-txs-state timeout tx-topic doc-topic]
-    :or {timeout 5000}}]
-
+(defn consume-and-index-txes
+  [{:keys [offsets indexer pending-txs-state timeout tx-topic]
+    :or {timeout 5000}}
+   ^KafkaConsumer consumer]
   (let [tx-topic-partition (TopicPartition. tx-topic 0)
         _ (when (and (.contains (.paused consumer) tx-topic-partition)
                      (empty? @pending-txs-state))
             (log/debug "Resuming" tx-topic)
             (.resume consumer [tx-topic-partition]))
         records (.poll consumer (Duration/ofMillis timeout))
-        doc-records (vec (.records records (str doc-topic)))
-        _ (index-doc-records indexer doc-records)
         tx-records (vec (.records records (str tx-topic)))
         pending-tx-records (swap! pending-txs-state into tx-records)
-
         tx-records (->> pending-tx-records
                         (take-while
                          (fn [^ConsumerRecord tx-record]
@@ -230,20 +233,21 @@
                         (vec))]
 
     (doseq [record tx-records]
-      (index-tx-record indexer record))
+      (let [{:keys [crux.tx.event/tx-events] :as record} (tx-record->tx-log-entry record)]
+        (db/index-tx indexer (select-keys record [:crux.tx/tx-time :crux.tx/tx-id]) tx-events)
+        tx-events))
 
-    (when-let [records (seq (concat doc-records tx-records))]
-      (update-stored-consumer-state indexer consumer records)
+    (when-let [records (seq tx-records)]
+      (update-stored-consumer-state offsets consumer records)
       (swap! pending-txs-state (comp vec (partial drop (count tx-records)))))
 
-    {:txs (count tx-records)
-     :docs (count doc-records)}))
+    (count tx-records)))
 
 ;; TODO: This works as long as each node has a unique consumer group
 ;; id, if not the node will only get a subset of the doc-topic. The
 ;; tx-topic is always only one partition.
 (defn subscribe-from-stored-offsets
-  [indexer ^KafkaConsumer consumer ^List topics]
+  [offsets ^KafkaConsumer consumer ^List topics]
   (.subscribe consumer
               topics
               (reify ConsumerRebalanceListener
@@ -251,10 +255,10 @@
                   (log/info "Partitions revoked:" (str partitions)))
                 (onPartitionsAssigned [_ partitions]
                   (log/info "Partitions assigned:" (str partitions))
-                  (prune-consumer-state indexer consumer partitions)
-                  (seek-to-stored-offsets indexer consumer partitions)))))
+                  (prune-consumer-state offsets consumer partitions)
+                  (seek-to-stored-offsets offsets consumer partitions)))))
 
-(defrecord IndexingConsumer [running? ^Thread worker-thread consumer-config indexer options]
+(defrecord IndexingConsumer [running? ^Thread worker-thread consumer-config]
   status/Status
   (status-map [_]
     {:crux.zk/zk-active?
@@ -270,52 +274,44 @@
     (reset! running? false)
     (.join worker-thread)))
 
-(defn- indexing-consumer-thread-main-loop
-  [{:keys [running? indexer consumer-config options]}]
-  (with-open [consumer (create-consumer consumer-config)]
-    (subscribe-from-stored-offsets
-     indexer consumer [(::tx-topic options) (::doc-topic options)])
-    (let [pending-txs-state (atom [])]
-      (while @running?
-        (try
-          (consume-and-index-entities
-           {:indexer indexer
-            :consumer consumer
-            :timeout 1000
-            :pending-txs-state pending-txs-state
-            :tx-topic (::tx-topic options)
-            :doc-topic (::doc-topic options)})
-          (catch Exception e
-            (log/error e "Error while consuming and indexing from Kafka:")
-            (Thread/sleep 500)))))))
-
-(defn- ensure-tx-topic-has-single-partition [^AdminClient admin-client tx-topic]
-  (let [name->description @(.all (.describeTopics admin-client [tx-topic]))]
-    (assert (= 1 (count (.partitions ^TopicDescription (get name->description tx-topic)))))))
-
 (defn- start-indexing-consumer
   ^java.io.Closeable
-  [admin-client consumer-config indexer
-   {:keys [crux.kafka/tx-topic
-           crux.kafka/replication-factor
-           crux.kafka/doc-partitions
-           crux.kafka/doc-topic
-           crux.kafka/create-topics] :as options}]
+  [admin-client consumer-config offsets topic topic-config index-fn
+   {:keys [crux.kafka/replication-factor
+           crux.kafka/partitions
+           crux.kafka/create-topics]}]
   (when create-topics
-    (create-topic admin-client tx-topic 1 replication-factor tx-topic-config)
-    (create-topic admin-client doc-topic doc-partitions
-                  replication-factor doc-topic-config))
-  (ensure-tx-topic-has-single-partition admin-client tx-topic)
-  (let [indexing-consumer (map->IndexingConsumer {:running? (atom true)
-                                                  :indexer indexer
-                                                  :consumer-config consumer-config
-                                                  :options options})]
-    (assoc
-     indexing-consumer
-     :worker-thread
-     (doto (Thread. ^Runnable (partial indexing-consumer-thread-main-loop indexing-consumer)
-                    "crux.kafka.indexing-consumer-thread")
-       (.start)))))
+    (create-topic admin-client topic partitions replication-factor topic-config))
+  (let [running? (atom true)
+        worker-thread
+        (doto
+            (Thread. ^Runnable (fn []
+                                 (with-open [consumer (create-consumer consumer-config)]
+                                   (subscribe-from-stored-offsets offsets consumer [topic])
+                                   (while @running?
+                                     (try
+                                       (index-fn consumer)
+                                       (catch Exception e
+                                         (log/error e "Error while consuming and indexing from Kafka:")
+                                         (Thread/sleep 500))))))
+                     "crux.kafka.indexing-consumer-thread")
+            (.start))]
+    (map->IndexingConsumer {:running? running?
+                            :consumer-config consumer-config
+                            :worker-thread worker-thread})))
+
+(defn consume-and-index-documents
+  [{:keys [offsets indexer timeout doc-topic]
+    :or {timeout 5000}}
+   ^KafkaConsumer consumer]
+  (let [records (.poll consumer (Duration/ofMillis timeout))
+        doc-records (vec (.records records (str doc-topic)))]
+    (db/index-docs indexer (->> doc-records
+                                (into {} (map (fn [^ConsumerRecord record]
+                                                [(c/new-id (.key record)) (.value record)])))))
+    (when-let [records (seq doc-records)]
+      (update-stored-consumer-state offsets consumer records))
+    (count doc-records)))
 
 (def default-options
   {::bootstrap-servers {:doc "URL for connecting to Kafka i.e. \"kafka-cluster-kafka-brokers.crux.svc.cluster.local:9092\""
@@ -346,17 +342,36 @@
    ::kafka-properties-map {:doc "Used for supplying Kafka connection properties to the underlying Kafka API."
                            :crux.config/type [map? identity]}})
 
-(def indexing-consumer
+(def tx-indexing-consumer
+  {:start-fn (fn [{:keys [crux.kafka/admin-client crux.node/indexer]} {:keys [::tx-topic] :as options}]
+               (let [kafka-config (derive-kafka-config options)
+                     consumer-config (merge {"group.id" (::group-id options)} kafka-config)
+                     offsets (map->IndexedOffsets {:indexer indexer
+                                                   :k :crux.tx-log/consumer-state})
+                     index-fn (partial consume-and-index-txes
+                                       {:indexer indexer
+                                        :offsets offsets
+                                        :timeout 1000
+                                        :pending-txs-state (atom [])
+                                        :tx-topic tx-topic})]
+                 (ensure-tx-topic-has-single-partition admin-client tx-topic)
+                 (start-indexing-consumer admin-client consumer-config offsets index-fn options)))
+   :deps [:crux.node/indexer ::admin-client]
+   :args default-options})
+
+(def doc-indexing-consumer
   {:start-fn (fn [{:keys [crux.kafka/admin-client crux.node/indexer]} options]
                (let [kafka-config (derive-kafka-config options)
-                     consumer-config (merge {"group.id" (::group-id options)} kafka-config)]
-                 (start-indexing-consumer admin-client consumer-config indexer options)))
+                     consumer-config (merge {"group.id" (::group-id options)} kafka-config)
+                     offsets (map->IndexedOffsets {:indexer indexer
+                                                   :k :crux.doc-log/consumer-state})
+                     tx-indexing-fn (partial consume-and-index-documents {:indexer indexer
+                                                                          :offsets offsets
+                                                                          :timeout 1000
+                                                                          :doc-topic (::doc-topic options)})]
+                 (start-indexing-consumer admin-client consumer-config offsets options tx-indexing-fn)))
    :deps [:crux.node/indexer ::admin-client]
-   :args (merge default-options
-                {::doc-threads
-                 {:doc "Threads for document consumer"
-                  :default (+ (.availableProcessors (Runtime/getRuntime)) 2)
-                  :crux.config/type :crux.config/nat-int}})})
+   :args default-options})
 
 (def admin-client
   {:start-fn (fn [_ options]
@@ -391,5 +406,6 @@
           ::admin-client admin-client
           ::admin-wrapper admin-wrapper
           ::producer producer
-          ::indexing-consumer indexing-consumer
+          ::tx-indexing-consumer tx-indexing-consumer
+          ::doc-indexing-consumer doc-indexing-consumer
           ::latest-submitted-tx-consumer latest-submitted-tx-consumer}))

--- a/crux-kafka/src/crux/kafka/consumer.clj
+++ b/crux-kafka/src/crux/kafka/consumer.clj
@@ -1,0 +1,118 @@
+(ns crux.kafka.consumer
+  (:require [clojure.tools.logging :as log]
+            [crux.db :as db]
+            [crux.status :as status])
+  (:import crux.kafka.nippy.NippyDeserializer
+           java.io.Closeable
+           [java.util List Map]
+           [org.apache.kafka.clients.consumer ConsumerRebalanceListener ConsumerRecord KafkaConsumer]
+           org.apache.kafka.common.TopicPartition))
+
+(def default-consumer-config
+  {"enable.auto.commit" "false"
+   "isolation.level" "read_committed"
+   "auto.offset.reset" "earliest"
+   "key.deserializer" (.getName NippyDeserializer)
+   "value.deserializer" (.getName NippyDeserializer)})
+
+(defn create-consumer
+  ^org.apache.kafka.clients.consumer.KafkaConsumer [config]
+  (KafkaConsumer. ^Map (merge default-consumer-config config)))
+
+(defprotocol Offsets
+  (read-offsets [this])
+  (store-offsets [this offsets]))
+
+(defrecord IndexedOffsets [indexer k]
+  Offsets
+  (read-offsets [this]
+    (db/read-index-meta indexer k))
+  (store-offsets [this offsets]
+    (db/store-index-meta indexer k offsets)))
+
+(defn- topic-partition-meta-key [^TopicPartition partition]
+  (keyword "crux.kafka.topic-partition" (str partition)))
+
+(defn seek-to-stored-offsets [offsets ^KafkaConsumer consumer partitions]
+  (let [consumer-state (read-offsets offsets)]
+    (doseq [^TopicPartition partition partitions]
+      (if-let [offset (get-in consumer-state [(topic-partition-meta-key partition) :next-offset])]
+        (.seek consumer partition (long offset))
+        (.seekToBeginning consumer [partition])))))
+
+(defn update-stored-consumer-state [offsets ^KafkaConsumer consumer records]
+  (let [partition->records (group-by (fn [^ConsumerRecord r]
+                                       (TopicPartition. (.topic r)
+                                                        (.partition r))) records)
+        partitions (vec (keys partition->records))
+        stored-consumer-state (or (read-offsets offsets) {})
+        consumer-state (->> (for [^TopicPartition partition partitions
+                                  :let [^ConsumerRecord last-record-in-batch (->> (get partition->records partition)
+                                                                                  (sort-by #(.offset ^ConsumerRecord %))
+                                                                                  (last))
+                                        next-offset (inc (.offset last-record-in-batch))]]
+                              [(topic-partition-meta-key partition)
+                               {:next-offset next-offset}])
+                            (into stored-consumer-state))]
+    (store-offsets offsets consumer-state)))
+
+(defn- prune-consumer-state [offsets ^KafkaConsumer consumer partitions]
+  (let [consumer-state (read-offsets offsets)]
+    (->> (for [^TopicPartition partition partitions
+               :let [partition-key (topic-partition-meta-key partition)
+                     next-offset (or (get-in consumer-state [partition-key :next-offset]) 0)]]
+           [partition-key {:next-offset next-offset}])
+         (into {})
+         (store-offsets offsets))))
+
+;; TODO: This works as long as each node has a unique consumer group
+;; id, if not the node will only get a subset of the doc-topic. The
+;; tx-topic is always only one partition.
+(defn subscribe-from-stored-offsets
+  [offsets ^KafkaConsumer consumer ^List topics]
+  (.subscribe consumer
+              topics
+              (reify ConsumerRebalanceListener
+                (onPartitionsRevoked [_ partitions]
+                  (log/info "Partitions revoked:" (str partitions)))
+                (onPartitionsAssigned [_ partitions]
+                  (log/info "Partitions assigned:" (str partitions))
+                  (prune-consumer-state offsets consumer partitions)
+                  (seek-to-stored-offsets offsets consumer partitions)))))
+
+(defrecord IndexingConsumer [running? ^Thread worker-thread consumer-config]
+  status/Status
+  (status-map [_]
+    {:crux.zk/zk-active?
+     (try
+       (with-open [^KafkaConsumer consumer (create-consumer (merge consumer-config {"default.api.timeout.ms" (int 1000)}))]
+         (boolean (.listTopics consumer)))
+       (catch Exception e
+         (log/debug e "Could not list Kafka topics:")
+         false))})
+
+  Closeable
+  (close [_]
+    (reset! running? false)
+    (.join worker-thread)))
+
+(defn start-indexing-consumer
+  ^java.io.Closeable
+  [consumer-config offsets topic index-fn]
+  (let [running? (atom true)
+        worker-thread
+        (doto
+            (Thread. ^Runnable (fn []
+                                 (with-open [consumer (create-consumer consumer-config)]
+                                   (subscribe-from-stored-offsets offsets consumer [topic])
+                                   (while @running?
+                                     (try
+                                       (index-fn consumer)
+                                       (catch Exception e
+                                         (log/error e "Error while consuming and indexing from Kafka:")
+                                         (Thread/sleep 500))))))
+                     "crux.kafka.indexing-consumer-thread")
+            (.start))]
+    (map->IndexingConsumer {:running? running?
+                            :consumer-config consumer-config
+                            :worker-thread worker-thread})))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -77,7 +77,7 @@
 
 (t/deftest test-can-use-api-to-access-crux
   (t/testing "status"
-    (t/is (= (merge {:crux.index/index-version 5}
+    (t/is (= (merge {:crux.index/index-version 6}
                     (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                       {:crux.zk/zk-active? true}))
              (select-keys (.status *api*) [:crux.index/index-version :crux.zk/zk-active?]))))

--- a/crux-test/test/crux/fixtures/kafka.clj
+++ b/crux-test/test/crux/fixtures/kafka.clj
@@ -51,17 +51,23 @@
 
 (def ^:dynamic ^KafkaProducer *producer*)
 (def ^:dynamic ^KafkaConsumer *consumer*)
+(def ^:dynamic ^KafkaConsumer *consumer2*)
 
 (def ^:dynamic *consumer-options* {})
 
 (defn with-kafka-client [f & {:keys [consumer-options]}]
   (with-open [producer (k/create-producer {"bootstrap.servers" *kafka-bootstrap-servers*})
               consumer (k/create-consumer
+                        (merge {"bootstrap.servers" *kafka-bootstrap-servers*
+                                "group.id" (str (UUID/randomUUID))}
+                               *consumer-options*))
+              consumer2 (k/create-consumer
                          (merge {"bootstrap.servers" *kafka-bootstrap-servers*
                                  "group.id" (str (UUID/randomUUID))}
                                 *consumer-options*))]
     (binding [*producer* producer
-              *consumer* consumer]
+              *consumer* consumer
+              *consumer2* consumer2]
       (f))))
 
 (def ^:dynamic *cluster-node*)

--- a/crux-test/test/crux/fixtures/kafka.clj
+++ b/crux-test/test/crux/fixtures/kafka.clj
@@ -4,6 +4,7 @@
             [crux.fixtures.kv-only :refer [*kv-module*]]
             [crux.io :as cio]
             [crux.kafka :as k]
+            [crux.kafka.consumer :as kc]
             [crux.kafka.embedded :as ek]
             [crux.api :as api])
   (:import [java.util Properties UUID]
@@ -57,11 +58,11 @@
 
 (defn with-kafka-client [f & {:keys [consumer-options]}]
   (with-open [producer (k/create-producer {"bootstrap.servers" *kafka-bootstrap-servers*})
-              consumer (k/create-consumer
+              consumer (kc/create-consumer
                         (merge {"bootstrap.servers" *kafka-bootstrap-servers*
                                 "group.id" (str (UUID/randomUUID))}
                                *consumer-options*))
-              consumer2 (k/create-consumer
+              consumer2 (kc/create-consumer
                          (merge {"bootstrap.servers" *kafka-bootstrap-servers*
                                  "group.id" (str (UUID/randomUUID))}
                                 *consumer-options*))]

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -48,15 +48,20 @@
         doc-topic "test-can-transact-entities-doc"
         tx-ops (rdf/->tx-ops (rdf/ntriples "crux/example-data-artists.nt"))
         tx-log (k/->KafkaTxLog fk/*producer* fk/*consumer* tx-topic doc-topic {})
-        indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log (bus/->EventBus (atom #{})) nil)]
+        indexer (tx/->KvIndexer (os/->KvObjectStore *kv*) *kv* tx-log (bus/->EventBus (atom #{})) nil)
+        tx-offsets (k/map->IndexedOffsets {:indexer indexer
+                                           :k :crux.tx-log/consumer-state})
+        doc-offsets (k/map->IndexedOffsets {:indexer indexer
+                                            :k :crux.doc-log/consumer-state})]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
     (k/create-topic fk/*admin-client* doc-topic 1 1 k/doc-topic-config)
-    (k/subscribe-from-stored-offsets indexer fk/*consumer* [doc-topic])
+    (k/subscribe-from-stored-offsets tx-offsets fk/*consumer* [tx-topic])
+    (k/subscribe-from-stored-offsets doc-offsets fk/*consumer2* [doc-topic])
 
     (db/submit-tx tx-log tx-ops)
 
-    (let [docs (map consumer-record->value (.poll fk/*consumer* (Duration/ofMillis 10000)))]
+    (let [docs (map consumer-record->value (.poll fk/*consumer2* (Duration/ofMillis 10000)))]
       (t/is (= 7 (count docs)))
       (t/is (= (rdf/with-prefix {:foaf "http://xmlns.com/foaf/0.1/"}
                  {:foaf/firstName "Pablo"
@@ -64,7 +69,10 @@
                (select-keys (first docs)
                             (rdf/with-prefix {:foaf "http://xmlns.com/foaf/0.1/"}
                               [:foaf/firstName
-                               :foaf/surname])))))))
+                               :foaf/surname])))))
+
+    (let [txes (map consumer-record->value (.poll fk/*consumer* (Duration/ofMillis 10000)))]
+      (t/is (= 7 (count (first txes)))))))
 
 (t/deftest test-can-transact-and-query-entities
   (let [tx-topic "test-can-transact-and-query-entities-tx"
@@ -79,7 +87,14 @@
         tx-offsets (k/map->IndexedOffsets {:indexer indexer
                                            :k :crux.tx-log/consumer-state})
         doc-offsets (k/map->IndexedOffsets {:indexer indexer
-                                            :k :crux.doc-log/consumer-state})]
+                                            :k :crux.doc-log/consumer-state})
+        consume-opts {:indexer indexer
+                      :offsets tx-offsets
+                      :pending-txs-state (atom [])
+                      :tx-topic tx-topic}
+        doc-consume-opts {:indexer indexer
+                          :offsets doc-offsets
+                          :doc-topic doc-topic}]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
     (k/create-topic fk/*admin-client* doc-topic 1 1 k/doc-topic-config)
@@ -87,14 +102,7 @@
     (k/subscribe-from-stored-offsets doc-offsets fk/*consumer2* [doc-topic])
 
     (t/testing "transacting and indexing"
-      (let [{:crux.tx/keys [tx-id tx-time]} @(db/submit-tx tx-log tx-ops)
-            consume-opts {:indexer indexer
-                          :offsets tx-offsets
-                          :pending-txs-state (atom [])
-                          :tx-topic tx-topic}
-            doc-consume-opts {:indexer indexer
-                              :offsets doc-offsets
-                              :doc-topic doc-topic}]
+      (let [{:crux.tx/keys [tx-id tx-time]} @(db/submit-tx tx-log tx-ops)]
         (t/is (= 3
                  (k/consume-and-index-documents doc-consume-opts fk/*consumer2*)))
         (t/is (= 1
@@ -125,6 +133,12 @@
               (t/is (= 1 (count log)))
               (t/is (= 3 (count (:crux.tx.event/tx-events (first log))))))))))))
 
+(defn- consume-topics [tx-consume-opts doc-consume-opts]
+  (loop []
+    (when (or (not= 0 (k/consume-and-index-documents doc-consume-opts fk/*consumer2*))
+              (not= 0 (k/consume-and-index-txes tx-consume-opts fk/*consumer*)))
+      (recur))))
+
 (t/deftest test-can-process-compacted-documents
   ;; when doing a evict a tombstone document will be written to
   ;; replace the original document. The original document will be then
@@ -142,40 +156,41 @@
 
         node (reify crux.api.ICruxAPI
                (db [this]
-                 (q/db *kv* object-store (cio/next-monotonic-date) (cio/next-monotonic-date))))]
+                 (q/db *kv* object-store (cio/next-monotonic-date) (cio/next-monotonic-date))))
+        tx-offsets (k/map->IndexedOffsets {:indexer indexer
+                                           :k :crux.tx-log/consumer-state})
+        doc-offsets (k/map->IndexedOffsets {:indexer indexer
+                                            :k :crux.doc-log/consumer-state})
+        tx-consume-opts {:indexer indexer
+                         :offsets tx-offsets
+                         :pending-txs-state (atom [])
+                         :tx-topic tx-topic}
+        doc-consume-opts {:indexer indexer
+                          :offsets doc-offsets
+                          :doc-topic doc-topic}]
 
     (k/create-topic fk/*admin-client* tx-topic 1 1 k/tx-topic-config)
     (k/create-topic fk/*admin-client* doc-topic 1 1 k/doc-topic-config)
-    (k/subscribe-from-stored-offsets indexer fk/*consumer* [tx-topic doc-topic])
+    (k/subscribe-from-stored-offsets tx-offsets fk/*consumer* [tx-topic])
+    (k/subscribe-from-stored-offsets doc-offsets fk/*consumer2* [doc-topic])
 
     (t/testing "transacting and indexing"
-      (let [consume-opts {:indexer indexer
-                          :consumer fk/*consumer*
-                          :pending-txs-state (atom [])
-                          :tx-topic tx-topic
-                          :doc-topic doc-topic}
-
-            evicted-doc {:crux.db/id :to-be-eviceted :personal "private"}
+      (let [evicted-doc {:crux.db/id :to-be-evicted :personal "private"}
             non-evicted-doc {:crux.db/id :not-evicted :personal "private"}
             evicted-doc-hash
-            (do @(db/submit-tx
-                  tx-log
-                  [[:crux.tx/put evicted-doc]
-                   [:crux.tx/put non-evicted-doc]])
-
-                (k/consume-and-index-txes consume-opts)
-                (while (not= {:txs 0 :docs 0} (k/consume-and-index-txes consume-opts)))
+            (do @(db/submit-tx tx-log [[:crux.tx/put evicted-doc]
+                                       [:crux.tx/put non-evicted-doc]])
+                (t/is (= 2 (k/consume-and-index-documents doc-consume-opts fk/*consumer2*)))
+                (t/is (= 1 (k/consume-and-index-txes tx-consume-opts fk/*consumer*)))
                 (:crux.db/content-hash (q/entity-tx (api/db node) (:crux.db/id evicted-doc))))
 
             after-evict-doc {:crux.db/id :after-evict :personal "private"}
             {:crux.tx/keys [tx-id tx-time]}
             (do
               @(db/submit-tx tx-log [[:crux.tx/evict (:crux.db/id evicted-doc)]])
-              @(db/submit-tx
-                tx-log
-                [[:crux.tx/put after-evict-doc]]))]
+              @(db/submit-tx tx-log [[:crux.tx/put after-evict-doc]]))]
 
-        (while (not= {:txs 0 :docs 0} (k/consume-and-index-txes consume-opts)))
+        (consume-topics tx-consume-opts doc-consume-opts)
 
         (t/testing "querying transacted data"
           (t/is (= non-evicted-doc (q/entity (api/db node) (:crux.db/id non-evicted-doc))))
@@ -190,19 +205,23 @@
                   (fn []
                     (let [object-store (os/->KvObjectStore *kv*)
                           indexer (tx/->KvIndexer object-store *kv* tx-log (bus/->EventBus (atom #{})) nil)
-                          consume-opts {:indexer indexer
-                                        :consumer fk/*consumer*
-                                        :pending-txs-state (atom [])
-                                        :tx-topic tx-topic
-                                        :doc-topic doc-topic}]
-                      (k/subscribe-from-stored-offsets indexer fk/*consumer* [tx-topic doc-topic])
-                      (k/consume-and-index-txes consume-opts)
-                      (t/is (= {:txs 0, :docs 1} (k/consume-and-index-txes consume-opts)))
+                          tx-offsets (k/map->IndexedOffsets {:indexer indexer
+                                                             :k :crux.tx-log/consumer-state})
+                          doc-offsets (k/map->IndexedOffsets {:indexer indexer
+                                                              :k :crux.doc-log/consumer-state})
+                          tx-consume-opts {:indexer indexer
+                                           :offsets tx-offsets
+                                           :pending-txs-state (atom [])
+                                           :tx-topic tx-topic}
+                          doc-consume-opts {:indexer indexer
+                                            :offsets doc-offsets
+                                            :doc-topic doc-topic}]
+                      (k/subscribe-from-stored-offsets tx-offsets fk/*consumer* [tx-topic])
+                      (k/subscribe-from-stored-offsets doc-offsets fk/*consumer2* [doc-topic])
+                      (consume-topics tx-consume-opts doc-consume-opts)
+
                       ;; delete the object that would have been compacted away
                       (db/delete-objects object-store [evicted-doc-hash])
-
-                      (while (not= {:txs 0 :docs 0} (k/consume-and-index-txes consume-opts)))
-                      (t/is (empty? (.poll fk/*consumer* (Duration/ofMillis 1000))))
 
                       (t/testing "querying transacted data"
                         (t/is (= non-evicted-doc (q/entity (api/db node) (:crux.db/id non-evicted-doc))))

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -103,10 +103,8 @@
 
     (t/testing "transacting and indexing"
       (let [{:crux.tx/keys [tx-id tx-time]} @(db/submit-tx tx-log tx-ops)]
-        (t/is (= 3
-                 (k/consume-and-index-documents doc-consume-opts fk/*consumer2*)))
-        (t/is (= 1
-                 (k/consume-and-index-txes consume-opts fk/*consumer*)))
+        (t/is (= 3 (k/consume-and-index-documents doc-consume-opts fk/*consumer2*)))
+        (t/is (= 1 (k/consume-and-index-txes consume-opts fk/*consumer*)))
         (t/is (empty? (.poll fk/*consumer* (Duration/ofMillis 1000))))
 
         (t/testing "restoring to stored offsets"


### PR DESCRIPTION
Pulling out the boilerplate consume code into a separate supporting namespace, helps see the woods through the trees of the main kafka namespace. This PR subsumes #554 which should be merged first.