### PR TITLE
Increase timeout on tx-log poll to that of the doc topic poll

### DIFF
--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -151,7 +151,7 @@
                      (.assign (keys tp-offsets))
                      (seek-consumer tp-offsets))]
       (db/->closeable-tx-log-iterator #(.close consumer)
-                                      (->> (consumer-seqs consumer (Duration/ofMillis 100))
+                                      (->> (consumer-seqs consumer (Duration/ofSeconds 1))
                                            (mapcat identity)
                                            (map tx-record->tx-log-entry)))))
 


### PR DESCRIPTION
Potentially fix for #726, albeit with a potential negative performance hit. Increasing the timeout does appear to fix the issue with the TLS handshake when polling a remote tx-log topic, though I would like to leave the issue open and confirm that it does.