### PR TITLE
Replace spec/assert in places where it is necessary for data integrity to check the data.

### DIFF
--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -23,10 +23,6 @@
            [java.util.concurrent Executors]
            java.util.concurrent.locks.StampedLock))
 
-(s/check-asserts (if-let [check-asserts (System/getProperty "clojure.spec.compile-asserts")]
-                   (Boolean/parseBoolean check-asserts)
-                   true))
-
 (def crux-version
   (when-let [pom-file (io/resource "META-INF/maven/juxt/crux-core/pom.properties")]
     (with-open [in (io/reader pom-file)]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1087,13 +1087,17 @@
                            q)
                          identity
                          (fn [q]
-                           (let [q (normalize-query (s/assert ::query q))]
-                             (->ConformedQuery q (s/conform ::query q)))))]
+                           (if-let [s-error (s/explain-data ::query q)]
+                             (throw (ex-info "Spec assertion failed:" s-error))
+                             (let [q (normalize-query q)]
+                               (->ConformedQuery q (s/conform ::query q))))))]
     (if args
-      (do (s/assert ::args args)
+      (if-let [s-error (s/explain-data  ::args args)]
+        (throw (ex-info "Spec assertion failed:" s-error))
+        (do
           (-> conformed-query
               (assoc-in [:q-normalized :args] args)
-              (assoc-in [:q-conformed :args] args)))
+              (assoc-in [:q-conformed :args] args))))
       conformed-query)))
 
 ;; TODO: Move future here to a bounded thread pool.

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1087,17 +1087,17 @@
                            q)
                          identity
                          (fn [q]
-                           (if-let [s-error (s/explain-data ::query q)]
-                             (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
-                             (let [q (normalize-query q)]
-                               (->ConformedQuery q (s/conform ::query q))))))]
+                           (when-not (s/valid? ::query q)
+                             (throw (ex-info (str "Spec assertion failed\n" (s/explain-str ::query q)) (s/explain-data ::query q))))
+                           (let [q (normalize-query q)]
+                             (->ConformedQuery q (s/conform ::query q)))))]
     (if args
-      (if-let [s-error (s/explain-data  ::args args)]
-        (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
-        (do
-          (-> conformed-query
-              (assoc-in [:q-normalized :args] args)
-              (assoc-in [:q-conformed :args] args))))
+      (do
+        (when-not (s/valid? ::args args)
+          (throw (ex-info (str "Spec assertion failed\n" (s/explain-str ::args args)) (s/explain-data ::args args))))
+        (-> conformed-query
+            (assoc-in [:q-normalized :args] args)
+            (assoc-in [:q-conformed :args] args)))
       conformed-query)))
 
 ;; TODO: Move future here to a bounded thread pool.

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1088,12 +1088,12 @@
                          identity
                          (fn [q]
                            (if-let [s-error (s/explain-data ::query q)]
-                             (throw (ex-info "Spec assertion failed:" s-error))
+                             (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
                              (let [q (normalize-query q)]
                                (->ConformedQuery q (s/conform ::query q))))))]
     (if args
       (if-let [s-error (s/explain-data  ::args args)]
-        (throw (ex-info "Spec assertion failed:" s-error))
+        (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
         (do
           (-> conformed-query
               (assoc-in [:q-normalized :args] args)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -295,7 +295,11 @@
         args-id (:crux.db/id args-doc)
         fn-result (try
                     (let [tx-ops (apply (tx-fn-eval-cache body) db args)
-                          _ (when tx-ops (s/assert :crux.api/tx-ops tx-ops))
+                          _ (when tx-ops
+                              (when-not (s/valid? :crux.api/tx-ops tx-ops)
+                                (throw (ex-info
+                                        (str "Spec assertion failed\n" (s/explain-str :crux.api/tx-ops tx-ops))
+                                        (s/explain-data :crux.api/tx-ops tx-ops)))))
                           docs (mapcat tx-op->docs tx-ops)
                           {arg-docs true docs false} (group-by (comp boolean :crux.db.fn/args) docs)]
                       ;; TODO: might lead to orphaned and unevictable

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -59,7 +59,7 @@
 
 (defn tx-ops->id-and-docs [tx-ops]
   (if-let [s-error (s/explain-data :crux.api/tx-ops tx-ops)]
-    (throw (ex-info "Spec assertion failed:" s-error))
+    (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
     (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops))))
 
 (defn tx-op->tx-event [tx-op]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -58,8 +58,9 @@
     (filter map? args)))
 
 (defn tx-ops->id-and-docs [tx-ops]
-  (s/assert :crux.api/tx-ops tx-ops)
-  (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops)))
+  (if-let [s-error (s/explain-data :crux.api/tx-ops tx-ops)]
+    (throw (ex-info "Spec assertion failed:" s-error))
+    (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops))))
 
 (defn tx-op->tx-event [tx-op]
   (let [[op id & args] (conform-tx-op tx-op)]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -58,9 +58,9 @@
     (filter map? args)))
 
 (defn tx-ops->id-and-docs [tx-ops]
-  (if-let [s-error (s/explain-data :crux.api/tx-ops tx-ops)]
-    (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
-    (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops))))
+  (when-not (s/valid? :crux.api/tx-ops tx-ops)
+    (throw (ex-info (str "Spec assertion failed\n" (s/explain-str :crux.api/tx-ops tx-ops)) (s/explain-data :crux.api/tx-ops tx-ops))))
+  (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops)))
 
 (defn tx-op->tx-event [tx-op]
   (let [[op id & args] (conform-tx-op tx-op)]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -164,22 +164,21 @@
                                   :opt-un [::valid-time
                                            ::transact-time])))
 
-(defn- check-and-return-body [spec body-edn]
-  (if-let [s-error (s/explain-data spec body-edn)]
-    (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
-    body-edn))
+(defn- validate-or-throw [body-edn spec]
+  (when-not (s/valid? spec body-edn)
+    (throw (ex-info (str "Spec assertion failed\n" (s/explain-str spec body-edn)) (s/explain-data spec body-edn)))))
 
 ;; TODO: Potentially require both valid and transaction time sent by
 ;; the client?
 (defn- query [^ICruxAPI crux-node request]
-  (let [query-map (check-and-return-body ::query-map (body->edn request))
+  (let [query-map (doto (body->edn request) (validate-or-throw ::query-map))
         db (db-for-request crux-node query-map)]
     (-> (success-response
          (.q db (:query query-map)))
         (add-last-modified (.transactionTime db)))))
 
 (defn- query-stream [^ICruxAPI crux-node request]
-  (let [query-map (check-and-return-body ::query-map (body->edn request))
+  (let [query-map (doto (body->edn request) (validate-or-throw ::query-map))
         db (db-for-request crux-node query-map)
         snapshot (.newSnapshot db)
         result (.q db snapshot (:query query-map))]
@@ -194,21 +193,21 @@
 
 ;; TODO: Could support as-of now via path and GET.
 (defn- entity [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         {:keys [crux.tx/tx-time] :as entity-tx} (.entityTx db eid)]
     (-> (success-response (.entity db eid))
         (add-last-modified tx-time))))
 
 (defn- entity-tx [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         {:keys [crux.tx/tx-time] :as entity-tx} (.entityTx db eid)]
     (-> (success-response entity-tx)
         (add-last-modified tx-time))))
 
 (defn- history-ascending [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         snapshot (.newSnapshot db)
         history (.historyAscending db snapshot (c/new-id eid))]
@@ -216,7 +215,7 @@
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- history-descending [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         snapshot (.newSnapshot db)
         history (.historyDescending db snapshot (c/new-id eid))]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -164,17 +164,22 @@
                                   :opt-un [::valid-time
                                            ::transact-time])))
 
+(defn- check-and-return-body [spec body-edn]
+  (if-let [s-error (s/explain-data spec body-edn)]
+    (throw (ex-info "Spec assertion failed:" s-error))
+    body-edn))
+
 ;; TODO: Potentially require both valid and transaction time sent by
 ;; the client?
 (defn- query [^ICruxAPI crux-node request]
-  (let [query-map (s/assert ::query-map (body->edn request))
+  (let [query-map (check-and-return-body ::query-map (body->edn request))
         db (db-for-request crux-node query-map)]
     (-> (success-response
          (.q db (:query query-map)))
         (add-last-modified (.transactionTime db)))))
 
 (defn- query-stream [^ICruxAPI crux-node request]
-  (let [query-map (s/assert ::query-map (body->edn request))
+  (let [query-map (check-and-return-body ::query-map (body->edn request))
         db (db-for-request crux-node query-map)
         snapshot (.newSnapshot db)
         result (.q db snapshot (:query query-map))]
@@ -189,21 +194,21 @@
 
 ;; TODO: Could support as-of now via path and GET.
 (defn- entity [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (s/assert ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
         db (db-for-request crux-node body)
         {:keys [crux.tx/tx-time] :as entity-tx} (.entityTx db eid)]
     (-> (success-response (.entity db eid))
         (add-last-modified tx-time))))
 
 (defn- entity-tx [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (s/assert ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
         db (db-for-request crux-node body)
         {:keys [crux.tx/tx-time] :as entity-tx} (.entityTx db eid)]
     (-> (success-response entity-tx)
         (add-last-modified tx-time))))
 
 (defn- history-ascending [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (s/assert ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
         db (db-for-request crux-node body)
         snapshot (.newSnapshot db)
         history (.historyAscending db snapshot (c/new-id eid))]
@@ -211,7 +216,7 @@
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- history-descending [^ICruxAPI crux-node request]
-  (let [{:keys [eid] :as body} (s/assert ::entity-map (body->edn request))
+  (let [{:keys [eid] :as body} (check-and-return-body ::entity-map (body->edn request))
         db (db-for-request crux-node body)
         snapshot (.newSnapshot db)
         history (.historyDescending db snapshot (c/new-id eid))]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -166,7 +166,7 @@
 
 (defn- check-and-return-body [spec body-edn]
   (if-let [s-error (s/explain-data spec body-edn)]
-    (throw (ex-info "Spec assertion failed:" s-error))
+    (throw (ex-info (str "Spec assertion failed\n" (with-out-str (s/explain-out s-error))) s-error))
     body-edn))
 
 ;; TODO: Potentially require both valid and transaction time sent by

--- a/project.clj
+++ b/project.clj
@@ -85,8 +85,8 @@
                "crux-test/test"]
 
   :jvm-opts ["-Dlogback.configurationFile=resources/logback-test.xml"
-             "-Dclojure.spec.compile-asserts=false"
-             "-Dclojure.spec.check-asserts=false"]
+             "-Dclojure.spec.compile-asserts=true"
+             "-Dclojure.spec.check-asserts=true"]
   :global-vars {*warn-on-reflection* true}
 
   :aliases {"check" ["sub" "-s" ~(->> modules (remove #{"crux-jdbc"}) (clojure.string/join ":")) "check"]

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,9 @@
                "crux-metrics/test"
                "crux-test/test"]
 
-  :jvm-opts ["-Dlogback.configurationFile=resources/logback-test.xml"]
+  :jvm-opts ["-Dlogback.configurationFile=resources/logback-test.xml"
+             "-Dclojure.spec.compile-asserts=false"
+             "-Dclojure.spec.check-asserts=false"]
   :global-vars {*warn-on-reflection* true}
 
   :aliases {"check" ["sub" "-s" ~(->> modules (remove #{"crux-jdbc"}) (clojure.string/join ":")) "check"]


### PR DESCRIPTION
Resolves #686 

Notes from the commit messages:
- I have replaced calls to (s/assert) in functions which are triggered by data entered by a user (submitted transactions, submitted queries and data submitted in calls to the REST API). I make use of `s/explain-data`, as spec's assert does the same, and throw an **ex-info** of the same format as that thrown by (s/assert).