### PR TITLE
Consistent result multiplicity, #631

### DIFF
--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -97,7 +97,10 @@
     (t/is (= #{["Ivan"]} (ex/query-example-with-arguments-4 node)))
     (t/is (= #{[22]} (ex/query-example-with-arguments-5 node)))
     (t/is (= #{[21]} (ex/query-example-with-predicate-1 node)))
-    (t/is (= [:smith] (first (ex/query-example-lazy node))))))
+
+    (let [!results (atom [])]
+      (ex/query-example-lazy node #(swap! !results conj %))
+      (t/is (= [[:smith]] @!results)))))
 
 (t/deftest test-example-time-queries
   (with-open [node (ex/start-standalone-node *storage-dir*)]

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -397,21 +397,16 @@ connected to a given entity via the `:follow` attribute.
 [#queries_lazy_queries]
 == Lazy Queries
 
-The function `crux.api/q` takes 2 or 3 arguments, `db` and `q` but also
-optionally a `snapshot` which is already opened and managed by the caller
-(using `with-open` for example). This version of the call returns a lazy
-sequence of the results, while the other version provides a set. A snapshot can
-be retrieved from a `kv` instance via `crux.api/new-snapshot`. For example, a lazy version of a basic query from the top of this section (using `with-open` to ensure that the snapshot is closed):
+The function `crux.api/q` also has a 3-argument arity (`db`, `snapshot` and `q`)
+that can return results lazily. A snapshot can be retrieved from a `node` via
+`crux.api/new-snapshot` - the snapshot must be closed when no longer used, and
+the query results must be processed while the snapshot is open. For example, a
+lazy version of a basic query from the top of this section (using `with-open` to
+ensure that the snapshot is closed):
 
 [source,clj]
 ----
 include::./src/docs/examples.clj[tags=lazy-query]
-----
-
-This will lazily return:
-[source,clj]
-----
-include::./src/docs/examples.clj[tags=lazy-query-r]
 ----
 
 [#queries_history_api]

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -267,24 +267,18 @@
 ;; end::query-with-pred-1-r[]
 )
 
-(defn query-example-lazy [node]
+(defn query-example-lazy [node prn]
   ;; tag::lazy-query[]
 (with-open [snapshot (crux.api/new-snapshot (crux/db node))]
-  (crux/q
-   (crux/db node)
-   snapshot
-   '{:find [p1]
-     :where [[p1 :name n]
-             [p1 :last-name n]
-             [p1 :name "Smith"]]}))
+  (doseq [tuple (crux/q (crux/db node)
+                        snapshot
+                        '{:find [p1]
+                          :where [[p1 :name n]
+                                  [p1 :last-name n]
+                                  [p1 :name "Smith"]]})]
+    (prn tuple)))
   ;; end::lazy-query[]
   )
-
-#_(comment
-;; tag::lazy-query-r[]
-([:smith])
-;; end::lazy-query-r[]
-)
 
 (defn query-example-at-time-setup [node]
  (crux/submit-tx


### PR DESCRIPTION
resolves #631 by deduping the results in the lazy case too:

* eager query returns set (deduped by definition)
* order-by returns vec of deduped results
* lazy returns lazy-seq of deduped results

