### PR TITLE
Passing tx-events to submit-tx

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -28,7 +28,7 @@
 
 ;; tag::TxLog[]
 (defprotocol TxLog
-  (submit-tx [this tx-ops])
+  (submit-tx [this tx-events])
   (open-tx-log ^crux.api.ITxLog [this after-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -105,7 +105,7 @@
     (cio/with-read-lock lock
       (ensure-node-open this)
       (db/submit-docs document-store (tx/tx-ops->id-and-docs tx-ops))
-      @(db/submit-tx tx-log tx-ops)))
+      @(db/submit-tx tx-log (map tx/tx-op->tx-event tx-ops))))
 
   (hasTxCommitted [this {:keys [::tx/tx-id ::tx/tx-time] :as submitted-tx}]
     (cio/with-read-lock lock
@@ -175,7 +175,7 @@
     (cio/with-read-lock lock
       (ensure-node-open this)
       (db/submit-docs document-store (tx/tx-ops->id-and-docs tx-ops))
-      (db/submit-tx tx-log tx-ops)))
+      (db/submit-tx tx-log (map tx/tx-op->tx-event tx-ops))))
 
   backup/INodeBackup
   (write-checkpoint [this {:keys [crux.backup/checkpoint-directory] :as opts}]

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -32,14 +32,14 @@
 (defrecord StandaloneTxLog [^ExecutorService tx-submit-executor
                             indexer event-log-kv-store]
   db/TxLog
-  (submit-tx [this tx-ops]
+  (submit-tx [this tx-events]
     (when (.isShutdown tx-submit-executor)
       (throw (IllegalStateException. "TxLog is closed.")))
 
     (let [!submitted-tx (promise)]
       (.submit tx-submit-executor
                ^Runnable #(submit-tx {:!submitted-tx !submitted-tx
-                                      :tx-events (mapv tx/tx-op->tx-event tx-ops)}
+                                      :tx-events tx-events}
                                      this))
       (delay
         (let [submitted-tx @!submitted-tx]

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -100,9 +100,8 @@
 
 (defrecord JdbcTxLog [ds dbtype]
   db/TxLog
-  (submit-tx [this tx-ops]
-    (let [tx-events (map tx/tx-op->tx-event tx-ops)
-          ^Tx tx (tx-result->tx-data ds dbtype (insert-event! ds nil tx-events "txs"))]
+  (submit-tx [this tx-events]
+    (let [^Tx tx (tx-result->tx-data ds dbtype (insert-event! ds nil tx-events "txs"))]
       (delay {:crux.tx/tx-id (.id tx)
               :crux.tx/tx-time (.time tx)})))
 

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -132,10 +132,9 @@
 
 (defrecord KafkaTxLog [^KafkaProducer producer, ^KafkaConsumer latest-submitted-tx-consumer, tx-topic, kafka-config]
   db/TxLog
-  (submit-tx [this tx-ops]
+  (submit-tx [this tx-events]
     (try
-      (let [tx-events (map tx/tx-op->tx-event tx-ops)
-            content-hashes (->> (set (map c/new-id (mapcat tx/tx-op->docs tx-ops))))
+      (let [content-hashes (->> (set (map c/new-id (mapcat tx/tx-event->doc-hashes tx-events))))
             tx-send-future (->> (doto (ProducerRecord. tx-topic nil tx-events)
                                   (-> (.headers) (.add (str :crux.tx/docs)
                                                        (nippy/fast-freeze content-hashes))))

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -11,7 +11,7 @@
   ICruxAsyncIngestAPI
   (submitTxAsync [_ tx-ops]
     (db/submit-docs document-store (tx/tx-ops->id-and-docs tx-ops))
-    (db/submit-tx tx-log tx-ops))
+    (db/submit-tx tx-log (map tx/tx-op->tx-event tx-ops)))
 
   (submitTx [this tx-ops]
     @(.submitTxAsync this tx-ops))


### PR DESCRIPTION
Had this on a branch before I went away - quick change: passing tx-events to TxLog's submit-tx - because all the implementations turned tx-ops into tx-events as soon as they received them anyway