### PR TITLE
Add `open-db` to share a snapshot between DB queries/history reqs/etc

### DIFF
--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -12,33 +12,55 @@ import clojure.lang.Keyword;
  *  Provides API access to Crux.
  */
 public interface ICruxAPI extends ICruxIngestAPI, Closeable {
+
     /**
-     * Returns a db as of now. Will return the latest consistent
-     * snapshot of the db currently known. Does not block.
-     *
-     * @return the database.
+     * Returns a db as of now. Will return the latest consistent snapshot of the
+     * db currently known. Does not block.
      */
     public ICruxDatasource db();
 
     /**
-     * Returns a db as of valid time. Will return the latest
-     * consistent snapshot of the db currently known, but does not
-     * wait for valid time to be current. Does not block.
+     * Returns a db as of now. Will return the latest consistent snapshot of the
+     * db currently known. Does not block.
      *
-     * @param validTime    the valid time.
-     * @return             the database.
+     * This method returns a DB that opens resources shared between method calls
+     * - it must be `.close`d when you've finished using it.
+     */
+    public ICruxDatasource openDB();
+
+    /**
+     * Returns a db as of the provided valid time. Will return the latest
+     * consistent snapshot of the db currently known, but does not wait for
+     * valid time to be current. Does not block.
      */
     public ICruxDatasource db(Date validTime);
 
     /**
-     * Returns a db as of valid time and transaction time. Will
-     * block until the transaction time is present in the index.
+     * Returns a db as of the provided valid time. Will return the latest
+     * consistent snapshot of the db currently known, but does not wait for
+     * valid time to be current. Does not block.
      *
-     * @param validTime       the valid time.
-     * @param transactionTime the transaction time.
-     * @return                the database.
+     * This method returns a DB that opens resources shared between method calls
+     * - it must be `.close`d when you've finished using it.
+     */
+    public ICruxDatasource openDB(Date validTime);
+
+    /**
+     * Returns a db as of valid time and transaction time.
+     *
+     * @throws NodeOutOfSyncException if the node hasn't indexed up to the given `transactionTime`
      */
     public ICruxDatasource db(Date validTime, Date transactionTime) throws NodeOutOfSyncException;
+
+    /**
+     * Returns a db as of valid time and transaction time.
+     *
+     * This method returns a DB that opens resources shared between method calls
+     * - it must be `.close`d when you've finished using it.
+     *
+     * @throws NodeOutOfSyncException if the node hasn't indexed up to the given `transactionTime`
+     */
+    public ICruxDatasource openDB(Date validTime, Date transactionTime) throws NodeOutOfSyncException;
 
     /**
      *  Reads a document from the document store based on its

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -13,7 +13,7 @@ import clojure.lang.Keyword;
  * Represents the database as of a specific valid and
  * transaction time.
  */
-public interface ICruxDatasource {
+public interface ICruxDatasource extends Closeable {
     /**
      * Returns the document map for an entity.
      *
@@ -29,6 +29,7 @@ public interface ICruxDatasource {
      * @param eid an object that can be coerced into an entity id.
      * @return    the entity document map.
      */
+    @Deprecated
     public Map<Keyword,Object> entity(Closeable snapshot, Object eid);
 
     /**
@@ -49,6 +50,7 @@ public interface ICruxDatasource {
      *
      * @return an implementation specific snapshot
      */
+    @Deprecated
     public Closeable newSnapshot();
 
     /**

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -37,11 +37,8 @@
 (defrecord CruxNode [kv-store tx-log document-store indexer tx-consumer object-store bus
                      options close-fn status-fn closed? ^StampedLock lock]
   ICruxAPI
-  (db [this]
-    (.db this nil nil))
-
-  (db [this valid-time]
-    (.db this valid-time nil))
+  (db [this] (.db this nil nil))
+  (db [this valid-time] (.db this valid-time nil))
 
   (db [this valid-time tx-time]
     (cio/with-read-lock lock
@@ -55,6 +52,12 @@
             valid-time (or valid-time (Date.))]
 
         (q/db kv-store object-store bus valid-time tx-time))))
+
+  (openDB [this] (.openDB this nil nil))
+  (openDB [this valid-time] (.openDB this valid-time nil))
+  (openDB [this valid-time tx-time]
+    (let [db (.db this valid-time tx-time)]
+      (assoc db :snapshot (q/open-snapshot db))))
 
   (document [this content-hash]
     (cio/with-read-lock lock

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -290,7 +290,7 @@
 
   (let [fn-id (c/new-id k)
         db (q/db kv-store object-store nil tx-time tx-time)
-        {:crux.db.fn/keys [body] :as fn-doc} (q/entity db fn-id)
+        {:crux.db.fn/keys [body] :as fn-doc} (q/entity db snapshot fn-id)
         {:crux.db.fn/keys [args] :as args-doc} (let [arg-id (c/new-id args-v)]
                                                  (or (get nested-fn-args arg-id)
                                                      (db/get-single-object object-store snapshot arg-id)))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -44,6 +44,16 @@
 (t/use-fixtures :once fk/with-embedded-kafka-cluster)
 (t/use-fixtures :each with-each-api-implementation)
 
+(defmacro with-both-dbs [[db db-args] & body]
+  `(do
+     (t/testing "with open-db"
+       (with-open [~db (api/open-db ~@db-args)]
+         ~@body))
+
+     (t/testing "with db"
+       (let [~db (api/db ~@db-args)]
+         ~@body))))
+
 (defn execute-sparql [^RepositoryConnection conn q]
   (with-open [tq (.evaluate (.prepareTupleQuery conn q))]
     (set ((fn step []
@@ -93,10 +103,10 @@
              (select-keys (.status *api*) [:crux.index/index-version :crux.zk/zk-active?]))))
 
   (t/testing "empty db"
-    (t/is (.db *api*)))
+    (t/is (api/db *api*)))
 
   (t/testing "syncing empty db"
-    (t/is (nil? (.sync *api* (Duration/ofSeconds 10)))))
+    (t/is (nil? (api/sync *api* (Duration/ofSeconds 10)))))
 
   (t/testing "transaction"
     (let [valid-time (Date.)
@@ -115,90 +125,95 @@
         (t/is (= #{} (.q (.db *api* #inst "1999") '{:find  [e]
                                                     :where [[e :name "Ivan"]]})))
 
-        (t/testing "query string"
-          (t/is (= #{[:ivan]} (.q (.db *api*)
-                                  "{:find [e] :where [[e :name \"Ivan\"]]}"))))
+        (with-both-dbs [db (*api*)]
+          (t/testing "query string"
+            (t/is (= #{[:ivan]} (.q db "{:find [e] :where [[e :name \"Ivan\"]]}"))))
 
-        (t/testing "query vector"
-          (t/is (= #{[:ivan]} (.q (.db *api*) '[:find e
-                                                :where [e :name "Ivan"]]))))
+          (t/testing "query vector"
+            (t/is (= #{[:ivan]} (.q db '[:find e
+                                         :where [e :name "Ivan"]]))))
 
-        (t/testing "malformed query"
-          (t/is (thrown-with-msg? Exception
-                                  #"(status 400|Spec assertion failed)"
-                                  (.q (.db *api*) '{:find [e]}))))
+          (t/testing "malformed query"
+            (t/is (thrown-with-msg? Exception
+                                    #"(status 400|Spec assertion failed)"
+                                    (.q db '{:find [e]}))))
 
-        (t/testing "query with streaming result"
-          (let [db (.db *api*)]
+          (t/testing "query with streaming result"
             (with-open [res (api/open-q db '{:find [e]
                                              :where [[e :name "Ivan"]]})]
-              (t/is (= '([:ivan]) res)))))
+              (t/is (= '([:ivan]) res))))
 
-        (t/testing "query returning full results"
-          (let [db (.db *api*)]
+          (t/testing "query returning full results"
             (with-open [res (api/open-q db '{:find [e]
                                              :where [[e :name "Ivan"]]
                                              :full-results? true})]
-              (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}]) res)))))
+              (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}]) res))))
 
-        (t/testing "SPARQL query"
-          (when (bound? #'fh/*api-url*)
-            (let [repo (SPARQLRepository. (str fh/*api-url* "/sparql"))]
-              (try
-                (.initialize repo)
-                (with-open [conn (.getConnection repo)]
-                  (t/is (= #{[:ivan]} (execute-sparql conn "SELECT ?e WHERE { ?e <http://juxt.pro/crux/unqualified/name> \"Ivan\" }"))))
-                (finally
-                  (.shutDown repo)))))))
+          (t/testing "entity"
+            (t/is (= {:crux.db/id :ivan :name "Ivan"} (api/entity db :ivan)))
+            (with-both-dbs [db (*api* #inst "1999")]
+              (t/is (nil? (api/entity db :ivan)))))
 
-      (t/testing "entity"
-        (t/is (= {:crux.db/id :ivan :name "Ivan"} (.entity (.db *api*) :ivan)))
-        (t/is (nil? (.entity (.db *api* #inst "1999") :ivan))))
+          (t/testing "entity-tx, document and history"
+            (let [entity-tx (api/entity-tx db :ivan)
+                  ivan {:crux.db/id :ivan :name "Ivan"}
+                  ivan-crux-id (c/new-id ivan)]
+              (t/is (= (merge submitted-tx
+                              {:crux.db/id (str (c/new-id :ivan))
+                               :crux.db/content-hash (str ivan-crux-id)
+                               :crux.db/valid-time valid-time})
+                       entity-tx))
+              (t/is (= ivan (.document *api* (:crux.db/content-hash entity-tx))))
+              (t/is (= {ivan-crux-id ivan} (api/documents *api* #{(:crux.db/content-hash entity-tx)})))
+              (t/is (= [entity-tx] (api/history *api* :ivan)))
+              (t/is (= [entity-tx] (api/history-range *api* :ivan #inst "1990" #inst "1990" tx-time tx-time)))
 
-      (t/testing "entity-tx, document and history"
-        (let [entity-tx (.entityTx (.db *api*) :ivan)
-              ivan {:crux.db/id :ivan :name "Ivan"}
-              ivan-crux-id (c/new-id ivan)]
-          (t/is (= (merge submitted-tx
-                          {:crux.db/id           (str (c/new-id :ivan))
-                           :crux.db/content-hash (str ivan-crux-id)
-                           :crux.db/valid-time   valid-time})
-                   entity-tx))
-          (t/is (= ivan (.document *api* (:crux.db/content-hash entity-tx))))
-          (t/is (= {ivan-crux-id ivan} (.documents *api* #{(:crux.db/content-hash entity-tx)})))
-          (t/is (= [entity-tx] (.history *api* :ivan)))
-          (t/is (= [entity-tx] (.historyRange *api* :ivan #inst "1990" #inst "1990" tx-time tx-time)))
+              (t/is (nil? (api/document *api* (c/new-id :does-not-exist))))
+              (t/is (nil? (api/entity-tx (api/db *api* #inst "1999") :ivan))))))))))
 
-          (t/is (nil? (.document *api* (c/new-id :does-not-exist))))
-          (t/is (nil? (.entityTx (.db *api* #inst "1999") :ivan)))))
+(t/deftest test-sparql
+  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
+    (api/await-tx *api* submitted-tx))
 
-      (t/testing "statistics"
-        (let [stats (.attributeStats *api*)]
-          (t/is (= 1 (:name stats))))
+  (t/testing "SPARQL query"
+    (when (bound? #'fh/*api-url*)
+      (let [repo (SPARQLRepository. (str fh/*api-url* "/sparql"))]
+        (try
+          (.initialize repo)
+          (with-open [conn (.getConnection repo)]
+            (t/is (= #{[:ivan]} (execute-sparql conn "SELECT ?e WHERE { ?e <http://juxt.pro/crux/unqualified/name> \"Ivan\" }"))))
+          (finally
+            (.shutDown repo)))))))
 
-        (t/testing "updated"
-          (let [valid-time (Date.)
-                submitted-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"} valid-time]])]
-            (t/is (= submitted-tx (.awaitTx *api* submitted-tx nil)))
-            (t/is (true? (.hasTxCommitted *api* submitted-tx))))
+(t/deftest test-statistics
+  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
+    (api/await-tx *api* submitted-tx))
 
-          (let [stats (.attributeStats *api*)]
-            (t/is (= 2 (:name stats)))))
+  (let [stats (api/attribute-stats *api*)]
+    (t/is (= 1 (:name stats))))
 
-        (t/testing "reflect evicted documents"
-          (let [valid-time (Date.)
-                submitted-tx (.submitTx *api* [[:crux.tx/evict :ivan]])]
-            (t/is (.awaitTx *api* submitted-tx nil))
+  (t/testing "updated"
+    (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"}]])]
+      (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
+      (t/is (true? (api/tx-committed? *api* submitted-tx))))
 
-            ;; actual removal of the document happens asynchronously after
-            ;; the transaction has been processed so waiting on the
-            ;; submitted transaction time is not enough
-            (while (.entity (.db *api*) :ivan)
-              (assert (< (- (.getTime (Date.)) (.getTime valid-time)) 4000))
-              (Thread/sleep 500))
+    (let [stats (api/attribute-stats *api*)]
+      (t/is (= 2 (:name stats)))))
 
-            (let [stats (.attributeStats *api*)]
-              (t/is (= 0 (:name stats))))))))))
+  (t/testing "reflect evicted documents"
+    (let [now (Date.)
+          submitted-tx (api/submit-tx *api* [[:crux.tx/evict :ivan]])]
+      (t/is (api/await-tx *api* submitted-tx))
+
+      ;; actual removal of the document happens asynchronously after
+      ;; the transaction has been processed so waiting on the
+      ;; submitted transaction time is not enough
+      (while (api/entity (api/db *api*) :ivan)
+        (assert (< (- (.getTime (Date.)) (.getTime now)) 4000))
+        (Thread/sleep 500))
+
+      (let [stats (api/attribute-stats *api*)]
+        (t/is (= 0 (:name stats)))))))
 
 (t/deftest test-adding-back-evicted-document
   (fapi/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
@@ -277,7 +292,7 @@
     (let [history (.history *api* :ivan)]
       (t/is (= 4 (count history))))
 
-    (let [db (.db *api* #inst "2019-02-03")]
+    (with-both-dbs [db (*api* #inst "2019-02-03")]
       (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 3}]
                (map :crux.db/doc (api/history-ascending db :ivan))))
 
@@ -295,7 +310,7 @@
                   {:crux.db/id :ivan :name "Ivan" :version 1}]
                  (map :crux.db/doc history-desc)))))
 
-    (let [db (.db *api* #inst "2019-02-02")]
+    (with-both-dbs [db (*api* #inst "2019-02-02")]
       (with-open [snapshot (.newSnapshot db)]
         (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
                   {:crux.db/id :ivan :name "Ivan" :version 3}]
@@ -304,7 +319,7 @@
                   {:crux.db/id :ivan :name "Ivan" :version 1}]
                  (map :crux.db/doc (.historyDescending db snapshot :ivan))))))
 
-    (let [db (.db *api* #inst "2019-01-31")]
+    (with-both-dbs [db (*api* #inst "2019-01-31")]
       (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 1}
                 {:crux.db/id :ivan :name "Ivan" :version 2 :corrected true}
                 {:crux.db/id :ivan :name "Ivan" :version 3}]
@@ -319,7 +334,7 @@
                  (map :crux.db/doc history-asc)))
         (t/is (empty? (map :crux.db/doc history-desc)))))
 
-    (let [db (.db *api* #inst "2019-02-04")]
+    (with-both-dbs [db (*api* #inst "2019-02-04")]
       (with-open [history-asc (api/open-history-ascending db :ivan)
                   history-desc (api/open-history-descending db :ivan)]
         (t/is (empty? (map :crux.db/doc history-asc)))
@@ -328,12 +343,12 @@
                   {:crux.db/id :ivan :name "Ivan" :version 1}]
                  (map :crux.db/doc history-desc)))))
 
-    (let [db (.db *api* #inst "2019-02-04" #inst "2019-01-31")]
+    (with-both-dbs [db (*api* #inst "2019-02-04" #inst "2019-01-31")]
       (with-open [snapshot (.newSnapshot db)]
         (t/is (empty? (map :crux.db/doc (.historyAscending db snapshot :ivan))))
         (t/is (empty? (map :crux.db/doc (.historyDescending db snapshot :ivan))))))
 
-    (let [db (.db *api* #inst "2019-02-02" version-2-submitted-tx-time)]
+    (with-both-dbs [db (*api* #inst "2019-02-02" version-2-submitted-tx-time)]
       (with-open [history-asc (api/open-history-ascending db :ivan)
                   history-desc (api/open-history-descending db :ivan)]
         (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2}]
@@ -342,7 +357,7 @@
                   {:crux.db/id :ivan :name "Ivan" :version 1}]
                  (map :crux.db/doc history-desc)))))
 
-    (let [db (.db *api* #inst "2019-02-03" version-2-submitted-tx-time)]
+    (with-both-dbs [db (*api* #inst "2019-02-03" version-2-submitted-tx-time)]
       (with-open [snapshot (.newSnapshot db)]
         (t/is (empty? (map :crux.db/doc (.historyAscending db snapshot :ivan))))
         (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2751,8 +2751,8 @@
   (let [ivan {:crux.db/id :ivan}
         _ (f/transact! *api* [ivan])
         db (api/db *api*)]
-    (with-open [snapshot (api/new-snapshot db)]
-      (t/is (= (api/entity db :ivan) (api/entity db snapshot :ivan) ivan))
+    (with-open [shared-db (api/open-db *api*)]
+      (t/is (= (api/entity db :ivan) (api/entity shared-db :ivan) ivan))
       (let [n 1000
             acceptable-snapshot-speedup 1.4
             factors (->> #(let [db-hit-ns-start (System/nanoTime)
@@ -2760,7 +2760,7 @@
                                 db-hit-ns (- (System/nanoTime) db-hit-ns-start)
 
                                 snapshot-hit-ns-start (System/nanoTime)
-                                _ (api/entity db snapshot :ivan)
+                                _ (api/entity shared-db :ivan)
                                 snapshot-hit-ns (- (System/nanoTime) snapshot-hit-ns-start)]
 
                             (double (/ db-hit-ns snapshot-hit-ns)))

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -17,14 +17,38 @@ toc::[]
     [node]
     [node ^Date valid-time]
     [node ^Date valid-time ^Date transaction-time]
-    "Will return the latest value of the db currently known. Non-blocking.
+    "When a valid time is specified then returned db value contains only those
+     documents whose valid time is before the specified time.
 
-     When a valid time is specified then returned db value contains only those
-     documents whose valid time is not after the specified. Non-blocking.
+     When both valid and transaction time are specified returns a db value as of
+     the valid time and the latest transaction time indexed at or before the
+     specified transaction time.
 
-     When both valid and transaction time are specified returns a db value
-     as of the valid and transaction time. Will block until the transaction
-     time is present in the index.")
+     If the node hasn't yet indexed a transaction at or past the given
+     transaction-time, this throws NodeOutOfSyncException")
+----
+
+==== open-db
+
+[source,clj]
+----
+  (open-db
+    [node]
+    [node ^Date valid-time]
+    [node ^Date valid-time ^Date transaction-time]
+    "When a valid time is specified then returned db value contains only those
+     documents whose valid time is before the specified time.
+
+     When both valid and transaction time are specified returns a db value as of
+     the valid time and the latest transaction time indexed at or before the
+     specified transaction time.
+
+     If the node hasn't yet indexed a transaction at or past the given
+     transaction-time, this throws NodeOutOfSyncException
+
+     This DB opens up shared resources to make multiple requests faster - it must
+     be `.close`d when you've finished using it (for example, in a `with-open`
+     block)")
 ----
 
 ==== document
@@ -35,7 +59,6 @@ toc::[]
     "Reads a document from the document store based on its
     content hash.")
 ----
-
 
 ==== history
 


### PR DESCRIPTION
Easy case is unchanged: `(crux/q (crux/db *api*) '{...})`

If you want to share a snapshot between different calls to query/history/entity/etc, it's pretty much the same, but call `open-db` (most likely in a `with-open`)

```clojure
(with-open [db (crux/open-db *api*)]
  (t/is (= ... (crux/entity db ...)))
  (t/is (= ... (crux/q db '{...}))))
```

Have deliberately kept the change surface as small as possible, but happy to talk about bigger changes if you feel they'd be more suitable?

As with the other #410 PRs, this one is backwards compatible - the backwards compatibility will be removed in a later PR.

This PR is based on top of #782, I'll merge that before merging this PR