### PR TITLE
Explicit value->buffer impl for Map et al, index-docs performance gain

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -199,6 +199,18 @@
   (value->buffer [this to]
     (id->buffer this to))
 
+  Map
+  (value->buffer [this to]
+    (id->buffer this to))
+
+  DirectBuffer
+  (value->buffer [this to]
+    (id->buffer this to))
+
+  ByteBuffer
+  (value->buffer [this to]
+    (id->buffer this to))
+
   Object
   (value->buffer [this ^MutableDirectBuffer to]
     (if (satisfies? IdToBuffer this)


### PR DESCRIPTION
directly implementing ValueToBuffer for Map cuts index-docs down by 40%

avoids call to `satisfies?` which is expensive and uncached, see https://clojure.atlassian.net/browse/CLJ-1814