### PR TITLE
Replace `sync` in clojure api section of docs #466

### DIFF
--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -120,6 +120,24 @@ toc::[]
   this node has caught up as of this call.")
 ----
 
+=== sync
+
+[source,clj]
+----
+ (sync
+    [node]
+    [node ^Duration timeout]
+    "Blocks until the node has caught up indexing to the latest tx available at
+  the time this method is called. Will throw an exception on timeout. The
+  returned date is the latest transaction time indexed by this node. This can be
+  used as the second parameter in (db valid-time, transaction-time) for
+  consistent reads.
+
+  timeout – max time to wait, can be nil for the default.
+  Returns the latest known transaction time.")
+
+----
+
 === new-tx-log-context
 
 [source,clj]

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -96,24 +96,28 @@ toc::[]
      if the node has not yet indexed the transaction.")
 ----
 
-
-
-=== sync
+=== await-tx
 
 [source,clj]
 ----
-  (sync
-    [node ^Duration timeout]
-    [node ^Date transaction-time ^Duration timeout]
-    "If the transaction-time is supplied, blocks until indexing has
-    processed a tx with a greater-than transaction-time, otherwise
-    blocks until the node has caught up indexing the tx-log
-    backlog. Will throw an exception on timeout. The returned date is
-    the latest index time when this node has caught up as of this
-    call. This can be used as the second parameter in (db valid-time,
-    transaction-time) for consistent reads.
-    timeout – max time to wait, can be null for the default.
-    Returns the latest known transaction time.")
+  (await-tx
+    [node tx]
+    [node tx ^Duration timeout]
+    "Blocks until the node has indexed a transaction that is at or past the
+  supplied tx. Will throw on timeout. Returns the most recent tx indexed by the
+  node.")
+----
+
+=== await-tx-time
+
+[source,clj]
+----
+  (await-tx-time
+    [node ^Date tx-time]
+    [node ^Date tx-time ^Duration timeout]
+    "Blocks until the node has indexed a transaction that is past the supplied
+  txTime. Will throw on timeout. The returned date is the latest index time when
+  this node has caught up as of this call.")
 ----
 
 === new-tx-log-context


### PR DESCRIPTION
Small PR to remove `sync` from the Clojure API section of the docs and add in **await-tx** and **await-tx-time**