### PR TITLE
Await waits indefinitely unless given a timeout, #578

### DIFF
--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -117,8 +117,8 @@
     (catch Throwable t
       (log/error t "Could not close:" c))))
 
-(defn wait-while [p timeout-ms]
-  (let [timeout-at (some-> timeout-ms (+ (System/currentTimeMillis)))]
+(defn wait-while [p ^Duration timeout]
+  (let [timeout-at (some-> timeout .toMillis (+ (System/currentTimeMillis)))]
     (loop []
       (if (p)
         (do (Thread/sleep 100)

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -117,12 +117,12 @@
     (catch Throwable t
       (log/error t "Could not close:" c))))
 
-(defn wait-while [p timeout]
-  (let [timeout-at (+ timeout (System/currentTimeMillis))]
+(defn wait-while [p timeout-ms]
+  (let [timeout-at (some-> timeout-ms (+ (System/currentTimeMillis)))]
     (loop []
       (if (p)
         (do (Thread/sleep 100)
-            (if (>= (System/currentTimeMillis) timeout-at)
+            (if (and timeout-at (>= (System/currentTimeMillis) timeout-at))
               false
               (recur)))
         true))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -149,15 +149,13 @@
   (awaitTxTime [this tx-time timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (-> (tx/await-tx-time indexer tx-time (or (and timeout (.toMillis timeout))
-                                                (:crux.tx-log/await-tx-timeout options)))
+      (-> (tx/await-tx-time indexer tx-time (or timeout (:crux.tx-log/await-tx-timeout options)))
           :crux.tx/tx-time)))
 
   (awaitTx [this submitted-tx timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (tx/await-tx indexer submitted-tx (or (and timeout (.toMillis timeout))
-                                            (:crux.tx-log/await-tx-timeout options)))))
+      (tx/await-tx indexer submitted-tx (or timeout (:crux.tx-log/await-tx-timeout options)))))
 
   (latestCompletedTx [this]
     (db/read-index-meta indexer ::tx/latest-completed-tx))
@@ -197,9 +195,9 @@
                                :closed? (atom false)
                                :lock (StampedLock.)}))
    :deps #{::indexer ::kv-store ::bus ::object-store ::tx-log}
-   :args {:crux.tx-log/await-tx-timeout {:doc "Default timeout in milliseconds for waiting."
-                                         :default 10000
-                                         :crux.config/type :crux.config/nat-int}}})
+   :args {:crux.tx-log/await-tx-timeout {:doc "Default timeout for awaiting transactions being indexed."
+                                         :default nil
+                                         :crux.config/type :crux.config/duration}}})
 
 (def base-topology
   {::kv-store 'crux.kv.rocksdb/kv

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -426,26 +426,26 @@
                             (Executors/newSingleThreadExecutor (cio/thread-factory "crux.tx.update-stats-thread"))))
    :deps [:crux.node/kv-store :crux.node/tx-log :crux.node/object-store :crux.node/bus]})
 
-(defn await-tx [indexer {::keys [tx-id] :as tx} timeout-ms]
+(defn await-tx [indexer {::keys [tx-id] :as tx} timeout]
   (let [seen-tx (atom nil)]
     (if (cio/wait-while #(let [latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)]
                            (reset! seen-tx latest-completed-tx)
                            (or (nil? latest-completed-tx)
                                (pos? (compare tx-id (:crux.tx/tx-id latest-completed-tx)))))
-                        timeout-ms)
+                        timeout)
       @seen-tx
       (throw (TimeoutException.
               (str "Timed out waiting for: " (cio/pr-edn-str tx)
                    " index has: " (cio/pr-edn-str @seen-tx)))))))
 
-(defn await-tx-time [indexer transact-time timeout-ms]
+(defn await-tx-time [indexer tx-time timeout]
   (let [seen-tx (atom nil)]
     (if (cio/wait-while #(let [latest-completed-tx (db/read-index-meta indexer :crux.tx/latest-completed-tx)]
                            (reset! seen-tx latest-completed-tx)
                            (or (nil? latest-completed-tx)
-                               (pos? (compare transact-time (:crux.tx/tx-time latest-completed-tx)))))
-                        timeout-ms)
+                               (pos? (compare tx-time (:crux.tx/tx-time latest-completed-tx)))))
+                        timeout)
       @seen-tx
       (throw (TimeoutException.
-              (str "Timed out waiting for: " (cio/pr-edn-str transact-time)
+              (str "Timed out waiting for: " (cio/pr-edn-str tx-time)
                    " index has: " (cio/pr-edn-str @seen-tx)))))))

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -14,7 +14,8 @@
            java.util.Date
            crux.api.Crux
            (java.util HashMap)
-           (clojure.lang Keyword)))
+           (clojure.lang Keyword)
+           (java.time Duration)))
 
 (t/deftest test-calling-shutdown-node-fails-gracefully
   (f/with-tmp-dir "data" [data-dir]
@@ -70,7 +71,7 @@
                              :crux.db/db-dir (str (io/file data-dir "db"))
                              :crux.standalone/event-log-dir (str (io/file data-dir "event-log"))))]
       (t/is (instance? MobergTxLog (-> n :tx-log)))
-      (t/is (= 20000 (-> n :options :crux.tx-log/await-tx-timeout))))))
+      (t/is (= (Duration/ofSeconds 20) (-> n :options :crux.tx-log/await-tx-timeout))))))
 
 (t/deftest test-conflicting-standalone-props
   (f/with-tmp-dir "data" [data-dir]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -750,6 +750,6 @@
 (t/deftest test-wait-while
   (let [twice-no (let [!atom (atom 3)]
                    #(pos? (swap! !atom dec)))]
-    (t/is (false? (cio/wait-while twice-no 100)))
-    (t/is (true? (cio/wait-while twice-no 400)))
+    (t/is (false? (cio/wait-while twice-no (Duration/ofMillis 100))))
+    (t/is (true? (cio/wait-while twice-no (Duration/ofMillis 400))))
     (t/is (true? (cio/wait-while twice-no nil)))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -14,7 +14,8 @@
             [crux.api :as api]
             [crux.rdf :as rdf]
             [crux.query :as q]
-            [crux.node :as n])
+            [crux.node :as n]
+            [crux.io :as cio])
   (:import [java.util Date]
            [java.time Duration]
            [crux.api ITxLog]))
@@ -745,3 +746,10 @@
                 {::bus/event-type ::tx/indexing-tx, ::tx/submitted-tx submitted-tx}
                 {::bus/event-type ::tx/indexed-tx, ::tx/submitted-tx submitted-tx, :committed? true}]
                @!events)))))
+
+(t/deftest test-wait-while
+  (let [twice-no (let [!atom (atom 3)]
+                   #(pos? (swap! !atom dec)))]
+    (t/is (false? (cio/wait-while twice-no 100)))
+    (t/is (true? (cio/wait-while twice-no 400)))
+    (t/is (true? (cio/wait-while twice-no nil)))))

--- a/crux-test/test/sample.properties
+++ b/crux-test/test/sample.properties
@@ -1,3 +1,3 @@
 crux.node/topology = crux.standalone/topology
 crux.node/kv-store = crux.kv.memdb/kv
-crux.tx-log/await-tx-timeout = 20000
+crux.tx-log/await-tx-timeout = PT20S


### PR DESCRIPTION
resolves #578 

main change is in cio/wait-while (needs to handle nils) and changing the node arg, but I've also made a change to pass Duration objects all the way down - safer than everywhere assuming millis. RFC?