### PR TITLE
Remove nodes using memdb from crux-bench.

### DIFF
--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -109,44 +109,12 @@
 (defn nodes
   [data-dir]
 
-  {#_"standalone-lmdb"
-   #_{:crux.node/topology '[crux.standalone/topology
-                            crux.metrics/with-cloudwatch
-                            crux.kv.lmdb/kv-store]
-      :crux.kv/db-dir (str (io/file data-dir "kv/lmdb"))
-      :crux.standalone/event-log-kv-store 'crux.kv.lmdb/kv
-      :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/lmdb"))}
-
-   #_"standalone-rocksdb"
-   #_{:crux.node/topology '[crux.standalone/topology
+  {"standalone-rocksdb"
+   {:crux.node/topology '[crux.standalone/topology
                             crux.metrics/with-cloudwatch
                             crux.kv.rocksdb/kv-store]
       :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))
       :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/rocksdb"))
-      :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv}
-
-   #_"standalone-memdb"
-   #_{:crux.node/topology '[crux.standalone/topology
-                            crux.metrics/with-cloudwatch
-                            crux.kv.memdb/kv-store]
-      :crux.kv/db-dir (str (io/file data-dir "kv/memdb"))
-      :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/memdb"))
-      :crux.standalone/event-log-kv-store 'crux.kv.memdb/kv}
-
-   #_"standalone-memdb-rocksdb"
-   #_{:crux.node/topology '[crux.standalone/topology
-                            crux.metrics/with-cloudwatch
-                            crux.kv.memdb/kv-store]
-      :crux.kv/db-dir (str (io/file data-dir "kv/memdb"))
-      :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/rocksdb"))
-      :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv}
-
-   #_"standalone-rocksdb-memdb"
-   #_{:crux.node/topology '[crux.standalone/topology
-                            crux.metrics/with-cloudwatch
-                            crux.kv.rocksdb/kv-store]
-      :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))
-      :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/memdb"))
       :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv}
 
    "kafka-rocksdb"
@@ -158,6 +126,14 @@
     :crux.kafka/tx-topic "kafka-rocksdb-tx"
     :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))}
 
+   #_"standalone-lmdb"
+   #_{:crux.node/topology '[crux.standalone/topology
+                            crux.metrics/with-cloudwatch
+                            crux.kv.lmdb/kv-store]
+      :crux.kv/db-dir (str (io/file data-dir "kv/lmdb"))
+      :crux.standalone/event-log-kv-store 'crux.kv.lmdb/kv
+      :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/lmdb"))}
+
    #_"kafka-lmdb"
    #_{:crux.node/topology '[crux.kafka/topology
                             crux.metrics/with-cloudwatch
@@ -165,16 +141,7 @@
       :crux.kafka/bootstrap-servers "localhost:9092"
       :crux.kafka/doc-topic "kafka-lmdb-doc"
       :crux.kafka/tx-topic "kafka-lmdb-tx"
-      :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))}
-
-   #_"kafka-mem"
-   #_{:crux.node/topology '[crux.kafka/topology
-                            crux.metrics/with-cloudwatch
-                            crux.kv.memdb/kv-store]
-      :crux.kafka/bootstrap-servers "localhost:9092"
-      :crux.kafka/doc-topic "kafka-mem-doc"
-      :crux.kafka/tx-topic "kafka-mem-tx"
-      :crux.kv/db-dir (str (io/file data-dir "kv/memdb"))}})
+      :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))}})
 
 (defn with-nodes* [f]
   (f/with-tmp-dir "dev-storage" [data-dir]


### PR DESCRIPTION
These memdb nodes would fail, as they would run out of memory fairly quickly (which was to be expected). I haved removed these from the bench run entirely, as we likely do not want to benchmark them in such a way.