### PR TITLE
Bump memory allocated to container/JVM heap on crux-bench

### DIFF
--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -132,7 +132,7 @@ Resources:
       - LogGroup
     Properties:
       Cpu: '2 vCPU'
-      Memory: '4GB'
+      Memory: '7GB'
       Family: 'crux-bench'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]
@@ -163,7 +163,7 @@ Resources:
       - LogGroup
     Properties:
       Cpu: '2 vCPU'
-      Memory: '4GB'
+      Memory: '7GB'
       Family: 'crux-bench-latest'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]

--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -132,7 +132,7 @@ Resources:
       - LogGroup
     Properties:
       Cpu: '2 vCPU'
-      Memory: '7GB'
+      Memory: '8GB'
       Family: 'crux-bench'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]
@@ -163,7 +163,7 @@ Resources:
       - LogGroup
     Properties:
       Cpu: '2 vCPU'
-      Memory: '7GB'
+      Memory: '8GB'
       Family: 'crux-bench-latest'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]

--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -37,6 +37,6 @@
   :middleware [leiningen.project-version/middleware]
 
   :resource-paths ["resources" "data"]
-  :jvm-opts ["-Xms3g" "-Xmx3g"]
+  :jvm-opts ["-Xms4g" "-Xmx4g"]
   :uberjar-name "crux-bench-standalone.jar"
   :pedantic? :warn)

--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -37,6 +37,6 @@
   :middleware [leiningen.project-version/middleware]
 
   :resource-paths ["resources" "data"]
-  :jvm-opts ["-Xms4g" "-Xmx4g"]
+  :jvm-opts ["-Xms3g" "-Xmx3g"]
   :uberjar-name "crux-bench-standalone.jar"
   :pedantic? :warn)

--- a/crux-bench/src/crux/bench/watdiv_crux.clj
+++ b/crux-bench/src/crux/bench/watdiv_crux.clj
@@ -37,7 +37,7 @@
      :rdf4j-time-taken (->> crux-correct (map :rdf4j-time-taken-ms) (reduce +) (Duration/ofMillis) (str))}))
 
 (defn run-watdiv-bench [node {:keys [test-count] :as opts}]
-  (let [rdf4j-results (some-> (bench/load-from-s3 "rdf4j-3.0.0/rdf4j-20200210-163208Z.edn") parse-results)
+  (let [rdf4j-results (some-> (bench/load-from-s3 "rdf4j-3.0.0/rdf4j-20200214-122734Z.edn") parse-results)
         watdiv-results
         (bench/with-bench-ns :watdiv-crux
           (bench/with-crux-dimensions


### PR DESCRIPTION
Attempting to fix the OutOfMemory error on the AWS container by allocating it the same amount of memory as used previously in the Kubernetes setup: https://github.com/juxt/crux/blob/master/crux-bench-watdiv/kubernetes_templates/app_deployment.yml 