### PR TITLE
Eager history API

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -285,10 +285,11 @@
   ")
 
   (history-ascending
+    [db eid]
     ^:deprecated [db snapshot eid]
-    "Retrieves entity history lazily in chronological order
-  from and including the valid time of the db while respecting
-  transaction time. Includes the documents.")
+    "Retrieves entity history (lazily, in the deprecated 3-arg arity - see
+  `open-history-ascending`) in chronological order from and including the valid
+  time of the db while respecting transaction time. Includes the documents.")
 
   (open-history-ascending ^java.io.Closeable [db eid]
     "Retrieves entity history lazily in chronological order
@@ -296,10 +297,12 @@
   transaction time. Includes the documents.")
 
   (history-descending
+    [db eid]
     ^:deprecated [db snapshot eid]
-    "Retrieves entity history lazily in reverse chronological order
-  from and including the valid time of the db while respecting
-  transaction time. Includes the documents.")
+    "Retrieves entity history (lazily, in the deprecated 3-arg arity - see
+  `open-history-descending`) in reverse chronological order from and including
+  the valid time of the db while respecting transaction time. Includes the
+  documents.")
 
   (open-history-descending ^java.io.Closeable [db eid]
     "Retrieves entity history lazily in reverse chronological order
@@ -338,9 +341,16 @@
 
   (open-q [this query] (cio/<-stream (.openQuery this query)))
 
-  (history-ascending [this snapshot eid] (.historyAscending this snapshot eid))
+  (history-ascending
+    ([this eid] (.historyAscending this eid))
+    ([this snapshot eid] (.historyAscending this snapshot eid)))
+
   (open-history-ascending [this eid] (cio/<-stream (.openHistoryAscending this eid)))
-  (history-descending [this snapshot eid] (.historyDescending this snapshot eid))
+
+  (history-descending
+    ([this eid] (.historyDescending this eid))
+    ([this snapshot eid] (.historyDescending this snapshot eid)))
+
   (open-history-descending [this eid] (cio/<-stream (.openHistoryDescending this eid)))
 
   (valid-time [this] (.validTime this))

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -78,6 +78,16 @@ public interface ICruxDatasource {
     public Stream<List<?>> openQuery(Object query);
 
     /**
+     * Retrieves entity history in chronological order from and
+     * including the valid time of the db while respecting
+     * transaction time. Includes the documents.
+     *
+     * @param eid      an object that can be coerced into an entity id.
+     * @return         the history of the given entity.
+     */
+    public List<Map<Keyword,?>> historyAscending(Object eid);
+
+    /**
      * Retrieves entity history lazily in chronological order from and
      * including the valid time of the db while respecting
      * transaction time. Includes the documents.
@@ -98,6 +108,16 @@ public interface ICruxDatasource {
      * @return         a stream of history.
      */
     public Stream<Map<Keyword,?>> openHistoryAscending(Object eid);
+
+    /**
+     * Retrieves entity history in reverse chronological order
+     * from and including the valid time of the db while respecting
+     * transaction time. Includes the documents.
+     *
+     * @param eid      an object that can be coerced into an entity id.
+     * @return         the history of the given entity.
+     */
+    public List<Map<Keyword,?>> historyDescending(Object eid);
 
     /**
      * Retrieves entity history lazily in reverse chronological order

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1246,6 +1246,10 @@
                                        ::query safe-query
                                        ::query-id query-id}))))))))
 
+  (historyAscending [this eid]
+    (with-open [history (cio/<-stream (.openHistoryAscending this eid))]
+      (vec history)))
+
   (historyAscending [this snapshot eid]
     (for [^EntityTx entity-tx (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid valid-time transact-time)]
       (assoc (c/entity-tx->edn entity-tx) :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
@@ -1257,6 +1261,10 @@
                             (assoc (c/entity-tx->edn entity-tx)
                                    :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))
         (.onClose #(run! cio/try-close [i snapshot])))))
+
+  (historyDescending [this eid]
+    (with-open [history (cio/<-stream (.openHistoryDescending this eid))]
+      (vec history)))
 
   (historyDescending [this snapshot eid]
     (for [^EntityTx entity-tx (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid valid-time transact-time)]

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -135,6 +135,10 @@
       (doto (cio/->stream (edn-list->lazy-seq in))
         (.onClose #(.close ^Closeable in)))))
 
+  (historyAscending [this eid]
+    (with-open [history (cio/<-stream (.openHistoryAscending this eid))]
+      (vec history)))
+
   (historyAscending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-ascending")
                                (assoc (as-of-map this) :eid eid)
@@ -148,6 +152,10 @@
                                {:as :stream})]
       (doto (cio/->stream (edn-list->lazy-seq in))
         (.onClose #(.close ^java.io.Closeable in)))))
+
+  (historyDescending [this eid]
+    (with-open [history (cio/<-stream (.openHistoryDescending this eid))]
+      (vec history)))
 
   (historyDescending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-descending")

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -278,6 +278,14 @@
       (t/is (= 4 (count history))))
 
     (let [db (.db *api* #inst "2019-02-03")]
+      (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 3}]
+               (map :crux.db/doc (api/history-ascending db :ivan))))
+
+      (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 3}
+                {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
+                {:crux.db/id :ivan :name "Ivan" :version 1}]
+               (map :crux.db/doc (api/history-descending db :ivan))))
+
       (with-open [history-asc (api/open-history-ascending db :ivan)
                   history-desc (api/open-history-descending db :ivan)]
         (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 3}]
@@ -297,6 +305,12 @@
                  (map :crux.db/doc (.historyDescending db snapshot :ivan))))))
 
     (let [db (.db *api* #inst "2019-01-31")]
+      (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 1}
+                {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
+                {:crux.db/id :ivan :name "Ivan" :version 3}]
+               (map :crux.db/doc (api/history-ascending db :ivan))))
+      (t/is (empty? (map :crux.db/doc (api/history-descending db :ivan))))
+
       (with-open [history-asc (api/open-history-ascending db :ivan)
                   history-desc (api/open-history-descending db :ivan)]
         (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 1}

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -230,15 +230,37 @@ Represents the database as of a specific valid and transaction time.
      ")
 ----
 
+=== history-ascending
+
+[source,clj]
+----
+  (history-ascending
+    [db eid]
+    "Retrieves entity history in chronological order from and including the
+    valid time of the db while respecting transaction time. Includes the
+    documents.")
+----
+
 === open-history-ascending
 
 [source,clj]
 ----
   (open-history-ascending
     [db eid]
-    "Retrieves entity history lazily in chronological order
-    from and including the valid time of the db while respecting
-    transaction time. Includes the documents.")
+    "Retrieves entity history lazily in chronological order from and including
+    the valid time of the db while respecting transaction time. Includes the
+    documents.")
+----
+
+=== history-descending
+
+[source,clj]
+----
+  (history-descending
+    [db eid]
+    "Retrieves entity history in reverse chronological order from and including
+    the valid time of the db while respecting transaction time. Includes the
+    documents.")
 ----
 
 === open-history-descending
@@ -247,9 +269,9 @@ Represents the database as of a specific valid and transaction time.
 ----
   (open-history-descending
     [db eid]
-    "Retrieves entity history lazily in reverse chronological order
-    from and including the valid time of the db while respecting
-    transaction time. Includes the documents.")
+    "Retrieves entity history lazily in reverse chronological order from and
+    including the valid time of the db while respecting transaction time.
+    Includes the documents.")
 ----
 
 === valid-time


### PR DESCRIPTION
add eager equivalents of `open-history-*` to match up with `q` and `open-q`

`(history-* db eid)` returns a vector of history entries.

Will remove the three-arg `(history-* db snapshot eid)` with the rest of the deprecation removals