### PR TITLE
Incremental refactor to Kafka consuming code

### DIFF
--- a/crux-core/src/crux/tx/consumer.clj
+++ b/crux-core/src/crux/tx/consumer.clj
@@ -1,5 +1,6 @@
 (ns crux.tx.consumer
-  (:import java.util.Date))
+  (:import java.util.Date
+           java.io.Closeable))
 
 (deftype Message [body topic ^long message-id ^Date message-time key headers])
 
@@ -9,3 +10,16 @@
   (next-events [this context next-offset])
 
   (end-offset [this]))
+
+(defn start-indexing-consumer
+  ^java.io.Closeable
+  [{:keys [index-fn]}]
+  (let [running? (atom true)
+        worker-thread
+        (doto
+            (Thread. ^Runnable (partial index-fn running?) "crux.tx.event-log-consumer-thread")
+            (.start))]
+    (reify Closeable
+      (close [_]
+        (reset! running? false)
+        (.join worker-thread)))))

--- a/crux-core/src/crux/tx/consumer.clj
+++ b/crux-core/src/crux/tx/consumer.clj
@@ -6,11 +6,7 @@
 (deftype Message [body topic ^long message-id ^Date message-time key headers])
 
 (defprotocol PolledEventLog
-  (new-event-log-context ^java.io.Closeable [this])
-
-  (next-events [this context next-offset])
-
-  (end-offset [this]))
+  (next-events [this next-offset]))
 
 (defn start-indexing-consumer
   ^java.io.Closeable

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -7,42 +7,33 @@
   (:import crux.tx.consumer.Message
            java.io.Closeable))
 
-(defn- polling-consumer [running? indexer event-log-consumer {:keys [idle-sleep-ms]
-                                                              :or {idle-sleep-ms 10}}]
-  (when-not (db/read-index-meta indexer :crux.tx-log/consumer-state)
-    (db/store-index-meta
-     indexer
-     :crux.tx-log/consumer-state {:crux.tx/event-log {:next-offset 0}}))
-  (while @running?
-    (let [idle? (with-open [context (tc/new-event-log-context event-log-consumer)]
-                  (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
-                        msgs (tc/next-events event-log-consumer context next-offset)
-                        {doc-msgs :docs, tx-msgs :txs} (->> msgs (group-by #(:crux.tx/sub-topic (.headers ^Message %))))]
+(defn- polling-consumer [indexer event-log-consumer]
+  (with-open [context (tc/new-event-log-context event-log-consumer)]
+    (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
+          msgs (tc/next-events event-log-consumer context next-offset)
+          {doc-msgs :docs, tx-msgs :txs} (->> msgs (group-by #(:crux.tx/sub-topic (.headers ^Message %))))]
 
-                    (when (seq doc-msgs)
-                      (db/index-docs indexer (->> doc-msgs
-                                                  (into {} (map (fn [^Message m]
-                                                                  [(c/new-id (.key m)) (.body m)]))))))
+      (when (seq doc-msgs)
+        (db/index-docs indexer (->> doc-msgs
+                                    (into {} (map (fn [^Message m]
+                                                    [(c/new-id (.key m)) (.body m)]))))))
 
-                    (doseq [^Message tx-msg tx-msgs]
-                      (let [tx {:crux.tx/tx-time (.message-time tx-msg)
-                                :crux.tx/tx-id (.message-id tx-msg)}]
-                        (db/index-tx indexer tx (.body tx-msg))))
+      (doseq [^Message tx-msg tx-msgs]
+        (let [tx {:crux.tx/tx-time (.message-time tx-msg)
+                  :crux.tx/tx-id (.message-id tx-msg)}]
+          (db/index-tx indexer tx (.body tx-msg))))
 
-                    (if-let [^Message last-msg (last msgs)]
-                      (let [next-offset (inc (long (.message-id last-msg)))
-                            consumer-state {:crux.tx/event-log {:next-offset next-offset}}]
-                        (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
-                        (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
-                        false)
+      (if-let [^Message last-msg (last msgs)]
+        (let [next-offset (inc (long (.message-id last-msg)))
+              consumer-state {:crux.tx/event-log {:next-offset next-offset}}]
+          (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
+          (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
+          false)
 
-                      true)))]
-      (when idle?
-        (Thread/sleep idle-sleep-ms)))))
+        true))))
 
 (defn start-event-log-consumer ^java.io.Closeable [indexer event-log-consumer]
-  (tc/start-indexing-consumer (fn [running?]
-                                (try
-                                  (polling-consumer running? indexer event-log-consumer {})
-                                  (catch Throwable t
-                                    (log/fatal t "Event log consumer threw exception, consumption has stopped:"))))))
+  (when-not (db/read-index-meta indexer :crux.tx-log/consumer-state)
+    (db/store-index-meta indexer :crux.tx-log/consumer-state {:crux.tx/event-log {:next-offset 0}}))
+  (tc/start-indexing-consumer {:idle-sleep-ms 10
+                               :index-fn (partial polling-consumer indexer event-log-consumer)}))

--- a/crux-core/src/crux/tx/polling.clj
+++ b/crux-core/src/crux/tx/polling.clj
@@ -8,29 +8,28 @@
            java.io.Closeable))
 
 (defn- polling-consumer [indexer event-log-consumer]
-  (with-open [context (tc/new-event-log-context event-log-consumer)]
-    (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
-          msgs (tc/next-events event-log-consumer context next-offset)
-          {doc-msgs :docs, tx-msgs :txs} (->> msgs (group-by #(:crux.tx/sub-topic (.headers ^Message %))))]
+  (let [next-offset (get-in (db/read-index-meta indexer :crux.tx-log/consumer-state) [:crux.tx/event-log :next-offset])
+        msgs (tc/next-events event-log-consumer next-offset)
+        {doc-msgs :docs, tx-msgs :txs} (->> msgs (group-by #(:crux.tx/sub-topic (.headers ^Message %))))]
 
-      (when (seq doc-msgs)
-        (db/index-docs indexer (->> doc-msgs
-                                    (into {} (map (fn [^Message m]
-                                                    [(c/new-id (.key m)) (.body m)]))))))
+    (when (seq doc-msgs)
+      (db/index-docs indexer (->> doc-msgs
+                                  (into {} (map (fn [^Message m]
+                                                  [(c/new-id (.key m)) (.body m)]))))))
 
-      (doseq [^Message tx-msg tx-msgs]
-        (let [tx {:crux.tx/tx-time (.message-time tx-msg)
-                  :crux.tx/tx-id (.message-id tx-msg)}]
-          (db/index-tx indexer tx (.body tx-msg))))
+    (doseq [^Message tx-msg tx-msgs]
+      (let [tx {:crux.tx/tx-time (.message-time tx-msg)
+                :crux.tx/tx-id (.message-id tx-msg)}]
+        (db/index-tx indexer tx (.body tx-msg))))
 
-      (if-let [^Message last-msg (last msgs)]
-        (let [next-offset (inc (long (.message-id last-msg)))
-              consumer-state {:crux.tx/event-log {:next-offset next-offset}}]
-          (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
-          (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
-          false)
+    (if-let [^Message last-msg (last msgs)]
+      (let [next-offset (inc (long (.message-id last-msg)))
+            consumer-state {:crux.tx/event-log {:next-offset next-offset}}]
+        (log/debug "Event log consumer state:" (cio/pr-edn-str consumer-state))
+        (db/store-index-meta indexer :crux.tx-log/consumer-state consumer-state)
+        false)
 
-        true))))
+      true)))
 
 (defn start-event-log-consumer ^java.io.Closeable [indexer event-log-consumer]
   (when-not (db/read-index-meta indexer :crux.tx-log/consumer-state)

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -122,9 +122,9 @@
       (db/->closeable-tx-log-iterator
        #(.close tx-topic-consumer)
        ((fn step []
-           (when-let [records (seq (.poll tx-topic-consumer (Duration/ofMillis 1000)))]
-             (concat (map tx-record->tx-log-entry records)
-                     (step))))))))
+          (when-let [records (seq (.poll tx-topic-consumer (Duration/ofMillis 1000)))]
+            (concat (map tx-record->tx-log-entry records)
+                    (step))))))))
 
   (latest-submitted-tx [this]
     (let [tx-tp (TopicPartition. tx-topic 0)
@@ -136,8 +136,7 @@
   (status-map [_]
     {:crux.zk/zk-active?
      (try
-       (with-open [^KafkaConsumer consumer (kc/create-consumer (assoc kafka-config {"default.api.timeout.ms" (int 1000)}))]
-         (boolean (.listTopics consumer)))
+       (boolean (.listTopics latest-submitted-tx-consumer))
        (catch Exception e
          (log/debug e "Could not list Kafka topics:")
          false))}))

--- a/crux-kafka/src/crux/kafka/consumer.clj
+++ b/crux-kafka/src/crux/kafka/consumer.clj
@@ -100,7 +100,7 @@
 
 (defn consume-and-block
   [{:keys [offsets indexer pending-records-state timeout topic ^KafkaConsumer consumer accept-fn index-fn]}]
-  (let [_ (when (empty @pending-records-state)
+  (let [_ (when (empty? @pending-records-state)
             (reset! pending-records-state (let [records (.poll consumer (Duration/ofMillis timeout))]
                                             (vec (.records records (str topic))))))
         records (->> @pending-records-state


### PR DESCRIPTION
Aims to

- Remove unnecessary pause/resume of blocking consumer 
- Move kafka status to tx-log rather than duplication amongst consumers
- Reuse/centralise consuming threading code between standalone (poller) / Kafka

The broader aim is to more closely align jdbc/standalone with Kafka.