### PR TITLE
Start up kafka containers alongside bench

### DIFF
--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -133,8 +133,8 @@ Resources:
       - ECRRepository
       - LogGroup
     Properties:
-      Cpu: '2 vCPU'
-      Memory: '8GB'
+      Cpu: '4 vCPU'
+      Memory: '12GB'
       Family: 'crux-bench'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]
@@ -144,7 +144,40 @@ Resources:
         - 'FARGATE'
       NetworkMode: 'awsvpc'
       ContainerDefinitions:
+        - Name: 'zookeeper-container'
+          Cpu: 1024
+          Memory: 2048
+          Image: confluentinc/cp-zookeeper:5.3.1
+          Essential: true
+          Environment:
+            - Name: 'ZOOKEEPER_CLIENT_PORT'
+              Value: '2181'
+            - Name: 'ZOOKEEPER_TICK_TIME'
+              Value: '2000'
+          PortMappings:
+            - ContainerPort: 2181
+        - Name: 'broker-container'
+          Cpu: 1024
+          Memory: 2048
+          Image: confluentinc/cp-enterprise-kafka:5.3.1
+          DependsOn:
+            - Condition: 'START'
+              ContainerName: 'zookeeper-container'
+          Essential: true
+          Environment:
+            - Name: 'KAFKA_BROKER_ID'
+              Value: '1'
+            - Name: 'KAFKA_ZOOKEEPER_CONNECT'
+              Value: 'localhost:2181'
+            - Name: 'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR'
+              Value: 1
+            - Name: 'KAFKA_ADVERTISED_LISTENERS'
+              Value: PLAINTEXT://localhost:9092
+          PortMappings:
+            - ContainerPort: 9092
         - Name: 'bench-container'
+          Cpu: 2048
+          Memory: 8146
           Image: '955308952094.dkr.ecr.eu-west-2.amazonaws.com/crux-bench:master'
           Essential: true
           Secrets:
@@ -164,8 +197,8 @@ Resources:
       - ECRRepository
       - LogGroup
     Properties:
-      Cpu: '2 vCPU'
-      Memory: '8GB'
+      Cpu: '4 vCPU'
+      Memory: '12GB'
       Family: 'crux-bench-latest'
       ExecutionRoleArn:
         Fn::GetAtt: ["ECSTaskExecutionRole", "Arn"]
@@ -175,8 +208,44 @@ Resources:
         - 'FARGATE'
       NetworkMode: 'awsvpc'
       ContainerDefinitions:
+        - Name: 'zookeeper-container'
+          Cpu: 1024
+          Memory: 2048
+          Image: confluentinc/cp-zookeeper:5.3.1
+          Essential: true
+          Environment:
+            - Name: 'ZOOKEEPER_CLIENT_PORT'
+              Value: '2181'
+            - Name: 'ZOOKEEPER_TICK_TIME'
+              Value: '2000'
+          PortMappings:
+            - ContainerPort: 2181
+        - Name: 'broker-container'
+          Cpu: 1024
+          Memory: 2048
+          Image: confluentinc/cp-enterprise-kafka:5.3.1
+          DependsOn:
+            - Condition: 'START'
+              ContainerName: 'zookeeper-container'
+          Essential: true
+          Environment:
+            - Name: 'KAFKA_BROKER_ID'
+              Value: '1'
+            - Name: 'KAFKA_ZOOKEEPER_CONNECT'
+              Value: 'localhost:2181'
+            - Name: 'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR'
+              Value: 1
+            - Name: 'KAFKA_ADVERTISED_LISTENERS'
+              Value: PLAINTEXT://localhost:9092
+          PortMappings:
+            - ContainerPort: 9092
         - Name: 'bench-container'
+          Cpu: 2048
+          Memory: 8146
           Image: '955308952094.dkr.ecr.eu-west-2.amazonaws.com/crux-bench:latest'
+          DependsOn:
+            - Condition: 'START'
+              ContainerName: 'broker-container'
           Essential: true
           Secrets:
             - Name: "SLACK_URL"

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -127,6 +127,15 @@
       :crux.kafka/tx-topic "kafka-rocksdb-tx"
       :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))})
 
+   "embedded-kafka-rocksdb"
+   (fn [data-dir]
+     {:crux.node/topology '[crux.kafka/topology
+                            crux.metrics/with-cloudwatch
+                            crux.kv.rocksdb/kv-store]
+      :crux.kafka/bootstrap-servers "localhost:9091"
+      :crux.kafka/doc-topic "kafka-rocksdb-doc"
+      :crux.kafka/tx-topic "kafka-rocksdb-tx"
+      :crux.kv/db-dir (str (io/file data-dir "kv/rocksdb"))})
    #_"standalone-lmdb"
    #_(fn [data-dir]
        {:crux.node/topology '[crux.standalone/topology
@@ -151,7 +160,7 @@
     (with-open [emb (ek/start-embedded-kafka
                       {:crux.kafka.embedded/zookeeper-data-dir (str (io/file data-dir "zookeeper"))
                        :crux.kafka.embedded/kafka-log-dir (str (io/file data-dir "kafka-log"))
-                       :crux.kafka.embedded/kafka-port 9092})]
+                       :crux.kafka.embedded/kafka-port 9091})]
       (vec
        (for [[node-type ->node] nodes]
          (with-open [node (api/start-node (->node data-dir))]

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -14,7 +14,7 @@
   (bench/post-to-slack (format "*Starting Benchmark*, Crux Version: %s, Commit Hash: %s\n"
                                bench/crux-version bench/commit-hash))
 
-  (let [bench-results (concat (bench/with-nodes [node (select-keys bench/nodes ["standalone-rocksdb" "kafka-rocksdb" "embedded-kafka-rocksdb"])]
+  (let [bench-results (concat (bench/with-nodes [node (select-keys bench/nodes ["embedded-kafka-rocksdb"])]
                                 [(-> (sorted-maps/run-sorted-maps-microbench node)
                                      (doto post-to-slack))])
 

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -14,7 +14,7 @@
   (bench/post-to-slack (format "*Starting Benchmark*, Crux Version: %s, Commit Hash: %s\n"
                                bench/crux-version bench/commit-hash))
 
-  (let [bench-results (concat (bench/with-nodes [node (select-keys bench/nodes ["standalone-rocksdb" "kafka-rocksdb"])]
+  (let [bench-results (concat (bench/with-nodes [node (select-keys bench/nodes ["standalone-rocksdb" "kafka-rocksdb" "embedded-kafka-rocksdb"])]
                                 [(-> (sorted-maps/run-sorted-maps-microbench node)
                                      (doto post-to-slack))])
 


### PR DESCRIPTION
(Resolves #663) 

Starts up a zookeeper and kafka container on the bench tasks, connecting to them within the `kafka-rocksdb` node. (Increases the memory/cpu usage of the benchmark, each of the new containers using 1vCPU and 4GB RAM).