### PR TITLE
removing kv/open fn, #613

### DIFF
--- a/crux-core/src/crux/kv.clj
+++ b/crux-core/src/crux/kv.clj
@@ -18,7 +18,6 @@
 
 ;; tag::KvStore[]
 (defprotocol KvStore
-  (open ^crux.kv.KvStore [this options])
   (new-snapshot ^java.io.Closeable [this])
   (store [this kvs])
   (delete [this ks])


### PR DESCRIPTION
... so that we don't create an unstarted record. KV initialisation now done in start-fn

fixes #613