### PR TITLE
Crux Data Browser - Accept map keys

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -284,6 +284,12 @@
     (URL. s)
     (catch MalformedURLException _)))
 
+(defn- maybe-map-str [s]
+  (try
+    (let [edn (edn/read-string s)]
+      (when (map? edn) edn))
+    (catch Exception _)))
+
 (extend-protocol IdToBuffer
   (class (byte-array 0))
   (id->buffer [this ^MutableDirectBuffer to]
@@ -330,9 +336,10 @@
         to)
       (if-let [id (or (maybe-uuid-str this)
                       (maybe-keyword-str this)
-                      (maybe-url-str this))]
+                      (maybe-url-str this)
+                      (maybe-map-str this))]
         (id->buffer id to)
-        (throw (IllegalArgumentException. (format "Not a %s hex, keyword, URL or an UUID string: %s" hash/id-hash-algorithm this))))))
+        (throw (IllegalArgumentException. (format "Not a %s hex, keyword, EDN map, URL or an UUID string: %s" hash/id-hash-algorithm this))))))
 
   Map
   (id->buffer [this to]

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -7,6 +7,7 @@
             [crux.query :as q])
   (:import (java.io Closeable InputStreamReader IOException PushbackReader)
            java.time.Duration
+           java.net.URLEncoder
            java.util.Date
            (crux.api Crux ICruxAPI ICruxDatasource NodeOutOfSyncException)))
 
@@ -209,10 +210,10 @@
     (api-request-sync (str url "/documents") content-hash-set {:method :post}))
 
   (history [_ eid]
-    (api-request-sync (str url "/history/" eid) nil {:method :get}))
+    (api-request-sync (str url "/history/" (URLEncoder/encode (pr-str eid))) nil {:method :get}))
 
   (historyRange [_ eid valid-time-start transaction-time-start valid-time-end transaction-time-end]
-    (api-request-sync (str url "/history-range/" eid "?"
+    (api-request-sync (str url "/history-range/" (URLEncoder/encode (pr-str eid)) "?"
                            (str/join "&"
                                      (map (partial str/join "=")
                                           [["valid-time-start" (cio/format-rfc3339-date valid-time-start)]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -28,6 +28,7 @@
            [java.io Closeable IOException OutputStream]
            java.time.Duration
            java.util.Date
+           java.net.URLDecoder
            org.eclipse.jetty.server.Server))
 
 ;; ---------------------------------------------------
@@ -401,7 +402,7 @@
 
 (defn- entity-state [^ICruxAPI crux-node options request]
   (let [[_ encoded-eid] (re-find #"^/_entity/(.+)$" (req/path-info request))]
-    (let [eid (c/id-edn-reader encoded-eid)
+    (let [eid (c/id-edn-reader (URLDecoder/decode encoded-eid))
           query-params (:query-params request)
           db (db-for-request crux-node {:valid-time (some-> (get query-params "valid-time")
                                                             (instant/read-instant-date))

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -116,7 +116,7 @@
 
 (defn- history [^ICruxAPI crux-node request]
   (let [[_ eid] (re-find #"^/history/(.+)$" (req/path-info request))
-        history (.history crux-node (c/new-id eid))]
+        history (.history crux-node (c/new-id (URLDecoder/decode eid)))]
     (-> (success-response history)
         (add-last-modified (:crux.tx/tx-time (first history))))))
 
@@ -128,7 +128,7 @@
 
 (defn- history-range [^ICruxAPI crux-node request]
   (let [[eid valid-time-start transaction-time-start valid-time-end transaction-time-end] (parse-history-range-params request)
-        history (.historyRange crux-node (c/new-id eid) valid-time-start transaction-time-start valid-time-end transaction-time-end)
+        history (.historyRange crux-node (c/new-id (URLDecoder/decode eid)) valid-time-start transaction-time-start valid-time-end transaction-time-end)
         last-modified (:crux.tx/tx-time (last history))]
     (-> (success-response history)
         (add-last-modified (:crux.tx/tx-time (last history))))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -166,7 +166,8 @@
   (let [doc {:crux.db/id {:user "Xwop1A7Xog4nD6AfhZaPgg"} :name "Adam"}
         submitted-tx (api/submit-tx *api* [[:crux.tx/put doc]])]
     (api/await-tx *api* submitted-tx)
-    (t/is (api/entity (api/db *api*) {:user "Xwop1A7Xog4nD6AfhZaPgg"}))))
+    (t/is (api/entity (api/db *api*) {:user "Xwop1A7Xog4nD6AfhZaPgg"}))
+    (t/is (not-empty (api/history *api* {:user "Xwop1A7Xog4nD6AfhZaPgg"})))))
 
 (t/deftest test-content-hash-invalid
   (let [valid-time (Date.)


### PR DESCRIPTION
The issue here has two parts to it - firstly, maps passed through URLs would be encoded, and there was no call to decode the URL before attempting to read as a Crux ID. Secondly, the `id-edn-reader` within `crux.codec` did not handle maps passed in as strings (there were `maybe-x-str` functions for the other types of IDs here, but none for maps). 

If there are issues to adding this to `crux.codec`, we could likely replace the `c/id-edn-reader` call in the handler with calls to `c/read-edn-string-with-readers` and `c/valid-id?`