### PR TITLE
Freezing CruxId's in Documents (Java Alpha API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 * [#565](https://github.com/juxt/crux/pull/565): query predicate at zero join depth can now stop tuples from being returned
 * [#507](https://github.com/juxt/crux/issues/507): ranges in rules revert to a predicate if neither argument is a logic var
+* [#637](https://github.com/juxt/crux/pull/637): allow usage of CruxIds within Documents in the Java alpha API.
 
 ### New Features
 * [#495](https://github.com/juxt/crux/issues/495): Adding metrics to expose various indexer ingest metrics

--- a/crux-core/src/crux/api/alpha/CruxId.java
+++ b/crux-core/src/crux/api/alpha/CruxId.java
@@ -33,7 +33,7 @@ public class CruxId {
         return new CruxId(obj);
     }
 
-    protected Object toEdn() {
+    public Object toEdn() {
         return id;
     }
 }

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -13,7 +13,8 @@
            [java.nio ByteOrder ByteBuffer]
            [java.util Arrays Date Map UUID]
            [org.agrona DirectBuffer ExpandableDirectByteBuffer MutableDirectBuffer]
-           org.agrona.concurrent.UnsafeBuffer))
+           org.agrona.concurrent.UnsafeBuffer
+           crux.api.alpha.CruxId))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -418,6 +419,17 @@
  :crux.codec/edn-id
  [data-input]
  (id-edn-reader (nippy/thaw-from-in! data-input)))
+
+(nippy/extend-freeze
+ CruxId
+ :crux.alpha.api/crux-id
+ [^CruxId x data-output]
+ (nippy/freeze-to-out! data-output (.toEdn x)))
+
+(nippy/extend-thaw
+ :crux.alpha.api/crux-id
+ [data-input]
+ (CruxId/cruxId (nippy/thaw-from-in! data-input)))
 
 (defn valid-id? [x]
   (try

--- a/crux-test/test/crux/java_api_test.clj
+++ b/crux-test/test/crux/java_api_test.clj
@@ -73,3 +73,23 @@
           (t/is (thrown-with-msg? IllegalStateException
                                   #"Crux node is closed"
                                   (.db node))))))))
+
+(t/deftest test-can-freeze-cruxid
+  (f/with-tmp-dir "data" [data-dir]
+    (t/testing "Can create, put and query document with a CruxId in it"
+      (let [node (-> (StandaloneTopology/standaloneTopology)
+                     (.withDbDir (str (io/file data-dir "db-dir-1")))
+                     (.withEventLogDir (str (io/file data-dir "eventlog-1")))
+                     (.startNode))]
+
+
+        (let [id (CruxId/cruxId "test-id")
+              id2 (CruxId/cruxId "test-id2")
+              doc (-> (Document/document id)
+                      (.with "Key" id2))]
+
+          (let [putOp (PutOperation/putOp doc)]
+            (.submitTx node (apif/vec->array-list [putOp]))
+            (Thread/sleep 300)))
+
+        (.close node)))))

--- a/crux-test/test/crux/java_api_test.clj
+++ b/crux-test/test/crux/java_api_test.clj
@@ -76,7 +76,7 @@
 
 (t/deftest test-can-freeze-cruxid
   (f/with-tmp-dir "data" [data-dir]
-    (t/testing "Can create, put and query document with a CruxId in it"
+    (t/testing "Can create, put and get a document with a CruxId in it"
       (let [node (-> (StandaloneTopology/standaloneTopology)
                      (.withDbDir (str (io/file data-dir "db-dir-1")))
                      (.withEventLogDir (str (io/file data-dir "eventlog-1")))
@@ -90,6 +90,9 @@
 
           (let [putOp (PutOperation/putOp doc)]
             (.submitTx node (apif/vec->array-list [putOp]))
-            (Thread/sleep 300)))
+            (Thread/sleep 300))
+
+          (let [returned-doc (.entity (.db node) id)]
+            (t/is :test-id2 (.toEdn (.get returned-doc "Key")))))
 
         (.close node)))))


### PR DESCRIPTION
(Resolves #636)

Makes the `.toEdn()` function public on `CruxId`, and uses it to delegate freezing to the underlying type of CruxId. Thawing reconstructs a CruxId from these types. 