### PR TITLE
Benching SQL TxLogs, #774

### DIFF
--- a/crux-bench/README.md
+++ b/crux-bench/README.md
@@ -22,7 +22,7 @@ Circle is responsible for building and pushing the bench docker images - it does
 
 To deploy Docker images to ECR from your own branches, set up CircleCI to build your fork, and ensure you've added the four AWS env vars (`AWS_REGION`, `AWS_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY` and `AWS_ECR_ACCOUNT_URL`).
 
-Assuming you have `awscli` and `jq` installed, and you are authenticated with AWS and ECR (see [**here**](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html)), you can run the bench for a CI-built commit using `bin/run-bench.sh <COMMIT-ISH>`.
+Assuming you have `awscli` and `jq` installed, and you are authenticated with AWS and ECR (see [**here**](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html)), you can run the bench for a CI-built commit using `bin/run-bench.sh [-r <COMMIT-ISH>] [--nodes node1,node2] [--tests test1,test2]`.
 
 ## Running Non-Crux Benchmarks
 

--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -1,6 +1,7 @@
 (defproject juxt/crux-bench "derived-from-git"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/data.json "0.2.7"]
+                 [org.clojure/tools.cli "1.0.194"]
                  [juxt/crux-core "derived-from-git"]
                  [juxt/crux-kafka "derived-from-git"]
                  [juxt/crux-kafka-embedded "derived-from-git"]

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -215,6 +215,22 @@
       :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/rocksdb-with-metrics"))
       :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv})
 
+   "h2-rocksdb"
+   (fn [data-dir]
+     {:crux.node/topology '[crux.jdbc/topology
+                            crux.metrics.dropwizard.cloudwatch/reporter]
+      :crux.kv/db-dir (str (io/file data-dir "kv"))
+      :crux.jdbc/dbtype "h2"
+      :crux.jdbc/dbname (str (io/file data-dir "h2"))})
+
+   "sqlite-rocksdb"
+   (fn [data-dir]
+     {:crux.node/topology '[crux.jdbc/topology
+                            crux.metrics.dropwizard.cloudwatch/reporter]
+      :crux.kv/db-dir (str (io/file data-dir "kv"))
+      :crux.jdbc/dbtype "sqlite"
+      :crux.jdbc/dbname (str (io/file data-dir "sqlite"))})
+
    "kafka-rocksdb"
    (fn [data-dir]
      (let [uuid (UUID/randomUUID)]

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -107,12 +107,14 @@
        :compacted-bytes-on-disk (:crux.kv/size (api/status node))})))
 
 (defn post-to-slack [message]
-  (when-let [slack-url (System/getenv "SLACK_URL")]
+  (if-let [slack-url (System/getenv "SLACK_URL")]
     (client/post (-> slack-url
                      (json/read-str)
                      (get "slack-url"))
                  {:body (json/write-str {:text message})
-                  :content-type :json})))
+                  :content-type :json})
+
+    (println "Would post to Slack:\n" message)))
 
 (defn- result->slack-message [{:keys [time-taken-ms bench-type percentage-difference-since-last-run
                                       minimum-time-taken-this-week maximum-time-taken-this-week

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -1,44 +1,78 @@
 (ns crux.bench.main
   (:require [clojure.string :as string]
+            [clojure.tools.cli :as cli]
             [crux.bench :as bench]
             [crux.bench.sorted-maps-microbench :as sorted-maps]
             [crux.bench.ts-devices :as devices]
             [crux.bench.ts-weather :as weather]
-            [crux.bench.watdiv-crux :as watdiv-crux]))
+            [crux.bench.watdiv-crux :as watdiv-crux]
+            [clojure.set :as set]))
 
 (defn post-to-slack [results]
   (doto results
     (-> (bench/results->slack-message) (bench/post-to-slack))))
 
-(defn -main []
+(def bench-tests
+  {:sorted-maps (fn [nodes]
+                  (bench/with-nodes [node (select-keys nodes #{"embedded-kafka-rocksdb"})]
+                    (-> (bench/with-comparison-times
+                          (sorted-maps/run-sorted-maps-microbench node))
+                        (doto post-to-slack))))
+
+   :ts-devices (fn [nodes]
+                 (bench/with-nodes [node nodes]
+                   (-> (bench/with-comparison-times
+                         (devices/run-devices-bench node))
+                       (doto post-to-slack))))
+
+   :ts-weather (fn [nodes]
+                 (bench/with-nodes [node nodes]
+                   (-> (bench/with-comparison-times
+                         (weather/run-weather-bench node))
+                       (doto post-to-slack))))
+
+   :watdiv (fn [nodes]
+             (bench/with-nodes [node nodes]
+               (let [[ingest-results query-results] (->> (watdiv-crux/run-watdiv-bench node {:test-count 100})
+                                                         (split-at 2))]
+                 (-> (concat (->> ingest-results (map watdiv-crux/render-comparison-durations))
+                             (watdiv-crux/summarise-query-results query-results))
+                     (bench/with-comparison-times)
+                     (doto post-to-slack)))))})
+
+(defn parse-args [args]
+  (let [{:keys [options summary errors]}
+        (cli/parse-opts args
+                        [[nil "--nodes node1,node2" "Node types"
+                          :id :selected-nodes
+                          :default (keys bench/nodes)
+                          :parse-fn #(set (string/split % #","))]
+
+                         [nil "--tests test1,test2" "Tests to run"
+                          :id :selected-tests
+                          :default (keys bench-tests)
+                          :parse-fn #(map keyword (set (string/split % #",")))]])]
+    (if errors
+      (binding [*out* *err*]
+        (run! println errors)
+        (println summary))
+
+      options)))
+
+(defn run-benches [{:keys [selected-nodes selected-tests]}]
+  (let [nodes (select-keys bench/nodes selected-nodes)]
+    (bench/with-embedded-kafka
+      (->> (for [test-fn (vals (select-keys bench-tests selected-tests))]
+             (test-fn nodes))
+           (into [] (mapcat identity))))))
+
+(defn -main [& args]
   (bench/post-to-slack (format "*Starting Benchmark*, Crux Version: %s, Commit Hash: %s\n"
                                bench/crux-version bench/commit-hash))
 
-  (bench/with-embedded-kafka
-    (let [bench-results
-          (concat (bench/with-nodes [node (select-keys bench/nodes ["embedded-kafka-rocksdb"])]
-                    (-> (bench/with-comparison-times
-                          (sorted-maps/run-sorted-maps-microbench node))
-                        (doto post-to-slack)))
+  (let [bench-results (run-benches (or (parse-args args)
+                                       (System/exit 1)))]
 
-                  (bench/with-nodes [node bench/nodes]
-                    (-> (bench/with-comparison-times
-                          (devices/run-devices-bench node))
-                        (doto post-to-slack)))
-
-                  (bench/with-nodes [node bench/nodes]
-                    (-> (bench/with-comparison-times
-                          (weather/run-weather-bench node))
-                        (doto post-to-slack)))
-
-                  (bench/with-nodes [node bench/nodes]
-                    (let [[ingest-results query-results] (->> (watdiv-crux/run-watdiv-bench node {:test-count 100})
-                                                              (split-at 2))]
-                      (-> (concat (->> ingest-results (map watdiv-crux/render-comparison-durations))
-                                  (watdiv-crux/summarise-query-results query-results))
-                          (bench/with-comparison-times)
-                          (doto post-to-slack)))))]
-      (bench/send-email-via-ses
-       (bench/results->email bench-results))))
+    (bench/send-email-via-ses (bench/results->email bench-results)))
 
   (shutdown-agents))


### PR DESCRIPTION
resolves #774 

bonus extra change to make a bench CLI, you can now select the tests you want to run, and the nodes you want to run them on. e.g.:
```
./bin/run-bench 
  [-r/--rev branch-or-sha]
  [--nodes standalone-rocksdb,kafka-rocksdb]
  [--tests ts-devices,ts-weather]`