### PR TITLE
Tidying up entity-history

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -564,13 +564,6 @@
            (not-empty)
            (map second)))))
 
-(defn all-entities [snapshot valid-time transact-time]
-  (with-open [i (kv/new-iterator snapshot)]
-    (let [eids (->> (all-keys-in-prefix i (c/encode-entity+vt+tt+tx-id-key-to (.get seek-buffer-tl)))
-                    (map (comp :eid c/decode-entity+vt+tt+tx-id-key-from))
-                    (distinct))]
-      (entities-at snapshot eids valid-time transact-time))))
-
 ;; TODO: Entity history would need to be able to use the Z order index
 ;; for us to be able to remove the old index. Outstanding questions
 ;; around how and if LITMAX would work together with seeks and prev

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -569,34 +569,36 @@
   (-> (c/decode-entity+vt+tt+tx-id-key-from k)
       (enrich-entity-tx v)))
 
-(defn entity-history-seq-ascending [i eid ^Date from-valid-time ^Date transaction-time]
-  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-valid-time)]
-    (->> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
-                             {:reverse? true, :entries? true})
-         (map ->entity-tx)
-         (drop-while (fn [^EntityTx entity-tx]
-                       (neg? (compare (.vt entity-tx) from-valid-time))))
-         (partition-by :vt)
-         (map (fn [group]
-                (->> group
-                     (reverse)
-                     (drop-while (fn [^EntityTx entity-tx]
-                                   (pos? (compare (.tt entity-tx) transaction-time))))
-                     (first))))
-         (remove nil?))))
+(defn entity-history-seq-ascending [i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
+                                           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until}]
 
-(defn entity-history-seq-descending [i eid ^Date from-valid-time ^Date transaction-time]
-  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-valid-time)]
-    (->> (all-keys-in-prefix i (-> seek-k (mem/limit-buffer (+ c/index-id-size c/id-size))) seek-k
-                             {:entries? true})
-         (map ->entity-tx)
-         (partition-by :vt)
-         (map (fn [group]
-                (->> group
-                     (drop-while (fn [^EntityTx entity-tx]
-                                   (pos? (compare (.tt entity-tx) transaction-time))))
-                     (first))))
-         (remove nil?))))
+  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+    (-> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
+                            {:reverse? true, :entries? true})
+        (->> (map ->entity-tx))
+        (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
+                                        (neg? (compare (.vt entity-tx) until-vt))))
+                 from-tt (filter (fn [^EntityTx entity-tx]
+                                    (pos? (compare (.tt entity-tx) from-tt))))
+                 until-tt (remove (fn [^EntityTx entity-tx]
+                                    (pos? (compare (.tt entity-tx) until-tt)))))
+        (->> (partition-by :vt)
+             (map last)))))
+
+(defn entity-history-seq-descending [i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
+                                            {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until}]
+  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+    (-> (all-keys-in-prefix i (-> seek-k (mem/limit-buffer (+ c/index-id-size c/id-size))) seek-k
+                            {:entries? true})
+        (->> (map ->entity-tx))
+        (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
+                                        (pos? (compare (.vt entity-tx) until-vt))))
+                 from-tt (remove (fn [^EntityTx entity-tx]
+                                    (pos? (compare (.tt entity-tx) from-tt))))
+                 until-tt (filter (fn [^EntityTx entity-tx]
+                                    (pos? (compare (.tt entity-tx) until-tt)))))
+        (->> (partition-by :vt)
+             (map first)))))
 
 ;; TODO: This would need to change to simply walk the entire Z curve
 ;; from a point in the right order.

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -569,54 +569,44 @@
   (-> (c/decode-entity+vt+tt+tx-id-key-from k)
       (enrich-entity-tx v)))
 
-(defn entity-history-seq-ascending [i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
-                                           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until}]
+(defn entity-history-seq-ascending
+  ([i eid] ([i eid] (entity-history-seq-ascending i eid {})))
 
-  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
-    (-> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
-                            {:reverse? true, :entries? true})
-        (->> (map ->entity-tx))
-        (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
-                                        (neg? (compare (.vt entity-tx) until-vt))))
-                 from-tt (filter (fn [^EntityTx entity-tx]
+  ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
+           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
+           :keys [with-corrections?]}]
+
+   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+     (-> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
+                             {:reverse? true, :entries? true})
+         (->> (map ->entity-tx))
+         (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
+                                         (neg? (compare (.vt entity-tx) until-vt))))
+                  from-tt (filter (fn [^EntityTx entity-tx]
                                     (pos? (compare (.tt entity-tx) from-tt))))
-                 until-tt (remove (fn [^EntityTx entity-tx]
-                                    (pos? (compare (.tt entity-tx) until-tt)))))
-        (->> (partition-by :vt)
-             (map last)))))
+                  until-tt (remove (fn [^EntityTx entity-tx]
+                                     (pos? (compare (.tt entity-tx) until-tt)))))
+         (cond-> (not with-corrections?) (->> (partition-by :vt)
+                                              (map last)))))))
 
-(defn entity-history-seq-descending [i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
-                                            {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until}]
-  (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
-    (-> (all-keys-in-prefix i (-> seek-k (mem/limit-buffer (+ c/index-id-size c/id-size))) seek-k
-                            {:entries? true})
-        (->> (map ->entity-tx))
-        (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
-                                        (pos? (compare (.vt entity-tx) until-vt))))
-                 from-tt (remove (fn [^EntityTx entity-tx]
+(defn entity-history-seq-descending
+  ([i eid] (entity-history-seq-descending i eid {}))
+
+  ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
+           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
+           :keys [with-corrections?]}]
+   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+     (-> (all-keys-in-prefix i (-> seek-k (mem/limit-buffer (+ c/index-id-size c/id-size))) seek-k
+                             {:entries? true})
+         (->> (map ->entity-tx))
+         (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
+                                         (pos? (compare (.vt entity-tx) until-vt))))
+                  from-tt (remove (fn [^EntityTx entity-tx]
                                     (pos? (compare (.tt entity-tx) from-tt))))
-                 until-tt (filter (fn [^EntityTx entity-tx]
-                                    (pos? (compare (.tt entity-tx) until-tt)))))
-        (->> (partition-by :vt)
-             (map first)))))
-
-;; TODO: This would need to change to simply walk the entire Z curve
-;; from a point in the right order.
-
-(defn- entity-history-seq [i eid]
-  (let [prefix (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid))]
-    (for [[k v] (all-keys-in-prefix i prefix prefix {:entries? true})]
-      (-> (c/decode-entity+vt+tt+tx-id-key-from k)
-          (enrich-entity-tx v)))))
-
-(defn entity-history
-  ([snapshot eid]
-   (entity-history snapshot eid Long/MAX_VALUE))
-  ([snapshot eid n]
-   (with-open [i (kv/new-iterator snapshot)]
-     (->> (entity-history-seq i eid)
-          (take n)
-          (vec)))))
+                  until-tt (filter (fn [^EntityTx entity-tx]
+                                     (pos? (compare (.tt entity-tx) until-tt)))))
+         (cond-> (not with-corrections?) (->> (partition-by :vt)
+                                              (map first)))))))
 
 (defn all-content-hashes [snapshot eid]
   (with-open [i (kv/new-iterator snapshot)]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -372,7 +372,6 @@
 (defn all-keys-in-prefix
   ([i prefix] (all-keys-in-prefix i prefix prefix {}))
   ([i prefix seek-k] (all-keys-in-prefix i prefix seek-k {}))
-
   ([i ^DirectBuffer prefix, ^DirectBuffer seek-k, {:keys [entries? reverse?]}]
    (letfn [(step [k]
              (lazy-seq
@@ -571,11 +570,9 @@
 
 (defn entity-history-seq-ascending
   ([i eid] ([i eid] (entity-history-seq-ascending i eid {})))
-
   ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
            {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
            :keys [with-corrections?]}]
-
    (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
      (-> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
                              {:reverse? true, :entries? true})
@@ -591,7 +588,6 @@
 
 (defn entity-history-seq-descending
   ([i eid] (entity-history-seq-descending i eid {}))
-
   ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
            {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
            :keys [with-corrections?]}]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -346,8 +346,10 @@
 
   (entity-valid-time-history [this eid start-valid-time transact-time ascending?]
     (if ascending?
-      (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid start-valid-time transact-time)
-      (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid start-valid-time transact-time)))
+      (idx/entity-history-seq-ascending (kv/new-iterator snapshot) eid {:from {::db/valid-time start-valid-time}
+                                                                        :until {::tx-time transact-time}})
+      (idx/entity-history-seq-descending (kv/new-iterator snapshot) eid {:from {::db/valid-time start-valid-time
+                                                                                ::tx-time transact-time}})))
 
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end]
     (idx/entity-history-range snapshot eid valid-time-start transaction-time-start valid-time-end transaction-time-end))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -49,16 +49,11 @@
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
       (t/testing "can see entity at transact and valid time"
         (t/is (= expected-entities
-                 (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] tx-time tx-time)))
-        (t/is (= expected-entities
-                 (idx/all-entities snapshot tx-time tx-time))))
+                 (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] tx-time tx-time))))
 
       (t/testing "cannot see entity before valid or transact time"
         (t/is (empty? (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] #inst "2018-05-20" tx-time)))
-        (t/is (empty? (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] tx-time #inst "2018-05-20")))
-
-        (t/is (empty? (idx/all-entities snapshot #inst "2018-05-20" tx-time)))
-        (t/is (empty? (idx/all-entities snapshot tx-time #inst "2018-05-20"))))
+        (t/is (empty? (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] tx-time #inst "2018-05-20"))))
 
       (t/testing "can see entity after valid or transact time"
         (t/is (some? (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] #inst "2018-05-22" tx-time)))
@@ -81,17 +76,12 @@
             (fapi/submit+await-tx [[:crux.tx/put new-picasso new-valid-time]])]
 
         (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
-          (t/is (= [(c/map->EntityTx {:eid          picasso-eid
+          (t/is (= [(c/map->EntityTx {:eid picasso-eid
                                       :content-hash new-content-hash
-                                      :vt           new-valid-time
-                                      :tt           new-tx-time
-                                      :tx-id        new-tx-id})]
+                                      :vt new-valid-time
+                                      :tt new-tx-time
+                                      :tx-id new-tx-id})]
                    (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] new-valid-time new-tx-time)))
-          (t/is (= [(c/map->EntityTx {:eid          picasso-eid
-                                      :content-hash new-content-hash
-                                      :vt           new-valid-time
-                                      :tt           new-tx-time
-                                      :tx-id        new-tx-id})] (idx/all-entities snapshot new-valid-time new-tx-time)))
 
           (t/is (empty? (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] #inst "2018-05-20" #inst "2018-05-21"))))))
 
@@ -104,23 +94,18 @@
             (fapi/submit+await-tx [[:crux.tx/put new-picasso new-valid-time]])]
 
         (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
-          (t/is (= [(c/map->EntityTx {:eid          picasso-eid
+          (t/is (= [(c/map->EntityTx {:eid picasso-eid
                                       :content-hash new-content-hash
-                                      :vt           new-valid-time
-                                      :tt           new-tx-time
-                                      :tx-id        new-tx-id})]
+                                      :vt new-valid-time
+                                      :tt new-tx-time
+                                      :tx-id new-tx-id})]
                    (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] new-valid-time new-tx-time)))
-          (t/is (= [(c/map->EntityTx {:eid          picasso-eid
+          (t/is (= [(c/map->EntityTx {:eid picasso-eid
                                       :content-hash content-hash
-                                      :vt           valid-time
-                                      :tt           tx-time
-                                      :tx-id        tx-id})]
-                   (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] new-valid-time tx-time)))
-          (t/is (= [(c/map->EntityTx {:eid          picasso-eid
-                                      :content-hash new-content-hash
-                                      :vt           new-valid-time
-                                      :tt           new-tx-time
-                                      :tx-id        new-tx-id})] (idx/all-entities snapshot new-valid-time new-tx-time))))
+                                      :vt valid-time
+                                      :tt tx-time
+                                      :tx-id tx-id})]
+                   (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] new-valid-time tx-time))))
 
         (t/testing "can correct entity at earlier valid time"
           (let [new-picasso (assoc picasso :bar :foo)
@@ -133,17 +118,12 @@
                 (fapi/submit+await-tx [[:crux.tx/put new-picasso new-valid-time]])]
 
             (with-open [snapshot (kv/new-snapshot (:kv-store *api*))]
-              (t/is (= [(c/map->EntityTx {:eid          picasso-eid
+              (t/is (= [(c/map->EntityTx {:eid picasso-eid
                                           :content-hash new-content-hash
-                                          :vt           new-valid-time
-                                          :tt           new-tx-time
-                                          :tx-id        new-tx-id})]
+                                          :vt new-valid-time
+                                          :tt new-tx-time
+                                          :tx-id new-tx-id})]
                        (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] new-valid-time new-tx-time)))
-              (t/is (= [(c/map->EntityTx {:eid          picasso-eid
-                                          :content-hash new-content-hash
-                                          :vt           new-valid-time
-                                          :tt           new-tx-time
-                                          :tx-id        new-tx-id})] (idx/all-entities snapshot new-valid-time new-tx-time)))
 
               (t/is (= prev-tx-id (-> (idx/entities-at snapshot [:http://dbpedia.org/resource/Pablo_Picasso] prev-tx-time prev-tx-time)
                                       (first)


### PR DESCRIPTION
Been tidying up the entity-history fns in index.clj in preparation for whatever changes we end up making to the entity-history API (no API changes in this PR).

* `idx/all-keys-in-prefix` now works in reverse order as well
* `idx/entity-history-seq-*` written in terms of `idx/all-keys-in-prefix` (`idx/entity-history-step` was pretty much doing this anyway)
* `idx/entity-history-seq-*` also now accept two bitemporal instants, and a `with-corrections?` flag
* removed some `idx/` fns that were only used in tests - these can also use `idx/entity-history-seq-*` now

RFC - regarding the range semantics: I've opted to have the minimum vt/tt as _exclusive_, maximum vt/tt as _inclusive_ - because of the common case of setting max-tt as the transaction time you've just got back from a transaction. This is intuitive for descending - start inclusive, end exclusive - but potentially counter-intuitive for ascending where it's start exclusive, end inclusive. I didn't want to go for either inclusive/inclusive, or having ascending not include the most recent transaction time. See the new `crux.tx-test/test-entity-history-seq-corner-cases` test for examples. Thoughts?