### PR TITLE
Not eval'ing tx-fn args

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -278,7 +278,7 @@
         {:crux.db.fn/keys [args] :as args-doc} (db/get-single-object object-store snapshot (c/new-id args-v))
         args-id (:crux.db/id args-doc)
         fn-result (try
-                    (let [tx-ops (apply (tx-fn-eval-cache body) db (eval args))
+                    (let [tx-ops (apply (tx-fn-eval-cache body) db args)
                           _ (when tx-ops (s/assert :crux.api/tx-ops tx-ops))
                           docs (mapcat tx-op->docs tx-ops)
                           {arg-docs true docs false} (group-by (comp boolean :crux.db.fn/args) docs)]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -504,7 +504,7 @@
             update-attribute-fn {:crux.db/id :update-attribute-fn
                                  :crux.db.fn/body
                                  '(fn [db eid k f]
-                                    [[:crux.tx/put (update (crux.api/entity db eid) k f)]])}]
+                                    [[:crux.tx/put (update (crux.api/entity db eid) k (eval f))]])}]
         (fapi/submit+await-tx [[:crux.tx/put v1-ivan]
                                [:crux.tx/put update-attribute-fn]])
         (t/is (= v1-ivan (api/entity (api/db *api*) :ivan)))
@@ -513,9 +513,7 @@
 
         (let [v2-ivan (assoc v1-ivan :age 41)
               inc-ivans-age '{:crux.db/id :inc-ivans-age
-                              :crux.db.fn/args [:ivan
-                                                :age
-                                                inc]}]
+                              :crux.db.fn/args [:ivan :age inc]}]
           (fapi/submit+await-tx [[:crux.tx/fn :update-attribute-fn inc-ivans-age]])
           (t/is (= v2-ivan (api/entity (api/db *api*) :ivan)))
           (t/is (= inc-ivans-age (api/entity (api/db *api*) :inc-ivans-age)))


### PR DESCRIPTION
(from @refset)

If a transaction needs to eval its args (for example, for higher-order functions), it can do this in the tx-fn body