### PR TITLE
'Node' is just another component

### DIFF
--- a/crux-core/src/crux/config.clj
+++ b/crux-core/src/crux/config.clj
@@ -11,8 +11,8 @@
    ::nat-int [nat-int? (fn [x]
                          (or (and (string? x) (Long/parseLong x)) x))]
    ::string [string? identity]
-   ::module [(fn [m] (s/valid? :crux.node/module m))
-             (fn [m] (s/conform :crux.node/module m))]})
+   ::module [(fn [m] (s/valid? :crux.topology/module m))
+             (fn [m] (s/conform :crux.topology/module m))]})
 
 (s/def ::type (s/and (s/conformer (fn [x] (or (property-types x) x)))
                      (fn [x] (and (vector? x) (-> x first fn?) (some-> x second fn?)))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -14,6 +14,7 @@
             crux.object-store
             [crux.query :as q]
             [crux.status :as status]
+            [crux.topology :as topo]
             [crux.tx :as tx]
             [crux.bus :as bus])
   (:import [crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException ITxLog]
@@ -185,109 +186,6 @@
       (when (and (not @closed?) close-fn) (close-fn))
       (reset! closed? true))))
 
-(s/def ::resolvable-id
-  (fn [id]
-    (and (or (string? id) (keyword? id) (symbol? id))
-         (namespace (symbol id)))))
-
-(defn- resolve-id [id]
-  (s/assert ::resolvable-id id)
-  (-> (or (-> id symbol requiring-resolve)
-          (throw (IllegalArgumentException. (format "Can't resolve symbol: '%s'" id))))
-      var-get))
-
-(s/def ::start-fn ifn?)
-(s/def ::deps (s/coll-of keyword?))
-
-(s/def ::args
-  (s/map-of keyword?
-            (s/keys :req [:crux.config/type]
-                    :req-un [:crux.config/doc]
-                    :opt-un [:crux.config/default
-                             :crux.config/required?])))
-
-(s/def ::component
-  (s/and (s/or :component-id ::resolvable-id, :component map?)
-         (s/conformer (fn [[c-or-id s]]
-                        (cond-> s (= :component-id c-or-id) resolve-id)))
-         (s/keys :req-un [::start-fn]
-                 :opt-un [::deps ::args])))
-
-(s/def ::module
-  (s/and (s/or :module-id ::resolvable-id, :module map?)
-         (s/conformer (fn [[m-or-id s]]
-                        (cond-> s (= :module-id m-or-id) resolve-id)))))
-
-(s/def ::resolved-topology (s/map-of keyword? ::component))
-
-(defn options->topology [{:keys [crux.node/topology] :as options}]
-  (when-not topology
-    (throw (IllegalArgumentException. "Please specify :crux.node/topology")))
-
-  (let [topology (-> topology
-                     (cond-> (not (vector? topology)) vector)
-                     (->> (map #(s/conform ::module %))
-                          (apply merge)))]
-    (->> (merge topology (select-keys options (keys topology)))
-         (s/conform ::resolved-topology))))
-
-(defn- start-order [system]
-  (let [g (reduce-kv (fn [g k c]
-                       (let [c (s/conform ::component c)]
-                         (reduce (fn [g d] (dep/depend g k d)) g (:deps c))))
-                     (dep/graph)
-                     system)
-        dep-order (dep/topo-sort g)
-        dep-order (->> (keys system)
-                       (remove #(contains? (set dep-order) %))
-                       (into dep-order))]
-    dep-order))
-
-(defn- parse-opts [args options]
-  (into {}
-        (for [[k {:keys [crux.config/type default required?]}] args]
-          (let [[validate-fn parse-fn] (s/conform :crux.config/type type)
-                v (some-> (get options k) parse-fn)
-                v (if (nil? v) default v)]
-
-            (when (and required? (not v))
-              (throw (IllegalArgumentException. (format "Arg %s required" k))))
-
-            (when (and v (not (validate-fn v)))
-              (throw (IllegalArgumentException. (format "Arg %s invalid" k))))
-
-            [k v]))))
-
-(defn start-component [c started options]
-  (s/assert ::component c)
-  (let [{:keys [start-fn deps spec args]} (s/conform ::component c)
-        deps (select-keys started deps)
-        options (merge options (parse-opts args options))]
-    (start-fn deps options)))
-
-(defn start-components [topology options]
-  (s/assert ::resolved-topology topology)
-  (let [started-order (atom [])
-        started (atom {})
-        started-modules (try
-                          (into {}
-                                (for [k (start-order topology)]
-                                  (let [c (or (get topology k)
-                                              (throw (IllegalArgumentException. (str "Could not find component " k))))
-                                        c (start-component c @started options)]
-                                    (swap! started-order conj c)
-                                    (swap! started assoc k c)
-                                    [k c])))
-                          (catch Throwable t
-                            (doseq [c (reverse @started-order)]
-                              (when (instance? Closeable c)
-                                (cio/try-close c)))
-                            (throw t)))]
-    [started-modules (fn []
-                       (doseq [c (reverse @started-order)
-                               :when (instance? Closeable c)]
-                         (cio/try-close c)))]))
-
 (def base-topology
   {::kv-store 'crux.kv.rocksdb/kv
    ::object-store 'crux.object-store/kv-object-store
@@ -301,12 +199,10 @@
     :crux.config/type :crux.config/nat-int}})
 
 (defn start ^crux.api.ICruxAPI [options]
-  (let [options (into {} options)
-        topology (options->topology options)
-        [components close-fn] (start-components topology options)
+  (let [[components close-fn] (topo/start-topology options)
         {::keys [kv-store tx-log indexer object-store bus]} components
         status-fn (fn [] (apply merge (map status/status-map (cons (crux-version) (vals components)))))
-        node-opts (parse-opts node-args options)]
+        node-opts (topo/parse-opts node-args options)]
     (map->CruxNode {:close-fn close-fn
                     :status-fn status-fn
                     :options node-opts

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -202,8 +202,9 @@
 
 (defn start ^crux.api.ICruxAPI [options]
   (let [[{::keys [node] :as components} close-fn] (topo/start-topology options)]
-    (assoc node
-      :status-fn (fn []
-                   (merge crux-version
-                          (into {} (mapcat status/status-map) (vals (dissoc components ::node)))))
-      :close-fn close-fn)))
+    (-> node
+        (assoc :status-fn (fn []
+                            (merge crux-version
+                                   (into {} (mapcat status/status-map) (vals (dissoc components ::node)))))
+               :close-fn close-fn)
+        (vary-meta assoc ::topology components))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -38,7 +38,7 @@
   (when @closed?
     (throw (IllegalStateException. "Crux node is closed"))))
 
-(defrecord CruxNode [kv-store tx-log indexer object-store bus
+(defrecord CruxNode [kv-store tx-log indexer object-store
                      options close-fn status-fn closed? ^StampedLock lock]
   ICruxAPI
   (db [this]
@@ -179,13 +179,12 @@
       (reset! closed? true))))
 
 (def ^:private node-component
-  {:start-fn (fn [{::keys [indexer object-store bus tx-log kv-store]} node-opts]
+  {:start-fn (fn [{::keys [indexer object-store tx-log kv-store]} node-opts]
                (map->CruxNode {:options node-opts
                                :kv-store kv-store
                                :tx-log tx-log
                                :indexer indexer
                                :object-store object-store
-                               :bus bus
                                :closed? (atom false)
                                :lock (StampedLock.)}))
    :deps #{::indexer ::kv-store ::bus ::object-store ::tx-log}

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -4,6 +4,7 @@
             [crux.kv :as kv]
             [crux.moberg :as moberg]
             [crux.node :as n]
+            [crux.topology :as topo]
             [crux.tx.polling :as p])
   (:import java.io.Closeable))
 
@@ -34,7 +35,7 @@
   (let [options {:crux.kv/db-dir event-log-dir
                  :crux.kv/sync? event-log-sync?
                  :crux.kv/check-and-store-index-version false}]
-    (n/start-component event-log-kv-store nil options)))
+    (topo/start-component event-log-kv-store nil options)))
 
 (defn- start-event-log-consumer [{:keys [crux.standalone/event-log-kv crux.node/indexer]} _]
   (when event-log-kv

--- a/crux-core/src/crux/topology.clj
+++ b/crux-core/src/crux/topology.clj
@@ -1,0 +1,110 @@
+(ns crux.topology
+  (:require [clojure.spec.alpha :as s]
+            [com.stuartsierra.dependency :as dep]
+            [crux.io :as cio])
+  (:import (java.io Closeable)))
+
+(s/def ::resolvable-id
+  (fn [id]
+    (and (or (string? id) (keyword? id) (symbol? id))
+         (namespace (symbol id)))))
+
+(defn- resolve-id [id]
+  (s/assert ::resolvable-id id)
+  (-> (or (-> id symbol requiring-resolve)
+          (throw (IllegalArgumentException. (format "Can't resolve symbol: '%s'" id))))
+      var-get))
+
+(s/def ::start-fn ifn?)
+(s/def ::deps (s/coll-of keyword?))
+
+(s/def ::args
+  (s/map-of keyword?
+            (s/keys :req [:crux.config/type]
+                    :req-un [:crux.config/doc]
+                    :opt-un [:crux.config/default
+                             :crux.config/required?])))
+
+(s/def ::component
+  (s/and (s/or :component-id ::resolvable-id, :component map?)
+         (s/conformer (fn [[c-or-id s]]
+                        (cond-> s (= :component-id c-or-id) resolve-id)))
+         (s/keys :req-un [::start-fn]
+                 :opt-un [::deps ::args])))
+
+(s/def ::module
+  (s/and (s/or :module-id ::resolvable-id, :module map?)
+         (s/conformer (fn [[m-or-id s]]
+                        (cond-> s (= :module-id m-or-id) resolve-id)))))
+
+(s/def ::resolved-topology (s/map-of keyword? ::component))
+
+(defn options->topology [{:keys [crux.node/topology] :as options}]
+  (when-not topology
+    (throw (IllegalArgumentException. "Please specify :crux.node/topology")))
+
+  (let [topology (-> topology
+                     (cond-> (not (vector? topology)) vector)
+                     (->> (map #(s/conform ::module %))
+                          (apply merge)))]
+    (->> (merge topology (select-keys options (keys topology)))
+         (s/conform ::resolved-topology))))
+
+(defn- start-order [system]
+  (let [g (reduce-kv (fn [g k c]
+                       (let [c (s/conform ::component c)]
+                         (reduce (fn [g d] (dep/depend g k d)) g (:deps c))))
+                     (dep/graph)
+                     system)
+        dep-order (dep/topo-sort g)
+        dep-order (->> (keys system)
+                       (remove #(contains? (set dep-order) %))
+                       (into dep-order))]
+    dep-order))
+
+(defn parse-opts [args options]
+  (into {}
+        (for [[k {:keys [crux.config/type default required?]}] args]
+          (let [[validate-fn parse-fn] (s/conform :crux.config/type type)
+                v (some-> (get options k) parse-fn)
+                v (if (nil? v) default v)]
+
+            (when (and required? (not v))
+              (throw (IllegalArgumentException. (format "Arg %s required" k))))
+
+            (when (and v (not (validate-fn v)))
+              (throw (IllegalArgumentException. (format "Arg %s invalid" k))))
+
+            [k v]))))
+
+(defn start-component [c started options]
+  (s/assert ::component c)
+  (let [{:keys [start-fn deps spec args]} (s/conform ::component c)
+        deps (select-keys started deps)
+        options (merge options (parse-opts args options))]
+    (start-fn deps options)))
+
+(defn start-topology [options]
+  (let [options (into {} options)
+        topology (options->topology options)]
+    (s/assert ::resolved-topology topology)
+    (let [started-order (atom [])
+          started (atom {})
+          started-modules (try
+                            (into {}
+                                  (for [k (start-order topology)]
+                                    (let [c (or (get topology k)
+                                                (throw (IllegalArgumentException. (str "Could not find component " k))))
+                                          c (start-component c @started options)]
+                                      (swap! started-order conj c)
+                                      (swap! started assoc k c)
+                                      [k c])))
+                            (catch Throwable t
+                              (doseq [c (reverse @started-order)]
+                                (when (instance? Closeable c)
+                                  (cio/try-close c)))
+                              (throw t)))]
+      [started-modules (fn []
+                         (->> (reverse @started-order)
+                              (filter #(instance? Closeable %))
+                              (run! cio/try-close)))])))

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -1,7 +1,7 @@
 (ns crux.kafka-ingest-client
-  (:require [crux.node :as n]
-            [crux.db :as db]
-            [crux.kafka :as k])
+  (:require [crux.db :as db]
+            [crux.kafka :as k]
+            [crux.topology :as topo])
   (:import crux.api.ICruxAsyncIngestAPI
            java.io.Closeable))
 
@@ -29,5 +29,6 @@
                :crux.kafka/latest-submitted-tx-consumer k/latest-submitted-tx-consumer})
 
 (defn new-ingest-client ^ICruxAsyncIngestAPI [options]
-  (let [[{:keys [crux.node/tx-log]} close-fn] (n/start-components topology options)]
+  (let [[{:keys [crux.node/tx-log]} close-fn] (topo/start-topology (merge {:crux.node/topology topology}
+                                                                          options))]
     (map->CruxKafkaIngestClient {:tx-log tx-log :close-fn close-fn})))

--- a/crux-test/test/crux/fixtures/kv_only.clj
+++ b/crux-test/test/crux/fixtures/kv_only.clj
@@ -2,7 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.test :as t]
             [crux.io :as cio]
-            [crux.node :as n])
+            [crux.topology :as topo])
   (:import java.io.Closeable))
 
 (def ^:dynamic *kv*)
@@ -11,7 +11,7 @@
 (def ^:dynamic *sync* false)
 
 (defn ^Closeable start-kv-store [opts]
-  (n/start-component *kv-module* nil opts))
+  (topo/start-component *kv-module* nil opts))
 
 (defn with-kv-store [f]
   (let [db-dir (cio/create-tmpdir "kv-store")]

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -16,23 +16,6 @@
            (java.util HashMap)
            (clojure.lang Keyword)))
 
-(t/deftest test-properties-to-topology
-  (let [t (n/options->topology {:crux.node/topology ['crux.jdbc/topology]})]
-
-    (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
-             (-> t :crux.node/tx-log)))
-    (t/is (= (s/conform ::n/component crux.kv.rocksdb/kv)
-             (-> t :crux.node/kv-store))))
-
-  (t/testing "override module in topology"
-    (let [t (n/options->topology {:crux.node/topology ['crux.jdbc/topology]
-                                  :crux.node/kv-store :crux.kv.memdb/kv})]
-
-      (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
-               (-> t :crux.node/tx-log)))
-      (t/is (= (s/conform ::n/component crux.kv.memdb/kv)
-               (-> t :crux.node/kv-store))))))
-
 (t/deftest test-calling-shutdown-node-fails-gracefully
   (let [data-dir (cio/create-tmpdir "kv-store")
         event-log-dir (cio/create-tmpdir "kv-store")]

--- a/crux-test/test/crux/topology_test.clj
+++ b/crux-test/test/crux/topology_test.clj
@@ -1,0 +1,21 @@
+(ns crux.topology-test
+  (:require [crux.topology :as topo]
+            [clojure.spec.alpha :as s]
+            [clojure.test :as t]))
+
+(t/deftest test-properties-to-topology
+  (let [t (topo/options->topology {:crux.node/topology ['crux.jdbc/topology]})]
+
+    (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
+             (-> t :crux.node/tx-log)))
+    (t/is (= (s/conform ::topo/component crux.kv.rocksdb/kv)
+             (-> t :crux.node/kv-store))))
+
+  (t/testing "override module in topology"
+    (let [t (topo/options->topology {:crux.node/topology ['crux.jdbc/topology]
+                                     :crux.node/kv-store :crux.kv.memdb/kv})]
+
+      (t/is (= (-> crux.jdbc/topology :crux.node/tx-log)
+               (-> t :crux.node/tx-log)))
+      (t/is (= (s/conform ::topo/component crux.kv.memdb/kv)
+               (-> t :crux.node/kv-store))))))

--- a/crux-test/test/crux/topology_test.clj
+++ b/crux-test/test/crux/topology_test.clj
@@ -19,3 +19,62 @@
                (-> t :crux.node/tx-log)))
       (t/is (= (s/conform ::topo/component crux.kv.memdb/kv)
                (-> t :crux.node/kv-store))))))
+
+(t/deftest test-option-parsing
+  (t/is (= {:foo 2, :bar false, :baz 5, :quux 5}
+           (topo/parse-opts {:foo {:crux.config/type :crux.config/int
+                                   :doc "An argument"
+                                   :default 3}
+                             :bar {:crux.config/type :crux.config/boolean
+                                   :doc "An argument"
+                                   :default true}
+                             :baz {:crux.config/type :crux.config/nat-int
+                                   :doc "An argument"
+                                   :default 5}
+                             :quux {:crux.config/type :crux.config/nat-int
+                                    :doc "An argument"
+                                    :default 6}}
+
+                            {:foo 2
+                             :bar false
+                             :quux "5"}))))
+
+(t/deftest test-components-shutdown-in-order
+  (let [started (atom [])
+        stopped (atom [])
+        [topo close-fn] (topo/start-topology
+                         {:crux.node/topology
+                          {:a {:deps [:b]
+                               :start-fn (fn [{:keys [b]} _]
+                                           (assert b)
+                                           (swap! started conj :a)
+                                           (reify java.io.Closeable
+                                             (close [_]
+                                               (swap! stopped conj :a))))}
+                           :b {:start-fn (fn [_ _]
+                                           (swap! started conj :b)
+                                           (reify java.io.Closeable
+                                             (close [_]
+                                               (swap! stopped conj :b))))}}})]
+    (t/is (= [:b :a] @started))
+    (close-fn)
+    (t/is (= [:a :b] @stopped)))
+
+  (t/testing "With Exception"
+    (let [started (atom [])
+          stopped (atom [])]
+      (try
+        (let [[topo close-fn] (topo/start-topology
+                               {:crux.node/topology
+                                {:a {:deps [:b]
+                                     :start-fn (fn [_ _]
+                                                 (throw (Exception.)))}
+                                 :b {:start-fn (fn [_ _]
+                                                 (swap! started conj :b)
+                                                 (reify java.io.Closeable
+                                                   (close [_]
+                                                     (swap! stopped conj :b))))}}})]
+          (t/is false))
+        (catch Exception e))
+      (t/is (= [:b] @started))
+      (t/is (= [:b] @stopped)))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -13,7 +13,8 @@
             [crux.kv :as kv]
             [crux.api :as api]
             [crux.rdf :as rdf]
-            [crux.query :as q])
+            [crux.query :as q]
+            [crux.node :as n])
   (:import [java.util Date]
            [java.time Duration]
            [crux.api ITxLog]))
@@ -707,8 +708,9 @@
 (t/deftest raises-tx-events-422
   (let [!events (atom [])
         !latch (promise)]
-    (bus/listen (:bus *api*) {::bus/event-types #{::tx/indexing-docs ::tx/indexed-docs
-                                                  ::tx/indexing-tx ::tx/indexed-tx}}
+    (bus/listen (get-in (meta *api*) [::n/topology ::n/bus])
+                {::bus/event-types #{::tx/indexing-docs ::tx/indexed-docs
+                                     ::tx/indexing-tx ::tx/indexed-tx}}
                 #(do
                    (swap! !events conj %)
                    (when (= ::tx/indexed-tx (::bus/event-type %))

--- a/crux-uberjar/src/crux/cli.clj
+++ b/crux-uberjar/src/crux/cli.clj
@@ -51,16 +51,13 @@
 
 (defn start-node-from-command-line [args]
   (cio/install-uncaught-exception-handler!)
-  (let [{:keys [options
-                errors
-                summary]} (cli/parse-opts args cli-options)
+  (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
         {:keys [server-port properties-file extra-edn-options]} options
         options (merge default-options
                        {:server-port server-port}
                        extra-edn-options
                        properties-file)
-        {:keys [version
-                revision]} (n/crux-version)]
+        {:keys [version revision]} n/crux-version]
     (cond
       (:help options)
       (println summary)

--- a/crux-uberjar/test/crux/uberjar_test.clj
+++ b/crux-uberjar/test/crux/uberjar_test.clj
@@ -9,10 +9,10 @@
   (:import (java.io File)))
 
 (def ^File working-directory
-  (.. (io/as-file (io/resource "crux/uberjar_test.clj"))
-      getParentFile
-      getParentFile
-      getParentFile))
+  (-> (io/as-file (io/resource "crux/uberjar_test.clj"))
+      (.getParentFile)
+      (.getParentFile)
+      (.getParentFile)))
 
 (defn build-uberjar []
   (log/info "building uberjar...")

--- a/crux-uberjar/test/crux/uberjar_test.clj
+++ b/crux-uberjar/test/crux/uberjar_test.clj
@@ -44,22 +44,10 @@
                       start)]
       (try
         (with-open [out (io/reader (.getInputStream process))]
-          (let [started-line? #(str/includes? % "org.eclipse.jetty.server.Server - Started")
-                out-lines (->> (line-seq out)
-                               (map #(doto % println)))
-                _ (or (t/is (->> out-lines (filter started-line?) first))
-                      (println (slurp (.getErrorStream process))))
-                results (->> out-lines
-                             (take-while (complement started-line?))
-                             (str/join "\n"))]
-
-            (t/testing "Crux version"
-              (t/is (str/includes? results "Crux version:")))
-
-            (t/testing "Options loaded"
-              (t/is (str/includes? results "options:")))
-
-            (t/testing "Options presented"
-              (t/is (str/includes? results ":server-port")))))
+          (or (t/is (->> (line-seq out)
+                         (map #(doto % println))
+                         (filter #(str/includes? % "org.eclipse.jetty.server.Server - Started"))
+                         first))
+              (println (slurp (.getErrorStream process)))))
         (finally
           (.destroy process))))))

--- a/crux-uberjar/test/crux/uberjar_test.clj
+++ b/crux-uberjar/test/crux/uberjar_test.clj
@@ -5,13 +5,14 @@
             [clojure.java.shell :as sh]
             [crux.fixtures :as f]
             [clojure.tools.logging :as log]
-            [crux.io :as cio]))
+            [crux.io :as cio])
+  (:import (java.io File)))
 
-(def working-directory
-  (-> (io/as-file (io/resource "crux/uberjar_test.clj"))
-      .getParentFile
-      .getParentFile
-      .getParentFile))
+(def ^File working-directory
+  (.. (io/as-file (io/resource "crux/uberjar_test.clj"))
+      getParentFile
+      getParentFile
+      getParentFile))
 
 (defn build-uberjar []
   (log/info "building uberjar...")
@@ -23,32 +24,42 @@
 
   (log/info "built uberjar, starting server..."))
 
+(defn- string-array ^"[Ljava.lang.String;" [& strs]
+  (into-array String strs))
+
 (t/deftest test-uberjar-can-start
   (f/with-tmp-dir "uberjar" [uberjar-dir]
     (build-uberjar)
 
-    (let [results (-> (sh/sh "timeout" "10s"
-                             "java" "-jar" "target/crux-test-uberjar.jar"
-                             "-x" (pr-str {:crux.node/topology 'crux.standalone/topology
-                                           :crux.standalone/event-log-dir (str (io/file uberjar-dir "event-log"))
-                                           :crux.kv/db-dir (str (io/file uberjar-dir "db-dir"))})
-                             "-s" (str (cio/free-port))
-                             :dir working-directory)
-                      :out)]
+    (let [opts {:crux.node/topology 'crux.standalone/topology
+                :crux.standalone/event-log-dir (str (io/file uberjar-dir "event-log"))
+                :crux.kv/db-dir (str (io/file uberjar-dir "db-dir"))}
 
-      (println results)
+          process (.. (ProcessBuilder. (string-array
+                                        "timeout" "30s"
+                                        "java" "-jar" "target/crux-test-uberjar.jar"
+                                        "-x" (pr-str opts)
+                                        "-s" (str (cio/free-port))))
+                      (directory working-directory)
+                      start)]
+      (try
+        (with-open [out (io/reader (.getInputStream process))]
+          (let [started-line? #(str/includes? % "org.eclipse.jetty.server.Server - Started")
+                out-lines (->> (line-seq out)
+                               (map #(doto % println)))
+                _ (or (t/is (->> out-lines (filter started-line?) first))
+                      (println (slurp (.getErrorStream process))))
+                results (->> out-lines
+                             (take-while (complement started-line?))
+                             (str/join "\n"))]
 
-      (t/testing "Results exist"
-        (t/is (string? results)))
+            (t/testing "Crux version"
+              (t/is (str/includes? results "Crux version:")))
 
-      (t/testing "Crux version"
-        (t/is (str/includes? results "Crux version:")))
+            (t/testing "Options loaded"
+              (t/is (str/includes? results "options:")))
 
-      (t/testing "Options loaded"
-        (t/is (str/includes? results "options:")))
-
-      (t/testing "Options presented"
-        (t/is (str/includes? results ":server-port")))
-
-      (t/testing "Server started"
-        (t/is (str/includes? results "org.eclipse.jetty.server.Server - Started"))))))
+            (t/testing "Options presented"
+              (t/is (str/includes? results ":server-port")))))
+        (finally
+          (.destroy process))))))


### PR DESCRIPTION
Refactored crux.node so that the node part is just another component - motivation is that we can then migrate the HTTP server (amongst other things) to be standard Crux modules.

I've refactored the topology code out to a separate namespace now, am aware that there wasn't much appetite for this when it was last discussed - I'm all in favour of larger namespaces for related functionality but, in this case, topology doesn't know about nodes, and the node doesn't know about the topology - it's now two very different areas of functionality. RFC?

also:
* making uberjar-test finish as soon as the server starts, for faster tests (it was previously always just waiting for the timeout)
* stopping node-test from creating directories within the repo