### PR TITLE
tx-op validation without using spec

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -17,58 +17,13 @@
 (s/def :crux.db.fn/body (s/cat :fn #{'fn}
                                :args (s/coll-of symbol? :kind vector? :min-count 1)
                                :body (s/* any?)))
-(s/def ::doc (s/and (s/map-of keyword? any?)
-                    (s/keys :req [:crux.db/id] :opt [:crux.db.fn/body :crux.db.fn/args])))
 
-(def ^:private date? (partial instance? Date))
-
-(defmulti tx-op first)
-
-(defmethod tx-op :crux.tx/put [_]
-  (s/cat :op #{:crux.tx/put}
-         :doc ::doc
-         :start-valid-time (s/? date?)
-         :end-valid-time (s/? date?)))
-
-(defmethod tx-op :crux.tx/delete [_]
-  (s/cat :op #{:crux.tx/delete}
-         :id :crux.db/id
-         :start-valid-time (s/? date?)
-         :end-valid-time (s/? date?)))
-
-(defmethod tx-op :crux.tx/cas [_]
-  (s/cat :op #{:crux.tx/cas}
-         :old-doc (s/nilable ::doc)
-         :new-doc ::doc
-         :at-valid-time (s/? date?)))
-
-(defmethod tx-op :crux.tx/match [_]
-  (s/cat :op #{:crux.tx/match}
-         :id :crux.db/id
-         :doc (s/nilable ::doc)
-         :at-valid-time (s/? date?)))
-
-(defmethod tx-op :crux.tx/evict [_]
-  (s/cat :op #{:crux.tx/evict}
-         :id :crux.db/id))
-
-(s/def ::args-doc (s/and ::doc (s/keys :req [:crux.db.fn/args])))
-
-(defmethod tx-op :crux.tx/fn [_]
-  (s/cat :op #{:crux.tx/fn}
-         :id :crux.db/id
-         :args-doc (s/? ::args-doc)))
-
-(s/def ::tx-op (s/multi-spec tx-op first))
-(s/def ::tx-ops (s/coll-of ::tx-op :kind vector?))
-
-(defn- conform-tx-ops  [tx-ops]
+(defn- conform-tx-ops [tx-ops]
   (->> tx-ops
        (mapv
         (fn [tx-op]
-          (map
-           #(if (instance? java.util.Map %) (into {} %) %)
-           tx-op)))
+          (map #(if (instance? java.util.Map %) (into {} %) %)
+               tx-op)))
        (mapv vec)))
 
 (defprotocol PCruxNode

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -18,7 +18,8 @@
             [crux.topology :as topo]
             [crux.tx :as tx]
             [crux.tx.event :as txe]
-            [crux.bus :as bus])
+            [crux.bus :as bus]
+            [crux.tx.conform :as txc])
   (:import [crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException ICursor]
            java.io.Closeable
            java.util.Date
@@ -103,8 +104,9 @@
   (submitTx [this tx-ops]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (db/submit-docs document-store (tx/tx-ops->id-and-docs tx-ops))
-      @(db/submit-tx tx-log (map tx/tx-op->tx-event tx-ops))))
+      (let [conformed-tx-ops (mapv txc/conform-tx-op tx-ops)]
+        (db/submit-docs document-store (into {} (mapcat :docs) conformed-tx-ops))
+        @(db/submit-tx tx-log (mapv txc/->tx-event conformed-tx-ops)))))
 
   (hasTxCommitted [this {:keys [::tx/tx-id ::tx/tx-time] :as submitted-tx}]
     (cio/with-read-lock lock
@@ -182,8 +184,9 @@
   (submitTxAsync [this tx-ops]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (db/submit-docs document-store (tx/tx-ops->id-and-docs tx-ops))
-      (db/submit-tx tx-log (map tx/tx-op->tx-event tx-ops))))
+      (let [conformed-tx-ops (mapv txc/conform-tx-op tx-ops)]
+        (db/submit-docs document-store (into {} (mapcat :docs) conformed-tx-ops))
+        (db/submit-tx tx-log (mapv txc/->tx-event conformed-tx-ops)))))
 
   backup/INodeBackup
   (write-checkpoint [this {:keys [crux.backup/checkpoint-directory] :as opts}]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -14,6 +14,7 @@
             [taoensso.nippy :as nippy]
             [clojure.set :as set]
             [crux.status :as status]
+            [crux.tx.conform :as txc]
             [crux.tx.event :as txe])
   (:import crux.codec.EntityTx
            java.io.Closeable
@@ -34,49 +35,11 @@
 (s/def ::av-count nat-int?)
 (s/def ::bytes-indexed nat-int?)
 (s/def ::doc-ids (s/coll-of #(instance? crux.codec.Id %) :kind set?))
+
 (defmethod bus/event-spec ::indexing-docs [_] (s/keys :req-un [::doc-ids]))
 (defmethod bus/event-spec ::indexed-docs [_] (s/keys :req-un [::doc-ids ::av-count ::bytes-indexed]))
 (defmethod bus/event-spec ::indexing-tx [_] (s/keys :req [::submitted-tx]))
 (defmethod bus/event-spec ::indexed-tx [_] (s/keys :req [::submitted-tx ::txe/tx-events], :req-un [::committed?]))
-
-(defmulti conform-tx-op first)
-
-(defmethod conform-tx-op ::put [tx-op]
-  (let [[op doc & args] tx-op
-        id (:crux.db/id doc)]
-    (into [::put id doc] args)))
-
-(defmethod conform-tx-op ::cas [tx-op]
-  (let [[op old-doc new-doc & args] tx-op
-        new-id (:crux.db/id new-doc)
-        old-id (:crux.db/id old-doc)]
-    (if (or (= nil old-id) (= new-id old-id))
-      (into [::cas new-id old-doc new-doc] args)
-      (throw (IllegalArgumentException.
-              (str "CAS, document ids do not match: " old-id " " new-id))))))
-
-(defmethod conform-tx-op :default [tx-op] tx-op)
-
-(defn tx-op->docs [tx-op]
-  (let [[op id & args] (conform-tx-op tx-op)]
-    (filter map? args)))
-
-(defn tx-ops->id-and-docs [tx-ops]
-  (when-not (s/valid? :crux.api/tx-ops tx-ops)
-    (throw (ex-info (str "Spec assertion failed\n" (s/explain-str :crux.api/tx-ops tx-ops)) (s/explain-data :crux.api/tx-ops tx-ops))))
-
-  (->> tx-ops
-       (into {} (comp (mapcat tx-op->docs)
-                      (map (juxt c/new-id identity))))))
-
-(defn tx-op->tx-event [tx-op]
-  (let [[op id & args] (conform-tx-op tx-op)]
-    (doto (into [op (str (c/new-id id))]
-                (for [arg args]
-                  (if (map? arg)
-                    (-> arg c/new-id str)
-                    arg)))
-      (->> (s/assert ::txe/tx-event)))))
 
 (defn- conform-tx-event [[op & args]]
   (-> (case op
@@ -97,17 +60,16 @@
   (keep (conform-tx-event tx-event) [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
 
 (defn tx-event->tx-op [[op id & args] index-store object-store]
-  (doto (into [op]
-              (concat (when (contains? #{:crux.tx/delete :crux.tx/evict :crux.tx/fn} op)
-                        [(c/new-id id)])
+  (into [op]
+        (concat (when (contains? #{:crux.tx/delete :crux.tx/evict :crux.tx/fn} op)
+                  [(c/new-id id)])
 
-                      (for [arg args]
-                        (or (when (satisfies? c/IdToBuffer arg)
-                              (or (db/get-single-object object-store index-store arg)
-                                  {:crux.db/id (c/new-id id)
-                                   :crux.db/evicted? true}))
-                            arg))))
-    (->> (s/assert :crux.api/tx-op))))
+                (for [arg args]
+                  (or (when (satisfies? c/IdToBuffer arg)
+                        (or (db/get-single-object object-store index-store arg)
+                            {:crux.db/id (c/new-id id)
+                             :crux.db/evicted? true}))
+                      arg)))))
 
 (defprotocol EntityHistory
   (with-entity-history-seq-ascending [_ eid valid-time tx-time f])
@@ -315,15 +277,9 @@
                                                      (db/get-single-object object-store index-store arg-id)))
         args-id (:crux.db/id args-doc)
 
-        {:keys [tx-ops fn-error]} (try
-                                    (let [tx-ops (apply (tx-fn-eval-cache body) db args)]
-                                      (when tx-ops
-                                        (when-not (s/valid? :crux.api/tx-ops tx-ops)
-                                          (throw (ex-info (str "Spec assertion failed\n"
-                                                               (s/explain-str :crux.api/tx-ops tx-ops))
-
-                                                          (s/explain-data :crux.api/tx-ops tx-ops)))))
-                                      {:tx-ops tx-ops})
+        {:keys [conformed-tx-ops fn-error]} (try
+                                              {:conformed-tx-ops (->> (apply (tx-fn-eval-cache body) db args)
+                                                                      (mapv txc/conform-tx-op))}
 
                                     (catch Throwable t
                                       {:fn-error t}))]
@@ -333,13 +289,14 @@
                         (log-tx-fn-error fn-error fn-id body args-id args)
                         false)}
 
-      (let [docs (mapcat tx-op->docs tx-ops)
-            {arg-docs true docs false} (group-by (comp boolean :crux.db.fn/args) docs)
-            _ (index-docs tx-consumer (->> docs (into {} (map (juxt c/new-id identity)))))
-            op-results (vec (for [[op :as tx-event] (map tx-op->tx-event tx-ops)]
+      (let [docs (->> conformed-tx-ops
+                      (into {} (mapcat :docs)))
+            {arg-docs true docs false} (group-by (comp boolean :crux.db.fn/args val) docs)
+            _ (index-docs tx-consumer (into {} docs))
+            op-results (vec (for [[op :as tx-event] (map txc/->tx-event conformed-tx-ops)]
                               (index-tx-event tx-event tx
                                               (-> tx-consumer
-                                                  (update :nested-fn-args (fnil into {}) (map (juxt c/new-id identity)) arg-docs)))))]
+                                                  (update :nested-fn-args (fnil into {}) arg-docs)))))]
         {:pre-commit-fn #(every? true? (for [{:keys [pre-commit-fn]} op-results
                                              :when pre-commit-fn]
                                          (pre-commit-fn)))

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -1,0 +1,133 @@
+(ns ^:no-doc crux.tx.conform
+  (:require [crux.codec :as c]))
+
+(defn- check-eid [eid op]
+  (when-not (and (c/valid-id? eid) (not (string? eid)))
+    (throw (ex-info "invalid entity id" {:eid eid, :op op}))))
+
+(defn- check-doc [doc op]
+  (when-not (and (map? doc)
+                 (every? keyword (keys doc)))
+    (throw (ex-info "invalid doc" {:op op, :doc doc})))
+
+  (check-eid (:crux.db/id doc) op))
+
+(defn- check-valid-time [valid-time op]
+  (when-not (inst? valid-time)
+    (throw (ex-info "invalid valid-time" {:valid-time valid-time, :op op}))))
+
+(defmulti ^:private conform-tx-op-type first
+  :default ::default)
+
+(defmethod conform-tx-op-type ::default [op]
+  (throw (ex-info "Invalid tx op" {:op op})))
+
+(defmethod conform-tx-op-type :crux.tx/put [[_ doc start-valid-time end-valid-time :as op]]
+  (check-doc doc op)
+  (some-> start-valid-time (check-valid-time op))
+  (some-> end-valid-time (check-valid-time op))
+
+  (let [doc-id (c/new-id doc)]
+    {:op :crux.tx/put
+     :eid (:crux.db/id doc)
+     :doc-id doc-id
+     :docs {doc-id doc}
+     :start-valid-time start-valid-time
+     :end-valid-time end-valid-time}))
+
+(defmethod conform-tx-op-type :crux.tx/delete [[_ eid start-valid-time end-valid-time :as op]]
+  (check-eid eid op)
+  (some-> start-valid-time (check-valid-time op))
+  (some-> end-valid-time (check-valid-time op))
+
+  {:op :crux.tx/delete
+   :eid eid
+   :start-valid-time start-valid-time
+   :end-valid-time end-valid-time})
+
+(defmethod conform-tx-op-type :crux.tx/cas [[_ old-doc new-doc at-valid-time :as op]]
+  (some-> old-doc (check-doc op))
+  (some-> new-doc (check-doc op))
+  (some-> at-valid-time (check-valid-time op))
+  (when-not (or (nil? (:crux.db/id old-doc))
+                (nil? (:crux.db/id new-doc))
+                (= (:crux.db/id old-doc) (:crux.db/id new-doc)))
+    (throw (ex-info "CaS document IDs don't match" {:old-doc old-doc, :new-doc new-doc, :op op})))
+
+  (let [old-doc-id (some-> old-doc c/new-id)
+        new-doc-id (some-> new-doc c/new-id)]
+    {:op :crux.tx/cas
+     :eid (or (:crux.db/id old-doc) (:crux.db/id new-doc))
+     :old-doc-id old-doc-id
+     :new-doc-id new-doc-id
+     :docs (into {} (filter val) {old-doc-id old-doc, new-doc-id new-doc})
+     :at-valid-time at-valid-time}))
+
+
+(defmethod conform-tx-op-type :crux.tx/match [[_ eid doc at-valid-time :as op]]
+  (check-eid eid op)
+  (some-> doc (check-doc op))
+  (some-> at-valid-time (check-valid-time op))
+
+  (let [doc-id (c/new-id doc)]
+    {:op :crux.tx/match
+     :eid eid
+     :at-valid-time at-valid-time
+     :doc-id doc-id
+     :docs (when doc
+             {doc-id doc})}))
+
+(defmethod conform-tx-op-type :crux.tx/evict [[_ eid :as op]]
+  (check-eid eid op)
+  {:op :crux.tx/evict
+   :eid eid})
+
+(defmethod conform-tx-op-type :crux.tx/fn [[_ fn-eid arg-doc :as op]]
+  (check-eid fn-eid op)
+
+  (let [arg-doc-id (c/new-id arg-doc)]
+    (merge {:op :crux.tx/fn
+            :fn-eid fn-eid}
+           (when arg-doc
+             (check-doc arg-doc op)
+             {:arg-doc-id arg-doc-id
+              :docs {arg-doc-id arg-doc}}))))
+
+(defn conform-tx-op [op]
+  (try
+    (when-not (vector? op)
+      (throw (ex-info "tx-op must be a vector" {:op op})))
+
+    (conform-tx-op-type op)
+    (catch Exception e
+      (throw (IllegalArgumentException. (str "invalid tx-op: " (.getMessage e)) e)))))
+
+(defmulti ->tx-event :op :default ::default)
+
+(defmethod ->tx-event :crux.tx/put [{:keys [op eid doc-id start-valid-time end-valid-time]}]
+  (cond-> [op eid doc-id]
+    start-valid-time (conj start-valid-time)
+    end-valid-time (conj end-valid-time)))
+
+(defmethod ->tx-event :crux.tx/delete [{:keys [op eid start-valid-time end-valid-time]}]
+  (cond-> [op eid]
+    start-valid-time (conj start-valid-time)
+    end-valid-time (conj end-valid-time)))
+
+(defmethod ->tx-event :crux.tx/match [{:keys [op eid doc-id at-valid-time]}]
+  (cond-> [op eid doc-id]
+    at-valid-time (conj at-valid-time)))
+
+(defmethod ->tx-event :crux.tx/cas [{:keys [op eid old-doc-id new-doc-id at-valid-time]}]
+  (cond-> [op eid old-doc-id new-doc-id]
+    at-valid-time (conj at-valid-time)))
+
+(defmethod ->tx-event :crux.tx/evict [{:keys [op eid]}]
+  [op eid])
+
+(defmethod ->tx-event :crux.tx/fn [{:keys [op fn-eid arg-doc-id]}]
+  (cond-> [op fn-eid]
+    arg-doc-id (conj arg-doc-id)))
+
+(defmethod ->tx-event ::default [tx-op]
+  (throw (IllegalArgumentException. (str "invalid op: " (pr-str tx-op)))))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -78,6 +78,11 @@
        (= 404 status)
        nil
 
+       (= 400 status)
+       (let [{:keys [^String cause data]} (edn/read-string body)]
+         (throw (IllegalArgumentException. cause (when data
+                                                   (ex-info cause data)))))
+
        (and (<= 200 status) (< status 400)
             (= "application/edn" (:content-type headers)))
        (if (string? body)

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -67,8 +67,9 @@
       (try
         (handler request)
         (catch Exception e
-          (if (and (.getMessage e)
-                   (str/starts-with? (.getMessage e) "Spec assertion failed"))
+          (if (or (instance? IllegalArgumentException e)
+                  (and (.getMessage e)
+                       (str/starts-with? (.getMessage e) "Spec assertion failed")))
             (exception-response 400 e) ;; Valid edn, invalid content
             (do (log/error e "Exception while handling request:" (cio/pr-edn-str request))
                 (exception-response 500 e))))) ;; Valid content; something internal failed, or content validity is not properly checked

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -71,7 +71,7 @@
   (let [valid-time (Date.)
         content-ivan {:crux.db/id :ivan :name "Ivan"}
         content-hash (str (c/new-id content-ivan))]
-    (t/is (thrown-with-msg? Exception (re-pattern  (str content-hash "|HTTP status 400"))
+    (t/is (thrown-with-msg? IllegalArgumentException #"invalid doc"
                             (.submitTx *api* [[:crux.tx/put content-hash valid-time]])))))
 
 (t/deftest test-can-write-entity-using-map-as-id

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -53,8 +53,8 @@
                    :crux.tx/tx-time (:crux.tx/tx-time submitted-tx)
                    :crux.tx.event/tx-events
                    [[:crux.tx/put
-                     (str (c/new-id (:crux.db/id doc)))
-                     (str (c/new-id doc))]]}]
+                     (c/new-id (:crux.db/id doc))
+                     (c/new-id doc)]]}]
                  (iterator-seq tx-log-iterator)))))))
 
 (defn- docs [dbtype ds id]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1279,10 +1279,8 @@
   (t/testing "entity ids cannot be raw strings"
     (let [id (UUID/randomUUID)
           id-str (str id)]
-      (t/is (thrown-with-msg?
-             RuntimeException
-             #"Spec assertion failed"
-             (f/transact! *api* (f/people [{:crux.db/id id-str :name "Ivan" :version 2}])))))))
+      (t/is (thrown-with-msg? IllegalArgumentException #"invalid entity id"
+                              (f/transact! *api* (f/people [{:crux.db/id id-str :name "Ivan" :version 2}])))))))
 
 (t/deftest test-arguments-bug-247
   (t/is (= #{} (api/q (api/db *api*)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -557,9 +557,9 @@
               inc-ivans-age '{:crux.db/id :inc-ivans-age
                               :crux.db.fn/args [:ivan :age inc]}]
           (fapi/submit+await-tx [[:crux.tx/fn :update-attribute-fn inc-ivans-age]])
+          (t/is (nil? (latest-exception)))
           (t/is (= v2-ivan (api/entity (api/db *api*) :ivan)))
           (t/is (= inc-ivans-age (api/entity (api/db *api*) :inc-ivans-age)))
-          (t/is (nil? (latest-exception)))
 
           (t/testing "resulting documents are indexed"
             (t/is (= #{[41]} (api/q (api/db *api*)
@@ -586,7 +586,7 @@
                                        '(fn [db]
                                           [[:crux.tx/foo]])}]])
               (fapi/submit+await-tx '[[:crux.tx/fn :invalid-fn]])
-              (t/is (thrown-with-msg? clojure.lang.ExceptionInfo #"Spec assertion failed" (rethrow-latest-exception))))
+              (t/is (thrown-with-msg? IllegalArgumentException #"Invalid tx op" (rethrow-latest-exception))))
 
             (t/testing "exception thrown"
               (fapi/submit+await-tx [[:crux.tx/put
@@ -647,7 +647,7 @@
             (let [submitted-tx (fapi/submit+await-tx '[[:crux.tx/fn :tx-metadata-fn]])]
               (t/is (nil? (latest-exception)))
               (t/is (= {:crux.db/id :tx-metadata
-                        :crux.tx/current-tx (assoc submitted-tx :crux.tx.event/tx-events [[:crux.tx/fn (str (c/new-id :tx-metadata-fn))]])}
+                        :crux.tx/current-tx (assoc submitted-tx :crux.tx.event/tx-events [[:crux.tx/fn :tx-metadata-fn]])}
                        (api/entity (api/db *api*) :tx-metadata))))))))))
 
 (t/deftest tx-log-evict-454 []
@@ -800,11 +800,11 @@
                  ::tx/submitted-tx submitted-tx,
                  :committed? true
                  ::txe/tx-events [[:crux.tx/put
-                                   "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
-                                   "974e28e6484fb6c66e5ca6444ec616207800d815"]
+                                   #crux/id "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+                                   #crux/id "974e28e6484fb6c66e5ca6444ec616207800d815"]
                                   [:crux.tx/put
-                                   "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
-                                   "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
+                                   #crux/id "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
+                                   #crux/id "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
                (-> (vec @!events)
                    (update 1 dissoc :bytes-indexed)))))))
 


### PR DESCRIPTION
While I was profiling CAV, I found a significant proportion of the time to submit-tx was being taken by `clojure.spec.alpha/valid?` checking the tx-ops input by the user. Our tx-ops aren't particularly complicated, so I've hand-written the validation/checking logic.

Chances are the `submit-tx` thread isn't the critical path thread in any batch ingest - it's more likely to be the tx-consumer - but this change means that the `submit-tx` thread spends less time doing work and more time sleeping peacefully in `await-tx` (or, more likely, serving other requests).

On a micro-benchmark of the ts-devices ingest (50k docs):
- before the change: ~8.5s submit-tx, 3.5s await-tx
- after the change: ~2.5s submit-tx, 8s await-tx.

Related change: I've also made the remote API client rethrow `IllegalArgumentException`s, so that errors thrown locally and errors thrown from a remote client behave similarly.