### PR TITLE
open-* back to iterators #410

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [crux.io :as cio])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
-            ICruxAsyncIngestAPI ICruxDatasource]
+            ICruxAsyncIngestAPI ICruxDatasource ICursor]
            java.io.Closeable
            java.util.Date
            java.time.Duration))
@@ -249,8 +249,8 @@
   (submit-tx [this tx-ops]
     (.submitTx this (conform-tx-ops tx-ops)))
 
-  (open-tx-log ^java.io.Closeable [this after-tx-id with-ops?]
-    (cio/<-stream (.openTxLog this after-tx-id with-ops?))))
+  (open-tx-log ^crux.api.ICursor [this after-tx-id with-ops?]
+    (cio/<-cursor (.openTxLog this after-tx-id with-ops?))))
 
 (defprotocol PCruxDatasource
   "Represents the database as of a specific valid and
@@ -354,19 +354,19 @@
     ([this snapshot query]
      (.q this snapshot query)))
 
-  (open-q [this query] (cio/<-stream (.openQuery this query)))
+  (open-q [this query] (cio/<-cursor (.openQuery this query)))
 
   (history-ascending
     ([this eid] (.historyAscending this eid))
     ([this snapshot eid] (.historyAscending this snapshot eid)))
 
-  (open-history-ascending [this eid] (cio/<-stream (.openHistoryAscending this eid)))
+  (open-history-ascending [this eid] (cio/<-cursor (.openHistoryAscending this eid)))
 
   (history-descending
     ([this eid] (.historyDescending this eid))
     ([this snapshot eid] (.historyDescending this snapshot eid)))
 
-  (open-history-descending [this eid] (cio/<-stream (.openHistoryDescending this eid)))
+  (open-history-descending [this eid] (cio/<-cursor (.openHistoryDescending this eid)))
 
   (valid-time [this] (.validTime this))
   (transaction-time [this] (.transactionTime this)))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -3,8 +3,7 @@
   (:refer-clojure :exclude [sync])
   (:require [clojure.spec.alpha :as s]
             [crux.codec :as c]
-            [clojure.tools.logging :as log]
-            [crux.io :as cio])
+            [clojure.tools.logging :as log])
   (:import [crux.api Crux ICruxAPI ICruxIngestAPI
             ICruxAsyncIngestAPI ICruxDatasource ICursor]
            java.io.Closeable
@@ -250,7 +249,7 @@
     (.submitTx this (conform-tx-ops tx-ops)))
 
   (open-tx-log ^crux.api.ICursor [this after-tx-id with-ops?]
-    (cio/<-cursor (.openTxLog this after-tx-id with-ops?))))
+    (.openTxLog this after-tx-id with-ops?)))
 
 (defprotocol PCruxDatasource
   "Represents the database as of a specific valid and
@@ -354,19 +353,19 @@
     ([this snapshot query]
      (.q this snapshot query)))
 
-  (open-q [this query] (cio/<-cursor (.openQuery this query)))
+  (open-q [this query] (.openQuery this query))
 
   (history-ascending
     ([this eid] (.historyAscending this eid))
     ([this snapshot eid] (.historyAscending this snapshot eid)))
 
-  (open-history-ascending [this eid] (cio/<-cursor (.openHistoryAscending this eid)))
+  (open-history-ascending [this eid] (.openHistoryAscending this eid))
 
   (history-descending
     ([this eid] (.historyDescending this eid))
     ([this snapshot eid] (.historyDescending this snapshot eid)))
 
-  (open-history-descending [this eid] (cio/<-cursor (.openHistoryDescending this eid)))
+  (open-history-descending [this eid] (.openHistoryDescending this eid))
 
   (valid-time [this] (.validTime this))
   (transaction-time [this] (.transactionTime this)))

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 import clojure.lang.Keyword;
 
 /**
@@ -75,9 +74,9 @@ public interface ICruxDatasource extends Closeable {
      * Queries the db lazily.
      *
      * @param query the query in map, vector or string form.
-     * @return      a stream of result tuples.
+     * @return      a cursor of result tuples.
      */
-    public Stream<List<?>> openQuery(Object query);
+    public ICursor<List<?>> openQuery(Object query);
 
     /**
      * Retrieves entity history in chronological order from and
@@ -109,7 +108,7 @@ public interface ICruxDatasource extends Closeable {
      * @param eid      an object that can be coerced into an entity id.
      * @return         a stream of history.
      */
-    public Stream<Map<Keyword,?>> openHistoryAscending(Object eid);
+    public ICursor<Map<Keyword,?>> openHistoryAscending(Object eid);
 
     /**
      * Retrieves entity history in reverse chronological order
@@ -141,7 +140,7 @@ public interface ICruxDatasource extends Closeable {
      * @param eid      an object that can be coerced into an entity id.
      * @return         a stream of history.
      */
-    public Stream<Map<Keyword,?>> openHistoryDescending(Object eid);
+    public ICursor<Map<Keyword,?>> openHistoryDescending(Object eid);
 
     /**
      * The valid time of this db.

--- a/crux-core/src/crux/api/ICruxIngestAPI.java
+++ b/crux-core/src/crux/api/ICruxIngestAPI.java
@@ -3,7 +3,6 @@ package crux.api;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import clojure.lang.Keyword;
 
 /**
@@ -28,5 +27,5 @@ public interface ICruxIngestAPI extends Closeable {
      * @return          a lazy sequence of the transaction log.
      */
 
-    public Stream<Map<Keyword, ?>> openTxLog(Long afterTxId, boolean withOps);
+    public ICursor<Map<Keyword, ?>> openTxLog(Long afterTxId, boolean withOps);
 }

--- a/crux-core/src/crux/api/ICursor.java
+++ b/crux-core/src/crux/api/ICursor.java
@@ -1,0 +1,7 @@
+package crux.api;
+
+import java.util.Iterator;
+import java.io.Closeable;
+
+public interface ICursor<E> extends Iterator<E>, Closeable {
+}

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -25,7 +25,7 @@
 ;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-events])
-  (open-tx-log ^java.lang.AutoCloseable [this after-tx-id])
+  (open-tx-log ^crux.api.ICursor [this after-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
 

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -5,7 +5,6 @@
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy])
   (:import [crux.api ICursor]
-           [clojure.lang ISeq Sequential IPending]
            [java.io Closeable DataInputStream DataOutputStream File IOException Reader]
            [java.lang AutoCloseable]
            [java.lang.ref PhantomReference ReferenceQueue]
@@ -263,24 +262,3 @@
 
 (defn ->cursor [close-fn ^Iterable sq]
   (->Cursor close-fn (.iterator (lazy-seq sq))))
-
-(defn <-cursor [^ICursor cursor]
-  (let [^ISeq sq (or (iterator-seq cursor) (list))]
-    (reify
-      Sequential
-
-      Closeable
-      (close [_] (.close cursor))
-
-      IPending
-      (isRealized [_] (.isRealized ^IPending sq))
-
-      ISeq
-      (first [_] (.first sq))
-      (next [_] (.next sq))
-      (more [_] (.more sq))
-      (cons [_ o] (.cons sq o))
-      (count [_] (.count sq))
-      (empty [_] (.empty sq))
-      (equiv [_ o] (.equiv sq o))
-      (seq [_] (.seq sq)))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1261,8 +1261,8 @@
                     (q this snapshot conformed-query))))
 
   (historyAscending [this eid]
-    (with-open [history (cio/<-cursor (.openHistoryAscending this eid))]
-      (vec history)))
+    (with-open [history (.openHistoryAscending this eid)]
+      (vec (iterator-seq history))))
 
   (historyAscending [this snapshot eid]
     (for [^EntityTx entity-tx (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid valid-time transact-time)]
@@ -1277,8 +1277,8 @@
                              :crux.db/doc (db/get-single-object object-store snapshot (.content-hash entity-tx)))))))
 
   (historyDescending [this eid]
-    (with-open [history (cio/<-cursor (.openHistoryDescending this eid))]
-      (vec history)))
+    (with-open [history (.openHistoryDescending this eid)]
+      (vec (iterator-seq history))))
 
   (historyDescending [this snapshot eid]
     (for [^EntityTx entity-tx (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid valid-time transact-time)]

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -63,8 +63,10 @@
                           (tx-log (kv/next iterator))))))]
 
         (let [k (kv/seek iterator (c/encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
-          (doto (cio/->stream (when k (tx-log (if after-tx-id (kv/next iterator) k))))
-            (.onClose #(run! cio/try-close [iterator snapshot])))))))
+          (->> (when k (tx-log (if after-tx-id (kv/next iterator) k)))
+               (cio/->cursor (fn []
+                                          (cio/try-close iterator)
+                                          (cio/try-close snapshot))))))))
 
   Closeable
   (close [_]

--- a/crux-core/src/crux/tx/consumer.clj
+++ b/crux-core/src/crux/tx/consumer.clj
@@ -4,8 +4,7 @@
             [crux.node :as n]
             [crux.tx :as tx]
             [crux.tx.event :as txe]
-            [crux.codec :as c]
-            [crux.io :as cio])
+            [crux.codec :as c])
   (:import java.io.Closeable
            java.time.Duration))
 
@@ -13,8 +12,9 @@
   (log/info "Started tx-consumer")
   (try
     (while true
-      (let [consumed-txs? (with-open [tx-log (cio/<-stream (db/open-tx-log tx-log (::tx/tx-id (db/latest-completed-tx indexer))))]
-                            (let [consumed-txs? (not (empty? tx-log))]
+      (let [consumed-txs? (with-open [tx-log (db/open-tx-log tx-log (::tx/tx-id (db/latest-completed-tx indexer)))]
+                            (let [tx-log (iterator-seq tx-log)
+                                  consumed-txs? (not (empty? tx-log))]
                               (doseq [tx-log (partition-all 1000 tx-log)]
                                 (doseq [doc-hashes (->> tx-log
                                                         (mapcat ::txe/tx-events)

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -135,11 +135,11 @@
                                (assoc (as-of-map this)
                                       :query (q/normalize-query q))
                                {:as :stream})]
-      (doto (cio/->stream (edn-list->lazy-seq in))
-        (.onClose #(.close ^Closeable in)))))
+      (cio/->cursor #(.close ^Closeable in)
+                    (edn-list->lazy-seq in))))
 
   (historyAscending [this eid]
-    (with-open [history (cio/<-stream (.openHistoryAscending this eid))]
+    (with-open [history (cio/<-cursor (.openHistoryAscending this eid))]
       (vec history)))
 
   (historyAscending [this snapshot eid]
@@ -153,11 +153,11 @@
     (let [in (api-request-sync (str url "/history-ascending")
                                (assoc (as-of-map this) :eid eid)
                                {:as :stream})]
-      (doto (cio/->stream (edn-list->lazy-seq in))
-        (.onClose #(.close ^java.io.Closeable in)))))
+      (cio/->cursor #(.close ^java.io.Closeable in)
+                    (edn-list->lazy-seq in))))
 
   (historyDescending [this eid]
-    (with-open [history (cio/<-stream (.openHistoryDescending this eid))]
+    (with-open [history (cio/<-cursor (.openHistoryDescending this eid))]
       (vec history)))
 
   (historyDescending [this snapshot eid]
@@ -171,8 +171,8 @@
     (let [in (api-request-sync (str url "/history-descending")
                                (assoc (as-of-map this) :eid eid)
                                {:as :stream})]
-      (doto (cio/->stream (edn-list->lazy-seq in))
-        (.onClose #(.close ^java.io.Closeable in)))))
+      (cio/->cursor #(.close ^java.io.Closeable in)
+                    (edn-list->lazy-seq in))))
 
   (validTime [_] valid-time)
   (transactionTime [_] transact-time))
@@ -240,8 +240,8 @@
                                nil
                                {:method :get
                                 :as :stream})]
-      (doto (cio/->stream (edn-list->lazy-seq in))
-        (.onClose #(.close ^Closeable in)))))
+      (cio/->cursor #(.close ^Closeable in)
+                    (edn-list->lazy-seq in))))
 
   (sync [_ timeout]
     (api-request-sync (cond-> (str url "/sync")

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -139,8 +139,8 @@
                     (edn-list->lazy-seq in))))
 
   (historyAscending [this eid]
-    (with-open [history (cio/<-cursor (.openHistoryAscending this eid))]
-      (vec history)))
+    (with-open [history (.openHistoryAscending this eid)]
+      (vec (iterator-seq history))))
 
   (historyAscending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-ascending")
@@ -157,8 +157,8 @@
                     (edn-list->lazy-seq in))))
 
   (historyDescending [this eid]
-    (with-open [history (cio/<-cursor (.openHistoryDescending this eid))]
-      (vec history)))
+    (with-open [history (.openHistoryDescending this eid)]
+      (vec (iterator-seq history))))
 
   (historyDescending [this snapshot eid]
     (let [in (api-request-sync (str url "/history-descending")

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -249,8 +249,8 @@
   (let [with-ops? (Boolean/parseBoolean (get-in request [:query-params "with-ops"]))
         after-tx-id (some->> (get-in request [:query-params "after-tx-id"])
                              (Long/parseLong))
-        result (api/open-tx-log crux-node after-tx-id with-ops?)]
-    (-> (streamed-edn-response result result)
+        result (.openTxLog crux-node after-tx-id with-ops?)]
+    (-> (streamed-edn-response result (iterator-seq result))
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- sync-handler [^ICruxAPI crux-node request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -187,7 +187,7 @@
   (let [query-map (doto (body->edn request) (validate-or-throw ::query-map))
         db (db-for-request crux-node query-map)
         result (api/open-q db (:query query-map))]
-    (-> (streamed-edn-response result result)
+    (-> (streamed-edn-response result (iterator-seq result))
         (add-last-modified (.transactionTime db)))))
 
 (s/def ::eid c/valid-id?)
@@ -227,14 +227,14 @@
   (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         history (api/open-history-ascending db (c/new-id eid))]
-    (-> (streamed-edn-response history history)
+    (-> (streamed-edn-response history (iterator-seq history))
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- history-descending [^ICruxAPI crux-node request]
   (let [{:keys [eid] :as body} (doto (body->edn request) (validate-or-throw ::entity-map))
         db (db-for-request crux-node body)
         history (api/open-history-descending db (c/new-id eid))]
-    (-> (streamed-edn-response history history)
+    (-> (streamed-edn-response history (iterator-seq history))
         (add-last-modified (:crux.tx/tx-time (.latestCompletedTx crux-node))))))
 
 (defn- transact [^ICruxAPI crux-node request]

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -111,12 +111,12 @@
                              ["SELECT EVENT_OFFSET, TX_TIME, V, TOPIC FROM tx_events WHERE TOPIC = 'txs' and EVENT_OFFSET > ? ORDER BY EVENT_OFFSET"
                               (or after-tx-id 0)])
           rs (.executeQuery stmt)]
-      (doto (cio/->stream (->> (resultset-seq rs)
-                               (map (fn [y]
-                                      {:crux.tx/tx-id (int (:event_offset y))
-                                       :crux.tx/tx-time (->date dbtype (:tx_time y))
-                                       :crux.tx.event/tx-events (->v dbtype (:v y))}))))
-        (.onClose #(run! cio/try-close [rs stmt conn])))))
+      (cio/->cursor #(run! cio/try-close [rs stmt conn])
+                    (->> (resultset-seq rs)
+                         (map (fn [y]
+                                {:crux.tx/tx-id (int (:event_offset y))
+                                 :crux.tx/tx-time (->date dbtype (:tx_time y))
+                                 :crux.tx.event/tx-events (->v dbtype (:v y))}))))))
 
   (latest-submitted-tx [this]
     (when-let [max-offset (-> (jdbc/execute-one! ds ["SELECT max(EVENT_OFFSET) AS max_offset FROM tx_events"]

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -149,10 +149,10 @@
           consumer (doto (create-consumer kafka-config)
                      (.assign (keys tp-offsets))
                      (seek-consumer tp-offsets))]
-      (doto (cio/->stream (->> (consumer-seqs consumer (Duration/ofSeconds 1))
-                               (mapcat identity)
-                               (map tx-record->tx-log-entry)))
-        (.onClose #(.close consumer)))))
+      (cio/->cursor #(.close consumer)
+                    (->> (consumer-seqs consumer (Duration/ofSeconds 1))
+                         (mapcat identity)
+                         (map tx-record->tx-log-entry)))))
 
   (latest-submitted-tx [this]
     (let [tx-tp (TopicPartition. tx-topic 0)

--- a/crux-kafka/src/crux/kafka_ingest_client.clj
+++ b/crux-kafka/src/crux/kafka_ingest_client.clj
@@ -17,7 +17,7 @@
   (submitTx [this tx-ops]
     @(.submitTxAsync this tx-ops))
 
-  (openTxLog ^java.util.stream.Stream [_ after-tx-id with-ops?]
+  (openTxLog ^crux.api.ICursor [_ after-tx-id with-ops?]
     (when with-ops?
       (throw (IllegalArgumentException. "with-ops? not supported")))
     (db/open-tx-log tx-log after-tx-id))

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -12,8 +12,7 @@
             [crux.api :as api]
             [crux.jdbc :as j]
             [next.jdbc :as jdbc]
-            [next.jdbc.result-set :as jdbcr]
-            [crux.io :as cio]))
+            [next.jdbc.result-set :as jdbcr]))
 
 (defn- with-each-jdbc-node [f]
   (f/with-tmp-dir "jdbc" [jdbc-dir]
@@ -42,14 +41,14 @@
     (.awaitTx *api* submitted-tx nil)
     (t/is (.entity (.db *api*) :origin-man))
     (t/testing "Tx log"
-      (with-open [log (api/open-tx-log *api* 0 false)]
+      (with-open [tx-log-iterator (.openTxLog *api* 0 false)]
         (t/is (= [{:crux.tx/tx-id 2,
                    :crux.tx/tx-time (:crux.tx/tx-time submitted-tx)
                    :crux.tx.event/tx-events
                    [[:crux.tx/put
                      (str (c/new-id (:crux.db/id doc)))
                      (str (c/new-id doc))]]}]
-                 log))))))
+                 (iterator-seq tx-log-iterator)))))))
 
 (defn- docs [dbtype ds id]
   (jdbc/with-transaction [t ds]

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -29,12 +29,13 @@
                                        '{:find [e]
                                          :where [[e :name "Ivan"]]})))
 
-            (with-open [tx-log (api/open-tx-log *ingest-client* nil false)]
-              (t/is (not (realized? tx-log)))
-              (t/is (= [(assoc submitted-tx
-                               :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"})]])]
-                       tx-log))
-              (t/is (realized? tx-log)))
+            (with-open [tx-log-iterator (api/open-tx-log *ingest-client* nil false)]
+              (let [result (iterator-seq tx-log-iterator)]
+                (t/is (not (realized? result)))
+                (t/is (= [(assoc submitted-tx
+                            :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan"})]])]
+                         result))
+                (t/is (realized? result))))
 
             (t/is (thrown? IllegalArgumentException (api/open-tx-log *ingest-client* nil true)))))))))
 

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -522,16 +522,17 @@
         (fapi/submit+await-tx [[:crux.tx/put tx2-ivan tx2-valid-time]
                                [:crux.tx/put tx2-petr tx2-valid-time]])]
 
-    (with-open [log (cio/<-stream (db/open-tx-log (:tx-log *api*) nil))]
-      (t/is (not (realized? log)))
-      (t/is (= [{:crux.tx/tx-id tx1-id
-                 :crux.tx/tx-time tx1-tx-time
-                 :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
-                {:crux.tx/tx-id tx2-id
-                 :crux.tx/tx-time tx2-tx-time
-                 :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
-                                           [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
-               log)))))
+    (with-open [log-iterator (db/open-tx-log (:tx-log *api*) nil)]
+      (let [log (iterator-seq log-iterator)]
+        (t/is (not (realized? log)))
+        (t/is (= [{:crux.tx/tx-id tx1-id
+                   :crux.tx/tx-time tx1-tx-time
+                   :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx1-ivan) tx1-valid-time]]}
+                  {:crux.tx/tx-id tx2-id
+                   :crux.tx/tx-time tx2-tx-time
+                   :crux.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id tx2-ivan) tx2-valid-time]
+                                             [:crux.tx/put (c/new-id :petr) (c/new-id tx2-petr) tx2-valid-time]]}]
+                 log))))))
 
 (t/deftest test-can-apply-transaction-fn
   (let [exception (atom nil)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -658,8 +658,9 @@
   (fapi/submit+await-tx [[:crux.tx/cas {:crux.db/id :to-evict} {:crux.db/id :to-evict :test "test"}]])
   (fapi/submit+await-tx [[:crux.tx/evict :to-evict]])
 
-  (with-open [tx-log (api/open-tx-log *api* nil true)]
-    (t/is (= (->> tx-log (map :crux.api/tx-ops))
+  (with-open [log-iterator (api/open-tx-log *api* nil true)]
+    (t/is (= (->> (iterator-seq log-iterator)
+                  (map :crux.api/tx-ops))
              [[[:crux.tx/put
                 #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
                           :evicted? true}]]

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -165,7 +165,7 @@ toc::[]
 
 [source,clj]
 ----
-(open-tx-log ^AutoCloseable [this after-tx-id with-ops?]
+(open-tx-log ^ICursor [this after-tx-id with-ops?]
   "Reads the transaction log. Optionally includes
   operations, which allow the contents under the :crux.api/tx-ops
   key to be piped into (submit-tx tx-ops) of another

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -275,7 +275,7 @@
                                  :where [[p1 :name n]
                                          [p1 :last-name n]
                                          [p1 :name "Smith"]]})]
-    (doseq [tuple res]
+    (doseq [tuple (iterator-seq res)]
       (prn tuple)))
   ;; end::streaming-query[]
   )


### PR DESCRIPTION
see #801, except we're solving it by going back to the original Iterator-based solution, because it's more explicit for users, and less chance of them making a mistake.

-- original PR below 

Jon flagged that open-q in its current form is going to hold on to the head of the seq
I'd thought that because we were taking an iterator over the query results and that because the iterator was (by its nature) stateful, it'd release elements from the sequence as it iterated through
and, in truth, it does - callers using the Java API will get a fully lazy sequence.
the problem comes, though, when the Clojure API calls iterator-seq on this iterator, and then uses that seq in a call to with-open:

```clojure
(with-open [res (crux/open-q ...)]
  (doseq [row res]
    ...))
```

which translates to

```clojure
(let [res (crux/open-q)]
  (try
    (doseq [row res]
      ...)
    (finally
      (.close res))))
```

which, then, keeps a reference to res; the implementation of the iterator-seq will hang on to the elements. sad times.