### PR TITLE
fix #612, range inversion edge case

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -146,10 +146,10 @@
                                           >= (comp not neg? compare)
                                           = =})
 
-(def ^:private range->inverse-range '{< >=
-                                      <= >
-                                      > <=
-                                      >= <
+(def ^:private range->inverse-range '{< >
+                                      <= >=
+                                      > <
+                                      >= <=
                                       = =})
 
 (defn- rewrite-self-join-triple-clause [{:keys [e v] :as triple}]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1006,10 +1006,17 @@
     (t/is (= #{[:ivan]} (api/q (api/db *api*) '{:find [i]
                                                 :where [[i :age age]
                                                         [(<= 20 age)]]})))
-
     (t/is (= #{[:petr]} (api/q (api/db *api*) '{:find [i]
                                                 :where [[i :age age]
-                                                        [(>= 20 age)]]})))))
+                                                        [(>= 20 age)]]})))
+
+    (t/testing "Range inversion edge cases, #612"
+      (t/is (= #{[:ivan]} (api/q (api/db *api*) '{:find [i]
+                                                  :where [[i :age age]
+                                                          [(<= 21 age)]]})))
+      (t/is (= #{} (api/q (api/db *api*) '{:find [i]
+                                           :where [[i :age age]
+                                                   [(> 18 age)]]}))))))
 
 (t/deftest test-mutiple-values
   (f/transact! *api* (f/people [{:crux.db/id :ivan :name "Ivan"}


### PR DESCRIPTION
 - e.g. `<=` should invert to `>=`, not `>`