### PR TITLE
Literal rule arguments bug #507

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 
 ### Bug fixes
 * [#565](https://github.com/juxt/crux/pull/565): query predicate at zero join depth can now stop tuples from being returned
+* [#507](https://github.com/juxt/crux/issues/507): ranges in rules revert to a predicate if neither argument is a logic var
 
 ## 20.01-1.6.2-alpha
 
 ### Changes
 * [#524](https://github.com/juxt/crux/issues/524): Batch ingesting docs into the KV store
-* [PR #520](https://github.com/juxt/crux/pull/520): New `entity` arity accepts a snapshot argument for >40% performance boost
+* [#520](https://github.com/juxt/crux/pull/520): New `entity` arity accepts a snapshot argument for >40% performance boost
 
 ### Bug fixes
 * [#371](https://github.com/juxt/crux/issues/371): Documents in failed CaS operations now get evicted correctly
@@ -40,7 +41,7 @@ These changes bump the index version to version 5 - a re-index of Crux nodes is 
 * [#326](https://github.com/juxt/crux/issues/326): Put/delete with start/end valid-time semantics made consistent
 
 ### New features
-* [PR #363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
+* [#363](https://github.com/juxt/crux/pull/363): Allow `full-results?` and other boolean flags in a vector-style query
 * [#372](https://github.com/juxt/crux/issues/372): Add support for Java collection types with submitTx
 * [#377](https://github.com/juxt/crux/issues/377): Can use 'cons' within query predicates
 * [#414](https://github.com/juxt/crux/issues/414): Developer tool for query tracing

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -141,7 +141,8 @@
 (def ^:private pred->built-in-range-pred {< (comp neg? compare)
                                           <= (comp not pos? compare)
                                           > (comp pos? compare)
-                                          >= (comp not neg? compare)})
+                                          >= (comp not neg? compare)
+                                          = =})
 
 (def ^:private range->inverse-range '{< >=
                                       <= >
@@ -177,7 +178,8 @@
                           {:keys [op sym val] :as clause} (cond-> clause
                                                             (= :val-sym order) (update :op range->inverse-range))]
                       (if-not (logic-var? sym)
-                        {:pred [{:pred {:pred-fn (resolve op), :args [sym val]}}]}
+                        {:pred [{:pred {:pred-fn (get pred->built-in-range-pred (var-get (resolve op)))
+                                        :args [sym val]}}]}
                         {:range [clause]}))
 
              :unify {:unify [(first clause)]}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2497,6 +2497,17 @@
                       :where [[(identity false)]
                               [(identity 4) f]]})))))
 
+(t/deftest test-literal-rule-arguments-bug-507
+  ;; supplying 4 as the rule arg here is a necessary condition
+  (t/testing "range clause in rule"
+    (t/is (= #{}
+             (api/q (api/db *api*)
+                    '{:find [f]
+                      :where [(foo 4 f)]
+                      :rules [[(foo n f)
+                               [(<= 6 n)]
+                               [(identity n) f]]]})))))
+
 ;; Test from Racket Datalog documentation:
 ;; https://docs.racket-lang.org/datalog/datalog.html
 (t/deftest test-racket-datalog-fib

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2701,9 +2701,10 @@
   (f/transact! *api* [{:crux.db/id :ivan :name "Ivan" :last-name "Ivanov"}
                       {:crux.db/id :petr :name "Petr" :last-name "Petrov"}])
 
-  (t/is (= #{[:ivan] [:petr]} (api/q (api/db *api*) '{:find [e]
-                                                  :where [[e :crux.db/id _]]
-                                                  :timeout 10}))))
+  (t/is (= #{[:ivan] [:petr]}
+           (api/q (api/db *api*) '{:find [e]
+                                   :where [[e :crux.db/id _]]
+                                   :timeout 100}))))
 
 (t/deftest test-nil-query-attribute-453
   (f/transact! *api* [{:crux.db/id :id :this :that :these :those}])

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2459,7 +2459,6 @@
                              (path x z)
                              [z :edge y]]]}))))
 
-
 (t/deftest test-racket-datalog-sym
   ;; sym(a).
   ;; sym(b).
@@ -2497,6 +2496,39 @@
                     '{:find [f]
                       :where [[(identity false)]
                               [(identity 4) f]]})))))
+
+;; Test from Racket Datalog documentation:
+;; https://docs.racket-lang.org/datalog/datalog.html
+(t/deftest test-racket-datalog-fib
+  ;; fib(0, 0).
+  ;; fib(1, 1).
+
+  ;;  fib(N, F) :- N != 1,
+  ;;               N != 0,
+  ;;               N1 :- -(N, 1),
+  ;;               N2 :- -(N, 2),
+  ;;               fib(N1, F1),
+  ;;               fib(N2, F2),
+  ;;               F :- +(F1, F2).
+
+  ;;  fib(30, F)?
+  (t/is (= #{[610]}
+           (api/q (api/db *api*)
+                  '{:find [f]
+                    ;; replacing n with 15 here returns 15 as well as
+                    ;; 610.
+                    :where [(fib n f)]
+                    :args [{n 15}] ;; 30 is too slow.
+                    :rules [[(fib n f)
+                             [(<= n 1)]
+                             [(identity n) f]]
+                            [(fib n f)
+                             [(> n 1)]
+                             [(- n 1) n1]
+                             [(- n 2) n2]
+                             (fib n1 f1)
+                             (fib n2 f2)
+                             [(+ f1 f2) f]]]}))))
 
 ;; Tests from
 ;; https://pdfs.semanticscholar.org/9374/f0da312f3ba77fa840071d68935a28cba364.pdf


### PR DESCRIPTION
fixes #507 by re-checking range predicates after expanding rules - if we spot that the symbol has been replaced by a literal, we convert it back to a vanilla predicate