### PR TITLE
Bug - predicates failing at zero depth should stop the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 20.01-1.6.3-alpha
+
+### Changes
+
+### Bug fixes
+* [#565](https://github.com/juxt/crux/pull/565): query predicate at zero join depth can now stop tuples from being returned
+
 ## 20.01-1.6.2-alpha
 
 ### Changes

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -989,10 +989,10 @@
     (log/debug :vars-in-join-order vars-in-join-order)
     (log/debug :attr-stats (cio/pr-edn-str attr-stats))
     (log/debug :var->bindings (cio/pr-edn-str var->bindings))
-    (constrain-result-fn [] [])
-    {:n-ary-join (-> (mapv idx/new-unary-join-virtual-index unary-join-index-groups)
-                     (idx/new-n-ary-join-layered-virtual-index)
-                     (idx/new-n-ary-constraining-layered-virtual-index constrain-result-fn))
+    {:n-ary-join (when (constrain-result-fn [] [])
+                   (-> (mapv idx/new-unary-join-virtual-index unary-join-index-groups)
+                       (idx/new-n-ary-join-layered-virtual-index)
+                       (idx/new-n-ary-constraining-layered-virtual-index constrain-result-fn)))
      :var->bindings var->bindings}))
 
 ;; NOTE: For ascending sort, it might be possible to pick the right

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2484,6 +2484,20 @@
                              [y :crux.db/id]
                              [(!= x y)]]]}))))
 
+(t/deftest test-failing-predicates-at-top-level-bug
+  (t/testing "predicate order shouldn't matter"
+    (t/is (= #{}
+             (api/q (api/db *api*)
+                    '{:find [f]
+                      :where [[(identity 4) f]
+                              [(identity false)]]})))
+
+    (t/is (= #{}
+             (api/q (api/db *api*)
+                    '{:find [f]
+                      :where [[(identity false)]
+                              [(identity 4) f]]})))))
+
 ;; Tests from
 ;; https://pdfs.semanticscholar.org/9374/f0da312f3ba77fa840071d68935a28cba364.pdf
 


### PR DESCRIPTION
bug @hraberg and I found and fixed while tracking down #507 

in the test case, the presence of the `(identity false)` predicate should mean that the query doesn't return any tuples - but, depending on which order the predicates were declared in, it did :grimacing: 