### PR TITLE
idx/entity-history-seq-* take iterators rather than snapshots

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -600,9 +600,8 @@
             (enrich-entity-tx (kv/value i)))
         (entity-history-step i seek-k f-next f-next))))))
 
-(defn entity-history-seq-ascending [snapshot eid ^Date from-valid-time ^Date transaction-time]
-  (let [i (kv/new-iterator snapshot)
-        seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) (Date. (dec (.getTime from-valid-time))))]
+(defn entity-history-seq-ascending [i eid ^Date from-valid-time ^Date transaction-time]
+  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) (Date. (dec (.getTime from-valid-time))))]
     (->> (entity-history-step i seek-k #(when-let [k (kv/seek i seek-k)]
                                           (kv/prev i)) #(kv/prev i))
          (drop-while (fn [^EntityTx entity-tx]
@@ -616,9 +615,8 @@
                      (first))))
          (remove nil?))))
 
-(defn entity-history-seq-descending [snapshot eid ^Date from-valid-time ^Date transaction-time]
-  (let [i (kv/new-iterator snapshot)
-        seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-valid-time)]
+(defn entity-history-seq-descending [i eid ^Date from-valid-time ^Date transaction-time]
+  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-valid-time)]
     (->> (entity-history-step i seek-k #(kv/seek i seek-k) #(kv/next i))
          (partition-by :vt)
          (map (fn [group]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1225,11 +1225,13 @@
     (q this snapshot (normalize-and-conform-query conform-cache query)))
 
   (historyAscending [this snapshot eid]
-    (for [^EntityTx entity-tx (idx/entity-history-seq-ascending snapshot eid valid-time transact-time)]
+    ;; TODO this doesn't close the iterator - we'll want to do this when we move to 'openHistoryAscending'
+    (for [^EntityTx entity-tx (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid valid-time transact-time)]
       (assoc (c/entity-tx->edn entity-tx) :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
 
   (historyDescending [this snapshot eid]
-    (for [^EntityTx entity-tx (idx/entity-history-seq-descending snapshot eid valid-time transact-time)]
+    ;; TODO this doesn't close the iterator - we'll want to do this when we move to 'openHistoryDescending'
+    (for [^EntityTx entity-tx (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid valid-time transact-time)]
       (assoc (c/entity-tx->edn entity-tx) :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
 
   (validTime [_]

--- a/crux-test/test/crux/sorted_maps_microbench.clj
+++ b/crux-test/test/crux/sorted_maps_microbench.clj
@@ -1,0 +1,12 @@
+(ns crux.sorted-maps-microbench)
+
+(comment
+  (let [submitted-tx (last (for [doc-batch (->> (for [n (range 25000)]
+                                                  [:crux.tx/put {:crux.db/id (keyword (str "doc-" n))
+                                                                 :doc-idx n
+                                                                 :nested-map {:foo :bar
+                                                                              :baz :quux}}])
+                                                (partition-all 5000))]
+                             (time (crux/submit-tx (user/crux-node) doc-batch))))]
+
+    (time (crux/await-tx (user/crux-node) submitted-tx (java.time.Duration/ofSeconds 20)))))


### PR DESCRIPTION
these iterators weren't getting closed (because the functions returned lazy seqs)

this made indexing slow (the parts that relied heavily on these calls, at least) because iterators weren't being returned to the pool. 

(I'm not massively happy with the `with-entity-history-seq-*` change in tx.clj, but atm it seems necessary because of the Snapshot+ETXs concept - refactoring that would have likely been a much bigger change)