### PR TITLE
Fix #700, arg vs literal full-scan performance issue

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -310,13 +310,14 @@
                                      (if (literal? v)
                                        (get literal->var v)
                                        e))
+                                   arg-vars
                                    (for [{:keys [e v]} literal-clauses]
                                      (if (literal? v)
                                        e
                                        v)))
         self-join-clauses (filter (comp :self-join? meta) triple-clauses)
         self-join-vars (map :v self-join-clauses)
-        join-order (loop [join-order (concat literal-join-order arg-vars self-join-vars)
+        join-order (loop [join-order (concat literal-join-order self-join-vars)
                           clauses (->> triple-clauses
                                        (remove (set self-join-clauses))
                                        (remove (set literal-clauses)))]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2817,3 +2817,14 @@
                     :args [{f true, g true}
                            {f true, g nil}
                            {f nil, g true}]}))))
+
+(t/deftest test-binds-args-before-entities
+  (t/is (= ['m 'e]
+           (->> (q/query-plan-for {:find '[e]
+                                   :where '[[e :foo/type "type"]
+                                            [e :foo/id m]]
+                                   :args [{'m 1}]}
+
+                                  {})
+                :vars-in-join-order
+                (filter #{'m 'e})))))


### PR DESCRIPTION
resolves #700 

When we determine the join order, we bump 'literal clauses' to the front, because these restrict the result-set size down quickly - but we also then immediately bind the associated entities, which means they're bound before the arg-vars. For the query in the issue, it means we then scanned through all the entities with type `"foo-type"` before filtering by `id`, just because the `id` was an arg.

paired with @hraberg 