### PR TITLE
Not creating unnecessary sorted maps, #685

### DIFF
--- a/crux-bench/src/crux/bench/sorted_maps_microbench.clj
+++ b/crux-bench/src/crux/bench/sorted_maps_microbench.clj
@@ -4,12 +4,12 @@
             [crux.bench :as bench]))
 
 (defn submit-batches [node]
-  (for [doc-batch (->> (for [n (range 15000)]
+  (for [doc-batch (->> (for [n (range 25000)]
                          [:crux.tx/put {:crux.db/id (keyword (str "doc-" n))
                                         :nested-map {:foo :bar
                                                      :baz :quux
                                                      :doc-idx n}}])
-                       (partition-all 5000))]
+                       (partition-all 1000))]
     (crux/submit-tx node (vec doc-batch))))
 
 (defn run-benches [node [submit-bench-type await-bench-type]]

--- a/crux-bench/src/crux/bench/sorted_maps_microbench.clj
+++ b/crux-bench/src/crux/bench/sorted_maps_microbench.clj
@@ -1,15 +1,16 @@
 (ns crux.bench.sorted-maps-microbench
-  (:require [crux.api :as crux]
+  (:require [clojure.java.io :as io]
+            [crux.api :as crux]
             [crux.bench :as bench]))
 
 (defn submit-batches [node]
-  (for [doc-batch (->> (for [n (range 25000)]
+  (for [doc-batch (->> (for [n (range 15000)]
                          [:crux.tx/put {:crux.db/id (keyword (str "doc-" n))
                                         :nested-map {:foo :bar
                                                      :baz :quux
                                                      :doc-idx n}}])
                        (partition-all 5000))]
-    (crux/submit-tx node doc-batch)))
+    (crux/submit-tx node (vec doc-batch))))
 
 (defn run-benches [node [submit-bench-type await-bench-type]]
   (bench/run-bench await-bench-type
@@ -26,3 +27,18 @@
   (bench/with-bench-ns :sorted-maps
     (run-benches node [:initial-submits :initial-await])
     (run-benches node [:subsequent-submits :subsequent-await])))
+
+(comment
+  (require '[crux.kafka.embedded :as ek]
+           '[crux.fixtures :as f])
+
+  (f/with-tmp-dir "crux" [tmp-dir]
+    (with-open [ek (ek/start-embedded-kafka
+                    #:crux.kafka.embedded{:zookeeper-data-dir (str (io/file tmp-dir "zk-data"))
+                                          :kafka-dir (str (io/file tmp-dir "kafka-data"))
+                                          :kafka-log-dir (str (io/file tmp-dir "kafka-log"))})
+                node (crux/start-node {:crux.node/topology 'crux.kafka/topology
+                                       :crux.node/kv-store 'crux.kv.rocksdb/kv
+                                       :crux.kv/db-dir (str (io/file tmp-dir "rocks"))})]
+      (bench/with-bench-ns :sorted-maps
+        (run-benches node [:initial-submits :initial-await])))))


### PR DESCRIPTION
(resolves #685)

Not creating extra sorted maps when hashing - we just serialise them in order. 

Does involve changing Nippy behaviour, but we set a flag s.t. we only alter the behaviour when it's us that's serialising the maps.

I've also corrected the behaviour for sets here - these will have been vulnerable to the same consistent hashing issue from way back.