### PR TITLE
fix tx-test running under memdb, #673

### DIFF
--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -20,8 +20,7 @@
   (:import [java.util Date]
            [java.time Duration]))
 
-;; FIXME using Rocks because the default memdb fails, see note in the tx-fn defmethod of `tx/index-tx-event`
-(t/use-fixtures :each fs/with-standalone-node fkv/with-rocksdb fkv/with-kv-dir fapi/with-node f/with-silent-test-check)
+(t/use-fixtures :each fs/with-standalone-node fkv/with-kv-dir fapi/with-node f/with-silent-test-check)
 
 (def picasso-id :http://dbpedia.org/resource/Pablo_Picasso)
 (def picasso-eid (c/new-id picasso-id))


### PR DESCRIPTION
we don't need to re-index nested tx-fn arg docs if we pass them into the recursive call, additionally saves us the eviction and the snapshot headaches outlined in the comment

resolves #673 