### PR TITLE
The remote API tests weren't actually running on the remote API

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -138,7 +138,6 @@
   supplied tx. Will throw on timeout. Returns the most recent tx indexed by the
   node.")
 
-
   (latest-completed-tx [node]
     "Returns the latest transaction to have been indexed by this node.")
 

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -142,6 +142,9 @@
   (latest-completed-tx [node]
     "Returns the latest transaction to have been indexed by this node.")
 
+  (latest-submitted-tx [node]
+    "Returns the latest transaction to have been submitted to this cluster")
+
   (attribute-stats [node]
     "Returns frequencies map for indexed attributes"))
 
@@ -217,6 +220,9 @@
 
   (latest-completed-tx [node]
     (.latestCompletedTx node))
+
+  (latest-submitted-tx [node]
+    (.latestSubmittedTx node))
 
   (attribute-stats [this]
     (.attributeStats this)))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -138,6 +138,10 @@
   supplied tx. Will throw on timeout. Returns the most recent tx indexed by the
   node.")
 
+
+  (latest-completed-tx [node]
+    "Returns the latest transaction to have been indexed by this node.")
+
   (attribute-stats [node]
     "Returns frequencies map for indexed attributes"))
 
@@ -210,6 +214,9 @@
      (await-tx-time this tx-time nil))
     ([this tx-time timeout]
      (.awaitTxTime this tx-time timeout)))
+
+  (latest-completed-tx [node]
+    (.latestCompletedTx node))
 
   (attribute-stats [this]
     (.attributeStats this)))

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -149,6 +149,12 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      */
     public Map<Keyword, ?> awaitTx(Map<Keyword,?> tx, Duration timeout);
 
+
+    /**
+       @return the latest transaction to have been indexed by this node.
+     */
+    public Map<Keyword, ?> latestCompletedTx();
+
     /**
      * Return frequencies of indexed attributes.
      *

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -156,6 +156,11 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
     public Map<Keyword, ?> latestCompletedTx();
 
     /**
+       @return the latest transaction to have been submitted to this cluster
+    */
+    public Map<Keyword, ?> latestSubmittedTx();
+
+    /**
      * Return frequencies of indexed attributes.
      *
      * @return         Map containing attribute freqencies.

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -157,6 +157,9 @@
       (tx/await-tx indexer submitted-tx (or (and timeout (.toMillis timeout))
                                             (:crux.tx-log/await-tx-timeout options)))))
 
+  (latestCompletedTx [this]
+    (db/read-index-meta indexer ::tx/latest-completed-tx))
+
   ICruxAsyncIngestAPI
   (submitTxAsync [this tx-ops]
     (cio/with-read-lock lock

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -160,6 +160,9 @@
   (latestCompletedTx [this]
     (db/read-index-meta indexer ::tx/latest-completed-tx))
 
+  (latestSubmittedTx [this]
+    (db/latest-submitted-tx tx-log))
+
   ICruxAsyncIngestAPI
   (submitTxAsync [this tx-ops]
     (cio/with-read-lock lock

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -187,7 +187,7 @@
     (api-request-sync (str url "/tx-log") tx-ops))
 
   (hasTxCommitted [_ submitted-tx]
-    (api-request-sync (str url "/tx-committed") submitted-tx))
+    (api-request-sync (str url "/tx-committed?tx-id=" (:crux.tx/tx-id submitted-tx)) nil {:method :get}))
 
   (openTxLog [this from-tx-id with-ops?]
     (let [params (->> [(when from-tx-id

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -213,6 +213,14 @@
                         transaction-time (str "?transactionTime=" (cio/format-rfc3339-date transaction-time))
                         timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
 
+  (awaitTxTime [_ tx-time timeout]
+    (api-request-sync (cond-> (str url "/await-tx-time?tx-time=" (cio/format-rfc3339-date tx-time))
+                        timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
+
+  (awaitTx [_ tx timeout]
+    (api-request-sync (cond-> (str url "/await-tx?tx-id=" (:crux.tx/tx-id tx))
+                        timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
+
   Closeable
   (close [_]))
 

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -5,10 +5,10 @@
             [crux.db :as db]
             [crux.codec :as c]
             [crux.query :as q])
-  (:import [java.io Closeable InputStreamReader IOException PushbackReader]
+  (:import (java.io Closeable InputStreamReader IOException PushbackReader)
            java.time.Duration
            java.util.Date
-           [crux.api Crux ICruxAPI ICruxDatasource]))
+           (crux.api Crux ICruxAPI ICruxDatasource NodeOutOfSyncException)))
 
 (defn- edn-list->lazy-seq [in]
   (let [in (PushbackReader. (InputStreamReader. in))
@@ -155,8 +155,16 @@
   (db [_ valid-time]
     (->RemoteDatasource url valid-time nil))
 
-  (db [_ valid-time transact-time]
-    (->RemoteDatasource url valid-time transact-time))
+  (db [_ valid-time tx-time]
+    (when tx-time
+      (let [latest-tx-time (-> (api-request-sync (str url "/latest-completed-tx") nil {:method :get})
+                               :crux.tx/tx-time)]
+        (when (or (nil? latest-tx-time) (pos? (compare tx-time latest-tx-time)))
+          (throw (NodeOutOfSyncException.
+                  (format "Node hasn't indexed the transaction: requested: %s, available: %s" tx-time latest-tx-time)
+                  tx-time latest-tx-time)))))
+
+    (->RemoteDatasource url valid-time tx-time))
 
   (document [_ content-hash]
     (api-request-sync (str url "/document/" content-hash) nil {:method :get}))
@@ -220,6 +228,9 @@
   (awaitTx [_ tx timeout]
     (api-request-sync (cond-> (str url "/await-tx?tx-id=" (:crux.tx/tx-id tx))
                         timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
+
+  (latestCompletedTx [_]
+    (api-request-sync (str url "/latest-completed-tx") nil {:method :get}))
 
   Closeable
   (close [_]))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -232,6 +232,9 @@
   (latestCompletedTx [_]
     (api-request-sync (str url "/latest-completed-tx") nil {:method :get}))
 
+  (latestSubmittedTx [_]
+    (api-request-sync (str url "/latest-submitted-tx") nil {:method :get}))
+
   Closeable
   (close [_]))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -272,8 +272,9 @@
 
 (defn- tx-committed? [^ICruxAPI crux-node request]
   (try
-    (let [submitted-tx (body->edn request)]
-      (success-response (.hasTxCommitted crux-node submitted-tx)))
+    (let [tx-id (-> (get-in request [:query-params "tx-id"])
+                    (Long/parseLong))]
+      (success-response (.hasTxCommitted crux-node {:crux.tx/tx-id tx-id})))
     (catch NodeOutOfSyncException e
       (exception-response 400 e))))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -44,9 +44,7 @@
     :body body}))
 
 (defn- success-response [m]
-  (response (if m
-              200
-              404)
+  (response (if (some? m) 200 404)
             {"Content-Type" "application/edn"}
             (cio/pr-edn-str m)))
 
@@ -71,10 +69,8 @@
         (exception-response 400 e))))) ;;Invalid edn
 
 (defn- add-last-modified [response date]
-  (if date
-    (->> (rt/format-date date)
-         (assoc-in response [:headers "Last-Modified"]))
-    response))
+  (cond-> response
+    date (assoc-in [:headers "Last-Modified"] (rt/format-date date))))
 
 ;; ---------------------------------------------------
 ;; Services

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -281,6 +281,9 @@
 (defn latest-completed-tx [^ICruxAPI crux-node]
   (success-response (.latestCompletedTx crux-node)))
 
+(defn latest-submitted-tx [^ICruxAPI crux-node]
+  (success-response (.latestSubmittedTx crux-node)))
+
 (def ^:private sparql-available?
   (try ; you can change it back to require when clojure.core fixes it to be thread-safe
     (requiring-resolve 'crux.sparql.protocol/sparql-query)
@@ -349,6 +352,9 @@
 
     [#"^/latest-completed-tx" [:get]]
     (latest-completed-tx crux-node)
+
+    [#"^/latest-submitted-tx" [:get]]
+    (latest-submitted-tx crux-node)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
              sparql-available?)

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -278,11 +278,15 @@
     (catch NodeOutOfSyncException e
       (exception-response 400 e))))
 
-(def ^:private sparql-available? (try ; you can change it back to require when clojure.core fixes it to be thread-safe
-                                   (requiring-resolve 'crux.sparql.protocol/sparql-query)
-                                   true
-                                   (catch IOException _
-                                     false)))
+(defn latest-completed-tx [^ICruxAPI crux-node]
+  (success-response (.latestCompletedTx crux-node)))
+
+(def ^:private sparql-available?
+  (try ; you can change it back to require when clojure.core fixes it to be thread-safe
+    (requiring-resolve 'crux.sparql.protocol/sparql-query)
+    true
+    (catch IOException _
+      false)))
 
 ;; ---------------------------------------------------
 ;; Jetty server
@@ -342,6 +346,9 @@
 
     [#"^/tx-committed$" [:get]]
     (tx-committed? crux-node request)
+
+    [#"^/latest-completed-tx" [:get]]
+    (latest-completed-tx crux-node)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
              sparql-available?)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -366,11 +366,11 @@
     (t/is (thrown? NodeOutOfSyncException (api/db *api* the-future the-future)))))
 
 (t/deftest test-latest-submitted-tx
-  (t/is (nil? (db/latest-submitted-tx (:tx-log *api*))))
+  (t/is (nil? (.latestSubmittedTx *api*)))
 
   (let [{:keys [crux.tx/tx-id] :as tx} (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]])]
     (t/is (= {:crux.tx/tx-id tx-id}
-             (db/latest-submitted-tx (:tx-log *api*)))))
+             (.latestSubmittedTx *api*))))
 
   (api/sync *api*)
 

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -26,18 +26,16 @@
 
 (defn- with-each-api-implementation [f]
   (t/testing "Local API ClusterNode"
-    (kf/with-cluster-node-opts f))
+    ((t/join-fixtures [kf/with-cluster-node-opts kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Local API StandaloneNode"
-    (fs/with-standalone-node f))
+    ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "JDBC Node"
-    (fj/with-jdbc-node :h2 f))
+    ((t/join-fixtures [#(fj/with-jdbc-node :h2 %) kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Remote API"
-    (fn [f]
-      (fh/with-http-server
-        fs/with-standalone-node))))
+    ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fapi/with-node fh/with-http-server]) f)))
 
 (t/use-fixtures :once fk/with-embedded-kafka-cluster)
-(t/use-fixtures :each with-each-api-implementation kvf/with-kv-dir fapi/with-node)
+(t/use-fixtures :each with-each-api-implementation)
 
 (declare execute-sparql)
 


### PR DESCRIPTION
Because of the test fixture order in api-test, the remote API node was getting created, but then `with-node` overrode the binding for `fapi/*api*` with the local node, because it was later in the text fixture order... :grimacing: 

Anyway, the remote API client has hence gotten out of sync with the local API, here's bringing it up to date again.