### PR TITLE
Entity history range semantics

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -31,8 +31,8 @@
   (new-attribute-value-entity-index-pair [this a entity-as-of-idx])
   (new-attribute-entity-value-index-pair [this a entity-as-of-idx])
   (new-entity-as-of-index [this valid-time transact-time])
-  (entity-valid-time-history [this eid start-valid-time transact-time ascending?])
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end])
+  (entity-history [this eid sort-order opts])
   (all-content-hashes [this eid])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -579,10 +579,10 @@
          (->> (map ->entity-tx))
          (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
                                          (neg? (compare (.vt entity-tx) until-vt))))
-                  from-tt (filter (fn [^EntityTx entity-tx]
-                                    (pos? (compare (.tt entity-tx) from-tt))))
-                  until-tt (remove (fn [^EntityTx entity-tx]
-                                     (pos? (compare (.tt entity-tx) until-tt)))))
+                  from-tt (remove (fn [^EntityTx entity-tx]
+                                    (neg? (compare (.tt entity-tx) from-tt))))
+                  until-tt (filter (fn [^EntityTx entity-tx]
+                                     (neg? (compare (.tt entity-tx) until-tt)))))
          (cond-> (not with-corrections?) (->> (partition-by :vt)
                                               (map last)))))))
 

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -321,8 +321,10 @@
     (tx/index-docs (:tx-consumer *api*) {(c/new-id ivan1) ivan1
                                          (c/new-id ivan2) ivan2})
 
-    (tx/index-tx (:tx-consumer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 1} [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]])
-    (tx/index-tx (:tx-consumer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 2} [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]])
+    (tx/index-tx (:tx-consumer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 1}
+                 [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]])
+    (tx/index-tx (:tx-consumer *api*) {:crux.tx/tx-time t, :crux.tx/tx-id 2}
+                 [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan2))]])
 
     (with-open [snapshot (kv/new-snapshot (:kv-store *api*))
                 i (kv/new-iterator snapshot)]
@@ -333,12 +335,11 @@
 
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
                (idx/entity-history-seq-descending i (c/new-id :ivan)
-                                                  {:from {::tx/tx-time t,::db/valid-time t}})))
+                                                  {:from {::tx/tx-time t, ::db/valid-time t}})))
 
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
                (idx/entity-history-seq-ascending i (c/new-id :ivan)
-                                                 {:from {::db/valid-time t}
-                                                  :until {::tx/tx-time t}}))))))
+                                                 {:from {::db/valid-time t}}))))))
 
 (t/deftest test-entity-history-seq-corner-cases
   (let [ivan {:crux.db/id :ivan}
@@ -365,38 +366,34 @@
                 (history-desc [opts]
                   (idx/entity-history-seq-descending i (c/new-id :ivan) opts))]
 
-          (t/testing "desc from is inclusive"
+          (t/testing "from is inclusive"
             (t/is (= [etx-v2-t2
                       etx-v1-t2]
                      (history-desc {:from {::tx/tx-time t2, ::db/valid-time t2}})))
 
             (t/is (= [etx-v1-t2]
-                     (history-desc {:from {::db/valid-time t1}}))))
+                     (history-desc {:from {::db/valid-time t1}})))
 
-          (t/testing "desc until is exclusive"
+            (t/is (= [etx-v1-t2 etx-v2-t2]
+                     (history-asc {:from {::tx/tx-time t2}})))
+
+            (t/is (= [etx-v1-t1 etx-v1-t2 etx-v2-t2]
+                     (history-asc {:from {::tx/tx-time t1
+                                          ::db/valid-time t1}
+                                   :with-corrections? true}))))
+
+          (t/testing "until is exclusive"
             (t/is (= [etx-v2-t2]
                      (history-desc {:from {::tx/tx-time t2, ::db/valid-time t2}
                                     :until {::tx/tx-time t1, ::db/valid-time t1}})))
 
             (t/is (= []
-                     (history-desc {:until {::db/valid-time t2}}))))
-
-          (t/testing "asc from is exclusive"
-            (t/is (= []
-                     (history-asc {:from {::tx/tx-time t2}})))
-
-            (t/is (= [etx-v1-t2
-                      etx-v2-t2]
-                     (history-asc {:from {::tx/tx-time t1
-                                          ::db/valid-time t1}}))))
-
-          (t/testing "asc until is inclusive"
-            (t/is (= [etx-v1-t2
-                      etx-v2-t2]
-                     (history-asc {:from {::db/valid-time t1},
-                                   :until {::tx/tx-time t2}})))
+                     (history-desc {:until {::db/valid-time t2}})))
 
             (t/is (= [etx-v1-t1]
+                     (history-asc {:until {::tx/tx-time t2}})))
+
+            (t/is (= []
                      (history-asc {:from {::db/valid-time t1},
                                    :until {::tx/tx-time t1}})))))))))
 
@@ -440,8 +437,7 @@
                                       [vt (get-in res [tx-idx :crux.tx/tx-id]) (c/new-id (when value
                                                                                            (assoc ivan :value value)))])
 
-                                    (->> (idx/entity-history-seq-ascending i eid {:from {::db/valid-time first-vt}
-                                                                                  :until last-tx})
+                                    (->> (idx/entity-history-seq-ascending i eid {:from {::db/valid-time first-vt}})
                                          (map (juxt :vt :tx-id :content-hash)))))))
 
     ;; pairs
@@ -791,8 +787,7 @@
                 i (kv/new-iterator snapshot)]
       (let [eid->history (fn [eid]
                            (->> (idx/entity-history-seq-ascending i (c/new-id eid)
-                                                                  {:until last-tx
-                                                                   :from {::db/valid-time #inst "2020-01-01"}})
+                                                                  {:from {::db/valid-time #inst "2020-01-01"}})
                                 (map (fn [{:keys [content-hash vt]}]
                                        [vt (:v (db/get-single-object (:object-store *api*) snapshot content-hash))]))))]
         ;; transaction functions, asserts both still apply at the start of the transaction


### PR DESCRIPTION
Wasn't 100% happy with the different semantics for asc and desc that were in #836, so I experimented to see whether it was possible to use the usual 'inclusive-start, exclusive-end' on both. The impact was that I had to explicitly specify in callers when I wanted inclusive-end behaviour - which turned out to only be in my later entity-history API change branch, and even then only when the DB provides an upper bound to the tx-time.

This PR also updates the IndexStore `entity-valid-time-history` fn to use the two bitemporal co-ordinates that you can now supply to `idx/entity-history-seq-[a,de]scending` - this is just `entity-history` now.