### PR TITLE
use :latest-completed-tx meta for tx indexer to avoid bumping index version

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -60,7 +60,7 @@
 (def ^:const ^:private failed-tx-id-index-id 5)
 
 ; to allow crux upgrades. rebuild indexes from kafka on backward incompatible
-(def ^:const ^:private index-version-index-id 6)
+(def ^:const ^:private index-version-index-id 5)
 
 ; second bitemp index [also reverse]
 ; z combines vt and tt

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -199,7 +199,7 @@
                (ensure-topic-exists admin-client tx-topic tx-topic-config 1 options)
                (ensure-tx-topic-has-single-partition admin-client tx-topic)
                (kc/start-indexing-consumer {:indexer indexer
-                                            :offsets :crux.tx-log/consumer-state
+                                            :offsets (kc/->TxOffset indexer)
                                             :kafka-config (derive-kafka-config options)
                                             :group-id group-id
                                             :topic tx-topic
@@ -219,7 +219,7 @@
                   {::keys [doc-topic doc-partitions group-id] :as options}]
                (ensure-topic-exists admin-client doc-topic doc-topic-config doc-partitions options)
                (kc/start-indexing-consumer {:indexer indexer
-                                            :offsets :crux.doc-log/consumer-state
+                                            :offsets (kc/->ConsumerOffsets indexer :crux.tx-log/consumer-state)
                                             :kafka-config (derive-kafka-config options)
                                             :group-id group-id
                                             :topic doc-topic
@@ -241,7 +241,7 @@
   {:start-fn (fn [{:keys [crux.node/indexer crux.node/document-store]}
                   {::keys [tx-topic doc-group-id] :as options}]
                (kc/start-indexing-consumer {:indexer indexer
-                                            :offsets :crux.tx-doc-log/consumer-state
+                                            :offsets (kc/->ConsumerOffsets indexer :crux.tx-log/consumer-state)
                                             :kafka-config (derive-kafka-config options)
                                             :group-id doc-group-id
                                             :topic tx-topic

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -20,7 +20,7 @@
 
 (defn- poll-topic [offsets topic]
   (with-open [tx-consumer ^KafkaConsumer (fk/with-consumer)]
-    (let [tx-offsets (kc/map->IndexedOffsets {:indexer (:indexer *api*) :k offsets})]
+    (let [tx-offsets (kc/map->ConsumerOffsets {:indexer (:indexer *api*) :k offsets})]
       (kc/subscribe-from-stored-offsets tx-offsets tx-consumer [topic]))
     (doall (map (juxt #(.key ^ConsumerRecord %) #(.value ^ConsumerRecord %))
                 (.poll tx-consumer (Duration/ofMillis 10000))))))


### PR DESCRIPTION
if we use the :latest-completed-tx meta for the tx indexer, the doc consumers can use the existing consumer state, and I _think_ we can save ourselves an index version bump or two :smile: 