### PR TITLE
HTTP server as a module

### DIFF
--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -89,9 +89,9 @@
   (status [this]
     (cio/with-read-lock lock
       (ensure-node-open this)
+      ;; we don't have status-fn set when other components use node as a dependency within the topology
       (if status-fn
         (status-fn)
-        ;; fallback for before status-fn's set
         (into {} (mapcat status/status-map) [indexer kv-store object-store tx-log]))))
 
   (attributeStats [this]
@@ -104,8 +104,7 @@
       (ensure-node-open this)
       @(db/submit-tx tx-log tx-ops)))
 
-  (hasTxCommitted [this {:keys [crux.tx/tx-id
-                                crux.tx/tx-time] :as submitted-tx}]
+  (hasTxCommitted [this {:keys [crux.tx/tx-id crux.tx/tx-time] :as submitted-tx}]
     (cio/with-read-lock lock
       (ensure-node-open this)
       (let [{latest-tx-id :crux.tx/tx-id

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -89,7 +89,10 @@
   (status [this]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (status-fn)))
+      (if status-fn
+        (status-fn)
+        ;; fallback for before status-fn's set
+        (into {} (mapcat status/status-map) [indexer kv-store object-store tx-log]))))
 
   (attributeStats [this]
     (cio/with-read-lock lock

--- a/crux-core/src/crux/topology.clj
+++ b/crux-core/src/crux/topology.clj
@@ -47,9 +47,14 @@
   (let [topology (-> topology
                      (cond-> (not (vector? topology)) vector)
                      (->> (map #(s/conform ::module %))
-                          (apply merge)))]
-    (->> (merge topology (select-keys options (keys topology)))
-         (s/conform ::resolved-topology))))
+                          (apply merge))
+                     (as-> topology (merge topology (select-keys options (keys topology)))))
+        resolved-topology (s/conform ::resolved-topology topology)]
+    (when (s/invalid? resolved-topology)
+      (s/explain ::resolved-topology topology)
+      (throw (IllegalArgumentException. "invalid topology")))
+
+    resolved-topology))
 
 (defn- start-order [system]
   (let [g (reduce-kv (fn [g k c]

--- a/crux-core/src/crux/topology.clj
+++ b/crux-core/src/crux/topology.clj
@@ -53,7 +53,6 @@
     (when (s/invalid? resolved-topology)
       (s/explain ::resolved-topology topology)
       (throw (IllegalArgumentException. "invalid topology")))
-
     resolved-topology))
 
 (defn- start-order [system]

--- a/crux-docker/crux.edn
+++ b/crux-docker/crux.edn
@@ -1,4 +1,4 @@
-{:crux/node-opts {:crux.node/topology ['crux.standalone/topology]
+{:crux/node-opts {:crux.node/topology '[crux.standalone/topology crux.http-server/module]
                   :crux.node/kv-store 'crux.kv.memdb/kv
                   :crux.kv/db-dir "/var/lib/crux/db"
                   :crux.standalone/event-log-dir "/var/lib/crux/events"

--- a/crux-docker/src/crux/docker.clj
+++ b/crux-docker/src/crux/docker.clj
@@ -15,21 +15,9 @@
 (defmethod ig/halt-key! :crux/node [_ ^Closeable node]
   (.close node))
 
-
-(defmethod ig/init-key :crux/http-server [_ {:keys [crux/node crux/server-config]}]
-  (let [cors-opts (:cors-access-control server-config)
-        server-opts (cond-> server-config
-                      (map? cors-opts) (assoc :cors-access-control (reduce into [] cors-opts)))]
-    (srv/start-http-server node server-opts)))
-
-(defmethod ig/halt-key! :crux/http-server [_ ^Closeable server]
-  (.close server))
-
 (def ig-config
   (let [{:keys [crux/node-opts crux/server-opts]} (read-string (slurp (io/file "/etc/crux.edn")))]
-    {:crux/node node-opts
-     :crux/http-server {:crux/node (ig/ref :crux/node)
-                        :crux/server-config server-opts}}))
+    {:crux/node node-opts}))
 
 (def cli-opts
   [[nil "--nrepl" "Starts an nrepl for the container"]

--- a/crux-http-server/README.adoc
+++ b/crux-http-server/README.adoc
@@ -1,8 +1,8 @@
 = crux-http-server
 
-This project contains a complete mapping of Crux APIs to HTTP endpoints that
-are exposed when running `start-http-server` using Ring middleware and Jetty.
-This can be used in conjunction with both cluster-node mode and standalone
-mode.  A `:server-port` number and CORS configuration may also be provided.
+This project contains a module to start up a Crux HTTP server.
+
+To start it, include `crux.http-server/module` in your topology.
+You can specify `:crux.http-server/port` in your topology to set the port.
 
 For tests, see usage of `/crux-test/test/crux/fixtures/http_server.clj`.

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -32,7 +32,10 @@
   (t/testing "JDBC Node"
     ((t/join-fixtures [#(fj/with-jdbc-node :h2 %) kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Remote API"
-    ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fapi/with-node fh/with-http-server]) f)))
+    ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fh/with-http-server
+                       fapi/with-node
+                       fh/with-http-client])
+     f)))
 
 (t/use-fixtures :once fk/with-embedded-kafka-cluster)
 (t/use-fixtures :each with-each-api-implementation)

--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -18,28 +18,29 @@
 (t/deftest test-example-standalone-node
   (let [node (ex/example-start-standalone)
         submitted (ex/example-submit-tx node)]
-    ;; Testing example standalone node is created properly
-    (t/is (not= nil node))
-    ;; Testing example submit-tx works properly (and wait for it to complete)
-    (t/is (not= nil submitted))
-    (crux/await-tx node submitted nil)
+    (t/testing "example standalone node is created properly"
+      (t/is (not= nil node)))
 
-    ;; Testing 'getting started' example queries
-    (t/is (= {:crux.db/id :dbpedia.resource/Pablo-Picasso
-              :name "Pablo"
-              :last-name "Picasso"}
-           (ex/example-query-entity node)))
-    (t/is (= #{[:dbpedia.resource/Pablo-Picasso]} (ex/example-query node)))
-    (t/is (not (empty? (ex/example-query-valid-time node))))
+    (t/testing "example submit-tx works properly (and wait for it to complete)"
+      (t/is (not= nil submitted))
+      (crux/await-tx node submitted nil))
 
-    ;; Testing example standalone node is closed properly
-    (t/is (nil? (ex/example-close-node node)))))
+    (t/testing "'getting started' example queries"
+      (t/is (= {:crux.db/id :dbpedia.resource/Pablo-Picasso
+                :name "Pablo"
+                :last-name "Picasso"}
+               (ex/example-query-entity node)))
+      (t/is (= #{[:dbpedia.resource/Pablo-Picasso]} (ex/example-query node)))
+      (t/is (not (empty? (ex/example-query-valid-time node)))))
+
+    (t/testing "example standalone node is closed properly"
+      (t/is (nil? (ex/example-close-node node))))))
 
 (t/deftest test-example-http-node
   (with-open [underlying-node ^Closeable (ex/example-start-standalone-http)
               node ^Closeable (ex/example-start-http-client)]
-    ;; Testing example standalone node is created properly
-    (t/is node)
+    (t/testing "example standalone node is created properly"
+      (t/is node))
 
     (let [submitted (ex/example-submit-tx node)]
       (crux/await-tx node submitted nil)
@@ -53,29 +54,33 @@
 (t/deftest test-example-kafka-node
   (let [embedded-kafka (ex/example-start-embedded-kafka)
         node (ex/example-start-cluster)]
-    ;; Testing example embedded kafka is created properly
-    (t/is (not= nil embedded-kafka))
-    ;; Testing example cluster node is created properly
-    (t/is (not= nil node))
-    ;; Testing example cluster node is closed properly
-    (t/is (nil? (ex/example-close-node node)))
-    ;; Testing example embedded kafka node is closed properly
-    (t/is (nil? (ex/example-stop-embedded-kafka embedded-kafka)))))
+    (t/testing "example embedded kafka is created properly"
+      (t/is (not= nil embedded-kafka)))
+
+    (t/testing "example cluster node is created properly"
+      (t/is (not= nil node)))
+
+    (t/testing "example cluster node is closed properly"
+      (t/is (nil? (ex/example-close-node node))))
+
+    (t/testing "example embedded kafka node is closed properly"
+      (t/is (nil? (ex/example-stop-embedded-kafka embedded-kafka))))))
 
 (t/deftest test-example-rocks-node
   (let [node (ex/example-start-rocks)]
-    ;; Testing example node with RocksDB is created properly
-    (t/is (not= nil node))
-    ;; Testing example node with RocksDB is closed properly
-    (t/is (nil? (ex/example-close-node node)))))
+    (t/testing "example node with RocksDB is created properly"
+      (t/is (not= nil node)))
+
+    (t/testing "example node with RocksDB is closed properly"
+      (t/is (nil? (ex/example-close-node node))))))
 
 (t/deftest test-example-lmdb-node
   (let [node (ex/example-start-lmdb)]
+    (t/testing "example node with LMDB is created properly"
+      (t/is (not= nil node)))
 
-    ;; Testing example node with LMDB is created properly
-    (t/is (not= nil node))
-    ;; Testing example node with LMDB is closed properly
-    (t/is (nil? (ex/example-close-node node)))))
+    (t/testing "example node with LMDB is closed properly"
+      (t/is (nil? (ex/example-close-node node))))))
 
 (t/deftest test-example-basic-queries
   (with-open [^crux.api.ICruxAPI node (ex/example-start-standalone)]
@@ -99,6 +104,7 @@
 (t/deftest test-example-join-queries
   (with-open [^crux.api.ICruxAPI node (ex/example-start-standalone)]
     (crux/await-tx node (ex/query-example-join-q1-setup node) nil)
+
     (t/is (= #{[:ivan :ivan]
                [:petr :petr]
                [:sergei :sergei]
@@ -107,6 +113,7 @@
                [:denis-a :denis-b]
                [:denis-b :denis-a]}
              (ex/query-example-join-q1 node)))
+
     (crux/await-tx node (ex/query-example-join-q2-setup node) nil)
     (t/is (= #{[:petr]}
              (ex/query-example-join-q2 node)))))

--- a/crux-test/test/crux/fixtures/standalone.clj
+++ b/crux-test/test/crux/fixtures/standalone.clj
@@ -5,7 +5,7 @@
 (defn with-standalone-node [f]
   (let [event-log-dir (str (cio/create-tmpdir "event-log-dir"))]
     (try
-      (apif/with-opts {:crux.node/topology 'crux.standalone/topology
+      (apif/with-opts {:crux.node/topology '[crux.standalone/topology]
                        :crux.standalone/event-log-dir event-log-dir}
         f)
       (finally

--- a/crux-uberjar/src/crux/cli.clj
+++ b/crux-uberjar/src/crux/cli.clj
@@ -16,10 +16,6 @@
   [["-p" "--properties-file PROPERTIES_FILE" "Properties file to load Crux options from"
     :parse-fn #(cc/load-properties %)]
 
-   ["-s" "--server-port SERVER_PORT" "Port on which to run the HTTP server"
-    :default srv/default-server-port
-    :parse-fn #(Long/parseLong %)]
-
    ["-x" "--extra-edn-options EDN_OPTIONS" "Extra options as an quoted EDN map."
     :default nil
     :parse-fn edn/read-string]
@@ -52,9 +48,8 @@
 (defn start-node-from-command-line [args]
   (cio/install-uncaught-exception-handler!)
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
-        {:keys [server-port properties-file extra-edn-options]} options
+        {:keys [properties-file extra-edn-options]} options
         options (merge default-options
-                       {:crux.http-server/port server-port}
                        extra-edn-options
                        properties-file)
         {:keys [version revision]} n/crux-version]

--- a/crux-uberjar/src/crux/cli.clj
+++ b/crux-uberjar/src/crux/cli.clj
@@ -10,7 +10,7 @@
   (:import java.io.Closeable))
 
 (def default-options
-  {:crux.node/topology 'crux.kafka/topology})
+  {:crux.node/topology '[crux.standalone/topology crux.http-server/module]})
 
 (def cli-options
   [["-p" "--properties-file PROPERTIES_FILE" "Properties file to load Crux options from"
@@ -54,7 +54,7 @@
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
         {:keys [server-port properties-file extra-edn-options]} options
         options (merge default-options
-                       {:server-port server-port}
+                       {:crux.http-server/port server-port}
                        extra-edn-options
                        properties-file)
         {:keys [version revision]} n/crux-version]
@@ -71,6 +71,5 @@
       :else
       (do (log/infof "Crux version: %s revision: %s" version revision)
           (log/info "options:" (options->table options))
-          (with-open [node (n/start options)
-                      http-server ^Closeable (srv/start-http-server node options)]
+          (with-open [node (n/start options)]
             @(shutdown-hook-promise))))))

--- a/crux-uberjar/test/crux/uberjar_test.clj
+++ b/crux-uberjar/test/crux/uberjar_test.clj
@@ -31,15 +31,15 @@
   (f/with-tmp-dir "uberjar" [uberjar-dir]
     (build-uberjar)
 
-    (let [opts {:crux.node/topology 'crux.standalone/topology
+    (let [opts {:crux.node/topology '[crux.standalone/topology crux.http-server/module]
                 :crux.standalone/event-log-dir (str (io/file uberjar-dir "event-log"))
+                :crux.http-server/port (cio/free-port)
                 :crux.kv/db-dir (str (io/file uberjar-dir "db-dir"))}
 
           process (.. (ProcessBuilder. (string-array
                                         "timeout" "30s"
                                         "java" "-jar" "target/crux-test-uberjar.jar"
-                                        "-x" (pr-str opts)
-                                        "-s" (str (cio/free-port))))
+                                        "-x" (pr-str opts)))
                       (directory working-directory)
                       start)]
       (try

--- a/docs/Confluent-QuickStart.adoc
+++ b/docs/Confluent-QuickStart.adoc
@@ -28,11 +28,9 @@ Ensure first that you have a running Kafka broker to connect to. We import the d
 (import (crux.api ICruxAPI))
 
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology ['crux.kafka/topology]
+  (crux/start-node {:crux.node/topology '[crux.kafka/topology crux.http-server/module]
                     :crux.kafka/bootstrap-servers "localhost:9092"
-		    :server-port 3000}))
-
-(srv/start-http-server node)
+		                :crux.http-server/port 3000}))
 ----
 
 == Sink Connector

--- a/docs/Kafka-QuickStart.adoc
+++ b/docs/Kafka-QuickStart.adoc
@@ -39,11 +39,9 @@ Ensure first that you have a running Kafka broker to connect to. We import the d
 (import (crux.api ICruxAPI))
 
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology ['crux.kafka/topology]
+  (crux/start-node {:crux.node/topology '[crux.kafka/topology crux.http-server/module]
                     :crux.kafka/bootstrap-servers "localhost:9092"
-		                :server-port 3000}))
-
-(srv/start-http-server node)
+		                :crux.http-server/port 3000}))
 ----
 
 == Sink Connector

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -312,7 +312,7 @@ expose a HTTP port that will accept REST requests:
 [#table-conversion%header,cols="d,d,d"]
 |===
 |Component|Property|Description
-|http-server|`server-port`|Port for Crux HTTP Server e.g. `8080`
+|crux.http-server|`port`|Port for Crux HTTP Server e.g. `8080`
 |===
 
 Visit the guide on using the <<#rest,REST api>> for examples
@@ -327,12 +327,12 @@ of how to interact with Crux over HTTP.
 include::./deps.edn[tags=HTTPDeps]
 ----
 
-You can start up a *HTTP server* on a node using `crux.http-server/start-http-server` and passing in a crux node, with the option of passing some further HTTP options. In the example below, we start a HTTP server on a pre-existing node with some *CORS options* and the *server port* (could also be set within the node itself) set within `http-options`:
+You can start up a *HTTP server* on a node by including
+`crux.http-server/module` in your topology, optionally passing the server port:
 
 [source,clj]
 ----
-include::./src/docs/examples.clj[tags=require-http-server]
-include::./src/docs/examples.clj[tags=start-http-server]
+include::./src/docs/examples.clj[tags=start-standalone-http-server]
 ----
 [#config-start-remote-client]
 === Using a Remote API Client

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -9,10 +9,6 @@
 (require '[crux.kafka.embedded :as ek])
 ;; end::require-ek[]
 
-;; tag::require-http-server[]
-(require '[crux.http-server :as srv])
-;; end::require-http-server[]
-
 (defn example-start-standalone []
 ;; tag::start-standalone-node[]
 (def ^crux.api.ICruxAPI node
@@ -25,10 +21,21 @@
   node)
 
 (defn example-close-node [^java.io.Closeable node]
-;; tag::close-node[]
-(.close node)
-;; end::close-node[]
-)
+  ;; tag::close-node[]
+  (.close node)
+  ;; end::close-node[]
+  )
+
+(defn example-start-standalone-http []
+;; tag::start-standalone-http-node[]
+(def ^crux.api.ICruxAPI node
+  (crux/start-node {:crux.node/topology '[crux.standalone/topology crux.http-server/module]
+                    :crux.node/kv-store 'crux.kv.memdb/kv
+                    :crux.kv/db-dir "data/db-dir-1"
+                    :crux.standalone/event-log-dir "data/eventlog-1"
+                    :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv}))
+;; end::start-standalone-http-node[]
+  node)
 
 (defn example-start-embedded-kafka []
 ;; tag::ek-example[]
@@ -88,25 +95,6 @@ node)
                     :crux.jdbc/user "<user>"
                     :crux.jdbc/password "<password>"}))
   ;; end::start-jdbc-node[]
-  )
-
-(defn example-start-http-server [node]
-;; tag::start-http-server[]
-(def http-options
-  {:server-port 3000
-   :cors-access-control
-   [:access-control-allow-origin [#".*"]
-    :access-control-allow-headers ["X-Requested-With"
-                                   "Content-Type"
-                                   "Cache-Control"
-                                   "Origin"
-                                   "Accept"
-                                   "Authorization"
-                                   "X-Custom-Header"]
-    :access-control-allow-methods [:get :post]]})
-
-(srv/start-http-server node http-options)
-;; end::start-http-server[]
   )
 
 (defn example-start-http-client []

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -12,7 +12,7 @@
 (defn example-start-standalone []
 ;; tag::start-standalone-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology 'crux.standalone/topology
+  (crux/start-node {:crux.node/topology '[crux.standalone/topology]
                     :crux.node/kv-store 'crux.kv.memdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
@@ -58,7 +58,7 @@ embedded-kafka)
 (defn example-start-cluster []
 ;; tag::start-cluster-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology 'crux.kafka/topology
+  (crux/start-node {:crux.node/topology '[crux.kafka/topology]
                     :crux.node/kv-store 'crux.kv.memdb/kv
                     :crux.kafka/bootstrap-servers "localhost:9092"}))
 ;; end::start-cluster-node[]
@@ -67,7 +67,7 @@ node)
 (defn example-start-rocks []
 ;; tag::start-standalone-with-rocks[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology 'crux.standalone/topology
+  (crux/start-node {:crux.node/topology '[crux.standalone/topology]
                     :crux.node/kv-store 'crux.kv.rocksdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"}))
@@ -77,7 +77,7 @@ node)
 (defn example-start-lmdb []
 ;; tag::start-standalone-with-lmdb[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology 'crux.standalone/topology
+  (crux/start-node {:crux.node/topology '[crux.standalone/topology]
                     :crux.node/kv-store 'crux.kv.lmdb/kv
                     :crux.kv/db-dir "data/db-dir-1"
                     :crux.standalone/event-log-dir "data/eventlog-1"
@@ -88,7 +88,7 @@ node)
 (defn example-start-jdbc []
 ;; tag::start-jdbc-node[]
 (def ^crux.api.ICruxAPI node
-  (crux/start-node {:crux.node/topology 'crux.jdbc/topology
+  (crux/start-node {:crux.node/topology '[crux.jdbc/topology]
                     :crux.jdbc/dbtype "postgresql"
                     :crux.jdbc/dbname "cruxdb"
                     :crux.jdbc/host "<host>"


### PR DESCRIPTION
Now that node's a module, we can start the HTTP server using a module, which means we can specify it in the data-oriented topology config (e.g. EDN/properties files)