### PR TITLE
Fix #697, sorting args before populating virtual index

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -970,7 +970,7 @@
 
 (defn- build-nested-index [tuples [range-constraints & next-range-constraints]]
   (-> (new-sorted-virtual-index
-       (for [prefix (partition-by first tuples)
+       (for [prefix (vals (group-by first tuples))
              :let [value (ffirst prefix)]]
          [(c/->value-buffer value)
           (RelationNestedIndexState.

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2802,3 +2802,18 @@
       (with-open [snapshot (api/new-snapshot db)]
         (t/is (= [[20] [25] [30]]
                  (sort (api/q db snapshot '{:find [a] :where [[_ :age a]]}))))))))
+
+(t/deftest test-unsorted-args-697
+  (f/transact! *api* [{:crux.db/id :foo-some-bar-nil, :bar nil, :foo true}
+                      {:crux.db/id :foo-nil-bar-some, :bar true, :foo nil}
+                      {:crux.db/id :foo-some-bar-some, :foo true, :bar true}])
+
+  (t/is (= #{[:foo-some-bar-nil] [:foo-nil-bar-some] [:foo-some-bar-some]}
+           (api/q (api/db *api*)
+                  '{:find [e]
+                    :where [[e :foo f]
+                            [e :bar g]]
+
+                    :args [{f true, g true}
+                           {f true, g nil}
+                           {f nil, g true}]}))))


### PR DESCRIPTION
When we create a virtual index from args, the query engine assumed that values were grouped together in the prefix tree - this works fine for indices pulled from the kv-store, but not so much for values from user-provided args.

This PR sorts user-provided args before populating the virtual indices, so that the `partition-by` in `build-nested-index` groups together values before generating the sorted arg indices