### PR TITLE
Removing snapshots from the public API, #410

### DIFF
--- a/crux-bench/src/crux/bench/ts_devices.clj
+++ b/crux-bench/src/crux/bench/ts_devices.clj
@@ -218,11 +218,14 @@
                                                           (or [device-id :device-info/model "pinto"]
                                                               [device-id :device-info/model "focus"])]})
                                         (reduce into []))
-                       db (crux/db node #inst "1970")]
-                   (with-open [snapshot (crux/new-snapshot db)]
-                     (->> (for [r reading-ids]
-                            (for [entity-tx (crux/history-ascending db snapshot r)]
-                              (update entity-tx :crux.db/valid-time #(Date/from (.truncatedTo (.toInstant ^Date %) ChronoUnit/HOURS)))))
+                       db (crux/db node #inst "1970")
+                       histories (for [r reading-ids]
+                                   (crux/open-history-ascending db r))]
+                   (try
+                     (->> (for [history histories]
+                            (for [entity-tx history]
+                              (-> entity-tx
+                                  (update :crux.db/valid-time #(Date/from (.truncatedTo (.toInstant ^Date %) ChronoUnit/HOURS))))))
                           (cio/merge-sort (fn [a b]
                                             (compare (:crux.db/valid-time a) (:crux.db/valid-time b))))
                           (partition-by :crux.db/valid-time)
@@ -231,7 +234,11 @@
                                   (let [battery-levels (sort (mapv (comp :reading/battery-level :crux.db/doc) group))]
                                     [(:crux.db/valid-time (first group))
                                      (first battery-levels)
-                                     (last battery-levels)]))))))
+                                     (last battery-levels)]))))
+
+                     (finally
+                       (run! cio/try-close histories))))
+
           successful? (= [[#inst "2016-11-15T12:00:00.000-00:00" 20.0 99.0]
                           [#inst "2016-11-15T13:00:00.000-00:00" 13.0 100.0]
                           [#inst "2016-11-15T14:00:00.000-00:00" 9.0 100.0]

--- a/crux-core/src/crux/api/ICruxIngestAPI.java
+++ b/crux-core/src/crux/api/ICruxIngestAPI.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import clojure.lang.Keyword;
+import java.util.stream.Stream;
 
 /**
  * Provides API access to Crux ingestion.
@@ -22,10 +23,10 @@ public interface ICruxIngestAPI extends Closeable {
      * under the :crux.api/tx-ops key to be piped into (submit-tx tx-ops) of another
      * Crux instance.
      *
-     * @param fromTxId         optional transaction id to start from.
-     * @param withOps          should the operations with documents be included?
-     * @return                 a lazy sequence of the transaction log.
+     * @param fromTxId optional transaction id to start from.
+     * @param withOps  should the operations with documents be included?
+     * @return         a stream of the transaction log.
      */
 
-    public ITxLog openTxLog (Long fromTxId, boolean withOps);
+    public Stream<?> openTxLog(Long fromTxId, boolean withOps);
 }

--- a/crux-core/src/crux/api/ITxLog.java
+++ b/crux-core/src/crux/api/ITxLog.java
@@ -1,9 +1,0 @@
-package crux.api;
-
-import java.io.Closeable;
-import java.util.Iterator;
-import java.util.Map;
-import clojure.lang.Keyword;
-
-public interface ITxLog extends Iterator<Map<Keyword, ?>>, Closeable {
-}

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -1,7 +1,6 @@
 (ns crux.db
   (:import java.io.Closeable
-           java.util.Iterator
-           crux.api.ITxLog))
+           java.util.Iterator))
 
 ;; tag::Index[]
 (defprotocol Index
@@ -28,7 +27,7 @@
 ;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-ops])
-  (open-tx-log ^crux.api.ITxLog [this from-tx-id])
+  (open-tx-log ^java.io.Closeable [this from-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
 
@@ -47,17 +46,3 @@
   (known-keys? [this snapshot ks])
   (put-objects [this kvs]))
 ;; end::ObjectStore[]
-
-(defrecord CloseableTxLogIterator [close-fn ^Iterator lazy-seq-iterator]
-  ITxLog
-  (next [this]
-    (.next lazy-seq-iterator))
-
-  (hasNext [this]
-    (.hasNext lazy-seq-iterator))
-
-  (close [_]
-    (close-fn)))
-
-(defn ->closeable-tx-log-iterator [close-fn ^Iterable sq]
-  (->CloseableTxLogIterator close-fn (.iterator (lazy-seq sq))))

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -11,7 +11,7 @@
            java.nio.file.attribute.FileAttribute
            java.text.SimpleDateFormat
            java.time.Duration
-           [java.util Comparator Date IdentityHashMap PriorityQueue Properties Spliterator Spliterators]
+           [java.util Comparator Date IdentityHashMap PriorityQueue Properties]
            [java.util.stream Stream StreamSupport]
            [java.util.concurrent ThreadFactory]
            java.util.concurrent.locks.StampedLock
@@ -255,11 +255,7 @@
       Iterable (iterator [_] (.iterator sq))
       Closeable (close [_] (.close stream)))))
 
-(def ^:private spliterator-characteristics
-  (bit-or Spliterator/IMMUTABLE Spliterator/NONNULL))
-
 (defn ^Stream seq->stream [^Iterable sq & closeables]
-  (-> (.iterator sq)
-      (Spliterators/spliteratorUnknownSize ^int spliterator-characteristics)
+  (-> (.spliterator sq)
       (StreamSupport/stream false)
       (doto (.onClose (fn [] (run! #(.close ^Closeable %) closeables))))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -19,8 +19,7 @@
            java.util.concurrent.TimeoutException
            java.util.function.Supplier
            (java.io Closeable)
-           (java.util Comparator UUID Spliterators Spliterator)
-           (java.util.stream Stream StreamSupport)
+           (java.util Comparator UUID)
            org.agrona.ExpandableDirectByteBuffer))
 
 (defn- logic-var? [x]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -15,7 +15,8 @@
             crux.api
             crux.tx.event
             [crux.query :as q]
-            [taoensso.nippy :as nippy])
+            [taoensso.nippy :as nippy]
+            [crux.api :as api])
   (:import [crux.codec EntityTx EntityValueContentHash]
            crux.tx.consumer.Message
            java.io.Closeable
@@ -269,7 +270,8 @@
     (throw (IllegalArgumentException. (str "Transaction functions not enabled: " (cio/pr-edn-str tx-op)))))
 
   (let [fn-id (c/new-id k)
-        db (q/db kv-store object-store nil tx-time tx-time)
+        db (-> (q/db kv-store object-store nil tx-time tx-time)
+               (assoc :snapshot snapshot))
         {:crux.db.fn/keys [body] :as fn-doc} (q/entity db fn-id)
         {:crux.db.fn/keys [args] :as args-doc} (db/get-single-object object-store snapshot (c/new-id args-v))
         args-id (:crux.db/id args-doc)

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -203,8 +203,7 @@
                                nil
                                {:method :get
                                 :as :stream})]
-      (db/->closeable-tx-log-iterator #(.close ^Closeable in)
-                                      (edn-list->lazy-seq in))))
+      (cio/seq->stream (edn-list->lazy-seq in) in)))
 
   (sync [_ timeout]
     (api-request-sync (cond-> (str url "/sync")

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -111,41 +111,35 @@
     (api-request-sync (str url "/entity-tx")
                       (assoc (as-of-map this) :eid eid)))
 
-  (newSnapshot [this]
-    (->RemoteApiStream (atom [])))
-
   (q [this q]
     (api-request-sync (str url "/query")
                       (assoc (as-of-map this)
                              :query (q/normalize-query q))))
 
-  (q [this snapshot q]
+  (openQ [this q]
     (let [in (api-request-sync (str url "/query-stream")
                                (assoc (as-of-map this)
                                       :query (q/normalize-query q))
                                {:as :stream})]
-      (register-stream-with-remote-stream! snapshot in)
-      (edn-list->lazy-seq in)))
+      (-> (edn-list->lazy-seq in)
+          (cio/seq->stream in))))
 
-  (historyAscending [this snapshot eid]
+  (openHistoryAscending [this eid]
     (let [in (api-request-sync (str url "/history-ascending")
                                (assoc (as-of-map this) :eid eid)
                                {:as :stream})]
-      (register-stream-with-remote-stream! snapshot in)
-      (edn-list->lazy-seq in)))
+      (-> (edn-list->lazy-seq in)
+          (cio/seq->stream in))))
 
-  (historyDescending [this snapshot eid]
+  (openHistoryDescending [this eid]
     (let [in (api-request-sync (str url "/history-descending")
                                (assoc (as-of-map this) :eid eid)
                                {:as :stream})]
-      (register-stream-with-remote-stream! snapshot in)
-      (edn-list->lazy-seq in)))
+      (-> (edn-list->lazy-seq in)
+          (cio/seq->stream in))))
 
-  (validTime [_]
-    valid-time)
-
-  (transactionTime [_]
-    transact-time))
+  (validTime [_] valid-time)
+  (transactionTime [_] transact-time))
 
 (defrecord RemoteApiClient [url]
   ICruxAPI

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -18,7 +18,7 @@
             [ring.util.request :as req]
             [ring.util.time :as rt]
             [crux.api :as api])
-  (:import [crux.api ICruxAPI ICruxDatasource NodeOutOfSyncException ITxLog]
+  (:import [crux.api ICruxAPI ICruxDatasource NodeOutOfSyncException]
            [java.io Closeable IOException]
            java.time.Duration
            java.util.Date
@@ -221,8 +221,8 @@
   (let [with-ops? (Boolean/parseBoolean (get-in request [:query-params "with-ops"]))
         from-tx-id (some->> (get-in request [:query-params "from-tx-id"])
                             (Long/parseLong))
-        ^ITxLog result (api/open-tx-log crux-node from-tx-id with-ops?)]
-    (-> (streamed-edn-response result (iterator-seq result))
+        result (api/open-tx-log crux-node from-tx-id with-ops?)]
+    (-> (streamed-edn-response result)
         (add-last-modified (:crux.tx/tx-time (api/latest-completed-tx crux-node))))))
 
 (defn- sync-handler [^ICruxAPI crux-node request]

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -3,7 +3,8 @@
             [crux.kafka :as k]
             [crux.topology :as topo]
             [crux.node :as n]
-            [crux.tx :as tx])
+            [crux.tx :as tx]
+            [crux.io :as cio])
   (:import crux.api.ICruxAsyncIngestAPI
            java.io.Closeable))
 
@@ -16,10 +17,11 @@
   (submitTx [this tx-ops]
     @(.submitTxAsync this tx-ops))
 
-  (openTxLog ^crux.api.ITxLog [_ from-tx-id with-ops?]
+  (openTxLog [_ from-tx-id with-ops?]
     (when with-ops?
       (throw (IllegalArgumentException. "with-ops? not supported")))
-    (db/open-tx-log tx-log from-tx-id))
+    (let [tx-log (db/open-tx-log tx-log from-tx-id)]
+      (cio/seq->stream tx-log tx-log)))
 
   Closeable
   (close [_]

--- a/crux-test/test/crux/cached_entities_index_test.clj
+++ b/crux-test/test/crux/cached_entities_index_test.clj
@@ -22,7 +22,7 @@
     (let [db (api/db *api*)
           d (java.util.Date.)]
       (t/is (api/entity db :currency.id/eur))
-      (with-open [snapshot (api/new-snapshot db)
+      (with-open [snapshot (kv/new-snapshot (:kv-store *api*))
                   i (kv/new-iterator snapshot)]
         (let [idx-raw (idx/new-entity-as-of-index i d d)
               idx-in-cache (lru/new-cached-index idx-raw 100)

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -142,16 +142,14 @@ toc::[]
 
 [source,clj]
 ----
-(open-tx-log ^ITxLog [this from-tx-id with-ops?]
+(open-tx-log ^Closeable [this from-tx-id with-ops?]
   "Reads the transaction log. Optionally includes
   operations, which allow the contents under the :crux.api/tx-ops
   key to be piped into (submit-tx tx-ops) of another
   Crux instance.
   from-tx-id      optional transaction id to start from.
   with-ops?       should the operations with documents be included?
-  Returns an iterator of the TxLog.")
-  (attribute-stats [node]
-    "Returns frequencies of indexed attributes")
+  Returns a closeable seq of the TxLog.")
 ----
 
 === attribute-stats


### PR DESCRIPTION
resolves #410, see proposal over there. draft for now

N.B.
* The Java API for lazy functions returns `Stream`s, the Clojure API returns Clojure seqs, so the tests now need to use the Clojure API (it still tests the Java API).
* @refset the 'extra arity' for `entity` goes as part of this - we keep the performance benefit when the user's opened up a read-tx
* @danmason have updated the `ITxLog` pattern to use streams too
* it's possible to open up nested ReadTxs, but mainly because it was easier to do this than prevent it. closing a nested ReadTx is a no-op - it's the outermost ReadTx that closes the snapshot (JDBC does it, too - we wouldn't be the first!)
* ReadTx name suggestions welcome. ironically, 'snapshot' would probably be ideal, if we didn't use it throughout.

TODO:
- [X] api-test/tx-test/query-test
- [ ] remaining tests
- [X] replace ITxLog with same pattern
- [ ] docs

could probably do with reflecting on this for a bit, too. 

particularly, I'm not convinced about the user needing to open-read-tx, then open-history-asc 
- might just have another `history-asc` within the read-tx (in addition/as opposed to `open-history-asc` on the DB, would require a separate interface)
- although this same pattern wouldn't work for `q` - we already have an eager `q` function which'd conflict with the one on the read-tx interface.