### PR TITLE
Run watdiv against datomic

### DIFF
--- a/crux-bench/bin/run_datomic.sh
+++ b/crux-bench/bin/run_datomic.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+aws ecs run-task\
+ --task-definition crux-bench-latest\
+ --cluster crux-bench\
+ --overrides "{\"containerOverrides\": [{\"name\":\"bench-container\",\"command\":[\"crux.bench.watdiv-datomic\"]}]}"\
+ --launch-type FARGATE\
+ --count 1\
+ --network-configuration \
+ "awsvpcConfiguration={subnets=[subnet-5140ba2b],assignPublicIp=\"ENABLED\"}"\
+ --output json

--- a/crux-bench/src/crux/bench/watdiv_crux.clj
+++ b/crux-bench/src/crux/bench/watdiv_crux.clj
@@ -26,7 +26,8 @@
 (def db-query-results
   {:rdf4j (some->
             (bench/load-from-s3 "rdf4j-3.0.0/rdf4j-20200214-174740Z.edn") parse-results)
-   :neo4j (some-> (bench/load-from-s3 "neo4j-4.0.0/neo4j-20200219-114016Z.edn") parse-results)})
+   :neo4j (some-> (bench/load-from-s3 "neo4j-4.0.0/neo4j-20200219-114016Z.edn") parse-results)
+   :datomic (some-> (bench/load-from-s3 "datomic-0.9.5697/datomic-20200303-155352Z.edn") parse-results)})
 
 (defn get-db-results-at-idx [idx]
   (into

--- a/crux-bench/src/crux/bench/watdiv_datomic.clj
+++ b/crux-bench/src/crux/bench/watdiv_datomic.clj
@@ -300,9 +300,7 @@
          (vec))))
 
 (defn with-datomic [f]
-  (let [uri (str "datomic:free://"
-                 (or (System/getenv "DATOMIC_TRANSACTOR_URI") "datomic")
-                 ":4334/bench?password=password")]
+  (let [uri (str "datomic:mem://bench")]
     (try
         (d/delete-database uri)
         (d/create-database uri)
@@ -354,4 +352,5 @@
                         (->> (run-watdiv-bench {:test-count 100})
                              (filter :query-idx)
                              (sort-by :query-idx)))
-    (bench/save-to-s3 {:database "datomic" :version "0.9.5697"} output-file)))
+    (bench/save-to-s3 {:database "datomic" :version "0.9.5697"} output-file))
+  (shutdown-agents))


### PR DESCRIPTION
(resolves #575)

Runs watdiv against in memory database, though currently with a `system/exit` on the end to ensure it closes properly,