### PR TITLE
Adding manual KV compaction for Rocks

### DIFF
--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -32,9 +32,10 @@
                         (doto post-to-slack)))
 
                   (bench/with-nodes [node bench/nodes]
-                    (let [raw-watdiv-results (watdiv-crux/run-watdiv-bench node {:test-count 100})]
-                      (-> (concat [(watdiv-crux/render-comparison-durations (first raw-watdiv-results))]
-                                  (watdiv-crux/summarise-query-results (rest raw-watdiv-results)))
+                    (let [[ingest-results query-results] (->> (watdiv-crux/run-watdiv-bench node {:test-count 100})
+                                                              (split-at 2))]
+                      (-> (concat (->> ingest-results (map watdiv-crux/render-comparison-durations))
+                                  (watdiv-crux/summarise-query-results query-results))
                           (bench/with-comparison-times)
                           (doto post-to-slack)))))]
       (bench/send-email-via-ses

--- a/crux-bench/src/crux/bench/ts_devices.clj
+++ b/crux-bench/src/crux/bench/ts_devices.clj
@@ -71,7 +71,7 @@
                                                                    [:crux.tx/put reading-doc time]))))
                                      nil))))]
         (crux/await-tx node last-tx (Duration/ofMinutes 20))
-        {:node-size-bytes (bench/node-size-in-bytes node)}))))
+        {}))))
 
 (defn test-battery-readings [node]
   ;; 10 most recent battery temperature readings for charging devices
@@ -254,6 +254,14 @@
   (bench/with-bench-ns :ts-devices
     (bench/with-crux-dimensions
       (submit-ts-devices-data node)
+      (bench/compact-node node)
       (test-battery-readings node)
       (test-busiest-devices node)
       (test-min-max-battery-level-per-hour node))))
+
+(comment
+  (bench/with-nodes [node (select-keys bench/nodes ["standalone-rocksdb"])]
+    (bench/with-bench-ns :ts-devices
+      (bench/with-crux-dimensions
+        (submit-ts-devices-data node)
+        (bench/compact-node node)))))

--- a/crux-bench/src/crux/bench/ts_weather.clj
+++ b/crux-bench/src/crux/bench/ts_weather.clj
@@ -61,7 +61,7 @@
                                                              [:crux.tx/put condition-doc time]))))
                                      nil))))]
         (api/await-tx node last-tx (Duration/ofMinutes 20))
-        {:node-size-bytes (bench/node-size-in-bytes node)}))))
+        {}))))
 
 (defn test-last-10-readings [node]
   ;; NOTE: Does not work with range, takes latest values.
@@ -348,6 +348,7 @@
   (bench/with-bench-ns :ts-weather
     (bench/with-crux-dimensions
       (submit-ts-weather-data node)
+      (bench/compact-node node)
       (test-last-10-readings node)
       (test-last-10-readings-from-outside-locations node)
       (test-hourly-average-min-max-temperatures-for-field-locations node))))

--- a/crux-bench/src/crux/bench/watdiv_crux.clj
+++ b/crux-bench/src/crux/bench/watdiv_crux.clj
@@ -33,7 +33,6 @@
                                              (rdf/submit-ntriples node in 1000))]
         (crux/await-tx node last-tx)
         {:entity-count entity-count
-         :node-size-bytes (bench/node-size-in-bytes node)
          :neo4j-time-taken-ms (get-in parsed-db-results [:neo4j :ingest])
          :rdf4j-time-taken-ms (get-in parsed-db-results [:rdf4j :ingest])
          :datomic-time-taken-ms (get-in parsed-db-results [:datomic :ingest])}))))
@@ -92,6 +91,7 @@
   (bench/with-bench-ns :watdiv-crux
     (bench/with-crux-dimensions
       (ingest-crux node)
+      (bench/compact-node node)
 
       (watdiv/with-watdiv-queries watdiv/watdiv-stress-100-1-sparql
         (fn [queries]

--- a/crux-core/src/crux/kv.clj
+++ b/crux-core/src/crux/kv.clj
@@ -23,6 +23,7 @@
   (store [this kvs])
   (delete [this ks])
   (fsync [this])
+  (compact [this])
   (backup [this dir])
   (count-keys [this])
   (db-dir [this])

--- a/crux-core/src/crux/kv/memdb.clj
+++ b/crux-core/src/crux/kv/memdb.clj
@@ -89,8 +89,10 @@
     (swap! db #(apply dissoc % (map mem/->off-heap ks)))
     nil)
 
+  (compact [_])
+
   (fsync [_]
-    (log/warn "Using fsync on MemKv has no effect."))
+    (log/debug "Using fsync on MemKv has no effect."))
 
   (backup [_ dir]
     (let [file (io/file dir)]

--- a/crux-core/src/crux/lru.clj
+++ b/crux-core/src/crux/lru.clj
@@ -129,36 +129,19 @@
 ;; to the lower levels.
 (defrecord CacheProvidingKvStore [kv cache-state cache-size]
   kv/KvStore
-  (open [this options]
-    (assoc this :kv (kv/open kv options)))
-
-  (new-snapshot [_]
-    (new-cached-snapshot (kv/new-snapshot kv) true))
-
-  (store [_ kvs]
-    (kv/store kv kvs))
-
-  (delete [_ ks]
-    (kv/delete kv ks))
-
-  (fsync [_]
-    (kv/fsync kv))
-
-  (backup [_ dir]
-    (kv/backup kv dir))
-
-  (count-keys [_]
-    (kv/count-keys kv))
-
-  (db-dir [_]
-    (kv/db-dir kv))
-
-  (kv-name [_]
-    (kv/kv-name kv))
+  (open [this options] (assoc this :kv (kv/open kv options)))
+  (new-snapshot [_] (new-cached-snapshot (kv/new-snapshot kv) true))
+  (store [_ kvs] (kv/store kv kvs))
+  (delete [_ ks] (kv/delete kv ks))
+  (fsync [_] (kv/fsync kv))
+  (compact [_] (kv/compact kv))
+  (backup [_ dir] (kv/backup kv dir))
+  (count-keys [_] (kv/count-keys kv))
+  (db-dir [_] (kv/db-dir kv))
+  (kv-name [_] (kv/kv-name kv))
 
   Closeable
-  (close [_]
-    (.close ^Closeable kv))
+  (close [_] (.close ^Closeable kv))
 
   CacheProvider
   (get-named-cache [this cache-name]

--- a/crux-lmdb/src/crux/kv/lmdb.clj
+++ b/crux-lmdb/src/crux/kv/lmdb.clj
@@ -247,6 +247,8 @@
             (kv/delete this ks))
           (throw e)))))
 
+  (compact [_])
+
   (fsync [this]
     (success? (LMDB/mdb_env_sync env true)))
 

--- a/crux-lmdb/src/crux/kv/lmdb/jnr.clj
+++ b/crux-lmdb/src/crux/kv/lmdb/jnr.clj
@@ -107,6 +107,8 @@
   (fsync [this]
     (.sync env true))
 
+  (compact [_])
+
   (backup [_ dir]
     (let [file (io/file dir)]
       (when (.exists file)

--- a/crux-rocksdb/src/crux/kv/rocksdb.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb.clj
@@ -118,6 +118,9 @@
         (.delete wb (mem/->on-heap k)))
       (.write db write-options wb)))
 
+  (compact [{:keys [^RocksDB db]}]
+    (.compactRange db))
+
   (fsync [{:keys [^RocksDB db]}]
     (with-open [flush-options (doto (FlushOptions.)
                                 (.setWaitForFlush true))]

--- a/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
@@ -282,6 +282,8 @@
           (.rocksdb_flushoptions_destroy rocksdb flush-options)
           (check-error errptr-out)))))
 
+  (compact [_])
+
   (backup [{:keys [^Pointer db]} dir]
     (let [dir (io/file dir)]
       (when (.exists dir)

--- a/crux-test/test/crux/kv_test.clj
+++ b/crux-test/test/crux/kv_test.clj
@@ -111,6 +111,17 @@
       (finally
         (cio/delete-dir backup-dir)))))
 
+(t/deftest test-compact []
+  (t/testing "store, retrieve and delete value"
+    (kv/store *kv* [[(.getBytes "key-with-a-long-prefix-1") (.getBytes "Crux")]])
+    (kv/store *kv* [[(.getBytes "key-with-a-long-prefix-2") (.getBytes "is")]])
+    (kv/store *kv* [[(.getBytes "key-with-a-long-prefix-3") (.getBytes "awesome")]])
+    (t/testing "compacting"
+      (kv/compact *kv*))
+    (t/is (= "Crux" (String. ^bytes (value *kv* (.getBytes "key-with-a-long-prefix-1")))))
+    (t/is (= "is" (String. ^bytes (value *kv* (.getBytes "key-with-a-long-prefix-2")))))
+    (t/is (= "awesome" (String. ^bytes (value *kv* (.getBytes "key-with-a-long-prefix-3")))))))
+
 (t/deftest test-sanity-check-can-start-with-sync-enabled
   (binding [fkv/*sync* true]
     (fkv/with-kv-store


### PR DESCRIPTION
Compacting the KV store after we ingest so that we get more reliable disk space usage stats in bench.

Bench shows pre/post compaction disk usage stats, as well as how many raw bytes we've thrown at it.

Have added support for compaction to Rocks but have left the others as no-ops for now, can't find an equivalent in LMDB?