### PR TITLE
Add status endpoint to the webservice, and use for health check.

### DIFF
--- a/examples/soak/cloudformation/load-balancer.yml
+++ b/examples/soak/cloudformation/load-balancer.yml
@@ -59,7 +59,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /
+      HealthCheckPath: /status
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2

--- a/examples/soak/src/crux/soak/main.clj
+++ b/examples/soak/src/crux/soak/main.clj
@@ -169,7 +169,7 @@
                           (some-fn {:homepage #(homepage-handler % {:crux-node crux-node})
                                     :weather #(weather-handler % {:crux-node crux-node})
                                     :status #(status-handler % {:crux-node crux-node})}
-                                   (fn [handler] (when (ifn? handler) handler))
+                                   identity
                                    (constantly (constantly (resp/not-found "Not found"))))))
 
 (defmethod ig/init-key :soak/crux-node [_ node-opts]

--- a/examples/soak/src/crux/soak/main.clj
+++ b/examples/soak/src/crux/soak/main.clj
@@ -165,12 +165,12 @@
      :body (pr-str status)}))
 
 (defn bidi-handler [{:keys [crux-node]}]
-  (bidi.ring/make-handler routes
-                          (some-fn {:homepage #(homepage-handler % {:crux-node crux-node})
-                                    :weather #(weather-handler % {:crux-node crux-node})
-                                    :status #(status-handler % {:crux-node crux-node})}
-                                   identity
-                                   (constantly (constantly (resp/not-found "Not found"))))))
+  (br/make-handler routes
+                   (some-fn {:homepage #(homepage-handler % {:crux-node crux-node})
+                             :weather #(weather-handler % {:crux-node crux-node})
+                             :status #(status-handler % {:crux-node crux-node})}
+                            identity
+                            (constantly (constantly (resp/not-found "Not found"))))))
 
 (defmethod ig/init-key :soak/crux-node [_ node-opts]
   (let [node (api/start-node node-opts)]

--- a/examples/soak/src/crux/soak/main.clj
+++ b/examples/soak/src/crux/soak/main.clj
@@ -6,7 +6,6 @@
             [clojure.tools.logging :as log]
             [crux.api :as api]
             [crux.soak.config :as config]
-            [crux.io :as cio]
             [hiccup2.core :refer [html]]
             [integrant.core :as ig]
             [integrant.repl :as ir]
@@ -158,7 +157,12 @@
 
 (defn status-handler [req {:keys [crux-node]}]
   (let [status (api/status crux-node)]
-    (resp/content-type (resp/response (cio/pr-edn-str status)) "application/edn")))
+    {:status (if (or (not (contains? status :crux.zk/zk-active?))
+                     (:crux.zk/zk-active? status))
+               200
+               500)
+     :headers {"Content-Type" "application/edn"}
+     :body (pr-str status)}))
 
 (defn bidi-handler [{:keys [crux-node]}]
   (bidi.ring/make-handler routes


### PR DESCRIPTION
Health check was failing, as it would expect a response code of 200
but was checking the `/` path, which would return a redirect (code
307) to index.html. This commit fixes that issue, and adds a status endpoint.