### PR TITLE
Kafka doc store ingest efficiency

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -317,7 +317,7 @@
 
 (defn evicted-doc?
   [{:crux.db/keys [id evicted?] :as doc}]
-  (or (= :crux.db/evicted id) evicted?))
+  (boolean (or (= :crux.db/evicted id) evicted?)))
 
 (defn keep-non-evicted-doc [doc]
   (when-not (evicted-doc? doc)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -60,7 +60,10 @@
 (defn tx-ops->id-and-docs [tx-ops]
   (when-not (s/valid? :crux.api/tx-ops tx-ops)
     (throw (ex-info (str "Spec assertion failed\n" (s/explain-str :crux.api/tx-ops tx-ops)) (s/explain-data :crux.api/tx-ops tx-ops))))
-  (map #(vector (str (c/new-id %)) %) (mapcat tx-op->docs tx-ops)))
+
+  (->> tx-ops
+       (into {} (comp (mapcat tx-op->docs)
+                      (map (juxt c/new-id identity))))))
 
 (defn tx-op->tx-event [tx-op]
   (let [[op id & args] (conform-tx-op tx-op)]

--- a/crux-core/src/crux/tx/consumer.clj
+++ b/crux-core/src/crux/tx/consumer.clj
@@ -27,7 +27,10 @@
 
                                 (doseq [{:keys [::txe/tx-events] :as tx} tx-log
                                         :let [tx (select-keys tx [::tx/tx-time ::tx/tx-id])]]
-                                  (db/index-tx indexer tx tx-events)
+                                  (when-let [{:keys [tombstones]} (db/index-tx indexer tx tx-events)]
+                                    (when (seq tombstones)
+                                      (db/submit-docs document-store tombstones)))
+
                                   (when (Thread/interrupted)
                                     (throw (InterruptedException.)))))
                               consumed-txs?))]


### PR DESCRIPTION
The Kafka doc store was putting objects into the object store, and then `index-docs` was later putting all the same docs in the object store again. Wouldn't have caused any extra space usage, but marshalling the docs to bytes won't have been free.

Changes:
- `index-docs` checks whether the docs are already indexed - we don't need to reindex them.
- The Kafka doc store now indexes documents rather than just putting them to the object store. (later, when the tx-consumer indexes the docs, this is now a no-op)
- We distinguish between unindexing docs (the result of indexing an evict tx) and indexing tombstones (as a result of log replay) - fixes #630