### PR TITLE
Add slack notifications to bench

### DIFF
--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -47,7 +47,11 @@ Resources:
                 # Allow the ECS tasks to upload logs to CloudWatch
                 - 'logs:CreateLogStream'
                 - 'logs:PutLogEvents'
+
+                # Allow the ECS tasks to get secret values from the secrets manager
+                - 'secretsmanager:GetSecretValue'
               Resource: '*'
+
 
   BenchTask:
     Type: AWS::ECS::TaskDefinition
@@ -67,6 +71,10 @@ Resources:
         - Name: 'bench-container'
           Image: '955308952094.dkr.ecr.eu-west-2.amazonaws.com/crux-bench:latest'
           Essential: true
+          Secrets:
+            - Name: "SLACK_URL"
+              ValueFrom:
+                "arn:aws:secretsmanager:eu-west-2:955308952094:secret:bench/slack-url-uumMHQ"
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -81,8 +89,7 @@ Resources:
        AssumeRolePolicyDocument:
          Version: "2012-10-17"
          Statement:
-           -
-             Effect: "Allow"
+           - Effect: "Allow"
              Principal:
                Service:
                  - "events.amazonaws.com"

--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -5,7 +5,8 @@
                  [juxt/crux-kafka "derived-from-git"]
                  [juxt/crux-kafka-embedded "derived-from-git"]
                  [juxt/crux-rocksdb "derived-from-git"]
-                 [ch.qos.logback/logback-classic "1.2.3"]]
+                 [ch.qos.logback/logback-classic "1.2.3"]
+                 [clj-http "3.10.0"]]
 
   :middleware [leiningen.project-version/middleware]
 

--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -5,6 +5,7 @@
                  [juxt/crux-kafka "derived-from-git"]
                  [juxt/crux-kafka-embedded "derived-from-git"]
                  [juxt/crux-rocksdb "derived-from-git"]
+                 [juxt/crux-test "derived-from-git"]
                  [ch.qos.logback/logback-classic "1.2.3"]
                  [clj-http "3.10.0"]]
 

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -47,8 +47,10 @@
 
 (defn post-to-slack [message]
   (when (System/getenv "SLACK_URL")
-    (client/post (System/getenv "SLACK_URL")
-                 {:body (clojure.data.json/write-str {:text message})
+    (client/post (-> (System/getenv "SLACK_URL")
+                      (clojure.data.json/read-str)
+                      (get "slack-url"))
+                 {:body (json/write-str {:text message})
                   :content-type :json})))
 
 (defn format-and-post-results-to-slack [result]

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -72,11 +72,13 @@
 
     (let [results @*!bench-results*]
       (run! (comp println json/write-str) results)
-      (->> results
-           (map ->slack-message)
-           (string/join "\n\n")
-           (format "*%s*\n========\n%s\n" *bench-ns*)
-           (post-to-slack)))))
+      (post-to-slack (format "*%s*\n========\n%s\n"
+                             *bench-ns*
+                             (->> results
+                                  (map ->slack-message)
+                                  (string/join "\n\n")
+
+                                  (post-to-slack)))))))
 
 (defmacro with-bench-ns [bench-ns & body]
   `(with-bench-ns* ~bench-ns (fn [] ~@body)))

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -55,11 +55,11 @@
                   :content-type :json})))
 
 (defn ->slack-message [{bench-time :time-taken-ms :as bench-map}]
-  (let [formatted-bench (-> (assoc bench-map :time-taken (java.time.Duration/ofMillis bench-time))
-                            (dissoc :bench-ns :crux-commit :crux-version :time-taken-ms))]
-    (->> (keys formatted-bench)
-         (map #(format "*%s*: %s" (name %) (formatted-bench %)))
-         (string/join "\n"))))
+  (->> (for [[k v] (-> bench-map
+                       (assoc :time-taken (java.time.Duration/ofMillis bench-time))
+                       (dissoc :bench-ns :crux-commit :crux-version :time-taken-ms))]
+         (format "*%s*: %s" (name k) v))
+       (string/join "\n")))
 
 (defn with-bench-ns* [bench-ns f]
   (log/infof "running bench-ns '%s'..." bench-ns)

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -71,7 +71,7 @@
     (log/infof "finished bench-ns '%s'." bench-ns)
 
     (let [results @*!bench-results*]
-      (run! #(println (json/write-str %)) results)
+      (run! (comp println json/write-str) results)
       (->> results
            (map ->slack-message)
            (string/join "\n\n")

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -61,7 +61,6 @@
          (map #(format "*%s*: %s" (name %) (formatted-bench %)))
          (string/join "\n"))))
 
-
 (defn with-bench-ns* [bench-ns f]
   (log/infof "running bench-ns '%s'..." bench-ns)
 

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -2,7 +2,8 @@
   (:require [crux.bench :as bench]
             [crux.bench.ts-weather :as weather]
             [crux.bench.ts-devices :as devices]
-            [clj-http.client :as client]))
+            [clj-http.client :as client]
+            [clojure.tools.logging :as log]))
 
 (defn -main []
   (bench/post-to-slack (format "*Starting Benchmark*, Crux Version: %s, Commit Hash: %s\n"

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -1,9 +1,12 @@
 (ns crux.bench.main
   (:require [crux.bench :as bench]
             [crux.bench.ts-weather :as weather]
-            [crux.bench.ts-devices :as devices]))
+            [crux.bench.ts-devices :as devices]
+            [clj-http.client :as client]))
 
 (defn -main []
+  (bench/post-to-slack (format "*Starting Benchmark*, Crux Version: %s, Commit Hash: %s\n"
+                               bench/crux-version bench/commit-hash))
   (bench/with-node [node]
     (devices/run-devices-bench node)
     (weather/run-weather-bench node)))

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
    "crux-http-client" "crux-http-server"
    "crux-kafka-embedded" "crux-kafka-connect" "crux-kafka"
    "crux-uberjar"
-   "crux-test"])
+   "crux-test"
+   "crux-bench"])
 
 (defproject juxt/crux-dev "crux-dev-SNAPSHOT"
   :url "https://github.com/juxt/crux"
@@ -29,6 +30,7 @@
                  [juxt/crux-http-server "derived-from-git"]
                  [juxt/crux-rdf "derived-from-git"]
                  [juxt/crux-test "derived-from-git"]
+                 [juxt/crux-bench "derived-from-git"]
 
                  ;; Håkan
                  [org.ejml/ejml-dsparse "0.38" :exclusions [com.google.code.findbugs/jsr305]]


### PR DESCRIPTION
Slack messages are only sent if the SLACK_URL environment variable is set. This secret is set up on the AWS secret manager, and has been added to the container using CloudFormation.

resolves #576