### PR TITLE
API iteration (removing snapshot parameters, `db` -> `at`), #410

### DIFF
--- a/crux-bench/test/crux/bench/rocksdb_microbench_test.clj
+++ b/crux-bench/test/crux/bench/rocksdb_microbench_test.clj
@@ -7,7 +7,8 @@
             [crux.kv :as kv]
             [crux.fixtures :as f]
             [crux.bench :as bench]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [crux.node :as n]))
 
 (defn with-rocksdb-node* [f]
   (f/with-tmp-dir "dev-storage" [data-dir]
@@ -34,4 +35,4 @@
                (db/index-docs (:indexer node) (->> doc-batch (into {} (map (juxt c/new-id identity)))))))
 
             (with-open [snapshot (kv/new-snapshot (:kv-store node))]
-              (t/is (= first-doc (db/get-single-object (:object-store node) snapshot (c/new-id first-doc)))))))))))
+              (t/is (= first-doc (db/get-single-object (::n/object-store node) snapshot (c/new-id first-doc)))))))))))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -138,7 +138,10 @@
   "Provides API access to Crux."
 
   (at [node] [node bitemp-inst] [node bitemp-inst timeout])
-  (open-snapshot-at [node] [node bitemp-inst] [node bitemp-inst timeout])
+  (open-snapshot-at
+    ^crux.api.ISnapshot [node]
+    ^crux.api.ISnapshot [node bitemp-inst]
+    ^crux.api.ISnapshot [node bitemp-inst timeout])
 
   (db
     [node]
@@ -218,17 +221,23 @@
   (attribute-stats [node]
     "Returns frequencies map for indexed attributes"))
 
+(defn- ->bitemp-inst [maybe-inst]
+  (cond
+    (instance? IBitemporalInstant maybe-inst) maybe-inst
+    (map? maybe-inst) (map->BitemporalInstant maybe-inst)
+    :else maybe-inst))
+
 (extend-protocol PCruxNode
   ICruxAPI
   (at
     ([this] (.at this))
-    ([this bitemp-inst] (.at this bitemp-inst))
-    ([this bitemp-inst timeout] (.at this bitemp-inst timeout)))
+    ([this bitemp-inst] (.at this (->bitemp-inst bitemp-inst)))
+    ([this bitemp-inst timeout] (.at this (->bitemp-inst bitemp-inst) timeout)))
 
   (open-snapshot-at
     ([this] (.openSnapshotAt this))
-    ([this bitemp-inst] (.openSnapshotAt this bitemp-inst))
-    ([this bitemp-inst timeout] (.openSnapshotAt this bitemp-inst timeout)))
+    ([this bitemp-inst] (.openSnapshotAt this (->bitemp-inst bitemp-inst)))
+    ([this bitemp-inst timeout] (.openSnapshotAt this (->bitemp-inst bitemp-inst) timeout)))
 
   (db
     ([this] (.db this))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -50,7 +50,7 @@
 (s/def ::tx-op (s/multi-spec tx-op first))
 (s/def ::tx-ops (s/coll-of ::tx-op :kind vector?))
 
-(defn- conform-tx-ops  [tx-ops]
+(defn- conform-tx-ops [tx-ops]
   (->> tx-ops
        (mapv
         (fn [tx-op]
@@ -62,7 +62,8 @@
 (defrecord BitemporalInstant []
   IBitemporalInstant
   (validTime [this] (:crux.db/valid-time this))
-  (transactionTime [this] (:crux.tx/tx-time this)))
+  (transactionTime [this] (:crux.tx/tx-time this))
+  (transactionId [this] (:crux.tx/tx-id this)))
 
 (defprotocol PReadDocumentsAPI
   (document [this content-hash]

--- a/crux-core/src/crux/api/IBitemporalInstant.java
+++ b/crux-core/src/crux/api/IBitemporalInstant.java
@@ -5,4 +5,5 @@ import java.util.Date;
 public interface IBitemporalInstant {
     Date validTime();
     Date transactionTime();
+    Long transactionId();
 }

--- a/crux-core/src/crux/api/IBitemporalInstant.java
+++ b/crux-core/src/crux/api/IBitemporalInstant.java
@@ -1,0 +1,8 @@
+package crux.api;
+
+import java.util.Date;
+
+public interface IBitemporalInstant {
+    Date validTime();
+    Date transactionTime();
+}

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -12,6 +12,7 @@ import clojure.lang.Keyword;
  * Represents the database as of a specific valid and
  * transaction time.
  */
+@Deprecated
 public interface ICruxDatasource {
     /**
      * Returns the document map for an entity.

--- a/crux-core/src/crux/api/ICruxIngestAPI.java
+++ b/crux-core/src/crux/api/ICruxIngestAPI.java
@@ -13,9 +13,9 @@ public interface ICruxIngestAPI extends Closeable {
      * Writes transactions to the log for processing.
      *
      * @param txOps the transactions to be processed.
-     * @return      a map with details about the submitted transaction.
+     * @return      the bitemporal instant of the submitted transaction.
      */
-    public Map<Keyword,?> submitTx(List<List<?>> txOps);
+    public IBitemporalInstant submitTx(List<List<?>> txOps);
 
     /**
      * Reads the transaction log. Optionally includes  operations, which allow the contents
@@ -27,5 +27,5 @@ public interface ICruxIngestAPI extends Closeable {
      * @return                 a lazy sequence of the transaction log.
      */
 
-    public ITxLog openTxLog (Long fromTxId, boolean withOps);
+    public ITxLog openTxLog(Long fromTxId, boolean withOps);
 }

--- a/crux-core/src/crux/api/IFixedInstantQueryAPI.java
+++ b/crux-core/src/crux/api/IFixedInstantQueryAPI.java
@@ -1,0 +1,4 @@
+package crux.api;
+
+// TODO name this better pls
+public interface IFixedInstantQueryAPI extends IQueryAPI, IBitemporalInstant {}

--- a/crux-core/src/crux/api/IQueryAPI.java
+++ b/crux-core/src/crux/api/IQueryAPI.java
@@ -1,0 +1,53 @@
+package crux.api;
+
+import java.util.List;
+import java.util.Map;
+import clojure.lang.Keyword;
+
+public interface IQueryAPI {
+
+    /**
+     * Queries the db.
+     *
+     * @param query the query in map, vector or string form.
+     * @return      an iterable of result tuples.
+     */
+    public Iterable<List<?>> query(Object query);
+
+    /**
+     * Returns the document map for an entity.
+     *
+     * @param eid an object that can be coerced into an entity id.
+     * @return    the entity document map.
+     */
+    public Map<Keyword, Object> entity(Object eid);
+
+    /**
+     * Returns the transaction details for an entity. Details include tx-id and
+     * tx-time.
+     *
+     * @param eid an object that can be coerced into an entity id.
+     * @return    the entity transaction details.
+     */
+    public Map<Keyword, Object> entityTx(Object eid);
+
+    /**
+     * Retrieves entity history in chronological order from and including the
+     * valid time of the db while respecting transaction time. Includes the
+     * documents.
+     *
+     * @param eid an object that can be coerced into an entity id.
+     * @return    a sequence of history.
+     */
+    public Iterable<Map<Keyword, Object>> historyAscending(Object eid);
+
+    /**
+     * Retrieves entity history in reverse chronological order from and
+     * including the valid time of the db while respecting transaction time.
+     * Includes the documents.
+     *
+     * @param eid an object that can be coerced into an entity id.
+     * @return    a sequence of history.
+     */
+    public Iterable<Map<Keyword, Object>> historyDescending(Object eid);
+}

--- a/crux-core/src/crux/api/IReadDocumentsAPI.java
+++ b/crux-core/src/crux/api/IReadDocumentsAPI.java
@@ -1,0 +1,28 @@
+package crux.api;
+
+import java.util.Map;
+import java.util.Set;
+import clojure.lang.Keyword;
+
+public interface IReadDocumentsAPI {
+    /**
+     *  Reads a document from the document store based on its
+     *  content hash.
+     *
+     * @param contentHash an object that can be coerced into a content
+     * hash.
+     * @return            the document map.
+     */
+    public Map<Keyword, Object> document(Object contentHash);
+
+    /**
+     *  Reads a document from the document store based on its
+     *  content hash.
+     *
+     * @param contentHashSet a set of objects that can be coerced into a content
+     * hashes.
+     * @return            a map from hashable objects to the corresponding documents.
+     */
+    public Map<String,Map<Keyword,?>> documents(Set<?> contentHashSet);
+
+}

--- a/crux-core/src/crux/api/ISnapshot.java
+++ b/crux-core/src/crux/api/ISnapshot.java
@@ -1,0 +1,5 @@
+package crux.api;
+
+import java.io.Closeable;
+
+public interface ISnapshot extends IFixedInstantQueryAPI, IReadDocumentsAPI, Closeable {}

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -168,8 +168,8 @@
   (sync [this]
     (api/map->BitemporalInstant {:crux.tx/tx-time (.sync this nil)}))
 
-  (sync [this timeout]
-    (when-let [tx (db/latest-submitted-tx (:tx-log this))]
+  (sync [{::keys [tx-log] :as this} timeout]
+    (when-let [tx (db/latest-submitted-tx tx-log)]
       (-> (api/await-tx this tx nil)
           :crux.tx/tx-time)))
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1209,6 +1209,11 @@
   (historyAscending [this eid] (history-ascending this eid))
   (historyDescending [this eid] (history-descending this eid))
 
+  IBitemporalInstant
+  (validTime [{::db/keys [valid-time]}] valid-time)
+  (transactionTime [{::tx/keys [tx-time]}] tx-time)
+  (transactionId [{::tx/keys [tx-id]}] tx-id)
+
   Closeable
   (close [_] (.close kv-snapshot)))
 
@@ -1258,6 +1263,7 @@
   IBitemporalInstant
   (validTime [{::db/keys [valid-time]}] valid-time)
   (transactionTime [{::tx/keys [tx-time]}] tx-time)
+  (transactionId [{::tx/keys [tx-id]}] tx-id)
 
   ;; HACK backwards compatibility
   ICruxDatasource

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -22,6 +22,9 @@
            [java.util.concurrent ExecutorService Executors TimeoutException TimeUnit]
            java.util.Date))
 
+(create-ns 'crux.node)
+(alias 'node 'crux.node)
+
 (set! *unchecked-math* :warn-on-boxed)
 
 (def ^:private date? (partial instance? Date))
@@ -269,7 +272,10 @@
     (throw (IllegalArgumentException. (str "Transaction functions not enabled: " (cio/pr-edn-str tx-op)))))
 
   (let [fn-id (c/new-id k)
-        db (q/db kv-store object-store nil tx-time tx-time)
+        db (q/->query-api {::node/kv-store kv-store
+                           ::node/object-store  object-store
+                           ::db/valid-time tx-time
+                           ::tx-time tx-time})
         {:crux.db.fn/keys [body] :as fn-doc} (q/entity db fn-id)
         {:crux.db.fn/keys [args] :as args-doc} (db/get-single-object object-store snapshot (c/new-id args-v))
         args-id (:crux.db/id args-doc)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -273,9 +273,10 @@
 
   (let [fn-id (c/new-id k)
         db (q/->query-api {::node/kv-store kv-store
-                           ::node/object-store  object-store
+                           ::node/object-store object-store
                            ::db/valid-time tx-time
-                           ::tx-time tx-time})
+                           ::tx-time tx-time
+                           :kv-snapshot snapshot})
         {:crux.db.fn/keys [body] :as fn-doc} (q/entity db fn-id)
         {:crux.db.fn/keys [args] :as args-doc} (db/get-single-object object-store snapshot (c/new-id args-v))
         args-id (:crux.db/id args-doc)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -287,14 +287,13 @@
                   {:crux.db/id :ivan :name "Ivan" :version 1}]
                  (map :crux.db/doc (.historyDescending db snapshot :ivan))))))
 
-    (let [db (.db *api* #inst "2019-02-02")]
-      (with-open [snapshot (.newSnapshot db)]
-        (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
-                  {:crux.db/id :ivan :name "Ivan" :version 3}]
-                 (map :crux.db/doc (.historyAscending db snapshot :ivan))))
-        (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
-                  {:crux.db/id :ivan :name "Ivan" :version 1}]
-                 (map :crux.db/doc (.historyDescending db snapshot :ivan))))))
+    (with-open [snapshot (api/open-snapshot-at *api* {::db/valid-time #inst "2019-02-02"})]
+      (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
+                {:crux.db/id :ivan :name "Ivan" :version 3}]
+               (->> (api/history-ascending snapshot :ivan) (map :crux.db/doc))))
+      (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
+                {:crux.db/id :ivan :name "Ivan" :version 1}]
+               (->> (api/history-descending snapshot :ivan) (map :crux.db/doc)))))
 
     (let [db (.db *api* #inst "2019-01-31")]
       (with-open [snapshot (.newSnapshot db)]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -442,14 +442,6 @@
                                 {:name "Ivan" :last-name "Ivannotov"}
                                 {:name "Bob" :last-name "Controlguy"}]))
 
-  ;; Here for dev reasons, delete when appropiate
-  (t/is (= '[[:triple {:e e :a :name :v name}]
-             [:triple {:e e :a :name :v "Ivan"}]
-             [:or [[:term [:triple {:e e :a :last-name :v "Ivanov"}]]]]]
-           (s/conform :crux.query/where '[[e :name name]
-                                          [e :name "Ivan"]
-                                          (or [e :last-name "Ivanov"])])))
-
   (t/testing "Or works as expected"
     (t/is (= 3 (count (api/q (api/db *api*) '{:find [e]
                                               :where [[e :name name]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2754,14 +2754,16 @@
       (t/is (= (api/entity db :ivan) (api/entity db snapshot :ivan) ivan))
       (let [n 1000
             acceptable-snapshot-speedup 1.4
-            factors (->> #(let [db-hit-ns-start (System/nanoTime)]
-                            (t/is (= ivan (api/entity db :ivan)))
-                            (let [db-hit-ns (- (System/nanoTime) db-hit-ns-start)
-                                  snapshot-hit-ns-start (System/nanoTime)]
-                              (t/is (= ivan (api/entity db snapshot :ivan)))
-                              (let [snapshot-hit-ns (- (System/nanoTime) snapshot-hit-ns-start)]
-                                (double (/ db-hit-ns
-                                           snapshot-hit-ns)))))
+            factors (->> #(let [db-hit-ns-start (System/nanoTime)
+                                _ (api/entity db :ivan)
+                                db-hit-ns (- (System/nanoTime) db-hit-ns-start)
+
+                                snapshot-hit-ns-start (System/nanoTime)
+                                _ (api/entity db snapshot :ivan)
+                                snapshot-hit-ns (- (System/nanoTime) snapshot-hit-ns-start)]
+
+                            (double (/ db-hit-ns snapshot-hit-ns)))
+
                          (repeatedly n))]
         (t/is (>= (/ (reduce + factors) n) acceptable-snapshot-speedup))))))
 


### PR DESCRIPTION
(eventually resolves #410)

Still a fair way to go on this one, but wanted to get the draft PR up to get some eyes on it before I go much further.

* [x] Update #410 with the aims of this new spike
* [ ] HTTP server/client API
* [ ] Docstrings/Javadoc
* [ ] Docs/tutorials

* I've kept it backwards-compatible for now, so the API tests are passing (for local nodes, I haven't updated the HTTP server/client yet). indeed, for however long we're preserving backwards compatibility, I'd like to keep these tests about. a lot of these API tests indirectly call through to the new API, so I'm not _too_ worried about not extensively testing the new API directly yet.
* There's a couple of names that could do with being clearer, particularly `IFixedInstantQueryAPI` :nauseated_face:.
* I've expanded `q` to `query` - we don't shorten much else in the public API (even less so in the Java API), auto-complete should get this most of the time, and even if it doesn't, I doubt it takes significantly longer to type. discuss?
* `BitemporalInstant` (containing vt, tt, tid) has namespaced keys, despite being a record, because this is how users currently access these fields. I've also experimented with moving a couple of other records that way - particularly Node - because most of its components come from a namespaced map, with the aim of trying to always refer to the components in the same way, no matter what map (or record) they're in. That said, namespaced keys in Clojure records aren't ideal, RFC. 
* I'm also not a fan of users needing to know which namespace each of the different keys are in - maybe `:crux/valid-time` is sufficient, given valid-time only has one meaning throughout Crux?