### PR TITLE
Add `_status` endpoint to data browser handler

### DIFF
--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -604,11 +604,13 @@
                    (with-out-str
                      (pp/pprint (Throwable->map e))))})))))
 
-(defn data-browser-status [^ICruxAPI crux-node _ request]
+(defn data-browser-status [^ICruxAPI crux-node options request]
   (let [status (api/status crux-node)]
     {:status 200
      :body (if (html? request)
-             (html5 (entity->html nil status))
+             (raw-html {:body (entity->html nil status)
+                        :title "/_status"
+                        :options options})
              status)}))
 
 (defn- data-browser-handler [crux-node options request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -457,6 +457,7 @@
                         edn))
       (sequential? edn) (into [:ol] (map (fn [v] [:li (entity->html links v)]) edn))
       (set? edn) (into [:ul] (map (fn [v] [:li (entity->html links v)]) edn))
+      (nil? edn) [:code "nil"]
       :else (str edn))))
 
 (defn- entity-state [^ICruxAPI crux-node options request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -603,6 +603,13 @@
                    (with-out-str
                      (pp/pprint (Throwable->map e))))})))))
 
+(defn data-browser-status [^ICruxAPI crux-node _ request]
+  (let [status (api/status crux-node)]
+    {:status 200
+     :body (if (html? request)
+             (html5 (entity->html nil status))
+             status)}))
+
 (defn- data-browser-handler [crux-node options request]
   (condp check-path request
     [#"^/_entity/.+$" [:get]]
@@ -610,6 +617,9 @@
 
     [#"^/_query" [:get]]
     (data-browser-query crux-node options request)
+
+    [#"^/_status" [:get]]
+    (data-browser-status crux-node options request)
 
     nil))
 


### PR DESCRIPTION
Renders the HTML using the `entity->html` function, and makes a couple of minor changes to rendering.