### PR TITLE
Tx consumer performance

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -220,11 +220,12 @@
 (defmethod index-tx-event :crux.tx/put [[op k v start-valid-time end-valid-time] tx {:keys [indexer] :as deps}]
   ;; This check shouldn't be required, under normal operation - the ingester checks for this before indexing
   ;; keeping this around _just in case_ - e.g. if we're refactoring the ingest code
-  {:pre-commit-fn #(let [content-hash (c/new-id v)
-                         correct-state? (empty? (db/missing-docs indexer #{content-hash}))]
-                     (when-not correct-state?
-                       (log/error "Put, incorrect doc state for:" content-hash "tx id:" (:crux.tx/tx-id tx)))
-                     correct-state?)
+  {:pre-commit-fn (fn []
+                    (let [content-hash (c/new-id v)]
+                      (assert (empty? (db/missing-docs indexer #{content-hash}))
+                              (format "Put, incorrect doc state for: '%s', tx-id '%s'"
+                                      content-hash (:crux.tx/tx-id tx)))
+                      true))
 
    :etxs (put-delete-etxs k start-valid-time end-valid-time (c/new-id v) tx deps)})
 


### PR DESCRIPTION
* Not sleeping if we've consumed transactions - let's get straight on with it :) the Thread/sleep in the tx consumer is intended to stop us polling the tx-log too quickly if there's nothing submitted - if we have consumed a batch of transactions then we ought to immediately check if there are more in the queue
* Downgrading the put pre-commit check to an assert - missing-docs was accounting for ~40% of the time in index-tx
* Not creating a tx-log consumer if we know there's no more transactions (particularly for Kafka where creating a consumer has a non-trivial cost)