### PR TITLE
Add `open-q` function, sans snapshot, for lazy queries

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -263,7 +263,7 @@
 
   (q
     [db query]
-    [db snapshot query]
+    ^:deprecated [db snapshot query]
     "q[uery] a Crux db.
   query param is a datalog query in map, vector or string form.
   First signature will evaluate eagerly and will return a set or vector
@@ -272,8 +272,20 @@
   Evaluates *lazily* consequently returns lazy sequence of result tuples.")
 
   (open-q ^java.io.Closeable [db query]
-    ;; TODO doc
-    )
+    "lazily q[uery] a Crux db.
+  query param is a datalog query in map, vector or string form.
+
+  This function returns a Closeable sequence of result tuples - once you've consumed
+  as much of the sequence as you need to, you'll need to `.close` the sequence.
+  A common way to do this is using `with-open`:
+
+  (with-open [res (crux/open-q db '{:find [...]
+                                    :where [...]})]
+    (doseq [row res]
+      ...))
+
+  Once the sequence is closed, attempting to iterate it is undefined.
+  ")
 
   (history-ascending
     [db snapshot eid]

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -5,7 +5,7 @@
             [crux.codec :as c]
             [clojure.tools.logging :as log])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
-            ICruxAsyncIngestAPI ICruxDatasource ITxLog]
+            ICruxAsyncIngestAPI ICruxDatasource ICursor]
            java.io.Closeable
            java.util.Date
            java.time.Duration))
@@ -155,7 +155,9 @@
   Returns a map with details about the submitted transaction,
   including tx-time and tx-id.")
 
-  (open-tx-log ^crux.api.ITxLog [this after-tx-id with-ops?]
+  ;; returning an iterator
+
+  (open-tx-log ^java.io.Closeable [this after-tx-id with-ops?]
     "Reads the transaction log. Optionally includes
   operations, which allow the contents under the :crux.api/tx-ops
   key to be piped into (submit-tx tx-ops) of another
@@ -231,7 +233,7 @@
   (submit-tx [this tx-ops]
     (.submitTx this (conform-tx-ops tx-ops)))
 
-  (open-tx-log ^crux.api.ITxLog [this after-tx-id with-ops?]
+  (open-tx-log ^crux.api.ICursor [this after-tx-id with-ops?]
     (.openTxLog this after-tx-id with-ops?)))
 
 (defprotocol PCruxDatasource

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -270,6 +270,10 @@
   Second signature accepts a db snapshot, see `new-snapshot`.
   Evaluates *lazily* consequently returns lazy sequence of result tuples.")
 
+  (open-q ^java.io.Closeable [db query]
+    ;; TODO doc
+    )
+
   (history-ascending
     [db snapshot eid]
     "Retrieves entity history lazily in chronological order
@@ -312,18 +316,13 @@
     ([this snapshot query]
      (.q this snapshot query)))
 
-  (history-ascending [this snapshot eid]
-    (.historyAscending this snapshot eid))
+  (open-q [this query] (.openQuery this query))
 
-  (history-descending [this snapshot eid]
-    (.historyDescending this snapshot eid))
+  (history-ascending [this snapshot eid] (.historyAscending this snapshot eid))
+  (history-descending [this snapshot eid] (.historyDescending this snapshot eid))
 
-  (valid-time
-    [this]
-    (.validTime this))
-
-  (transaction-time [this]
-    (.transactionTime this)))
+  (valid-time [this] (.validTime this))
+  (transaction-time [this] (.transactionTime this)))
 
 (defprotocol PCruxAsyncIngestClient
   "Provides API access to Crux async ingestion."

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [crux.io :as cio])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
-            ICruxAsyncIngestAPI ICruxDatasource ICursor]
+            ICruxAsyncIngestAPI ICruxDatasource]
            java.io.Closeable
            java.util.Date
            java.time.Duration))
@@ -234,8 +234,8 @@
   (submit-tx [this tx-ops]
     (.submitTx this (conform-tx-ops tx-ops)))
 
-  (open-tx-log ^crux.api.ICursor [this after-tx-id with-ops?]
-    (cio/<-cursor (.openTxLog this after-tx-id with-ops?))))
+  (open-tx-log ^java.io.Closeable [this after-tx-id with-ops?]
+    (cio/<-stream (.openTxLog this after-tx-id with-ops?))))
 
 (defprotocol PCruxDatasource
   "Represents the database as of a specific valid and
@@ -317,7 +317,7 @@
     ([this snapshot query]
      (.q this snapshot query)))
 
-  (open-q [this query] (cio/<-cursor (.openQuery this query)))
+  (open-q [this query] (cio/<-stream (.openQuery this query)))
 
   (history-ascending [this snapshot eid] (.historyAscending this snapshot eid))
   (history-descending [this snapshot eid] (.historyDescending this snapshot eid))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -3,7 +3,8 @@
   (:refer-clojure :exclude [sync])
   (:require [clojure.spec.alpha :as s]
             [crux.codec :as c]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [crux.io :as cio])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
             ICruxAsyncIngestAPI ICruxDatasource ICursor]
            java.io.Closeable
@@ -234,7 +235,7 @@
     (.submitTx this (conform-tx-ops tx-ops)))
 
   (open-tx-log ^crux.api.ICursor [this after-tx-id with-ops?]
-    (.openTxLog this after-tx-id with-ops?)))
+    (cio/<-cursor (.openTxLog this after-tx-id with-ops?))))
 
 (defprotocol PCruxDatasource
   "Represents the database as of a specific valid and
@@ -316,7 +317,7 @@
     ([this snapshot query]
      (.q this snapshot query)))
 
-  (open-q [this query] (.openQuery this query))
+  (open-q [this query] (cio/<-cursor (.openQuery this query)))
 
   (history-ascending [this snapshot eid] (.historyAscending this snapshot eid))
   (history-descending [this snapshot eid] (.historyDescending this snapshot eid))

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import clojure.lang.Keyword;
 
 /**
@@ -72,9 +73,9 @@ public interface ICruxDatasource {
      * Queries the db lazily.
      *
      * @param query the query in map, vector or string form.
-     * @return      a cursor of result tuples.
+     * @return      a stream of result tuples.
      */
-    public ICursor<List<?>> openQuery(Object query);
+    public Stream<List<?>> openQuery(Object query);
 
     /**
      * Retrieves entity history lazily in chronological order from and

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -65,7 +65,16 @@ public interface ICruxDatasource {
      * @param query    the query in map, vector or string form.
      * @return         a lazy sequence of result tuples.
      */
+    @Deprecated
     public Iterable<List<?>> q(Closeable snapshot, Object query);
+
+    /**
+     * Queries the db lazily.
+     *
+     * @param query the query in map, vector or string form.
+     * @return      a cursor of result tuples.
+     */
+    public ICursor<List<?>> openQuery(Object query);
 
     /**
      * Retrieves entity history lazily in chronological order from and

--- a/crux-core/src/crux/api/ICruxIngestAPI.java
+++ b/crux-core/src/crux/api/ICruxIngestAPI.java
@@ -3,6 +3,7 @@ package crux.api;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import clojure.lang.Keyword;
 
 /**
@@ -27,5 +28,5 @@ public interface ICruxIngestAPI extends Closeable {
      * @return          a lazy sequence of the transaction log.
      */
 
-    public ICursor<Map<Keyword, ?>> openTxLog(Long afterTxId, boolean withOps);
+    public Stream<Map<Keyword, ?>> openTxLog(Long afterTxId, boolean withOps);
 }

--- a/crux-core/src/crux/api/ICruxIngestAPI.java
+++ b/crux-core/src/crux/api/ICruxIngestAPI.java
@@ -22,10 +22,10 @@ public interface ICruxIngestAPI extends Closeable {
      * under the :crux.api/tx-ops key to be piped into (submit-tx tx-ops) of another
      * Crux instance.
      *
-     * @param afterTxId         optional transaction id to start after.
-     * @param withOps          should the operations with documents be included?
-     * @return                 a lazy sequence of the transaction log.
+     * @param afterTxId optional transaction id to start after.
+     * @param withOps   should the operations with documents be included?
+     * @return          a lazy sequence of the transaction log.
      */
 
-    public ITxLog openTxLog(Long afterTxId, boolean withOps);
+    public ICursor<Map<Keyword, ?>> openTxLog(Long afterTxId, boolean withOps);
 }

--- a/crux-core/src/crux/api/ICursor.java
+++ b/crux-core/src/crux/api/ICursor.java
@@ -1,7 +1,0 @@
-package crux.api;
-
-import java.util.Iterator;
-import java.io.Closeable;
-
-public interface ICursor<E> extends Iterator<E>, Closeable {
-}

--- a/crux-core/src/crux/api/ICursor.java
+++ b/crux-core/src/crux/api/ICursor.java
@@ -1,0 +1,7 @@
+package crux.api;
+
+import java.util.Iterator;
+import java.io.Closeable;
+
+public interface ICursor<E> extends Iterator<E>, Closeable {
+}

--- a/crux-core/src/crux/api/ITxLog.java
+++ b/crux-core/src/crux/api/ITxLog.java
@@ -1,9 +1,0 @@
-package crux.api;
-
-import java.io.Closeable;
-import java.util.Iterator;
-import java.util.Map;
-import clojure.lang.Keyword;
-
-public interface ITxLog extends Iterator<Map<Keyword, ?>>, Closeable {
-}

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -1,7 +1,4 @@
-(ns crux.db
-  (:import java.io.Closeable
-           java.util.Iterator
-           crux.api.ITxLog))
+(ns crux.db)
 
 ;; tag::Index[]
 (defprotocol Index
@@ -29,7 +26,7 @@
 ;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-events])
-  (open-tx-log ^crux.api.ITxLog [this after-tx-id])
+  (open-tx-log ^crux.api.ICursor [this after-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
 
@@ -51,17 +48,3 @@
   (missing-keys [this snapshot ks])
   (put-objects [this kvs]))
 ;; end::ObjectStore[]
-
-(defrecord CloseableTxLogIterator [close-fn ^Iterator lazy-seq-iterator]
-  ITxLog
-  (next [this]
-    (.next lazy-seq-iterator))
-
-  (hasNext [this]
-    (.hasNext lazy-seq-iterator))
-
-  (close [_]
-    (close-fn)))
-
-(defn ->closeable-tx-log-iterator [close-fn ^Iterable sq]
-  (->CloseableTxLogIterator close-fn (.iterator (lazy-seq sq))))

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -26,7 +26,7 @@
 ;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-events])
-  (open-tx-log ^crux.api.ICursor [this after-tx-id])
+  (open-tx-log ^java.lang.AutoCloseable [this after-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
 

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy])
   (:import [crux.api ICursor]
+           [clojure.lang ISeq Sequential IPending]
            [java.io Closeable DataInputStream DataOutputStream File IOException Reader]
            [java.lang AutoCloseable]
            [java.lang.ref PhantomReference ReferenceQueue]
@@ -262,3 +263,24 @@
 
 (defn ->cursor [close-fn ^Iterable sq]
   (->Cursor close-fn (.iterator (lazy-seq sq))))
+
+(defn <-cursor [^ICursor cursor]
+  (let [^ISeq sq (or (iterator-seq cursor) [])]
+    (reify
+      Sequential
+
+      Closeable
+      (close [_] (.close cursor))
+
+      IPending
+      (isRealized [_] (.isRealized ^IPending sq))
+
+      ISeq
+      (first [_] (.first sq))
+      (next [_] (.next sq))
+      (more [_] (.more sq))
+      (cons [_ o] (.cons sq o))
+      (count [_] (.count sq))
+      (empty [_] (.empty sq))
+      (equiv [_ o] (.equiv sq o))
+      (seq [_] (.seq sq)))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -17,7 +17,7 @@
             [crux.topology :as topo]
             [crux.tx :as tx]
             [crux.bus :as bus])
-  (:import [crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException ICursor]
+  (:import [crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException]
            java.io.Closeable
            java.util.Date
            [java.util.concurrent Executors]
@@ -116,33 +116,32 @@
            (kv/get-value (kv/new-snapshot kv-store)
                          (c/encode-failed-tx-id-key-to nil tx-id)))))))
 
-  (openTxLog ^ICursor [this after-tx-id with-ops?]
+  (openTxLog [this after-tx-id with-ops?]
     (cio/with-read-lock lock
       (ensure-node-open this)
       (if (let [latest-submitted-tx-id (::tx/tx-id (api/latest-submitted-tx this))]
             (or (nil? latest-submitted-tx-id)
                 (and after-tx-id (>= after-tx-id latest-submitted-tx-id))))
-        (cio/->cursor #() [])
+        (cio/->stream [])
 
-        (let [tx-log-iterator (db/open-tx-log tx-log after-tx-id)
-              snapshot (kv/new-snapshot kv-store)
-              tx-log (-> (iterator-seq tx-log-iterator)
-                         (->> (filter
-                               #(nil?
-                                 (kv/get-value snapshot
-                                               (c/encode-failed-tx-id-key-to nil (:crux.tx/tx-id %))))))
-                         (cond->> with-ops? (map (fn [{:keys [crux.tx/tx-id
-                                                              crux.tx.event/tx-events] :as tx-log-entry}]
-                                                   (-> tx-log-entry
-                                                       (dissoc :crux.tx.event/tx-events)
-                                                       (assoc :crux.api/tx-ops
-                                                              (->> tx-events
-                                                                   (mapv #(tx/tx-event->tx-op % snapshot object-store)))))))))]
+        (let [snapshot (kv/new-snapshot kv-store)
+              tx-log (cio/<-stream (db/open-tx-log tx-log after-tx-id))]
+          (letfn [(failed-tx? [{:keys [::tx/tx-id]}]
+                    (boolean (kv/get-value snapshot (c/encode-failed-tx-id-key-to nil tx-id))))
 
-          (cio/->cursor (fn []
+                  (with-ops [{:keys [::tx/tx-id crux.tx.event/tx-events] :as tx-log-entry}]
+                    (-> tx-log-entry
+                        (dissoc :crux.tx.event/tx-events)
+                        (assoc :crux.api/tx-ops
+                               (->> tx-events
+                                    (mapv #(tx/tx-event->tx-op % snapshot object-store))))))]
+
+            (doto (cio/->stream (-> tx-log
+                                    (->> (remove failed-tx?))
+                                    (cond->> with-ops? (map with-ops))))
+              (.onClose (fn []
                           (.close snapshot)
-                          (.close tx-log-iterator))
-                        tx-log)))))
+                          (.close tx-log)))))))))
 
   (sync [this timeout]
     (when-let [tx (db/latest-submitted-tx (:tx-log this))]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1238,14 +1238,13 @@
           (bus/send bus {:crux.bus/event-type ::submitted-query
                          ::query safe-query
                          ::query-id query-id}))
-        (cio/->cursor (fn []
-                                    (.close snapshot)
-                                    (when bus
-                                      (bus/send bus {:crux.bus/event-type ::completed-query
-                                                     ::query safe-query
-                                                     ::query-id query-id})))
-
-                                  (q this snapshot conformed-query)))))
+        (doto (cio/->stream (q this snapshot conformed-query))
+          (.onClose (fn []
+                      (.close snapshot)
+                      (when bus
+                        (bus/send bus {:crux.bus/event-type ::completed-query
+                                       ::query safe-query
+                                       ::query-id query-id}))))))))
 
   (historyAscending [this snapshot eid]
     ;; TODO this doesn't close the iterator - we'll want to do this when we move to 'openHistoryAscending'

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -64,9 +64,9 @@
 
         (let [k (kv/seek iterator (c/encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
           (->> (when k (tx-log (if after-tx-id (kv/next iterator) k)))
-               (db/->closeable-tx-log-iterator (fn []
-                                                 (cio/try-close iterator)
-                                                 (cio/try-close snapshot))))))))
+               (cio/->cursor (fn []
+                                          (cio/try-close iterator)
+                                          (cio/try-close snapshot))))))))
 
   Closeable
   (close [_]

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -63,10 +63,8 @@
                           (tx-log (kv/next iterator))))))]
 
         (let [k (kv/seek iterator (c/encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
-          (->> (when k (tx-log (if after-tx-id (kv/next iterator) k)))
-               (cio/->cursor (fn []
-                                          (cio/try-close iterator)
-                                          (cio/try-close snapshot))))))))
+          (doto (cio/->stream (when k (tx-log (if after-tx-id (kv/next iterator) k))))
+            (.onClose #(run! cio/try-close [iterator snapshot])))))))
 
   Closeable
   (close [_]

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -132,8 +132,8 @@
                                (assoc (as-of-map this)
                                       :query (q/normalize-query q))
                                {:as :stream})]
-      (cio/->cursor (fn [] (.close ^Closeable in))
-                    (edn-list->lazy-seq in))))
+      (doto (cio/->stream (edn-list->lazy-seq in))
+        (.onClose (fn [] (.close ^Closeable in))))))
 
   (historyAscending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-ascending")
@@ -217,8 +217,8 @@
                                nil
                                {:method :get
                                 :as :stream})]
-      (cio/->cursor #(.close ^Closeable in)
-                    (edn-list->lazy-seq in))))
+      (doto (cio/->stream (edn-list->lazy-seq in))
+        (.onClose #(.close ^Closeable in)))))
 
   (sync [_ timeout]
     (api-request-sync (cond-> (str url "/sync")

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -127,6 +127,14 @@
       (register-stream-with-remote-stream! snapshot in)
       (edn-list->lazy-seq in)))
 
+  (openQuery [this q]
+    (let [in (api-request-sync (str url "/query-stream")
+                               (assoc (as-of-map this)
+                                      :query (q/normalize-query q))
+                               {:as :stream})]
+      (cio/->cursor (fn [] (.close ^Closeable in))
+                    (edn-list->lazy-seq in))))
+
   (historyAscending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-ascending")
                                (assoc (as-of-map this) :eid eid)

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -209,8 +209,8 @@
                                nil
                                {:method :get
                                 :as :stream})]
-      (db/->closeable-tx-log-iterator #(.close ^Closeable in)
-                                      (edn-list->lazy-seq in))))
+      (cio/->cursor #(.close ^Closeable in)
+                    (edn-list->lazy-seq in))))
 
   (sync [_ timeout]
     (api-request-sync (cond-> (str url "/sync")

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -16,7 +16,8 @@
             [ring.middleware.params :as p]
             [ring.util.io :as rio]
             [ring.util.request :as req]
-            [ring.util.time :as rt])
+            [ring.util.time :as rt]
+            [crux.api :as api])
   (:import [crux.api ICruxAPI ICruxDatasource NodeOutOfSyncException]
            [java.io Closeable IOException]
            java.time.Duration
@@ -234,8 +235,8 @@
   (let [with-ops? (Boolean/parseBoolean (get-in request [:query-params "with-ops"]))
         after-tx-id (some->> (get-in request [:query-params "after-tx-id"])
                              (Long/parseLong))
-        result (.openTxLog crux-node after-tx-id with-ops?)]
-    (-> (streamed-edn-response result (iterator-seq result))
+        result (api/open-tx-log crux-node after-tx-id with-ops?)]
+    (-> (streamed-edn-response result result)
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- sync-handler [^ICruxAPI crux-node request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -17,7 +17,7 @@
             [ring.util.io :as rio]
             [ring.util.request :as req]
             [ring.util.time :as rt])
-  (:import [crux.api ICruxAPI ICruxDatasource NodeOutOfSyncException ITxLog]
+  (:import [crux.api ICruxAPI ICruxDatasource NodeOutOfSyncException]
            [java.io Closeable IOException]
            java.time.Duration
            java.util.Date
@@ -234,7 +234,7 @@
   (let [with-ops? (Boolean/parseBoolean (get-in request [:query-params "with-ops"]))
         after-tx-id (some->> (get-in request [:query-params "after-tx-id"])
                              (Long/parseLong))
-        ^ITxLog result (.openTxLog crux-node after-tx-id with-ops?)]
+        result (.openTxLog crux-node after-tx-id with-ops?)]
     (-> (streamed-edn-response result (iterator-seq result))
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -111,12 +111,12 @@
                              ["SELECT EVENT_OFFSET, TX_TIME, V, TOPIC FROM tx_events WHERE TOPIC = 'txs' and EVENT_OFFSET > ? ORDER BY EVENT_OFFSET"
                               (or after-tx-id 0)])
           rs (.executeQuery stmt)]
-      (cio/->cursor #(run! cio/try-close [rs stmt conn])
-                    (->> (resultset-seq rs)
-                         (map (fn [y]
-                                {:crux.tx/tx-id (int (:event_offset y))
-                                 :crux.tx/tx-time (->date dbtype (:tx_time y))
-                                 :crux.tx.event/tx-events (->v dbtype (:v y))}))))))
+      (doto (cio/->stream (->> (resultset-seq rs)
+                               (map (fn [y]
+                                      {:crux.tx/tx-id (int (:event_offset y))
+                                       :crux.tx/tx-time (->date dbtype (:tx_time y))
+                                       :crux.tx.event/tx-events (->v dbtype (:v y))}))))
+        (.onClose #(run! cio/try-close [rs stmt conn])))))
 
   (latest-submitted-tx [this]
     (when-let [max-offset (-> (jdbc/execute-one! ds ["SELECT max(EVENT_OFFSET) AS max_offset FROM tx_events"]

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -149,10 +149,10 @@
           consumer (doto (create-consumer kafka-config)
                      (.assign (keys tp-offsets))
                      (seek-consumer tp-offsets))]
-      (db/->closeable-tx-log-iterator #(.close consumer)
-                                      (->> (consumer-seqs consumer (Duration/ofSeconds 1))
-                                           (mapcat identity)
-                                           (map tx-record->tx-log-entry)))))
+      (cio/->cursor #(.close consumer)
+                    (->> (consumer-seqs consumer (Duration/ofSeconds 1))
+                         (mapcat identity)
+                         (map tx-record->tx-log-entry)))))
 
   (latest-submitted-tx [this]
     (let [tx-tp (TopicPartition. tx-topic 0)

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -149,10 +149,10 @@
           consumer (doto (create-consumer kafka-config)
                      (.assign (keys tp-offsets))
                      (seek-consumer tp-offsets))]
-      (cio/->cursor #(.close consumer)
-                    (->> (consumer-seqs consumer (Duration/ofSeconds 1))
-                         (mapcat identity)
-                         (map tx-record->tx-log-entry)))))
+      (doto (cio/->stream (->> (consumer-seqs consumer (Duration/ofSeconds 1))
+                               (mapcat identity)
+                               (map tx-record->tx-log-entry)))
+        (.onClose #(.close consumer)))))
 
   (latest-submitted-tx [this]
     (let [tx-tp (TopicPartition. tx-topic 0)

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -16,7 +16,7 @@
   (submitTx [this tx-ops]
     @(.submitTxAsync this tx-ops))
 
-  (openTxLog ^crux.api.ICursor [_ after-tx-id with-ops?]
+  (openTxLog ^java.util.stream.Stream [_ after-tx-id with-ops?]
     (when with-ops?
       (throw (IllegalArgumentException. "with-ops? not supported")))
     (db/open-tx-log tx-log after-tx-id))

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -16,7 +16,7 @@
   (submitTx [this tx-ops]
     @(.submitTxAsync this tx-ops))
 
-  (openTxLog ^crux.api.ITxLog [_ after-tx-id with-ops?]
+  (openTxLog ^crux.api.ICursor [_ after-tx-id with-ops?]
     (when with-ops?
       (throw (IllegalArgumentException. "with-ops? not supported")))
     (db/open-tx-log tx-log after-tx-id))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -25,23 +25,23 @@
            org.eclipse.rdf4j.query.Binding))
 
 (defn- with-each-api-implementation [f]
-  #_(t/testing "Local API ClusterNode"
+  (t/testing "Local API ClusterNode"
     ((t/join-fixtures [fk/with-cluster-node-opts kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Local API StandaloneNode"
     ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fapi/with-node]) f))
-  #_(t/testing "H2 Node"
+  (t/testing "H2 Node"
     ((t/join-fixtures [#(fj/with-jdbc-node :h2 %) kvf/with-kv-dir fapi/with-node]) f))
-  #_(t/testing "SQLite Node"
+  (t/testing "SQLite Node"
     ((t/join-fixtures [#(fj/with-jdbc-node :sqlite %) kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Remote API"
     ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fh/with-http-server
                        fapi/with-node
                        fh/with-http-client])
      f))
-  #_(t/testing "Kafka and Remote Doc Store"
+  (t/testing "Kafka and Remote Doc Store"
     ((t/join-fixtures [fk/with-cluster-node-opts fs/with-standalone-doc-store kvf/with-kv-dir fapi/with-node]) f)))
 
-(t/use-fixtures :once #_fk/with-embedded-kafka-cluster)
+(t/use-fixtures :once fk/with-embedded-kafka-cluster)
 (t/use-fixtures :each with-each-api-implementation)
 
 (defn execute-sparql [^RepositoryConnection conn q]

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -25,23 +25,23 @@
            org.eclipse.rdf4j.query.Binding))
 
 (defn- with-each-api-implementation [f]
-  (t/testing "Local API ClusterNode"
+  #_(t/testing "Local API ClusterNode"
     ((t/join-fixtures [fk/with-cluster-node-opts kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Local API StandaloneNode"
     ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fapi/with-node]) f))
-  (t/testing "H2 Node"
+  #_(t/testing "H2 Node"
     ((t/join-fixtures [#(fj/with-jdbc-node :h2 %) kvf/with-kv-dir fapi/with-node]) f))
-  (t/testing "SQLite Node"
+  #_(t/testing "SQLite Node"
     ((t/join-fixtures [#(fj/with-jdbc-node :sqlite %) kvf/with-kv-dir fapi/with-node]) f))
   (t/testing "Remote API"
     ((t/join-fixtures [fs/with-standalone-node kvf/with-kv-dir fh/with-http-server
                        fapi/with-node
                        fh/with-http-client])
      f))
-  (t/testing "Kafka and Remote Doc Store"
+  #_(t/testing "Kafka and Remote Doc Store"
     ((t/join-fixtures [fk/with-cluster-node-opts fs/with-standalone-doc-store kvf/with-kv-dir fapi/with-node]) f)))
 
-(t/use-fixtures :once fk/with-embedded-kafka-cluster)
+(t/use-fixtures :once #_fk/with-embedded-kafka-cluster)
 (t/use-fixtures :each with-each-api-implementation)
 
 (defn execute-sparql [^RepositoryConnection conn q]
@@ -130,22 +130,16 @@
 
         (t/testing "query with streaming result"
           (let [db (.db *api*)]
-            (with-open [snapshot (.newSnapshot db)]
-              (let [result (.q db snapshot '{:find [e]
+            (with-open [res (api/open-q db '{:find [e]
                                              :where [[e :name "Ivan"]]})]
-                (t/is (not (realized? result)))
-                (t/is (= '([:ivan]) result))
-                (t/is (realized? result))))))
+              (t/is (= '([:ivan]) res)))))
 
         (t/testing "query returning full results"
           (let [db (.db *api*)]
-            (with-open [snapshot (.newSnapshot db)]
-              (let [result (.q db snapshot '{:find [e]
+            (with-open [res (api/open-q db '{:find [e]
                                              :where [[e :name "Ivan"]]
                                              :full-results? true})]
-                (t/is (not (realized? result)))
-                (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}]) result))
-                (t/is (realized? result))))))
+              (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}]) res)))))
 
         (t/testing "SPARQL query"
           (when (bound? #'fh/*api-url*)
@@ -237,42 +231,38 @@
         tx1 (fapi/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
 
     (t/testing "tx-log"
-      (with-open [tx-log-iterator (.openTxLog *api* nil false)]
-        (let [result (iterator-seq tx-log-iterator)]
-          (t/is (not (realized? result)))
-          (t/is (= [(assoc tx1
-                      :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
-                   result))
-          (t/is (realized? result))))
+      (with-open [tx-log (api/open-tx-log *api* nil false)]
+        (t/is (not (realized? tx-log)))
+        (t/is (= [(assoc tx1
+                         :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
+                 tx-log))
+        (t/is (realized? tx-log)))
 
       (t/testing "with ops"
-        (with-open [tx-log-iterator (.openTxLog *api* nil true)]
-          (let [result (iterator-seq tx-log-iterator)]
-            (t/is (not (realized? result)))
-            (t/is (= [(assoc tx1
-                        :crux.api/tx-ops [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
-                     result))
-            (t/is (realized? result)))))
+        (with-open [tx-log (api/open-tx-log *api* nil true)]
+          (t/is (not (realized? tx-log)))
+          (t/is (= [(assoc tx1
+                           :crux.api/tx-ops [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"} valid-time]])]
+                   tx-log))
+          (t/is (realized? tx-log))))
 
       (t/testing "from tx id"
-        (with-open [tx-log-iterator (api/open-tx-log *api* (::tx/tx-id tx1) false)]
-          (t/is (empty? (iterator-seq tx-log-iterator))))))
+        (with-open [tx-log (api/open-tx-log *api* (::tx/tx-id tx1) false)]
+          (t/is (empty? tx-log)))))
 
     (t/testing "tx log skips failed transactions"
       (let [tx2 (fapi/submit+await-tx [[:crux.tx/cas {:crux.db/id :ivan :name "Ivan2"} {:crux.db/id :ivan :name "Ivan3"}]])]
         (t/is (false? (api/tx-committed? *api* tx2)))
 
-        (with-open [tx-log-iterator (api/open-tx-log *api* nil false)]
-          (let [result (iterator-seq tx-log-iterator)]
-            (t/is (= [(assoc tx1
-                        :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
-                     result))))
+        (with-open [tx-log (api/open-tx-log *api* nil false)]
+          (t/is (= [(assoc tx1
+                           :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"}) valid-time]])]
+                   tx-log)))
 
         (let [tx3 (fapi/submit+await-tx [[:crux.tx/cas {:crux.db/id :ivan :name "Ivan"} {:crux.db/id :ivan :name "Ivan3"}]])]
           (t/is (true? (api/tx-committed? *api* tx3)))
-          (with-open [tx-log-iterator (api/open-tx-log *api* nil false)]
-            (let [result (iterator-seq tx-log-iterator)]
-              (t/is (= 2 (count result))))))))))
+          (with-open [tx-log (api/open-tx-log *api* nil false)]
+            (t/is (= 2 (count tx-log)))))))))
 
 (t/deftest test-db-history-api
   (let [version-1-submitted-tx-time (-> (.awaitTx *api* (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1} #inst "2019-02-01"]]) nil)

--- a/crux-test/test/crux/examples_test.clj
+++ b/crux-test/test/crux/examples_test.clj
@@ -99,7 +99,7 @@
     (t/is (= #{[21]} (ex/query-example-with-predicate-1 node)))
 
     (let [!results (atom [])]
-      (ex/query-example-lazy node #(swap! !results conj %))
+      (ex/query-example-streaming node #(swap! !results conj %))
       (t/is (= [[:smith]] @!results)))))
 
 (t/deftest test-example-time-queries

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -12,7 +12,8 @@
             [crux.api :as api]
             [crux.jdbc :as j]
             [next.jdbc :as jdbc]
-            [next.jdbc.result-set :as jdbcr]))
+            [next.jdbc.result-set :as jdbcr]
+            [crux.io :as cio]))
 
 (defn- with-each-jdbc-node [f]
   (f/with-tmp-dir "jdbc" [jdbc-dir]
@@ -41,14 +42,14 @@
     (.awaitTx *api* submitted-tx nil)
     (t/is (.entity (.db *api*) :origin-man))
     (t/testing "Tx log"
-      (with-open [tx-log-iterator (.openTxLog *api* 0 false)]
+      (with-open [log (api/open-tx-log *api* 0 false)]
         (t/is (= [{:crux.tx/tx-id 2,
                    :crux.tx/tx-time (:crux.tx/tx-time submitted-tx)
                    :crux.tx.event/tx-events
                    [[:crux.tx/put
                      (str (c/new-id (:crux.db/id doc)))
                      (str (c/new-id doc))]]}]
-                 (iterator-seq tx-log-iterator)))))))
+                 log))))))
 
 (defn- docs [dbtype ds id]
   (jdbc/with-transaction [t ds]

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -29,13 +29,12 @@
                                        '{:find [e]
                                          :where [[e :name "Ivan"]]})))
 
-            (with-open [tx-log-iterator (api/open-tx-log *ingest-client* nil false)]
-              (let [result (iterator-seq tx-log-iterator)]
-                (t/is (not (realized? result)))
-                (t/is (= [(assoc submitted-tx
-                            :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"})]])]
-                         result))
-                (t/is (realized? result))))
+            (with-open [tx-log (api/open-tx-log *ingest-client* nil false)]
+              (t/is (not (realized? tx-log)))
+              (t/is (= [(assoc submitted-tx
+                               :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"})]])]
+                       tx-log))
+              (t/is (realized? tx-log)))
 
             (t/is (thrown? IllegalArgumentException (api/open-tx-log *ingest-client* nil true)))))))))
 

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -477,17 +477,16 @@
         (fapi/submit+await-tx [[:crux.tx/put tx2-ivan tx2-valid-time]
                                [:crux.tx/put tx2-petr tx2-valid-time]])]
 
-    (with-open [log-iterator (db/open-tx-log (:tx-log *api*) nil)]
-      (let [log (iterator-seq log-iterator)]
-        (t/is (not (realized? log)))
-        (t/is (= [{:crux.tx/tx-id tx1-id
-                   :crux.tx/tx-time tx1-tx-time
-                   :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
-                  {:crux.tx/tx-id tx2-id
-                   :crux.tx/tx-time tx2-tx-time
-                   :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
-                                             [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
-                 log))))))
+    (with-open [log (cio/<-stream (db/open-tx-log (:tx-log *api*) nil))]
+      (t/is (not (realized? log)))
+      (t/is (= [{:crux.tx/tx-id tx1-id
+                 :crux.tx/tx-time tx1-tx-time
+                 :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
+                {:crux.tx/tx-id tx2-id
+                 :crux.tx/tx-time tx2-tx-time
+                 :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
+                                           [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
+               log)))))
 
 (t/deftest test-can-apply-transaction-fn
   (let [exception (atom nil)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -18,8 +18,7 @@
             [crux.io :as cio]
             [taoensso.nippy :as nippy])
   (:import [java.util Date]
-           [java.time Duration]
-           [crux.api ITxLog]))
+           [java.time Duration]))
 
 ;; FIXME using Rocks because the default memdb fails, see note in the tx-fn defmethod of `tx/index-tx-event`
 (t/use-fixtures :each fs/with-standalone-node fkv/with-rocksdb fkv/with-kv-dir fapi/with-node f/with-silent-test-check)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -613,9 +613,8 @@
   (fapi/submit+await-tx [[:crux.tx/cas {:crux.db/id :to-evict} {:crux.db/id :to-evict :test "test"}]])
   (fapi/submit+await-tx [[:crux.tx/evict :to-evict]])
 
-  (with-open [log-iterator (api/open-tx-log *api* nil true)]
-    (t/is (= (->> (iterator-seq log-iterator)
-                  (map :crux.api/tx-ops))
+  (with-open [tx-log (api/open-tx-log *api* nil true)]
+    (t/is (= (->> tx-log (map :crux.api/tx-ops))
              [[[:crux.tx/put
                 #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
                           :evicted? true}]]

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -142,7 +142,7 @@ toc::[]
 
 [source,clj]
 ----
-(open-tx-log ^ICursor [this after-tx-id with-ops?]
+(open-tx-log ^AutoCloseable [this after-tx-id with-ops?]
   "Reads the transaction log. Optionally includes
   operations, which allow the contents under the :crux.api/tx-ops
   key to be piped into (submit-tx tx-ops) of another

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -192,11 +192,9 @@ Represents the database as of a specific valid and transaction time.
 [source,clj]
 ----
   (new-snapshot ^java.io.Closeable [db]
-     "Returns a new implementation specific snapshot allowing for lazy query
-     results in a try-with-resources block using (q db  snapshot  query)}.
-     Can also be used for
-     (history-ascending db snapshot  eid) and
-     (history-descending db snapshot  eid)
+     "Returns a new implementation-specific snapshot allowing for lazy history
+     results in a try-with-resources block. Can be passed to history-ascending
+     and history-descending.
      returns an implementation specific snapshot")
 ----
 
@@ -206,13 +204,31 @@ Represents the database as of a specific valid and transaction time.
 ----
   (q
     [db query]
-    [db snapshot query]
     "q[uery] a Crux db.
     query param is a datalog query in map, vector or string form.
-    First signature will evaluate eagerly and will return a set or vector
-    of result tuples.
-    Second signature accepts a db snapshot, see `new-snapshot`.
-    Evaluates *lazily* consequently returns lazy sequence of result tuples.")
+    Returns a vector of result tuples.")
+----
+
+=== open-q
+
+[source,clj]
+----
+  (open-q
+    [db query]
+    "lazily q[uery] a Crux db.
+      query param is a datalog query in map, vector or string form.
+
+     This function returns a Closeable sequence of result tuples - once you've consumed
+     as much of the sequence as you need to, you'll need to `.close` the sequence.
+     A common way to do this is using `with-open`:
+
+     (with-open [res (crux/open-q db '{:find [...]
+                                       :where [...]})]
+       (doseq [row res]
+         ...))
+
+     Once the sequence is closed, attempting to iterate it is undefined.
+     ")
 ----
 
 === history-ascending

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -142,14 +142,14 @@ toc::[]
 
 [source,clj]
 ----
-(open-tx-log ^ITxLog [this after-tx-id with-ops?]
+(open-tx-log ^ICursor [this after-tx-id with-ops?]
   "Reads the transaction log. Optionally includes
   operations, which allow the contents under the :crux.api/tx-ops
   key to be piped into (submit-tx tx-ops) of another
   Crux instance.
   after-tx-id      optional transaction id to start after.
-  with-ops?       should the operations with documents be included?
-  Returns an iterator of the TxLog.")
+  with-ops?        should the operations with documents be included?
+  Returns a cursor over the TxLog.")
   (attribute-stats [node]
     "Returns frequencies of indexed attributes")
 ----

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -38,9 +38,9 @@ section are not aware of valid times or transaction times.
 == Basic Query
 
 A Datalog query consists of a set of variables and a set of clauses. The result
-of running a query is a result set (or lazy sequence) of the possible
-combinations of values that satisfy all of the clauses at the same time. These
-combinations of values are referred to as "tuples".
+of running a query is a result set of the possible combinations of values that
+satisfy all of the clauses at the same time. These combinations of values are
+referred to as "tuples".
 
 The possible values within the result tuples are derived from your database of
 documents. The documents themselves are represented in the database indexes as
@@ -314,7 +314,7 @@ Note that because Crux is schemaless there is no need to have elsewhere declared
 == Ordering and Pagination
 
 A Datalog query naturally returns a result set of tuples, however, the tuples
-can also be consumed as a lazy sequence and therefore you will always have an
+can also be consumed as a sequence and therefore you will always have an
 implicit order available. Ordinarily this implicit order is not meaningful
 because the join order and result order are unlikely to correlate.
 
@@ -394,19 +394,22 @@ connected to a given entity via the `:follow` attribute.
            (follow ?t ?e2)]]})
 ----
 
-[#queries_lazy_queries]
-== Lazy Queries
+[#queries_streaming_queries]
+== Streaming Queries
 
-The function `crux.api/q` also has a 3-argument arity (`db`, `snapshot` and `q`)
-that can return results lazily. A snapshot can be retrieved from a `node` via
-`crux.api/new-snapshot` - the snapshot must be closed when no longer used, and
-the query results must be processed while the snapshot is open. For example, a
-lazy version of a basic query from the top of this section (using `with-open` to
-ensure that the snapshot is closed):
+Query results can also be streamed, particularly for queries whose results may
+not fit into memory. For these, we use `crux.api/open-q`, which returns a
+`Closeable` sequence.
 
-[source,clj]
+We'd recommend using `with-open` to ensure that the sequence is closed properly.
+Additionally, ensure that the sequence (as much of it as you need) is eagerly
+consumed within the `with-open` block - attempting to use it outside (either
+explicitly, or by accidentally returning a lazy sequence from the `with-open`
+block) will result in undefined behaviour.
+
+[source,clj,indent=0]
 ----
-include::./src/docs/examples.clj[tags=lazy-query]
+include::./src/docs/examples.clj[tags=streaming-query]
 ----
 
 [#queries_history_api]

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -267,17 +267,16 @@
 ;; end::query-with-pred-1-r[]
 )
 
-(defn query-example-lazy [node prn]
-  ;; tag::lazy-query[]
-(with-open [snapshot (crux.api/new-snapshot (crux/db node))]
-  (doseq [tuple (crux/q (crux/db node)
-                        snapshot
-                        '{:find [p1]
-                          :where [[p1 :name n]
-                                  [p1 :last-name n]
-                                  [p1 :name "Smith"]]})]
-    (prn tuple)))
-  ;; end::lazy-query[]
+(defn query-example-streaming [node prn]
+  ;; tag::streaming-query[]
+  (with-open [res (crux/open-q (crux/db node)
+                               '{:find [p1]
+                                 :where [[p1 :name n]
+                                         [p1 :last-name n]
+                                         [p1 :name "Smith"]]})]
+    (doseq [tuple res]
+      (prn tuple)))
+  ;; end::streaming-query[]
   )
 
 (defn query-example-at-time-setup [node]


### PR DESCRIPTION
Trying to cut down the API changes into small manageable chunks :) 

Adding `api/open-q` which returns a closeable seq, doesn't need a snapshot.

RFC:
* Calling it `openQuery` in Java - `openQ` didn't seem idiomatic.
* Clojure users see a Closeable seq, to be used within a `with-open` block; Java users see a Stream, to be used within a try-with-resources.
* I deliberately haven't tackled the 're-using snapshots between queries' in this PR
* Have also updated the new `open-tx-log` API to use the same pattern - it was using closeable iterators previously