### PR TITLE
Allowing multiple modules in `:crux.node/topology`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ Start a standalone in-memory (i.e. not persisted anywhere) node:
 (def my-node
   (crux/start-node
     {:crux.node/topology ['crux.standalone/topology]
-     :crux.node/kv-store "crux.kv.memdb/kv" ; see 'configuration' section of docs for LMDB/RocksDB storage options
+     :crux.node/kv-store 'crux.kv.memdb/kv ; see 'configuration' section of docs for LMDB/RocksDB storage options
      :crux.standalone/event-log-dir "data/event-log-dir-1"
-     :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
+     :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv
      :crux.kv/db-dir "data/db-dir-1"}))
 ```
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Start a standalone in-memory (i.e. not persisted anywhere) node:
 
 (def my-node
   (crux/start-node
-    {:crux.node/topology :crux.standalone/topology
+    {:crux.node/topology ['crux.standalone/topology]
      :crux.node/kv-store "crux.kv.memdb/kv" ; see 'configuration' section of docs for LMDB/RocksDB storage options
      :crux.standalone/event-log-dir "data/event-log-dir-1"
      :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"

--- a/crux-bench-watdiv/src/crux_bench/main.clj
+++ b/crux-bench-watdiv/src/crux_bench/main.clj
@@ -203,7 +203,7 @@
 (def ^:private default-block-size (* 16 SizeUnit/KB))
 
 (def crux-options
-  {:crux.node/topology :crux.kafka/topology
+  {:crux.node/topology 'crux.kafka/topology
    :crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.kafka/bootstrap-servers "kafka-cluster2-kafka-bootstrap.crux:9092"
    :crux.standalone/event-log-dir log-dir

--- a/crux-bench-watdiv/src/crux_bench/main.clj
+++ b/crux-bench-watdiv/src/crux_bench/main.clj
@@ -204,7 +204,7 @@
 
 (def crux-options
   {:crux.node/topology 'crux.kafka/topology
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+   :crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.kafka/bootstrap-servers "kafka-cluster2-kafka-bootstrap.crux:9092"
    :crux.standalone/event-log-dir log-dir
    :crux.kv/db-dir index-dir

--- a/crux-bench/src/crux/bench/utils.clj
+++ b/crux-bench/src/crux/bench/utils.clj
@@ -27,7 +27,7 @@
                                   :crux.kafka.embedded/kafka-log-dir "dev-storage/kafka-log"
                                   :crux.kafka.embedded/kafka-port 9092})
                 node (api/start-node {:crux.node/topology 'crux.kafka/topology
-                                      :crux.node/kv-store "crux.kv.rocksdb/kv"
+                                      :crux.node/kv-store 'crux.kv.rocksdb/kv
                                       :crux.kafka/bootstrap-servers "localhost:9092"
                                       :crux.kv/db-dir "dev-storage/db-dir-1"
                                       :crux.standalone/event-log-dir "dev-storage/eventlog-1"})]

--- a/crux-bench/src/crux/bench/utils.clj
+++ b/crux-bench/src/crux/bench/utils.clj
@@ -26,7 +26,7 @@
                                  {:crux.kafka.embedded/zookeeper-data-dir "dev-storage/zookeeper"
                                   :crux.kafka.embedded/kafka-log-dir "dev-storage/kafka-log"
                                   :crux.kafka.embedded/kafka-port 9092})
-                node (api/start-node {:crux.node/topology :crux.kafka/topology
+                node (api/start-node {:crux.node/topology 'crux.kafka/topology
                                       :crux.node/kv-store "crux.kv.rocksdb/kv"
                                       :crux.kafka/bootstrap-servers "localhost:9092"
                                       :crux.kv/db-dir "dev-storage/db-dir-1"

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -338,7 +338,7 @@
 (defn start-node
   "NOTE: requires any dependendies on the classpath that the Crux modules may need.
 
-  options {:crux.node/topology e.g. \"crux.standalone/topology\"}
+  options {:crux.node/topology 'crux.standalone/topology}
 
   Options are specified as keywords using their long format name, like
   :crux.kafka/bootstrap-servers etc. See the individual modules used in the specified

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -190,23 +190,25 @@
 
 (s/def ::start-fn ifn?)
 (s/def ::deps (s/coll-of keyword?))
-(s/def ::args (s/map-of keyword?
-                        (s/keys :req [:crux.config/type]
-                                :req-un [:crux.config/doc]
-                                :opt-un [:crux.config/default
-                                         :crux.config/required?])))
+
+(s/def ::args
+  (s/map-of keyword?
+            (s/keys :req [:crux.config/type]
+                    :req-un [:crux.config/doc]
+                    :opt-un [:crux.config/default
+                             :crux.config/required?])))
 
 (defn- resolve-topology-id [id]
   (s/assert ::topology-id id)
   (-> id symbol requiring-resolve var-get))
 
-(s/def ::module (s/and (s/and (s/or :module-id ::topology-id :module map?)
-                              (s/conformer
-                               (fn [[m-or-id s]]
-                                 (if (= :module-id m-or-id)
-                                   (resolve-topology-id s) s))))
-                       (s/keys :req-un [::start-fn]
-                               :opt-un [::deps ::args])))
+(s/def ::module
+  (s/and (s/and (s/or :module-id ::topology-id, :module map?)
+                (s/conformer
+                 (fn [[m-or-id s]]
+                   (cond-> s (= :module-id m-or-id) resolve-topology-id))))
+         (s/keys :req-un [::start-fn]
+                 :opt-un [::deps ::args])))
 
 (defn- start-order [system]
   (let [g (reduce-kv (fn [g k m]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -183,10 +183,16 @@
       (when (and (not @closed?) close-fn) (close-fn))
       (reset! closed? true))))
 
-(s/def ::topology-id
+(s/def ::resolvable-id
   (fn [id]
     (and (or (string? id) (keyword? id) (symbol? id))
          (namespace (symbol id)))))
+
+(defn- resolve-id [id]
+  (s/assert ::resolvable-id id)
+  (-> (or (-> id symbol requiring-resolve)
+          (throw (IllegalArgumentException. (format "Can't resolve symbol: '%s'" id))))
+      var-get))
 
 (s/def ::start-fn ifn?)
 (s/def ::deps (s/coll-of keyword?))
@@ -198,22 +204,35 @@
                     :opt-un [:crux.config/default
                              :crux.config/required?])))
 
-(defn- resolve-topology-id [id]
-  (s/assert ::topology-id id)
-  (-> id symbol requiring-resolve var-get))
-
-(s/def ::module
-  (s/and (s/and (s/or :module-id ::topology-id, :module map?)
-                (s/conformer
-                 (fn [[m-or-id s]]
-                   (cond-> s (= :module-id m-or-id) resolve-topology-id))))
+(s/def ::component
+  (s/and (s/or :component-id ::resolvable-id, :component map?)
+         (s/conformer (fn [[c-or-id s]]
+                        (cond-> s (= :component-id c-or-id) resolve-id)))
          (s/keys :req-un [::start-fn]
                  :opt-un [::deps ::args])))
 
+(s/def ::module
+  (s/and (s/or :module-id ::resolvable-id, :module map?)
+         (s/conformer (fn [[m-or-id s]]
+                        (cond-> s (= :module-id m-or-id) resolve-id)))))
+
+(s/def ::resolved-topology (s/map-of keyword? ::component))
+
+(defn options->topology [{:keys [crux.node/topology] :as options}]
+  (when-not topology
+    (throw (IllegalArgumentException. "Please specify :crux.node/topology")))
+
+  (let [topology (-> topology
+                     (cond-> (not (vector? topology)) vector)
+                     (->> (map #(s/conform ::module %))
+                          (apply merge)))]
+    (->> (merge topology (select-keys options (keys topology)))
+         (s/conform ::resolved-topology))))
+
 (defn- start-order [system]
-  (let [g (reduce-kv (fn [g k m]
-                       (let [m (s/conform ::module m)]
-                         (reduce (fn [g d] (dep/depend g k d)) g (:deps m))))
+  (let [g (reduce-kv (fn [g k c]
+                       (let [c (s/conform ::component c)]
+                         (reduce (fn [g d] (dep/depend g k d)) g (:deps c))))
                      (dep/graph)
                      system)
         dep-order (dep/topo-sort g)
@@ -224,64 +243,54 @@
 
 (defn- parse-opts [args options]
   (into {}
-        (for [[k {:keys [crux.config/type default required?]}] args
-              :let [[validate-fn parse-fn] (s/conform :crux.config/type type)
-                    v (some-> (get options k) parse-fn)
-                    v (if (nil? v) default v)]]
-          (do
+        (for [[k {:keys [crux.config/type default required?]}] args]
+          (let [[validate-fn parse-fn] (s/conform :crux.config/type type)
+                v (some-> (get options k) parse-fn)
+                v (if (nil? v) default v)]
+
             (when (and required? (not v))
               (throw (IllegalArgumentException. (format "Arg %s required" k))))
+
             (when (and v (not (validate-fn v)))
               (throw (IllegalArgumentException. (format "Arg %s invalid" k))))
+
             [k v]))))
 
-(defn start-module [m started options]
-  (s/assert ::module m)
-  (let [{:keys [start-fn deps spec args]} (s/conform ::module m)
+(defn start-component [c started options]
+  (s/assert ::component c)
+  (let [{:keys [start-fn deps spec args]} (s/conform ::component c)
         deps (select-keys started deps)
         options (merge options (parse-opts args options))]
     (start-fn deps options)))
 
-(s/def ::topology-map (s/map-of keyword? ::module))
-
-(defn start-modules [topology options]
-  (s/assert ::topology-map topology)
+(defn start-components [topology options]
+  (s/assert ::resolved-topology topology)
   (let [started-order (atom [])
         started (atom {})
         started-modules (try
                           (into {}
                                 (for [k (start-order topology)]
-                                  (let [m (topology k)
-                                        _ (assert m (str "Could not find module " k))
-                                        m (start-module m @started options)]
-                                    (swap! started-order conj m)
-                                    (swap! started assoc k m)
-                                    [k m])))
+                                  (let [c (or (get topology k)
+                                              (throw (IllegalArgumentException. (str "Could not find component " k))))
+                                        c (start-component c @started options)]
+                                    (swap! started-order conj c)
+                                    (swap! started assoc k c)
+                                    [k c])))
                           (catch Throwable t
                             (doseq [c (reverse @started-order)]
                               (when (instance? Closeable c)
                                 (cio/try-close c)))
                             (throw t)))]
     [started-modules (fn []
-                       (doseq [m (reverse @started-order)
-                               :when (instance? Closeable m)]
-                         (cio/try-close m)))]))
+                       (doseq [c (reverse @started-order)
+                               :when (instance? Closeable c)]
+                         (cio/try-close c)))]))
 
 (def base-topology
   {::kv-store 'crux.kv.rocksdb/kv
    ::object-store 'crux.object-store/kv-object-store
    ::indexer 'crux.tx/kv-indexer
    ::bus 'crux.bus/bus})
-
-(defn options->topology [{:keys [crux.node/topology] :as options}]
-  (when-not topology
-    (throw (IllegalArgumentException. "Please specify :crux.node/topology")))
-  (let [topology (if (map? topology) topology (resolve-topology-id topology))
-        topology-overrides (select-keys options (keys topology))
-        topology (merge topology (zipmap (keys topology-overrides)
-                                         (map resolve-topology-id (vals topology-overrides))))]
-    (s/assert ::topology-map topology)
-    topology))
 
 (def node-args
   {:crux.tx-log/await-tx-timeout
@@ -292,9 +301,9 @@
 (defn start ^crux.api.ICruxAPI [options]
   (let [options (into {} options)
         topology (options->topology options)
-        [modules close-fn] (start-modules topology options)
-        {::keys [kv-store tx-log indexer object-store bus]} modules
-        status-fn (fn [] (apply merge (map status/status-map (cons (crux-version) (vals modules)))))
+        [components close-fn] (start-components topology options)
+        {::keys [kv-store tx-log indexer object-store bus]} components
+        status-fn (fn [] (apply merge (map status/status-map (cons (crux-version) (vals components)))))
         node-opts (parse-opts node-args options)]
     (map->CruxNode {:close-fn close-fn
                     :status-fn status-fn

--- a/crux-dev/dev/dev.clj
+++ b/crux-dev/dev/dev.clj
@@ -129,7 +129,7 @@
 ;; (ns dev)
 ;; (def storage-dir "dev-storage-standalone")
 ;; (def dev-options (merge (dev-option-defaults storage-dir)
-;;                         {:crux.node/topology :crux.standalone/topology
+;;                         {:crux.node/topology 'crux.standalone/topology
 ;;                          :event-log-dir (str storage-dir "/event-log")
 ;;                          :crux.standalone/event-log-sync-interval-ms 1000
 ;;                          :dev/embed-kafka? false

--- a/crux-dev/dev/ivan/http_server.clj
+++ b/crux-dev/dev/ivan/http_server.clj
@@ -5,7 +5,7 @@
 
 
 (def opts
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.standalone/event-log-dir "data/eventlog-1"
    :crux.kv/db-dir "data/db-dir-1"})

--- a/crux-dev/dev/ivan/http_server.clj
+++ b/crux-dev/dev/ivan/http_server.clj
@@ -6,7 +6,7 @@
 
 (def opts
   {:crux.node/topology 'crux.standalone/topology
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+   :crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.standalone/event-log-dir "data/eventlog-1"
    :crux.kv/db-dir "data/db-dir-1"})
 

--- a/crux-dev/dev/ivan/stocks.clj
+++ b/crux-dev/dev/ivan/stocks.clj
@@ -10,6 +10,6 @@
   (def node
     (crux.api/start-node
      {:crux.node/topology 'crux.standalone/topology
-      :crux.node/kv-store "crux.kv.memdb.MemKv"
+      :crux.node/kv-store 'crux.kv.memdb.MemKv
       :crux.kv/db-dir "data/db-dir-1"
-      :crux.standalone/event-log-dir "data/eventlog-1"})))
+      :crux.standalone/event-log-dir 'data/eventlog-1})))

--- a/crux-dev/dev/ivan/stocks.clj
+++ b/crux-dev/dev/ivan/stocks.clj
@@ -9,7 +9,7 @@
   ; see crux-microbench neighbor for tickers data
   (def node
     (crux.api/start-node
-     {:crux.node/topology :crux.standalone/topology
+     {:crux.node/topology 'crux.standalone/topology
       :crux.node/kv-store "crux.kv.memdb.MemKv"
       :crux.kv/db-dir "data/db-dir-1"
       :crux.standalone/event-log-dir "data/eventlog-1"})))

--- a/crux-dev/dev/patrik.clj
+++ b/crux-dev/dev/patrik.clj
@@ -160,7 +160,7 @@
   (require 'crux.api)
 
   (def crux (crux.api/start-node
-             {:crux.node/topology :crux.standalone/topology
+             {:crux.node/topology 'crux.standalone/topology
               :crux.node/kv-store "crux.kv.rocksdb/kv"
               :crux.kv/db-dir "data/db-dir"
               :crux.standalone/event-log-dir "data/event-log-db"}))

--- a/crux-dev/dev/patrik.clj
+++ b/crux-dev/dev/patrik.clj
@@ -161,7 +161,7 @@
 
   (def crux (crux.api/start-node
              {:crux.node/topology 'crux.standalone/topology
-              :crux.node/kv-store "crux.kv.rocksdb/kv"
+              :crux.node/kv-store 'crux.kv.rocksdb/kv
               :crux.kv/db-dir "data/db-dir"
               :crux.standalone/event-log-dir "data/event-log-db"}))
 

--- a/crux-dev/dev/tmt/graph.clj
+++ b/crux-dev/dev/tmt/graph.clj
@@ -2,7 +2,7 @@
   (:require [crux.api :as api]))
 
 (def opts
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.memdb/kv"
    :crux.kv/db-dir "data/db-dir-1"
    :crux.standalone/event-log-dir "data/eventlog-1"

--- a/crux-dev/dev/tmt/graph.clj
+++ b/crux-dev/dev/tmt/graph.clj
@@ -3,10 +3,10 @@
 
 (def opts
   {:crux.node/topology 'crux.standalone/topology
-   :crux.node/kv-store "crux.kv.memdb/kv"
+   :crux.node/kv-store 'crux.kv.memdb/kv
    :crux.kv/db-dir "data/db-dir-1"
    :crux.standalone/event-log-dir "data/eventlog-1"
-   :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"})
+   :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv})
 
 (def node
   (api/start-node opts))

--- a/crux-dev/dev/tmt/lmdb.clj
+++ b/crux-dev/dev/tmt/lmdb.clj
@@ -1,7 +1,7 @@
 (ns tmt.lmdb
   (:require [crux.api :as api]))
 
-(def node (api/start-node {:crux.node/topology :crux.standalone/topology
+(def node (api/start-node {:crux.node/topology 'crux.standalone/topology
                            :crux.node/kv-store "crux.kv.lmdb/kv"
                            :crux.kv/db-dir "data/db-dir-1"
                            :crux.standalone/event-log-dir "data/eventlog-1"

--- a/crux-dev/dev/tmt/lmdb.clj
+++ b/crux-dev/dev/tmt/lmdb.clj
@@ -2,10 +2,10 @@
   (:require [crux.api :as api]))
 
 (def node (api/start-node {:crux.node/topology 'crux.standalone/topology
-                           :crux.node/kv-store "crux.kv.lmdb/kv"
+                           :crux.node/kv-store 'crux.kv.lmdb/kv
                            :crux.kv/db-dir "data/db-dir-1"
                            :crux.standalone/event-log-dir "data/eventlog-1"
-                           :crux.standalone/event-log-kv-store "crux.kv.lmdb/kv"}))
+                           :crux.standalone/event-log-kv-store 'crux.kv.lmdb/kv}))
 
 (api/submit-tx node [[:crux.tx/put {:crux.db/id :this
                                     :val :that}]])

--- a/crux-dev/dev/tmt/map-keys.clj
+++ b/crux-dev/dev/tmt/map-keys.clj
@@ -4,9 +4,9 @@
 
 (def node-mem
   (c/start-node {:crux.node/topology 'crux.standalone/topology
-                 :crux.node/kv-store "crux.kv.memdb/kv"
+                 :crux.node/kv-store 'crux.kv.memdb/kv
                  :crux.kv/db-dir "data/db-dir-mem"
-                 :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
+                 :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv
                  :crux.standalone/event-log-dir "data/eventlog-mem"}))
 
 (c/submit-tx node-mem [[:crux.tx/put {:crux.db/id {:a 1

--- a/crux-dev/dev/tmt/map-keys.clj
+++ b/crux-dev/dev/tmt/map-keys.clj
@@ -3,7 +3,7 @@
             [taoensso.nippy :as nippy]))
 
 (def node-mem
-  (c/start-node {:crux.node/topology :crux.standalone/topology
+  (c/start-node {:crux.node/topology 'crux.standalone/topology
                  :crux.node/kv-store "crux.kv.memdb/kv"
                  :crux.kv/db-dir "data/db-dir-mem"
                  :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
@@ -30,4 +30,3 @@
               (Integer/toString
                (+ (bit-and % 0xff) 0x100) 16) 1))
        (apply str)))
-

--- a/crux-dev/dev/tmt/maplistq.clj
+++ b/crux-dev/dev/tmt/maplistq.clj
@@ -2,7 +2,7 @@
   (:require [crux.api :as api]))
 
 (def opts
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.memdb/kv"
    :crux.kv/db-dir "data/db-dir-1"
    :crux.standalone/event-log-dir "data/eventlog-1"

--- a/crux-dev/dev/tmt/maplistq.clj
+++ b/crux-dev/dev/tmt/maplistq.clj
@@ -3,10 +3,10 @@
 
 (def opts
   {:crux.node/topology 'crux.standalone/topology
-   :crux.node/kv-store "crux.kv.memdb/kv"
+   :crux.node/kv-store 'crux.kv.memdb/kv
    :crux.kv/db-dir "data/db-dir-1"
    :crux.standalone/event-log-dir "data/eventlog-1"
-   :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"})
+   :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv})
 
 (def node
   (api/start-node opts))

--- a/crux-dev/dev/tmt/noopnil.clj
+++ b/crux-dev/dev/tmt/noopnil.clj
@@ -1,7 +1,7 @@
 (ns tmt.noopnil
   (:require [crux.api :as api]))
 
-(def node (api/start-node {:crux.node/topology :crux.standalone/topology
+(def node (api/start-node {:crux.node/topology 'crux.standalone/topology
                            :crux.kv/db-dir "data/db-dir-1"
                            :crux.standalone/event-log-dir "data/eventlog-1" }))
 
@@ -38,4 +38,3 @@
                        :crux.db.fn/args [:id (java.util.Date.) {:crux.db/id :id :this :that}]}]])
 
 (api/q (api/db node) {:find ['e] :where [['e :crux.db/id :id]] :full-results? true})
-

--- a/crux-dev/dev/tmt/server.clj
+++ b/crux-dev/dev/tmt/server.clj
@@ -4,12 +4,12 @@
             [crux.remote-api-client :as cli]))
 
 (def node-rocks
-  (api/start-node {:crux.node/topology :crux.standalone/topology
+  (api/start-node {:crux.node/topology 'crux.standalone/topology
                    :crux.kv/db-dir "data/db-dir-rocks"
                    :crux.standalone/event-log-dir "data/eventlog-rocks"}))
 
 (def node-mem
-  (api/start-node {:crux.node/topology :crux.standalone/topology
+  (api/start-node {:crux.node/topology 'crux.standalone/topology
                    :crux.node/kv-store "crux.kv.memdb/kv"
                    :crux.kv/db-dir "data/db-dir-mem"
                    :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"

--- a/crux-dev/dev/tmt/server.clj
+++ b/crux-dev/dev/tmt/server.clj
@@ -10,9 +10,9 @@
 
 (def node-mem
   (api/start-node {:crux.node/topology 'crux.standalone/topology
-                   :crux.node/kv-store "crux.kv.memdb/kv"
+                   :crux.node/kv-store 'crux.kv.memdb/kv
                    :crux.kv/db-dir "data/db-dir-mem"
-                   :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
+                   :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv
                    :crux.standalone/event-log-dir "data/eventlog-mem"}))
 
 (def srv-rocks

--- a/crux-docker/README.md
+++ b/crux-docker/README.md
@@ -30,7 +30,7 @@ within **crux.edn**. For example, you can change the KvStore of the node to Rock
 `:crux/node-opts`:
 
 ```clojure
-{:crux/node-opts {:crux.node/topology :crux.standalone/topology
+{:crux/node-opts {:crux.node/topology ['crux.standalone/topology]
                   :crux.node/kv-store "crux.kv.rocksdb/kv"
                   :crux.kv/db-dir "/var/lib/crux/db"
                   :crux.standalone/event-log-dir "/var/lib/crux/events"

--- a/crux-docker/README.md
+++ b/crux-docker/README.md
@@ -31,10 +31,10 @@ within **crux.edn**. For example, you can change the KvStore of the node to Rock
 
 ```clojure
 {:crux/node-opts {:crux.node/topology ['crux.standalone/topology]
-                  :crux.node/kv-store "crux.kv.rocksdb/kv"
+                  :crux.node/kv-store 'crux.kv.rocksdb/kv
                   :crux.kv/db-dir "/var/lib/crux/db"
                   :crux.standalone/event-log-dir "/var/lib/crux/events"
-                  :crux.standalone/event-log-kv-store "crux.kv.rocksdb/kv"}
+                  :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv}
  :crux/server-opts {}}
 ```
 

--- a/crux-docker/crux.edn
+++ b/crux-docker/crux.edn
@@ -1,6 +1,6 @@
 {:crux/node-opts {:crux.node/topology ['crux.standalone/topology]
-                  :crux.node/kv-store "crux.kv.memdb/kv"
+                  :crux.node/kv-store 'crux.kv.memdb/kv
                   :crux.kv/db-dir "/var/lib/crux/db"
                   :crux.standalone/event-log-dir "/var/lib/crux/events"
-                  :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"}
+                  :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv}
  :crux/server-opts {}}

--- a/crux-docker/crux.edn
+++ b/crux-docker/crux.edn
@@ -1,4 +1,4 @@
-{:crux/node-opts {:crux.node/topology :crux.standalone/topology
+{:crux/node-opts {:crux.node/topology ['crux.standalone/topology]
                   :crux.node/kv-store "crux.kv.memdb/kv"
                   :crux.kv/db-dir "/var/lib/crux/db"
                   :crux.standalone/event-log-dir "/var/lib/crux/events"

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -32,5 +32,5 @@
                :crux.kafka/latest-submitted-tx-consumer k/latest-submitted-tx-consumer})
 
 (defn new-ingest-client ^ICruxAsyncIngestAPI [options]
-  (let [[{:keys [crux.node/tx-log]} close-fn] (n/start-modules topology options)]
+  (let [[{:keys [crux.node/tx-log]} close-fn] (n/start-components topology options)]
     (map->CruxKafkaIngestClient {:tx-log tx-log :close-fn close-fn})))

--- a/crux-test/test/crux/bitemporal_tale_test.clj
+++ b/crux-test/test/crux/bitemporal_tale_test.clj
@@ -6,7 +6,7 @@
   ;; Test rocksDB node
   (with-open [system
               (crux/start-node ; it has clustering out-of-the-box though
-               {:crux.node/topology :crux.standalone/topology
+               {:crux.node/topology 'crux.standalone/topology
                 :crux.standalone/event-log-dir "data/eventlog-1"
                 :crux.kv/db-dir "data/db-dir-1"})]
     ;; Close rocksDB node so it does not interfere
@@ -15,7 +15,7 @@
 
   (with-open [system
               (crux/start-node
-               {:crux.node/topology :crux.standalone/topology
+               {:crux.node/topology 'crux.standalone/topology
                 :crux.node/kv-store "crux.kv.memdb/kv"
                 :crux.standalone/event-log-dir "data/eventlog-1"
                 :crux.kv/db-dir "data/db-dir-1"

--- a/crux-test/test/crux/bitemporal_tale_test.clj
+++ b/crux-test/test/crux/bitemporal_tale_test.clj
@@ -16,10 +16,10 @@
   (with-open [system
               (crux/start-node
                {:crux.node/topology 'crux.standalone/topology
-                :crux.node/kv-store "crux.kv.memdb/kv"
+                :crux.node/kv-store 'crux.kv.memdb/kv
                 :crux.standalone/event-log-dir "data/eventlog-1"
                 :crux.kv/db-dir "data/db-dir-1"
-                :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"})]
+                :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv})]
 
     (t/is system)
 

--- a/crux-test/test/crux/compaction_test.clj
+++ b/crux-test/test/crux/compaction_test.clj
@@ -17,7 +17,7 @@
 
 (t/deftest test-compaction-leaves-replayable-log
   (let [db-dir (str (cio/create-tmpdir "kv-store"))
-        opts {:crux.node/topology :crux.jdbc/topology
+        opts {:crux.node/topology 'crux.jdbc/topology
               :crux.jdbc/dbtype "h2"
               :crux.jdbc/dbname "cruxtest"
               :crux.kv/db-dir db-dir

--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -4,7 +4,8 @@
             [crux.api :as crux]
             [clojure.java.io :as io]
             [docs.examples :as ex]
-            [crux.io :as cio]))
+            [crux.io :as cio])
+  (:import (java.io Closeable)))
 
 (defn- clear-test-dirs [f]
   (try
@@ -32,8 +33,8 @@
     (t/is (not (empty? (ex/example-query-valid-time node))))
 
     ;; Testing http-server/http-client using the standalone node
-    (with-open [http-server (ex/example-start-http-server node)
-                remote-api (ex/example-start-http-client)]
+    (with-open [http-server ^Closeable (ex/example-start-http-server node)
+                remote-api ^Closeable (ex/example-start-http-client)]
       (t/is (= {:crux.db/id :dbpedia.resource/Pablo-Picasso
                 :name "Pablo"
                 :last-name "Picasso"}

--- a/crux-test/test/crux/fixtures/jdbc.clj
+++ b/crux-test/test/crux/fixtures/jdbc.clj
@@ -10,7 +10,7 @@
 
 (defn with-jdbc-node [dbtype f & [opts]]
   (let [dbtype (name dbtype)
-        options (merge {:crux.node/topology :crux.jdbc/topology
+        options (merge {:crux.node/topology 'crux.jdbc/topology
                         :crux.jdbc/dbtype (name dbtype)
                         :crux.jdbc/dbname "cruxtest"}
                        opts)

--- a/crux-test/test/crux/fixtures/kafka.clj
+++ b/crux-test/test/crux/fixtures/kafka.clj
@@ -78,7 +78,7 @@
   (let [test-id (UUID/randomUUID)]
     (binding [*tx-topic* (str "tx-topic-" test-id)
               *doc-topic* (str "doc-topic-" test-id)]
-      (apif/with-opts {:crux.node/topology :crux.kafka/topology
+      (apif/with-opts {:crux.node/topology [:crux.kafka/topology]
                        :crux.node/kv-store *kv-module*
                        :crux.kafka/tx-topic *tx-topic*
                        :crux.kafka/doc-topic *doc-topic*

--- a/crux-test/test/crux/fixtures/kv_only.clj
+++ b/crux-test/test/crux/fixtures/kv_only.clj
@@ -11,7 +11,7 @@
 (def ^:dynamic *sync* false)
 
 (defn ^Closeable start-kv-store [opts]
-  (n/start-module *kv-module* nil opts))
+  (n/start-component *kv-module* nil opts))
 
 (defn with-kv-store [f]
   (let [db-dir (cio/create-tmpdir "kv-store")]

--- a/crux-test/test/crux/fixtures/standalone.clj
+++ b/crux-test/test/crux/fixtures/standalone.clj
@@ -5,7 +5,7 @@
 (defn with-standalone-node [f]
   (let [event-log-dir (str (cio/create-tmpdir "event-log-dir"))]
     (try
-      (apif/with-opts {:crux.node/topology :crux.standalone/topology
+      (apif/with-opts {:crux.node/topology 'crux.standalone/topology
                        :crux.standalone/event-log-dir event-log-dir}
         f)
       (finally

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -15,7 +15,7 @@
            (clojure.lang Keyword)))
 
 (t/deftest test-properties-to-topology
-  (let [t (n/options->topology {:crux.node/topology [:crux.jdbc/topology]})]
+  (let [t (n/options->topology {:crux.node/topology ['crux.jdbc/topology]})]
 
     (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
              (-> t :crux.node/tx-log)))
@@ -23,7 +23,7 @@
              (-> t :crux.node/kv-store))))
 
   (t/testing "override module in topology"
-    (let [t (n/options->topology {:crux.node/topology [:crux.jdbc/topology]
+    (let [t (n/options->topology {:crux.node/topology ['crux.jdbc/topology]
                                   :crux.node/kv-store :crux.kv.memdb/kv})]
 
       (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
@@ -35,7 +35,7 @@
   (let [data-dir (cio/create-tmpdir "kv-store")
         event-log-dir (cio/create-tmpdir "kv-store")]
     (try
-      (let [n (n/start {:crux.node/topology [:crux.standalone/topology]
+      (let [n (n/start {:crux.node/topology ['crux.standalone/topology]
                         :crux.kv/db-dir (str data-dir)
                         :crux.standalone/event-log-dir (str event-log-dir)})]
         (t/is (.status n))
@@ -58,7 +58,7 @@
 (t/deftest test-start-node-should-throw-missing-argument-exception
   (let [data-dir (cio/create-tmpdir "kv-store")]
     (try
-      (with-open [n (n/start {:crux.node/topology [:crux.jdbc/topology]})]
+      (with-open [n (n/start {:crux.node/topology ['crux.jdbc/topology]})]
         (t/is false))
       (catch Throwable e
         (t/is (re-find #"Arg :crux.jdbc/dbtype required" (.getMessage e))))
@@ -117,7 +117,7 @@
 (t/deftest test-can-start-JDBC-node
   (let [data-dir (cio/create-tmpdir "kv-store")]
     (try
-      (with-open [n (n/start {:crux.node/topology [:crux.jdbc/topology]
+      (with-open [n (n/start {:crux.node/topology ['crux.jdbc/topology]
                               :crux.kv/db-dir (str data-dir)
                               :crux.jdbc/dbtype "h2"
                               :crux.jdbc/dbname "cruxtest"})]
@@ -128,7 +128,7 @@
 (t/deftest test-can-set-standalone-kv-store
   (let [event-log-dir (cio/create-tmpdir "kv-store")]
     (try
-      (with-open [n (n/start {:crux.node/topology [:crux.standalone/topology]
+      (with-open [n (n/start {:crux.node/topology ['crux.standalone/topology]
                               :crux.kv/kv-store :crux.kv.memdb/kv
                               :crux.standalone/event-log-dir (str event-log-dir)
                               :crux.standalone/event-log-kv-store :crux.kv.memdb/kv})]
@@ -149,7 +149,7 @@
 (t/deftest test-conflicting-standalone-props
   (let [event-log-dir (cio/create-tmpdir "kv-store")]
     (try
-      (with-open [n (n/start {:crux.node/topology [:crux.standalone/topology]
+      (with-open [n (n/start {:crux.node/topology ['crux.standalone/topology]
                               :crux.kv/kv-store :crux.kv.memdb/kv
                               :crux.standalone/event-log-sync-interval-ms 1000
                               :crux.standalone/event-log-sync? true
@@ -164,11 +164,11 @@
 (t/deftest topology-resolution-from-java
   (let [mem-db-node-options
         (doto (HashMap.)
-          (.put (Keyword/intern "crux.node/topology") (Keyword/intern "crux.standalone/topology"))
-          (.put (Keyword/intern "crux.node/kv-store") "crux.kv.memdb/kv")
-          (.put (Keyword/intern "crux.standalone/event-log-kv-store") "crux.kv.memdb/kv")
-          (.put (Keyword/intern "crux.standalone/event-log-dir") "data/eventlog")
-          (.put (Keyword/intern "crux.kv/db-dir") "data/db-dir"))
+          (.put :crux.node/topology 'crux.standalone/topology)
+          (.put :crux.node/kv-store 'crux.kv.memdb/kv)
+          (.put :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv)
+          (.put :crux.standalone/event-log-dir "data/eventlog")
+          (.put :crux.kv/db-dir "data/db-dir"))
         memdb-node (Crux/startNode mem-db-node-options)]
     (t/is memdb-node)
     (t/is (not (.close memdb-node)))))
@@ -177,7 +177,7 @@
   (let [kv-data-dir-1 (cio/create-tmpdir "kv-store1")
         kv-data-dir-2 (cio/create-tmpdir "kv-store2")]
     (try
-      (with-open [n (n/start {:crux.node/topology [:crux.jdbc/topology]
+      (with-open [n (n/start {:crux.node/topology ['crux.jdbc/topology]
                               :crux.kv/db-dir (str kv-data-dir-1)
                               :crux.jdbc/dbtype "h2"
                               :crux.jdbc/dbname "cruxtest1"})]
@@ -194,7 +194,7 @@
                                 '{:find [e]
                                   :where [[e :name "Ivan"]]})))
 
-        (with-open [n2 (n/start {:crux.node/topology [:crux.jdbc/topology]
+        (with-open [n2 (n/start {:crux.node/topology ['crux.jdbc/topology]
                                  :crux.kv/db-dir (str kv-data-dir-2)
                                  :crux.jdbc/dbtype "h2"
                                  :crux.jdbc/dbname "cruxtest2"})]

--- a/crux-test/test/crux/repl_walkthrough_test.clj
+++ b/crux-test/test/crux/repl_walkthrough_test.clj
@@ -47,8 +47,8 @@
 
   (def crux-options
     {:crux.node/topology 'crux.standalone/topology
-     :crux.node/kv-store "crux.kv.memdb/kv"
-     :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
+     :crux.node/kv-store 'crux.kv.memdb/kv
+     :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv
      :crux.standalone/event-log-dir "data/event-log-dir-1"
      :crux.kv/db-dir "data/db-dir-1"})
 

--- a/crux-test/test/crux/repl_walkthrough_test.clj
+++ b/crux-test/test/crux/repl_walkthrough_test.clj
@@ -46,7 +46,7 @@
                                    (keys n))))))
 
   (def crux-options
-    {:crux.node/topology :crux.standalone/topology
+    {:crux.node/topology 'crux.standalone/topology
      :crux.node/kv-store "crux.kv.memdb/kv"
      :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
      :crux.standalone/event-log-dir "data/event-log-dir-1"
@@ -96,7 +96,7 @@
 
 (t/deftest walkthrough-test
   (def crux-options
-    {:crux.node/topology :crux.standalone/topology
+    {:crux.node/topology 'crux.standalone/topology
      :crux.node/kv-store "crux.kv.memdb/kv"
      :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
      :crux.standalone/event-log-dir "data/event-log-dir-1"

--- a/crux-test/test/crux/space_tutorial_test.clj
+++ b/crux-test/test/crux/space_tutorial_test.clj
@@ -7,7 +7,7 @@
 (t/deftest space-tutorial-test
   (def ^crux.api.ICruxAPI crux
     (crux/start-node
-       {:crux.node/topology :crux.standalone/topology
+       {:crux.node/topology 'crux.standalone/topology
         :crux.node/kv-store "crux.kv.memdb/kv"
         :crux.standalone/event-log-dir "data/eventlog-1"
         :crux.kv/db-dir "data/db-dir"
@@ -565,7 +565,7 @@
     (.close ^Closeable crux)
     (def crux
       (crux/start-node
-       {:crux.node/topology :crux.standalone/topology
+       {:crux.node/topology 'crux.standalone/topology
         :crux.node/kv-store "crux.kv.memdb/kv"
         :crux.standalone/event-log-dir "data/eventlog-1"
         :crux.kv/db-dir "data/db-dir"

--- a/crux-test/test/crux/space_tutorial_test.clj
+++ b/crux-test/test/crux/space_tutorial_test.clj
@@ -8,10 +8,10 @@
   (def ^crux.api.ICruxAPI crux
     (crux/start-node
        {:crux.node/topology 'crux.standalone/topology
-        :crux.node/kv-store "crux.kv.memdb/kv"
+        :crux.node/kv-store 'crux.kv.memdb/kv
         :crux.standalone/event-log-dir "data/eventlog-1"
         :crux.kv/db-dir "data/db-dir"
-        :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"}))
+        :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv}))
 
   (def manifest
     {:crux.db/id :manifest

--- a/crux-uberjar/src/crux/cli.clj
+++ b/crux-uberjar/src/crux/cli.clj
@@ -10,7 +10,7 @@
   (:import java.io.Closeable))
 
 (def default-options
-  {:crux.node/topology :crux.kafka/topology})
+  {:crux.node/topology 'crux.kafka/topology})
 
 (def cli-options
   [["-p" "--properties-file PROPERTIES_FILE" "Properties file to load Crux options from"

--- a/crux-uberjar/src/crux/main/graal.clj
+++ b/crux-uberjar/src/crux/main/graal.clj
@@ -11,5 +11,5 @@
 (defn -main [& args]
   (with-open [node ^ICruxAPI (n/start sa/topology {:crux.kv/db-dir "graal-data"
                                                    :crux.standalone/event-log-dir "graal-event-log"
-                                                   :crux.node/kv-store "crux.kv.rocksdb/kv"})]
+                                                   :crux.node/kv-store 'crux.kv.rocksdb/kv})]
     (log/info "Starting Crux native image" (cio/pr-edn-str (.status node)))))

--- a/docs/Confluent-QuickStart.adoc
+++ b/docs/Confluent-QuickStart.adoc
@@ -28,7 +28,7 @@ Ensure first that you have a running Kafka broker to connect to. We import the d
 (import (crux.api ICruxAPI))
 
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.kafka/topology
+  (crux/start-node {:crux.node/topology ['crux.kafka/topology]
                     :crux.kafka/bootstrap-servers "localhost:9092"
 		    :server-port 3000}))
 

--- a/docs/Kafka-QuickStart.adoc
+++ b/docs/Kafka-QuickStart.adoc
@@ -39,9 +39,9 @@ Ensure first that you have a running Kafka broker to connect to. We import the d
 (import (crux.api ICruxAPI))
 
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.kafka/topology
+  (crux/start-node {:crux.node/topology ['crux.kafka/topology]
                     :crux.kafka/bootstrap-servers "localhost:9092"
-		    :server-port 3000}))
+		                :server-port 3000}))
 
 (srv/start-http-server node)
 ----

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -285,7 +285,7 @@ Options:
 
 [source,clj]
 ----
-{:crux.node/topology e.g. "crux.standalone/topology"}
+{:crux.node/topology ['crux.standalone/topology]}
 ----
 
 Options are specified as keywords using their long format name, like

--- a/docs/example/backup-restore/cli/backup.clj
+++ b/docs/example/backup-restore/cli/backup.clj
@@ -6,7 +6,7 @@
 (def opts
   {:crux.node/topology 'crux.standalone/topology
    :crux.standalone/event-log-dir "data/eventlog-1"
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+   :crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.kv/db-dir "data/db-dir-1"
    :backup-dir "checkpoint"})
 

--- a/docs/example/backup-restore/cli/backup.clj
+++ b/docs/example/backup-restore/cli/backup.clj
@@ -4,7 +4,7 @@
 
 (println "backup script")
 (def opts
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.standalone/event-log-dir "data/eventlog-1"
    :crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.kv/db-dir "data/db-dir-1"

--- a/docs/example/backup-restore/src/example_backup_restore/main.clj
+++ b/docs/example/backup-restore/src/example_backup_restore/main.clj
@@ -3,7 +3,7 @@
             [crux.backup :as backup]))
 
 (def crux-options
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.standalone/event-log-dir "data/eventlog-1"
    :crux.kv/db-dir "data/db-dir-1"

--- a/docs/example/backup-restore/src/example_backup_restore/main.clj
+++ b/docs/example/backup-restore/src/example_backup_restore/main.clj
@@ -4,7 +4,7 @@
 
 (def crux-options
   {:crux.node/topology 'crux.standalone/topology
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+   :crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.standalone/event-log-dir "data/eventlog-1"
    :crux.kv/db-dir "data/db-dir-1"
    :backup-dir "checkpoint"})

--- a/docs/example/crux-cloud/README.adoc
+++ b/docs/example/crux-cloud/README.adoc
@@ -48,7 +48,7 @@ code to connect to your cluster and make a transaction:
 
 (def ^crux.api.ICruxAPI node
   (crux/start-node
-   {:crux.node/topology :crux.kafka/topology
+   {:crux.node/topology 'crux.kafka/topology
     :crux.node/kv-store "crux.kv.memdb/kv"
     :crux.kafka/tx-topic "tx-1" ; choose your tx-topic name
     :crux.kafka/doc-topic "doc-1" ; choose your doc-topic name

--- a/docs/example/crux-cloud/README.adoc
+++ b/docs/example/crux-cloud/README.adoc
@@ -49,7 +49,7 @@ code to connect to your cluster and make a transaction:
 (def ^crux.api.ICruxAPI node
   (crux/start-node
    {:crux.node/topology 'crux.kafka/topology
-    :crux.node/kv-store "crux.kv.memdb/kv"
+    :crux.node/kv-store 'crux.kv.memdb/kv
     :crux.kafka/tx-topic "tx-1" ; choose your tx-topic name
     :crux.kafka/doc-topic "doc-1" ; choose your doc-topic name
     :crux.kafka/replication-factor 3 ; Confluent Cloud requires this to be `3`

--- a/docs/example/imdb/src/imdb/main.clj
+++ b/docs/example/imdb/src/imdb/main.clj
@@ -56,7 +56,7 @@
 
 (def crux-options
   {:crux.node/topology 'crux.kafka/topology
-   :crux.node/kv-store "crux.kv.rocksdb/kv"
+   :crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.kafka/bootstrap-servers "localhost:9092"
    :crux.standalone/event-log-dir log-dir
    :crux.kv/db-dir index-dir

--- a/docs/example/imdb/src/imdb/main.clj
+++ b/docs/example/imdb/src/imdb/main.clj
@@ -55,7 +55,7 @@
 (def log-dir "data/eventlog")
 
 (def crux-options
-  {:crux.node/topology :crux.kafka/topology
+  {:crux.node/topology 'crux.kafka/topology
    :crux.node/kv-store "crux.kv.rocksdb/kv"
    :crux.kafka/bootstrap-servers "localhost:9092"
    :crux.standalone/event-log-dir log-dir

--- a/docs/example/repl-walkthrough/graph-traversal.clj
+++ b/docs/example/repl-walkthrough/graph-traversal.clj
@@ -57,8 +57,8 @@
 ; this standalone configuration is the easiest way to try Crux, no Kafka needed
 (def crux-options
   {:crux.node/topology 'crux.standalone/topology
-   :crux.node/kv-store "crux.kv.memdb/kv" ; in-memory, see docs for LMDB/RocksDB storage
-   :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
+   :crux.node/kv-store 'crux.kv.memdb/kv ; in-memory, see docs for LMDB/RocksDB storage
+   :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv
    :crux.standalone/event-log-dir "data/event-log-dir-1" ; :event-log-dir is ignored when using MemKv
    :crux.kv/db-dir "data/db-dir-1"}) ; :db-dir is ignored when using MemKv
 

--- a/docs/example/repl-walkthrough/graph-traversal.clj
+++ b/docs/example/repl-walkthrough/graph-traversal.clj
@@ -56,7 +56,7 @@
 
 ; this standalone configuration is the easiest way to try Crux, no Kafka needed
 (def crux-options
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.memdb/kv" ; in-memory, see docs for LMDB/RocksDB storage
    :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"
    :crux.standalone/event-log-dir "data/event-log-dir-1" ; :event-log-dir is ignored when using MemKv

--- a/docs/example/repl-walkthrough/walkthrough.clj
+++ b/docs/example/repl-walkthrough/walkthrough.clj
@@ -9,7 +9,7 @@
 
 
 (def crux-options
-  {:crux.node/topology :crux.standalone/topology
+  {:crux.node/topology 'crux.standalone/topology
    :crux.node/kv-store "crux.kv.memdb/kv" ; in-memory, see docs for LMDB/RocksDB storage
    :crux.standalone/event-log-kv-store "crux.kv.memdb/kv" ; same as above
    :crux.standalone/event-log-dir "data/event-log-dir-1" ; :event-log-dir is ignored when using MemKv

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -688,7 +688,7 @@
 (def log-dir "data/eventlog-1")
 
 (def crux-options
-  {:crux.node/kv-store "crux.kv.rocksdb/kv"
+  {:crux.node/kv-store 'crux.kv.rocksdb/kv
    :crux.kafka/bootstrap-servers "kafka-cluster-kafka-brokers.crux.svc.cluster.local:9092"
    :crux.standalone/event-log-dir log-dir
    :crux.kv/db-dir index-dir

--- a/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
+++ b/docs/example/standalone_webservice/src/example_standalone_webservice/main.clj
@@ -704,9 +704,9 @@
 (defn run-node [{:keys [server-port http-port] :as options} with-node-fn]
   (with-open [crux-node (case (System/getenv "CRUX_MODE")
                           "CLUSTER_NODE" (api/start-node (assoc options
-                                                                :crux.node/topology :crux.kafka/topology))
+                                                                :crux.node/topology 'crux.kafka/topology))
                           (api/start-node (assoc options
-                                                 :crux.node/topology :crux.standalone/topology)))
+                                                 :crux.node/topology 'crux.standalone/topology)))
               api-server (srv/start-http-server
                            crux-node
                            {:server-port http-port

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -16,7 +16,7 @@
 (defn example-start-standalone []
 ;; tag::start-standalone-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.standalone/topology
+  (crux/start-node {:crux.node/topology 'crux.standalone/topology
                     :crux.node/kv-store "crux.kv.memdb/kv"
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
@@ -51,7 +51,7 @@ embedded-kafka)
 (defn example-start-cluster []
 ;; tag::start-cluster-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.kafka/topology
+  (crux/start-node {:crux.node/topology 'crux.kafka/topology
                     :crux.node/kv-store "crux.kv.memdb/kv"
                     :crux.kafka/bootstrap-servers "localhost:9092"}))
 ;; end::start-cluster-node[]
@@ -60,7 +60,7 @@ node)
 (defn example-start-rocks []
 ;; tag::start-standalone-with-rocks[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.standalone/topology
+  (crux/start-node {:crux.node/topology 'crux.standalone/topology
                     :crux.node/kv-store "crux.kv.rocksdb/kv"
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"}))
@@ -70,7 +70,7 @@ node)
 (defn example-start-lmdb []
 ;; tag::start-standalone-with-lmdb[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.standalone/topology
+  (crux/start-node {:crux.node/topology 'crux.standalone/topology
                     :crux.node/kv-store "crux.kv.lmdb/kv"
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
@@ -81,7 +81,7 @@ node)
 (defn example-start-jdbc []
 ;; tag::start-jdbc-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology :crux.jdbc/topology
+  (crux/start-node {:crux.node/topology 'crux.jdbc/topology
                     :crux.jdbc/dbtype "postgresql"
                     :crux.jdbc/dbname "cruxdb"
                     :crux.jdbc/host "<host>"

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -17,10 +17,10 @@
 ;; tag::start-standalone-node[]
 (def ^crux.api.ICruxAPI node
   (crux/start-node {:crux.node/topology 'crux.standalone/topology
-                    :crux.node/kv-store "crux.kv.memdb/kv"
+                    :crux.node/kv-store 'crux.kv.memdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
-                    :crux.standalone/event-log-kv-store "crux.kv.memdb/kv"}))
+                    :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv}))
 ;; end::start-standalone-node[]
   node)
 
@@ -52,7 +52,7 @@ embedded-kafka)
 ;; tag::start-cluster-node[]
 (def ^crux.api.ICruxAPI node
   (crux/start-node {:crux.node/topology 'crux.kafka/topology
-                    :crux.node/kv-store "crux.kv.memdb/kv"
+                    :crux.node/kv-store 'crux.kv.memdb/kv
                     :crux.kafka/bootstrap-servers "localhost:9092"}))
 ;; end::start-cluster-node[]
 node)
@@ -61,7 +61,7 @@ node)
 ;; tag::start-standalone-with-rocks[]
 (def ^crux.api.ICruxAPI node
   (crux/start-node {:crux.node/topology 'crux.standalone/topology
-                    :crux.node/kv-store "crux.kv.rocksdb/kv"
+                    :crux.node/kv-store 'crux.kv.rocksdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"}))
 ;; end::start-standalone-with-rocks[]
@@ -71,10 +71,10 @@ node)
 ;; tag::start-standalone-with-lmdb[]
 (def ^crux.api.ICruxAPI node
   (crux/start-node {:crux.node/topology 'crux.standalone/topology
-                    :crux.node/kv-store "crux.kv.lmdb/kv"
+                    :crux.node/kv-store 'crux.kv.lmdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
-                    :crux.standalone/event-log-kv-store "crux.kv.lmdb/kv"}))
+                    :crux.standalone/event-log-kv-store 'crux.kv.lmdb/kv}))
 ;; end::start-standalone-with-lmdb[]
 node)
 


### PR DESCRIPTION
Main part of this change is to allow the user multiple modules in `:crux.node/topology`, so that new modules (e.g. metrics, and we might migrate HTTP this way) can specify their own maps of components to be included in the Crux startup/shutdown topology. 

It's backwards compatible, you can still specify a single module, but you can now specify a vector of modules too - these get merged left-to-right, as you'd expect.

Some naming standardisation:
- 'component' - single closable resource (e.g. `crux.kafka/admin-client`, consistent with Stuart Sierra's library, hopefully won't surprise Clojure devs?)
- 'module' - map of related components (e.g. `crux-kafka` has a handful)
- 'topology' - a set of modules (the whole 'system', in Stuart Sierra land)

and also ensuring that, whenever we refer to a Clojure var in config (e.g. `:crux.node/topology`, `:crux.node/kv-store`), we refer to it using a *symbol* (i.e. not a string, nor a keyword) - it'll have to be a string in Java/JSON land, but we can at least be consistent in Clojure.

Making that consistent is quite a big diff, would recommend filtering the PR down to just the 'allowing a vector of modules' commit for the interesting bit.