### PR TITLE
Public bus #813

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -169,7 +169,16 @@
   node.")
 
   (listen ^java.lang.AutoCloseable [node event-opts f]
-    "TODO doc")
+    "Attaches a listener to Crux's event bus.
+
+  `event-opts` should contain `:crux/event-type`, along with any other options the event-type requires.
+
+  We currently only support one public event-type: `:crux/indexed-tx`.
+  Supplying `:with-tx-ops? true` will include the transaction's operations in the event passed to `f`.
+
+  `(.close ...)` the return value to detach the listener.
+
+  This is an experimental API, subject to change.")
 
   (latest-completed-tx [node]
     "Returns the latest transaction to have been indexed by this node.")

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -173,11 +173,26 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      */
     public Map<Keyword, ?> awaitTx(Map<Keyword,?> tx, Duration timeout);
 
+    /**
+     * Temporary helper value to pass to `listen`, to subscribe to tx-indexed events.
+     */
     @SuppressWarnings("unchecked")
     public static final Map<Keyword, ?> TX_INDEXED_EVENT_OPTS = (Map<Keyword, Object>) PersistentArrayMap.EMPTY
         .assoc(Keyword.intern("crux/event-type"), Keyword.intern("crux/tx-indexed"))
         .assoc(Keyword.intern("with-tx-ops?"), true);
 
+    /**
+     * Attaches a listener to Crux's event bus.
+     *
+     * We currently only support one public event-type: `:crux/indexed-tx`.
+     * Supplying `:with-tx-ops? true` will include the transaction's operations in the event passed to `f`.
+     * See/use {@link #TX_INDEXED_EVENT_OPTS TX_INDEXED_EVENT_OPTS}
+     *
+     * This is an experimental API, subject to change.
+     *
+     * @param event-opts should contain `:crux/event-type`, along with any other options the event-type requires.
+     * @return an AutoCloseable - closing the return value detaches the listener.
+     */
     public AutoCloseable listen(Map<Keyword, ?> eventOpts, Consumer<Map<Keyword, ?>> listener);
 
     /**

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.time.Duration;
 import java.util.Set;
+import java.util.function.Consumer;
 import clojure.lang.Keyword;
+import clojure.lang.PersistentArrayMap;
 
 /**
  *  Provides API access to Crux.
@@ -171,6 +173,11 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      */
     public Map<Keyword, ?> awaitTx(Map<Keyword,?> tx, Duration timeout);
 
+    @SuppressWarnings("unchecked")
+    public static final Map<Keyword, ?> TX_INDEXED_EVENT_OPTS = (Map<Keyword, Object>) PersistentArrayMap.EMPTY
+        .assoc(Keyword.intern("crux/event-type"), Keyword.intern("crux/tx-indexed"));
+
+    public AutoCloseable listen(Map<Keyword, ?> eventOpts, Consumer<Map<Keyword, ?>> listener);
 
     /**
        @return the latest transaction to have been indexed by this node.

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -175,7 +175,8 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
 
     @SuppressWarnings("unchecked")
     public static final Map<Keyword, ?> TX_INDEXED_EVENT_OPTS = (Map<Keyword, Object>) PersistentArrayMap.EMPTY
-        .assoc(Keyword.intern("crux/event-type"), Keyword.intern("crux/tx-indexed"));
+        .assoc(Keyword.intern("crux/event-type"), Keyword.intern("crux/tx-indexed"))
+        .assoc(Keyword.intern("with-tx-ops?"), true);
 
     public AutoCloseable listen(Map<Keyword, ?> eventOpts, Consumer<Map<Keyword, ?>> listener);
 

--- a/crux-core/src/crux/bus.clj
+++ b/crux-core/src/crux/bus.clj
@@ -17,8 +17,8 @@
 (defmulti event-spec :crux/event-type, :default ::default)
 (defmethod event-spec ::default [_] any?)
 
-(s/def ::event (s/and (s/keys :req [:crux/event-type])
-                      (s/multi-spec event-spec :crux/event-type)))
+(s/def ::event (s/merge (s/keys :req [:crux/event-type])
+                        (s/multi-spec event-spec :crux/event-type)))
 
 (defrecord EventBus [!listeners]
   EventSource

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1213,12 +1213,12 @@
           query-id (str (UUID/randomUUID))
           safe-query (-> conformed-query .q-normalized (dissoc :args))]
       (when bus
-        (bus/send bus {:crux.bus/event-type ::submitted-query
+        (bus/send bus {:crux/event-type ::submitted-query
                        ::query safe-query
                        ::query-id query-id}))
       (let [ret (q this conformed-query)]
         (when bus
-          (bus/send bus {:crux.bus/event-type ::completed-query
+          (bus/send bus {:crux/event-type ::completed-query
                          ::query safe-query
                          ::query-id query-id}))
         ret)))
@@ -1234,13 +1234,13 @@
           query-id (str (UUID/randomUUID))
           safe-query (-> conformed-query .q-normalized (dissoc :args))]
       (when bus
-        (bus/send bus {:crux.bus/event-type ::submitted-query
+        (bus/send bus {:crux/event-type ::submitted-query
                        ::query safe-query
                        ::query-id query-id}))
       (cio/->cursor (fn []
                       (.close index-store)
                       (when bus
-                        (bus/send bus {:crux.bus/event-type ::completed-query
+                        (bus/send bus {:crux/event-type ::completed-query
                                        ::query safe-query
                                        ::query-id query-id})))
                     (q this index-store conformed-query))))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -467,7 +467,7 @@
                                                       (or (idx/keep-non-evicted-doc (db/get-single-object object-store index-store (c/new-id k)))
                                                           (idx/evicted-doc? doc)))))
                                    not-empty)]
-      (bus/send bus {::bus/event-type ::indexing-docs, :doc-ids (set (keys docs))})
+      (bus/send bus {:crux/event-type ::indexing-docs, :doc-ids (set (keys docs))})
 
       (let [bytes-indexed (db/index-docs indexer docs-to-upsert)
             docs-stats (->> (vals docs-to-upsert)
@@ -475,7 +475,7 @@
 
         (db/put-objects object-store docs-to-upsert)
 
-        (bus/send bus {::bus/event-type ::indexed-docs,
+        (bus/send bus {:crux/event-type ::indexed-docs,
                        :doc-ids (set (keys docs))
                        :av-count (->> (vals docs) (apply concat) (count))
                        :bytes-indexed bytes-indexed})
@@ -486,7 +486,7 @@
   (s/assert :crux.tx.event/tx-events tx-events)
 
   (log/debug "Indexing tx-id:" tx-id "tx-events:" (count tx-events))
-  (bus/send bus {::bus/event-type ::indexing-tx, ::submitted-tx tx})
+  (bus/send bus {:crux/event-type ::indexing-tx, ::submitted-tx tx})
 
   (with-open [index-store (db/open-index-store indexer)]
     (binding [*current-tx* (assoc tx :crux.tx.event/tx-events tx-events)]
@@ -517,7 +517,7 @@
             (log/warn "Transaction aborted:" (cio/pr-edn-str tx-events) (cio/pr-edn-str tx-time) tx-id)
             (db/mark-tx-as-failed indexer tx)))
 
-        (bus/send bus {::bus/event-type ::indexed-tx, ::submitted-tx tx, :committed? committed?})
+        (bus/send bus {:crux/event-type ::indexed-tx, ::submitted-tx tx, :committed? committed?})
 
         {:tombstones (when committed?
                        (:tombstones res))}))))

--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -4,24 +4,18 @@
   (:import [crux.bus EventBus]))
 
 (t/deftest test-bus
-  (let [!unfiltered-events (atom [])
-        !filtered-events (atom [])]
+  (let [!events (atom [])]
     (with-open [bus ^EventBus (bus/->EventBus (atom #{}))]
-      (bus/send bus {::bus/event-type :foo, :value 1})
+      (bus/send bus {:crux/event-type :foo, :value 1})
 
-      (bus/listen bus {::bus/event-types #{:foo}} #(swap! !filtered-events conj %))
-      (bus/listen bus #(swap! !unfiltered-events conj %))
+      (bus/listen bus {:crux/event-type :foo} #(swap! !events conj %))
 
-      (bus/send bus {::bus/event-type :foo, :value 2})
-      (bus/send bus {::bus/event-type :bar, :value 1})
+      (bus/send bus {:crux/event-type :foo, :value 2})
+      (bus/send bus {:crux/event-type :bar, :value 1})
 
       ;; just to ensure all the jobs are handled
       ;; - we don't guarantee this if the node is shut down
       (Thread/sleep 100))
 
-    (t/is (= [{::bus/event-type :foo, :value 2}
-              {::bus/event-type :bar, :value 1}]
-             @!unfiltered-events))
-
-    (t/is (= [{::bus/event-type :foo, :value 2}]
-             @!filtered-events))))
+    (t/is (= [{:crux/event-type :foo, :value 2}]
+             @!events))))

--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -1,17 +1,19 @@
 (ns crux.bus-test
   (:require [crux.bus :as bus]
-            [clojure.test :as t])
-  (:import [crux.bus EventBus]))
+            [clojure.test :as t]
+            [crux.topology :as topo])
+  (:import (java.io Closeable)))
 
 (t/deftest test-bus
   (let [!events (atom [])]
-    (with-open [bus ^EventBus (bus/->EventBus (atom #{}))]
+    (with-open [bus ^Closeable (topo/start-component bus/bus {} {})]
       (bus/send bus {:crux/event-type :foo, :value 1})
 
-      (bus/listen bus {:crux/event-type :foo} #(swap! !events conj %))
+      (with-open [_ (bus/listen bus {:crux/event-type :foo} #(swap! !events conj %))]
+        (bus/send bus {:crux/event-type :foo, :value 2})
+        (bus/send bus {:crux/event-type :bar, :value 1}))
 
-      (bus/send bus {:crux/event-type :foo, :value 2})
-      (bus/send bus {:crux/event-type :bar, :value 1})
+      (bus/send bus {:crux/event-type :foo, :value 3})
 
       ;; just to ensure all the jobs are handled
       ;; - we don't guarantee this if the node is shut down

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -260,6 +260,9 @@
     (api-request-sync (cond-> (str url "/await-tx?tx-id=" (:crux.tx/tx-id tx))
                         timeout (str "&timeout=" (cio/format-duration-millis timeout))) nil {:method :get}))
 
+  (listen [_ opts f]
+    (throw (UnsupportedOperationException. "crux/listen not supported on remote clients")))
+
   (latestCompletedTx [_]
     (api-request-sync (str url "/latest-completed-tx") nil {:method :get}))
 

--- a/crux-metrics/src/crux/metrics/indexer.clj
+++ b/crux-metrics/src/crux/metrics/indexer.clj
@@ -15,7 +15,7 @@
 (defn assign-tx-latency-gauge [registry {:crux.node/keys [bus]}]
   (let [!last-tx-lag (atom 0)]
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexed-tx}}
+                {:crux/event-type :crux.tx/indexed-tx}
                 (fn [{::tx/keys [submitted-tx]}]
                   (reset! !last-tx-lag (- (System/currentTimeMillis)
                                           (.getTime ^Date (::tx/tx-time submitted-tx))))))
@@ -27,7 +27,7 @@
 (defn assign-doc-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-docs"])]
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexed-docs}}
+                {:crux/event-type :crux.tx/indexed-docs}
                 (fn [{:keys [doc-ids]}]
                   (dropwizard/mark! meter (count doc-ids))))
 
@@ -36,7 +36,7 @@
 (defn assign-av-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-avs"])]
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexed-docs}}
+                {:crux/event-type :crux.tx/indexed-docs}
                 (fn [{:keys [av-count]}]
                   (dropwizard/mark! meter av-count)))
     meter))
@@ -44,7 +44,7 @@
 (defn assign-bytes-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-bytes"])]
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexed-docs}}
+                {:crux/event-types :crux.tx/indexed-docs}
                 (fn [{:keys [bytes-indexed]}]
                   (dropwizard/mark! meter bytes-indexed)))
 
@@ -54,12 +54,12 @@
   (let [timer (dropwizard/timer registry ["indexer" "indexed-txs"])
         !timer (atom nil)]
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexing-tx}}
+                {:crux/event-type :crux.tx/indexing-tx}
                 (fn [_]
                   (reset! !timer (dropwizard/start timer))))
 
     (bus/listen bus
-                {:crux.bus/event-types #{:crux.tx/indexed-tx}}
+                {:crux/event-type :crux.tx/indexed-tx}
                 (fn [_]
                   (let [[ctx _] (reset-vals! !timer nil)]
                     (dropwizard/stop ctx))))

--- a/crux-metrics/src/crux/metrics/query.clj
+++ b/crux-metrics/src/crux/metrics/query.clj
@@ -6,11 +6,11 @@
   [registry {:crux.node/keys [bus]}]
   (let [!timer-store (atom {})
         query-timer (dropwizard/timer registry ["query" "timer"])]
-    (bus/listen bus {:crux.bus/event-types #{:crux.query/submitted-query}}
+    (bus/listen bus {:crux/event-type :crux.query/submitted-query}
               (fn [event]
                 (swap! !timer-store assoc (:crux.query/query-id event) (dropwizard/start query-timer))))
 
-    (bus/listen bus {:crux.bus/event-types #{:crux.query/completed-query}}
+    (bus/listen bus {:crux/event-type :crux.query/completed-query}
               (fn [event]
                 (dropwizard/stop (get @!timer-store (:crux.query/query-id event)))
                 (swap! !timer-store dissoc (:crux.query/query-id event))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -398,7 +398,8 @@
     (let [!events (atom [])]
       (fapi/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
 
-      (let [[bar-tx baz-tx] (with-open [_ (api/listen *api* {:crux/event-type :crux/indexed-tx}
+      (let [[bar-tx baz-tx] (with-open [_ (api/listen *api* {:crux/event-type :crux/indexed-tx
+                                                             :with-tx-ops? true}
                                                       (fn [evt]
                                                         (swap! !events conj evt)))]
 
@@ -413,6 +414,12 @@
 
         (Thread/sleep 100)
 
-        (t/is (= [(merge {:crux/event-type :crux/indexed-tx, :committed? true} bar-tx)
-                  (merge {:crux/event-type :crux/indexed-tx, :committed? true} baz-tx)]
+        (t/is (= [(merge {:crux/event-type :crux/indexed-tx,
+                          :committed? true
+                          :crux/tx-ops [[:crux.tx/put {:crux.db/id :bar}]]}
+                         bar-tx)
+                  (merge {:crux/event-type :crux/indexed-tx,
+                          :committed? true
+                          :crux/tx-ops [[:crux.tx/put {:crux.db/id :baz}]]}
+                         baz-tx)]
                  @!events))))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -16,7 +16,8 @@
             [crux.query :as q]
             [crux.node :as n]
             [crux.io :as cio]
-            [taoensso.nippy :as nippy])
+            [taoensso.nippy :as nippy]
+            [crux.tx.event :as txe])
   (:import [java.util Date]
            [java.time Duration]))
 
@@ -795,7 +796,15 @@
                  :doc-ids #{(c/new-id doc-1) (c/new-id doc-2)}
                  :av-count 4}
                 {:crux/event-type ::tx/indexing-tx, ::tx/submitted-tx submitted-tx}
-                {:crux/event-type ::tx/indexed-tx, ::tx/submitted-tx submitted-tx, :committed? true}]
+                {:crux/event-type ::tx/indexed-tx,
+                 ::tx/submitted-tx submitted-tx,
+                 :committed? true
+                 ::txe/tx-events [[:crux.tx/put
+                                   "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+                                   "974e28e6484fb6c66e5ca6444ec616207800d815"]
+                                  [:crux.tx/put
+                                   "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
+                                   "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
                (-> (vec @!events)
                    (update 1 dissoc :bytes-indexed)))))))
 

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -161,6 +161,22 @@ toc::[]
 
 ----
 
+=== listen
+[source,clj]
+----
+  (listen ^java.lang.AutoCloseable [node event-opts f]
+    "Attaches a listener to Crux's event bus.
+
+  `event-opts` should contain `:crux/event-type`, along with any other options the event-type requires.
+
+  We currently only support one public event-type: `:crux/indexed-tx`.
+  Supplying `:with-tx-ops? true` will include the transaction's operations in the event passed to `f`.
+
+  `(.close ...)` the return value to detach the listener.
+
+  This is an experimental API, subject to change.")
+----
+
 === tx-log
 
 [source,clj]

--- a/docs/transactions.adoc
+++ b/docs/transactions.adoc
@@ -64,8 +64,11 @@ into a valid ID. Use of `#crux/id` with a valid ID type will also work
 
 URIs and URLs are interpreted using Java classes (java.net.URI and java.net.URL respectively) and therefore you can also use these directly.
 
+[#transactions-operations]
+== Operations
+
 [#transactions-put]
-== Put
+=== Put
 
 Put's a document into Crux. If a document already exists with the
 given `:crux.db/id`, a new version of this document will be created at
@@ -90,7 +93,7 @@ several versions or a range in time, one is required to submit a
 transaction containing several operations.
 
 [#transactions-delete]
-== Delete
+=== Delete
 
 Deletes a document at a given `valid time`.
 Historical versions of the document will still be available.
@@ -102,7 +105,7 @@ Historical versions of the document will still be available.
 ----
 
 [#transactions-match]
-== Match
+=== Match
 
 Match operations check the current state of an entity - if the entity doesn't match the provided doc, the transaction will not continue.
 You can also pass `nil` to check that the entity doesn't exist prior to your transaction.
@@ -121,7 +124,7 @@ You can also pass `nil` to check that the entity doesn't exist prior to your tra
 
 
 [#transactions-evict]
-== Evict
+=== Evict
 
 Evicts a document from Crux. Historical versions of the document will no longer be available.
 
@@ -129,3 +132,34 @@ Evicts a document from Crux. Historical versions of the document will no longer 
 ----
 [:crux.tx/evict :dbpedia.resource/Pablo-Picasso]
 ----
+
+== Events
+
+You can subscribe to Crux events using the `(crux.api/listen node event-opts f)` function.
+Currently we expose one event type, `:crux/indexed-tx`, called when Crux indexes a transaction.
+
+[source,clojure]
+----
+(require '[crux.api :as crux])
+
+(crux/listen node {:crux/event-type :crux/indexed-tx, :with-tx-ops? true}
+  (fn [ev]
+    (println "event received!")
+    (clojure.pprint/pprint ev)))
+
+(crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
+----
+
+prints:
+
+[source,clojure]
+----
+event received!
+{:crux/event-type :crux/indexed-tx,
+ :crux.tx/tx-id ...,
+ :crux.tx/tx-time #inst "...",
+ :committed? true,
+ :crux/tx-ops [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]]}
+----
+
+You can `.close` the return value from `(crux.api/listen ...)` to detach the listener, should you need to.


### PR DESCRIPTION
resolves #813 

This PR creates a `listen` fn on crux nodes, taking `{:crux/event-type :crux/indexed-tx}` and a function.

```clojure
(api/listen *api* {:crux/event-type :crux/indexed-tx}
            ;; (keys evt) = #{:crux/event-type ::tx/tx-id ::tx/tx-time :committed?}
            (fn [evt]
              ...))
```

(from Java, using Lambdas)
```java
node.listen(ICruxAPI.TX_INDEXED_EVENT_OPTS, evt -> ...);
```

* `listen` returns an `AutoCloseable` - calling `.close` detaches the listener.
* I've updated the internal bus to only accept one event type per `listen` req.
* Should the `indexed-tx` event return the transaction ops? we don't have a good way for users to get hold of it otherwise, currently.

TODO:
* [ ] Docstrings/Javadocs
* [ ] Add to documentation
* [ ] Blog

