### PR TITLE
Entity history API, #830

### DIFF
--- a/crux-bench/src/crux/bench/ts_devices.clj
+++ b/crux-bench/src/crux/bench/ts_devices.clj
@@ -223,7 +223,7 @@
                                         (reduce into []))
                        db (crux/db node #inst "1970")
                        histories (for [r reading-ids]
-                                   (crux/open-history-ascending db r))]
+                                   (crux/open-entity-history db r :asc))]
                    (try
                      (->> (for [history histories]
                             (for [entity-tx history]

--- a/crux-bench/src/crux/bench/ts_weather.clj
+++ b/crux-bench/src/crux/bench/ts_weather.clj
@@ -298,7 +298,7 @@
                                           (reduce into []))
                        db (api/db node #inst "1970")
                        histories (for [c condition-ids]
-                                   (api/open-history-ascending db c))]
+                                   (api/open-entity-history db c :asc))]
                    (try
                      (->> (for [history histories]
                             (for [entity-tx history]

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -311,12 +311,31 @@
   (entity-history
     [node eid sort-order]
     [node eid sort-order opts]
-    "TODO docstring")
+    "Eagerly retrieves entity history for the given entity.
+
+  Options:
+  * `sort-order` (parameter): `#{:asc :desc}`
+  * `:with-docs?`: specifies whether to include documents in the entries
+  * `:with-corrections?`: specifies whether to include bitemporal corrections in the sequence, sorted first by valid-time, then transaction-time.
+  * `:start` (nested map, inclusive, optional): the `:crux.db/valid-time` and `:crux.tx/tx-time` to start at.
+  * `:end` (nested map, exclusive, optional): the `:crux.db/valid-time` and `:crux.tx/tx-time` to stop at.
+
+  No matter what `:start` and `:end` parameters you specify, you won't receive
+  results later than the valid-time and transact-time of this DB value.
+
+  Each entry in the result contains the following keys:
+   * `:crux.db/valid-time`,
+   * `:crux.db/tx-time`,
+   * `:crux.tx/tx-id`,
+   * `:crux.db/content-hash`
+   * `:crux.db/doc` (see `with-docs?`).")
 
   (open-entity-history
     ^crux.api.ICursor [node eid sort-order]
     ^crux.api.ICursor [node eid sort-order opts]
-    "TODO docstring")
+    "Lazily retrieves entity history for the given entity.
+  Don't forget to close the cursor when you've consumed enough history!
+  See `entity-history` for all the options")
 
   (valid-time [db]
     "returns the valid time of the db.
@@ -327,6 +346,15 @@
     "returns the time of the latest transaction applied to this db value.
   If a tx time was specified when db value was acquired then returns
   the specified time."))
+
+(let [arglists '(^crux.api.ICursor
+                 [db eid sort-order]
+                 ^crux.api.ICursor
+                 [db eid sort-order {:keys [with-docs? with-corrections?]
+                                     {start-vt :crux.db/valid-time, start-tt :crux.tx/tx-time} :start
+                                     {end-vt :crux.db/valid-time, end-tt :crux.tx/tx-time} :end}])]
+  (alter-meta! #'entity-history assoc :arglists arglists)
+  (alter-meta! #'open-entity-history assoc :arglists arglists))
 
 (extend-protocol PCruxDatasource
   ICruxDatasource

--- a/crux-core/src/crux/api/HistoryOptions.java
+++ b/crux-core/src/crux/api/HistoryOptions.java
@@ -1,0 +1,58 @@
+package crux.api;
+
+import java.util.Date;
+
+public class HistoryOptions {
+    public enum SortOrder {
+        ASC, DESC;
+    }
+
+    public final SortOrder sortOrder;
+    public final boolean withCorrections;
+    public final boolean withDocs;
+
+    public final Date startValidTime;
+    public final Date startTransactionTime;
+    public final Date endValidTime;
+    public final Date endTransactionTime;
+
+    public HistoryOptions(SortOrder sortOrder) {
+        this(sortOrder, false, true, null, null, null, null);
+    }
+
+    public HistoryOptions(SortOrder sortOrder, boolean withCorrections, boolean withDocs,
+                          Date startValidTime, Date startTransactionTime,
+                          Date endValidTime, Date endTransactionTime) {
+        this.sortOrder = sortOrder;
+        this.withCorrections = withCorrections;
+        this.withDocs = withDocs;
+        this.startValidTime = startValidTime;
+        this.startTransactionTime = startTransactionTime;
+        this.endValidTime = endValidTime;
+        this.endTransactionTime = endTransactionTime;
+    }
+
+    public HistoryOptions withCorrections(boolean withCorrections) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+
+    public HistoryOptions withDocs(boolean withDocs) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+
+    public HistoryOptions startValidTime(Date startValidTime) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+
+    public HistoryOptions startTransactionTime(Date startTransactionTime) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+
+    public HistoryOptions endValidTime(Date endValidTime) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+
+    public HistoryOptions endTransactionTime(Date endTransactionTime) {
+        return new HistoryOptions(sortOrder, withCorrections, withDocs, startValidTime, startTransactionTime, endValidTime, endTransactionTime);
+    }
+}

--- a/crux-core/src/crux/api/HistoryOptions.java
+++ b/crux-core/src/crux/api/HistoryOptions.java
@@ -8,12 +8,49 @@ public class HistoryOptions {
     }
 
     public final SortOrder sortOrder;
+
+    /**
+     * Specifies whether to return bitemporal corrections in the history response.
+     *
+     * If this is set to `true`, corrections will be returned within the
+     * sequence, sorted first by valid-time, then transaction-time.
+     */
     public final boolean withCorrections;
+
+    /**
+     * Specifies whether to return documents in the history response.
+     *
+     * If this is set to `true`, documents will be included under the
+     * `:crux.db/doc` key.
+     */
     public final boolean withDocs;
 
+    /**
+     * Sets the starting valid time.
+     *
+     * The history response will include entries starting at this valid time (inclusive).
+     */
     public final Date startValidTime;
+
+    /**
+     * Sets the starting transaction time.
+     *
+     * The history response will include entries starting at this transaction time (inclusive).
+     */
     public final Date startTransactionTime;
+
+    /**
+     * Sets the end valid time.
+     *
+     * The history response will include entries up to this valid time (exclusive).
+     */
     public final Date endValidTime;
+
+    /**
+     * Sets the end transaction time.
+     *
+     * The history response will include entries up to this transaction time (exclusive).
+     */
     public final Date endTransactionTime;
 
     public HistoryOptions(SortOrder sortOrder) {

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -92,6 +92,7 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      * @param eid an object that can be coerced into an entity id.
      * @return    the transaction history.
      */
+    @Deprecated
     public List<Map<Keyword,Object>> history(Object eid);
     // todo elaborate about corrections contents
 
@@ -111,6 +112,7 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      * @param transactionTimeEnd   the start transaction time or null, inclusive.
      * @return                     the transaction history.
      */
+    @Deprecated
     public List<Map<Keyword,?>> historyRange(Object eid, Date validTimeStart, Date transactionTimeStart, Date validTimeEnd, Date transactionTimeEnd);
     // todo elaborate
 

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -155,11 +155,37 @@ public interface ICruxDatasource extends Closeable {
     @Deprecated
     public ICursor<Map<Keyword,?>> openHistoryDescending(Object eid);
 
-    // TODO javadoc
-    public List<Map<Keyword, ?>> entityHistory(Object eid, HistoryOptions opts);
+    /**
+     * Eagerly retrieves entity history for the given entity.
+     *
+     * Each entry in the result contains the following keys:
+     * * `:crux.db/valid-time`,
+     * * `:crux.db/tx-time`,
+     * * `:crux.tx/tx-id`,
+     * * `:crux.db/content-hash`
+     * * `:crux.db/doc` (if {@link HistoryOptions#withDocs(boolean) withDocs} is set on the options).
+     *
+     * If {@link HistoryOptions#withCorrections(boolean) withCorrections} is set
+     * on the options, bitemporal corrections are also included in the sequence,
+     * sorted first by valid-time, then transaction-time.
+     *
+     * No matter what `start` and `end` parameters you specify, you won't receive
+     * results later than the valid-time and transact-time of this DB value.
+     *
+     * @param eid The entity id to return history for
+     * @return an eagerly-evaluated sequence of changes to the given entity.
+     */
+    public List<Map<Keyword, ?>> entityHistory(Object eid, HistoryOptions options);
 
-    // TODO javadoc
-    public ICursor<Map<Keyword, ?>> openEntityHistory(Object eid, HistoryOptions opts);
+    /**
+     * Lazily retrieves entity history for the given entity.
+     * Don't forget to close the cursor when you've consumed enough history!
+     *
+     * @see {@link entityHistory(Object, HistoryOptions)}
+     * @param eid The entity id to return history for
+     * @return a cursor of changes to the given entity.
+     */
+    public ICursor<Map<Keyword, ?>> openEntityHistory(Object eid, HistoryOptions options);
 
     /**
      * The valid time of this db.

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -118,6 +118,7 @@ public interface ICruxDatasource extends Closeable {
      * @param eid      an object that can be coerced into an entity id.
      * @return         a stream of history.
      */
+    @Deprecated
     public ICursor<Map<Keyword,?>> openHistoryAscending(Object eid);
 
     /**
@@ -128,6 +129,7 @@ public interface ICruxDatasource extends Closeable {
      * @param eid      an object that can be coerced into an entity id.
      * @return         the history of the given entity.
      */
+    @Deprecated
     public List<Map<Keyword,?>> historyDescending(Object eid);
 
     /**
@@ -150,7 +152,14 @@ public interface ICruxDatasource extends Closeable {
      * @param eid      an object that can be coerced into an entity id.
      * @return         a stream of history.
      */
+    @Deprecated
     public ICursor<Map<Keyword,?>> openHistoryDescending(Object eid);
+
+    // TODO javadoc
+    public List<Map<Keyword, ?>> entityHistory(Object eid, HistoryOptions opts);
+
+    // TODO javadoc
+    public ICursor<Map<Keyword, ?>> openEntityHistory(Object eid, HistoryOptions opts);
 
     /**
      * The valid time of this db.

--- a/crux-core/src/crux/api/alpha/CruxNode.java
+++ b/crux-core/src/crux/api/alpha/CruxNode.java
@@ -98,6 +98,7 @@ public class CruxNode implements AutoCloseable {
      * @return Iterable set of Documents containing transaction information
      */
     public Iterable<Document> history(CruxId id) {
+        @SuppressWarnings("deprecation")
         List<Map<Keyword,Object>> history = node.history(id.toEdn());
         return history.stream()
             .map(this::document)

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -32,7 +32,7 @@
   (new-attribute-entity-value-index-pair [this a entity-as-of-idx])
   (new-entity-as-of-index [this valid-time transact-time])
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end])
-  (entity-history [this eid sort-order opts])
+  (entity-history ^crux.api.ICursor [this eid sort-order opts])
   (all-content-hashes [this eid])
   (decode-value [this a content-hash value])
   (get-document [this content-hash])

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -573,37 +573,37 @@
 
 (defn entity-history-seq-ascending
   ([i eid] ([i eid] (entity-history-seq-ascending i eid {})))
-  ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
-           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
+  ([i eid {{^Date start-vt :crux.db/valid-time, ^Date start-tt :crux.tx/tx-time} :start
+           {^Date end-vt :crux.db/valid-time, ^Date end-tt :crux.tx/tx-time} :end
            :keys [with-corrections?]}]
-   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) start-vt)]
      (-> (all-keys-in-prefix i (mem/limit-buffer seek-k (+ c/index-id-size c/id-size)) seek-k
                              {:reverse? true, :entries? true})
          (->> (map ->entity-tx))
-         (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
-                                         (neg? (compare (.vt entity-tx) until-vt))))
-                  from-tt (remove (fn [^EntityTx entity-tx]
-                                    (neg? (compare (.tt entity-tx) from-tt))))
-                  until-tt (filter (fn [^EntityTx entity-tx]
-                                     (neg? (compare (.tt entity-tx) until-tt)))))
+         (cond->> end-vt (take-while (fn [^EntityTx entity-tx]
+                                       (neg? (compare (.vt entity-tx) end-vt))))
+                  start-tt (remove (fn [^EntityTx entity-tx]
+                                     (neg? (compare (.tt entity-tx) start-tt))))
+                  end-tt (filter (fn [^EntityTx entity-tx]
+                                   (neg? (compare (.tt entity-tx) end-tt)))))
          (cond-> (not with-corrections?) (->> (partition-by :vt)
                                               (map last)))))))
 
 (defn entity-history-seq-descending
   ([i eid] (entity-history-seq-descending i eid {}))
-  ([i eid {{^Date from-vt :crux.db/valid-time, ^Date from-tt :crux.tx/tx-time} :from
-           {^Date until-vt :crux.db/valid-time, ^Date until-tt :crux.tx/tx-time} :until
+  ([i eid {{^Date start-vt :crux.db/valid-time, ^Date start-tt :crux.tx/tx-time} :start
+           {^Date end-vt :crux.db/valid-time, ^Date end-tt :crux.tx/tx-time} :end
            :keys [with-corrections?]}]
-   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) from-vt)]
+   (let [seek-k (c/encode-entity+vt+tt+tx-id-key-to nil (c/->id-buffer eid) start-vt)]
      (-> (all-keys-in-prefix i (-> seek-k (mem/limit-buffer (+ c/index-id-size c/id-size))) seek-k
                              {:entries? true})
          (->> (map ->entity-tx))
-         (cond->> until-vt (take-while (fn [^EntityTx entity-tx]
-                                         (pos? (compare (.vt entity-tx) until-vt))))
-                  from-tt (remove (fn [^EntityTx entity-tx]
-                                    (pos? (compare (.tt entity-tx) from-tt))))
-                  until-tt (filter (fn [^EntityTx entity-tx]
-                                     (pos? (compare (.tt entity-tx) until-tt)))))
+         (cond->> end-vt (take-while (fn [^EntityTx entity-tx]
+                                         (pos? (compare (.vt entity-tx) end-vt))))
+                  start-tt (remove (fn [^EntityTx entity-tx]
+                                    (pos? (compare (.tt entity-tx) start-tt))))
+                  end-tt (filter (fn [^EntityTx entity-tx]
+                                   (pos? (compare (.tt entity-tx) end-tt)))))
          (cond-> (not with-corrections?) (->> (partition-by :vt)
                                               (map first)))))))
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1236,8 +1236,8 @@
     (let [index-store (open-index-store this)]
       (cio/->cursor #(cio/try-close index-store)
                     (for [^EntityTx entity-tx (db/entity-history index-store eid :asc
-                                                                 {:from {:crux.db/valid-time valid-time}
-                                                                  :until {:crux.tx/tx-time (Date. (inc (.getTime transact-time)))}})]
+                                                                 {:start {:crux.db/valid-time valid-time}
+                                                                  :end {:crux.tx/tx-time (Date. (inc (.getTime transact-time)))}})]
                       (assoc (c/entity-tx->edn entity-tx)
                              :crux.db/doc (db/get-document index-store (.content-hash entity-tx)))))))
 
@@ -1252,8 +1252,8 @@
     (let [index-store (open-index-store this)]
       (cio/->cursor #(cio/try-close index-store)
                     (for [^EntityTx entity-tx (db/entity-history index-store eid :desc
-                                                                 {:from {:crux.db/valid-time valid-time
-                                                                         :crux.tx/tx-time transact-time}})]
+                                                                 {:start {:crux.db/valid-time valid-time
+                                                                          :crux.tx/tx-time transact-time}})]
                       (assoc (c/entity-tx->edn entity-tx)
                              :crux.db/doc (db/get-document index-store (.content-hash entity-tx)))))))
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -12,7 +12,7 @@
             [crux.memory :as mem]
             [crux.bus :as bus])
   (:import clojure.lang.ExceptionInfo
-           crux.api.ICruxDatasource
+           (crux.api ICruxDatasource HistoryOptions HistoryOptions$SortOrder)
            crux.codec.EntityTx
            crux.index.BinaryJoinLayeredVirtualIndex
            (java.io Closeable)
@@ -1233,11 +1233,12 @@
     (.historyAscending this eid))
 
   (openHistoryAscending [this eid]
-    (let [index-store (open-index-store this)]
-      (cio/->cursor #(cio/try-close index-store)
-                    (for [^EntityTx entity-tx (db/entity-history index-store eid :asc
-                                                                 {:start {:crux.db/valid-time valid-time}
-                                                                  :end {:crux.tx/tx-time (Date. (inc (.getTime transact-time)))}})]
+    (let [index-store (open-index-store this)
+          history (db/entity-history index-store eid :asc
+                                     {:start {:crux.db/valid-time valid-time}
+                                      :end {:crux.tx/tx-time (Date. (inc (.getTime transact-time)))}})]
+      (cio/->cursor #(run! cio/try-close [history index-store])
+                    (for [^EntityTx entity-tx (iterator-seq history)]
                       (assoc (c/entity-tx->edn entity-tx)
                              :crux.db/doc (db/get-document index-store (.content-hash entity-tx)))))))
 
@@ -1249,13 +1250,58 @@
     (.historyDescending this eid))
 
   (openHistoryDescending [this eid]
-    (let [index-store (open-index-store this)]
-      (cio/->cursor #(cio/try-close index-store)
-                    (for [^EntityTx entity-tx (db/entity-history index-store eid :desc
-                                                                 {:start {:crux.db/valid-time valid-time
-                                                                          :crux.tx/tx-time transact-time}})]
+    (let [index-store (open-index-store this)
+          history (db/entity-history index-store eid :desc
+                                     {:start {:crux.db/valid-time valid-time
+                                              :crux.tx/tx-time transact-time}})]
+      (cio/->cursor #(run! cio/try-close [history index-store])
+                    (for [^EntityTx entity-tx (iterator-seq history)]
                       (assoc (c/entity-tx->edn entity-tx)
                              :crux.db/doc (db/get-document index-store (.content-hash entity-tx)))))))
+
+  (entityHistory [this eid opts]
+    (with-open [history (.openEntityHistory this eid opts)]
+      (into [] (iterator-seq history))))
+
+  (openEntityHistory [this eid opts]
+    (letfn [(inc-date [^Date d] (Date. (inc (.getTime d))))
+            (with-upper-bound [^Date d, ^Date upper-bound]
+              (if (and d (neg? (compare d upper-bound))) d upper-bound))]
+      (let [sort-order (condp = (.sortOrder opts)
+                         HistoryOptions$SortOrder/ASC :asc
+                         HistoryOptions$SortOrder/DESC :desc)
+            with-docs? (.withDocs opts)
+            index-store (db/open-index-store (:indexer query-engine))
+
+            opts (cond-> {:with-corrections? (.withCorrections opts)
+                          :with-docs? with-docs?
+                          :start {:crux.db/valid-time (.startValidTime opts)
+                                  :crux.tx/tx-time (.startTransactionTime opts)}
+                          :end {:crux.db/valid-time (.endValidTime opts)
+                                :crux.tx/tx-time (.endTransactionTime opts)}}
+                   (= sort-order :asc)
+                   (-> (update-in [:end :crux.db/valid-time]
+                                  with-upper-bound (inc-date valid-time))
+                       (update-in [:end :crux.tx/tx-time]
+                                  with-upper-bound (inc-date transact-time)))
+
+                   (= sort-order :desc)
+                   (-> (update-in [:start :crux.db/valid-time]
+                                  with-upper-bound valid-time)
+                       (update-in [:start :crux.tx/tx-time]
+                                  with-upper-bound transact-time)))
+
+            history (db/entity-history index-store eid sort-order opts)]
+
+        (cio/->cursor
+         #(run! cio/try-close [history index-store])
+         (->> (iterator-seq history)
+              (map (fn [^EntityTx etx]
+                     (cond-> {:crux.tx/tx-time (.tt etx)
+                              :crux.tx/tx-id (.tx-id etx)
+                              :crux.db/valid-time (.vt etx)
+                              :crux.db/content-hash (.content-hash etx)}
+                       with-docs? (assoc :crux.db/doc (db/get-document index-store (.content-hash etx)))))))))))
 
   (validTime [_]
     valid-time)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -101,7 +101,7 @@
     (with-open [nested-index-store (db/open-nested-index-store index-store)]
       (f (merge-histories etx->vt compare
                           (db/entity-history nested-index-store eid :asc
-                                             {:from {:crux.db/valid-time valid-time}})
+                                             {:start {:crux.db/valid-time valid-time}})
                           (->> (get etxs eid)
                                (drop-while (comp neg? #(compare % valid-time) etx->vt)))))))
 
@@ -109,7 +109,7 @@
     (with-open [nested-index-store (db/open-nested-index-store index-store)]
       (f (merge-histories etx->vt #(compare %2 %1)
                           (db/entity-history nested-index-store eid :desc
-                                             {:from {:crux.db/valid-time valid-time}})
+                                             {:start {:crux.db/valid-time valid-time}})
                           (->> (reverse (get etxs eid))
                                (drop-while (comp pos? #(compare % valid-time) etx->vt)))))))
 

--- a/crux-test/test/crux/space_tutorial_test.clj
+++ b/crux-test/test/crux/space_tutorial_test.clj
@@ -488,7 +488,7 @@
              (crux/entity (crux/db *api* #inst "2114-01-01T09") :kaarlang/clients)))
 
     ;; Check is not nil (that it runs), cannot confirm exact history state as tx-time changing
-    (with-open [history (crux/open-history-ascending (crux/db *api*) :kaarlang/clients)]
+    (with-open [history (crux/open-entity-history (crux/db *api*) :kaarlang/clients :asc)]
       (t/is history))
 
     (fix/submit+await-tx [[:crux.tx/delete :kaarlang/clients #inst "2110-01-01" #inst "2116-01-01"]])
@@ -496,7 +496,7 @@
     (t/is nil? (crux/entity (crux/db *api* #inst "2114-01-01T09") :kaarlang/clients))
 
     ;; Check is not nil (that it runs), cannot confirm exact history state as tx-time changing
-    (with-open [history (crux/open-history-ascending (crux/db *api*) :kaarlang/clients)]
+    (with-open [history (crux/open-entity-history (crux/db *api*) :kaarlang/clients :asc)]
       (t/is history))))
 
 (t/deftest Oumuamua-test
@@ -550,14 +550,14 @@
   (t/is empty? (full-query *api*))
 
   ;; Check not nil, history constantly changing so it is hard to check otherwise
-  (with-open [history (crux/open-history-descending (crux/db *api*) :person/kaarlang)]
+  (with-open [history (crux/open-entity-history (crux/db *api*) :person/kaarlang :desc)]
     (t/is history))
 
-  (with-open [history (crux/open-history-descending (crux/db *api*) :person/ilex)]
+  (with-open [history (crux/open-entity-history (crux/db *api*) :person/ilex :desc)]
     (t/is history))
 
-  (with-open [history (crux/open-history-descending (crux/db *api*) :person/thadd)]
+  (with-open [history (crux/open-entity-history (crux/db *api*) :person/thadd :desc)]
     (t/is history))
 
-  (with-open [history (crux/open-history-descending (crux/db *api*) :person/johanna)]
+  (with-open [history (crux/open-entity-history (crux/db *api*) :person/johanna :desc)]
     (t/is history)))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -332,11 +332,11 @@
 
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
                (idx/entity-history-seq-descending i (c/new-id :ivan)
-                                                  {:from {::tx/tx-time t, ::db/valid-time t}})))
+                                                  {:start {::tx/tx-time t, ::db/valid-time t}})))
 
       (t/is (= [(c/->EntityTx (c/new-id :ivan) t t 2 (c/new-id ivan2))]
                (idx/entity-history-seq-ascending i (c/new-id :ivan)
-                                                 {:from {::db/valid-time t}}))))))
+                                                 {:start {::db/valid-time t}}))))))
 
 (t/deftest test-entity-history-seq-corner-cases
   (let [ivan {:crux.db/id :ivan}
@@ -363,36 +363,36 @@
                 (history-desc [opts]
                   (idx/entity-history-seq-descending i (c/new-id :ivan) opts))]
 
-          (t/testing "from is inclusive"
+          (t/testing "start is inclusive"
             (t/is (= [etx-v2-t2
                       etx-v1-t2]
-                     (history-desc {:from {::tx/tx-time t2, ::db/valid-time t2}})))
+                     (history-desc {:start {::tx/tx-time t2, ::db/valid-time t2}})))
 
             (t/is (= [etx-v1-t2]
-                     (history-desc {:from {::db/valid-time t1}})))
+                     (history-desc {:start {::db/valid-time t1}})))
 
             (t/is (= [etx-v1-t2 etx-v2-t2]
-                     (history-asc {:from {::tx/tx-time t2}})))
+                     (history-asc {:start {::tx/tx-time t2}})))
 
             (t/is (= [etx-v1-t1 etx-v1-t2 etx-v2-t2]
-                     (history-asc {:from {::tx/tx-time t1
+                     (history-asc {:start {::tx/tx-time t1
                                           ::db/valid-time t1}
                                    :with-corrections? true}))))
 
-          (t/testing "until is exclusive"
+          (t/testing "end is exclusive"
             (t/is (= [etx-v2-t2]
-                     (history-desc {:from {::tx/tx-time t2, ::db/valid-time t2}
-                                    :until {::tx/tx-time t1, ::db/valid-time t1}})))
+                     (history-desc {:start {::tx/tx-time t2, ::db/valid-time t2}
+                                    :end {::tx/tx-time t1, ::db/valid-time t1}})))
 
             (t/is (= []
-                     (history-desc {:until {::db/valid-time t2}})))
+                     (history-desc {:end {::db/valid-time t2}})))
 
             (t/is (= [etx-v1-t1]
-                     (history-asc {:until {::tx/tx-time t2}})))
+                     (history-asc {:end {::tx/tx-time t2}})))
 
             (t/is (= []
-                     (history-asc {:from {::db/valid-time t1},
-                                   :until {::tx/tx-time t1}})))))))))
+                     (history-asc {:start {::db/valid-time t1},
+                                   :end {::tx/tx-time t1}})))))))))
 
 (t/deftest test-can-store-doc
   (let [content-hash (c/new-id picasso)]
@@ -434,7 +434,7 @@
                                       [vt (get-in res [tx-idx :crux.tx/tx-id]) (c/new-id (when value
                                                                                            (assoc ivan :value value)))])
 
-                                    (->> (idx/entity-history-seq-ascending i eid {:from {::db/valid-time first-vt}})
+                                    (->> (idx/entity-history-seq-ascending i eid {:start {::db/valid-time first-vt}})
                                          (map (juxt :vt :tx-id :content-hash)))))))
 
     ;; pairs
@@ -784,7 +784,7 @@
                 i (kv/new-iterator snapshot)]
       (let [eid->history (fn [eid]
                            (->> (idx/entity-history-seq-ascending i (c/new-id eid)
-                                                                  {:from {::db/valid-time #inst "2020-01-01"}})
+                                                                  {:start {::db/valid-time #inst "2020-01-01"}})
                                 (map (fn [{:keys [content-hash vt]}]
                                        [vt (:v (db/get-single-object (:object-store *api*) snapshot content-hash))]))))]
         ;; transaction functions, asserts both still apply at the start of the transaction

--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -15,4 +15,4 @@ include::rest.adoc[leveloffset=+1]
 [#clojureapi]
 == Clojure
 
-include::clojure_api.adoc[leveloffset=+1]
+include::clojure_api.adoc[leveloffset=+2]

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -1,17 +1,17 @@
-== (ns crux.api)
+= (ns crux.api)
 :toc: macro
 
-`crux.api` exposes a union of methods from `ICruxNode` and `ICruxDatasource`,
+`crux.api` exposes a union of methods from `ICruxAPI` and `ICruxDatasource`,
 with few lifecycle members added.
 
 toc::[]
 
-[#clojure-api-icruxnode]
-=== ICruxNode
+[#clojure-api-icruxapi]
+== ICruxAPI
 
-==== db
+=== db
 
-[source,clj]
+[source,clojure]
 ----
   (db
     [node]
@@ -28,9 +28,9 @@ toc::[]
      transaction-time, this throws NodeOutOfSyncException")
 ----
 
-==== open-db
+=== open-db
 
-[source,clj]
+[source,clojure]
 ----
   (open-db
     [node]
@@ -51,46 +51,27 @@ toc::[]
      block)")
 ----
 
-==== document
+=== document
 
-[source,clj]
+[source,clojure]
 ----
   (document [node content-hash]
     "Reads a document from the document store based on its
     content hash.")
 ----
 
-==== history
+=== documents
 
-[source,clj]
+[source,clojure]
 ----
-  (history [node eid]
-    "Returns the transaction history of an entity, in reverse
-    chronological order. Includes corrections, but does not include
-    the actual documents.")
-----
-
-=== history-range
-
-[source,clj]
-----
-  (history-range [node eid
-                  ^Date valid-time-start
-                  ^Date transaction-time-start
-                  ^Date valid-time-end
-                  ^Date transaction-time-end]
-    "Returns the transaction history of an entity, ordered by valid
-    time / transaction time in chronological order, earliest
-    first. Includes corrections, but does not include the actual
-    documents.
-
-    Giving null as any of the date arguments makes the range open
-    ended for that value.")
+  (documents [node content-hash-set]
+    "Reads the set of documents from the document store based on their
+    respective content hashes. Returns a map content-hash->document")
 ----
 
 === status
 
-[source,clj]
+[source,clojure]
 ----
   (status [node]
     "Returns the status of this node as a map.")
@@ -98,7 +79,7 @@ toc::[]
 
 === submit-tx
 
-[source,clj]
+[source,clojure]
 ----
   (submit-tx [node tx-ops]
     "Writes transactions to the log for processing
@@ -109,7 +90,7 @@ toc::[]
 
 === tx-committed?
 
-[source,clj]
+[source,clojure]
 ----
   (tx-committed? [node submitted-tx]
     "Checks if a submitted tx was successfully committed.
@@ -121,7 +102,7 @@ toc::[]
 
 === await-tx
 
-[source,clj]
+[source,clojure]
 ----
   (await-tx
     [node tx]
@@ -133,7 +114,7 @@ toc::[]
 
 === await-tx-time
 
-[source,clj]
+[source,clojure]
 ----
   (await-tx-time
     [node ^Date tx-time]
@@ -145,7 +126,7 @@ toc::[]
 
 === sync
 
-[source,clj]
+[source,clojure]
 ----
  (sync
     [node]
@@ -162,7 +143,7 @@ toc::[]
 ----
 
 === listen
-[source,clj]
+[source,clojure]
 ----
   (listen ^java.lang.AutoCloseable [node event-opts f]
     "Attaches a listener to Crux's event bus.
@@ -179,7 +160,7 @@ toc::[]
 
 === tx-log
 
-[source,clj]
+[source,clojure]
 ----
 (open-tx-log ^ICursor [this after-tx-id with-ops?]
   "Reads the transaction log. Optionally includes
@@ -195,7 +176,7 @@ toc::[]
 
 === attribute-stats
 
-[source,clj]
+[source,clojure]
 ----
   (attribute-stats [node]
     "Returns frequencies of indexed attributes")
@@ -208,7 +189,7 @@ Represents the database as of a specific valid and transaction time.
 
 === entity
 
-[source,clj]
+[source,clojure]
 ----
   (entity [db eid]
     "queries a document map for an entity.
@@ -218,7 +199,7 @@ Represents the database as of a specific valid and transaction time.
 
 === entity-tx
 
-[source,clj]
+[source,clojure]
 ----
   (entity-tx [db eid]
     "returns the transaction details for an entity. Details
@@ -226,19 +207,9 @@ Represents the database as of a specific valid and transaction time.
     eid is an object that can be coerced into an entity id.")
 ----
 
-=== new-snapshot
-
-[source,clj]
-----
-  (new-snapshot ^java.io.Closeable [db]
-     "Returns a new implementation-specific snapshot allowing for multiple
-     entity calls to share the same KV store snapshot.
-     returns an implementation specific snapshot")
-----
-
 === q
 
-[source,clj]
+[source,clojure]
 ----
   (q
     [db query]
@@ -249,7 +220,7 @@ Represents the database as of a specific valid and transaction time.
 
 === open-q
 
-[source,clj]
+[source,clojure]
 ----
   (open-q
     [db query]
@@ -269,53 +240,52 @@ Represents the database as of a specific valid and transaction time.
      ")
 ----
 
-=== history-ascending
+=== entity-history
 
-[source,clj]
+[source,clojure]
 ----
-  (history-ascending
-    [db eid]
-    "Retrieves entity history in chronological order from and including the
-    valid time of the db while respecting transaction time. Includes the
-    documents.")
-----
+  (entity-history
+    [db eid sort-order]
+    [db eid sort-order {:keys [with-docs? with-corrections?]
+                        {start-vt :crux.db/valid-time, start-tt :crux.tx/tx-time} :start
+                        {end-vt :crux.db/valid-time, end-tt :crux.tx/tx-time} :end}]
+    "Eagerly retrieves entity history for the given entity.
 
-=== open-history-ascending
+    Options:
+    * `sort-order`: `#{:asc :desc}`
+    * `:with-docs?`: specifies whether to include documents in the entries
+    * `:with-corrections?`: specifies whether to include bitemporal corrections in the sequence, sorted first by valid-time, then transaction-time.
+    * `:start` (nested map, inclusive, optional): the `:crux.db/valid-time` and `:crux.tx/tx-time` to start at.
+    * `:end` (nested map, exclusive, optional): the `:crux.db/valid-time` and `:crux.tx/tx-time` to stop at.
 
-[source,clj]
-----
-  (open-history-ascending
-    [db eid]
-    "Retrieves entity history lazily in chronological order from and including
-    the valid time of the db while respecting transaction time. Includes the
-    documents.")
-----
+    No matter what `:start` and `:end` parameters you specify, you won't receive
+    results later than the valid-time and transact-time of this DB value.
 
-=== history-descending
-
-[source,clj]
-----
-  (history-descending
-    [db eid]
-    "Retrieves entity history in reverse chronological order from and including
-    the valid time of the db while respecting transaction time. Includes the
-    documents.")
+    Each entry in the result contains the following keys:
+     * `:crux.db/valid-time`,
+     * `:crux.db/tx-time`,
+     * `:crux.tx/tx-id`,
+     * `:crux.db/content-hash`
+     * `:crux.db/doc` (see `with-docs?`).")
 ----
 
-=== open-history-descending
+=== open-entity-history
 
-[source,clj]
+[source,clojure]
 ----
-  (open-history-descending
-    [db eid]
-    "Retrieves entity history lazily in reverse chronological order from and
-    including the valid time of the db while respecting transaction time.
-    Includes the documents.")
+  (open-entity-history
+    [db eid sort-order]
+    [db eid sort-order {:keys [with-docs? with-corrections?]
+                        {start-vt :crux.db/valid-time, start-tt :crux.tx/tx-time} :start
+                        {end-vt :crux.db/valid-time, end-tt :crux.tx/tx-time} :end}]
+    "Lazily retrieves entity history for the given entity.
+    Don't forget to close the cursor when you've consumed enough history!
+    See `entity-history` for all the options")
 ----
 
 === valid-time
 
-[source,clj]
+[source,clojure]
 ----
   (valid-time [db]
     "returns the valid time of the db.
@@ -325,7 +295,7 @@ Represents the database as of a specific valid and transaction time.
 
 === transaction-time
 
-[source,clj]
+[source,clojure]
 ----
   (transaction-time [db]
     "returns the time of the latest transaction applied to this db value.
@@ -338,7 +308,7 @@ Represents the database as of a specific valid and transaction time.
 
 === start-node
 
-[source,clj]
+[source,clojure]
 ----
 (defn start-node ^ICruxAPI [options])
 ----
@@ -347,7 +317,7 @@ NOTE: requires any dependendies on the classpath that the Crux modules may need.
 
 Options:
 
-[source,clj]
+[source,clojure]
 ----
 {:crux.node/topology ['crux.standalone/topology]}
 ----
@@ -366,7 +336,7 @@ last run. Only applicable when using the event log.
 
 === new-api-client
 
-[source,clj]
+[source,clojure]
 ----
 (defn new-api-client ^ICruxAPI [url])
 ----
@@ -385,7 +355,7 @@ Returns a remote API client.
 
 === new-ingest-client
 
-[source,clj]
+[source,clojure]
 ----
 (defn new-ingest-client ^ICruxAsyncIngestAPI [options])
 ----
@@ -399,15 +369,15 @@ specified as keywords using their long format name, like
 
 Options:
 
-[source,clj]
+[source,clojure]
 ----
 {:crux.kafka/bootstrap-servers "kafka-cluster-kafka-brokers.crux.svc.cluster.local:9092"
-:crux.kafka/group-id           "group-id"
-:crux.kafka/tx-topic           "crux-transaction-log"
-:crux.kafka/doc-topic          "crux-docs"
-:crux.kafka/create-topics      true
-:crux.kafka/doc-partitions     1
-:crux.kafka/replication-factor 1}
+ :crux.kafka/group-id "group-id"
+ :crux.kafka/tx-topic "crux-transaction-log"
+ :crux.kafka/doc-topic "crux-docs"
+ :crux.kafka/create-topics true
+ :crux.kafka/doc-partitions 1
+ :crux.kafka/replication-factor 1}
 ----
 
 Returns a crux.api.ICruxIngestAPI component that implements

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -49,9 +49,9 @@ otherwise restrict the execution of queries.
 |<<#rest-home,`/`>>|GET|returns various details about the state of the database
 |<<#rest-document, `/document/[content-hash]`>>|GET or POST|returns the document for a given hash
 |<<#rest-documents, `/documents`>>|POST|returns a map of document ids and respective documents for a given set of content hashes submitted in the request body
-|<<#rest-entity, `/entity`>>|POST|Returns an entity for a given ID and optional valid-time/transaction-time co-ordinates
-|<<#rest-entity-tx, `/entity-tx`>>|POST|Returns the `:put` transaction that most recently set a key
-|<<#rest-history, `/history/[:key]`>>|GET OR POST|Returns the transaction history of a key
+|<<#rest-entity, `/entity/[:key]`>>|GET|Returns an entity for a given ID and optional valid-time/transaction-time co-ordinates
+|<<#rest-entity-tx, `/entity-tx/[:key]`>>|GET|Returns the transaction that most recently set a key
+|<<#rest-entity, `/entity-history/[:key]`>>|GET|Returns the history of the given entity and optional valid-time/transaction-time co-ordinates
 |<<#rest-query, `/query`>>|POST|Takes a datalog query and returns its results
 |<<#rest-query-stream, `/query-stream`>>|POST| Same as `/query` but the results are streamed
 |<<#rest-sync, `/sync`>>|GET| Wait until the Kafka consumer's lag is back to 0
@@ -99,11 +99,11 @@ Returns the document stored under that hash, if it exists.
 ----
 curl -X GET $nodeURL/document/7af0444315845ab3efdfbdfa516e68952c1486f2
 ----
-[source,clj]
+[source,clojure]
 ----
 {:crux.db/id :foobar, :name "FooBar"}
 ----
-NOTE: Hashes for older versions of a document can be obtained with `/history-range` or `/history`, under the `:crux.db/content-hash` keys.
+NOTE: Hashes for older versions of a document can be obtained with `/entity-history`, under the `:crux.db/content-hash` keys.
 
 [#rest-documents]
 === GET/POST `/documents`
@@ -124,7 +124,7 @@ curl -X POST $nodeURL/documents \
 ----
 
 [#rest-entity]
-=== POST `/entity`
+=== GET `/entity/[:key]`
 
 Takes a key and, optionally, a `:valid-time` and/or `:transact-time` (defaulting to now). Returns the value stored under that key at those times.
 
@@ -132,10 +132,9 @@ See <<#bitemporality, Bitemporality>> for more information.
 
 [source,bash]
 ----
-curl -X POST \
+curl -X GET \
      -H "Content-Type: application/edn" \
-     -d '{:eid :tommy}' \
-     $nodeURL/entity
+     $nodeURL/entity/:tommy
 ----
 
 [source,clj]
@@ -145,10 +144,9 @@ curl -X POST \
 
 [source,bash]
 ----
-curl -X POST \
+curl -X GET \
      -H "Content-Type: application/edn" \
-     -d '{:eid :tommy :valid-time #inst "1999-01-08T14:03:27.254-00:00"}' \
-     $nodeURL/entity
+     $nodeURL/entity/:tommy?valid-time=1999-01-08T14%3A03%3A27%3A254-00%3A00
 ----
 
 [source,clj]
@@ -157,7 +155,7 @@ nil
 ----
 
 [#rest-entity-tx]
-=== POST `/entity-tx`
+=== GET `/entity-tx`
 
 Takes a key and, optionally, `:valid-time` and/or `:transact-time` (defaulting to now). Returns the `:put` transaction that most recently set that key at those times.
 
@@ -165,10 +163,9 @@ See <<#bitemporality, Bitemporality>> for more information.
 
 [source,bash]
 ----
-curl -X POST \
+curl -X GET \
      -H "Content-Type: application/edn" \
-     -d '{:eid :foobar}' \
-     $nodeURL/entity-tx
+     $nodeURL/entity-tx/:foobar
 ----
 [source,clj]
 ----
@@ -179,15 +176,21 @@ curl -X POST \
  :crux.tx/tx-time #inst "2019-01-08T16:34:47.738-00:00"}
 ----
 
-[#rest-history]
-=== GET/POST `/history/[:key]`
+[#rest-entity-history]
+=== GET `/entity-history/[:key]`
 
-Returns the transaction history of a key, from newest to oldest transaction time.
+Returns the history for the given entity
 
 [source,bash]
 ----
-curl -X GET $nodeURL/history/:ivan
+curl -X GET $nodeURL/entity-history/:ivan?sort-order=desc
 ----
+
+Also accepts the following as optional query parameters:
+* `with-corrections` - includes bitemporal corrections in the response, inline, sorted by valid-time then transaction-time (default false)
+* `with-docs` - includes the documents in the response sequence, under the `:crux.db/doc` key (default false)
+* `start-valid-time`, `start-transaction-time` - bitemporal co-ordinates to start at (inclusive, default unbounded)
+* `end-valid-time`, `end-transaction-time` - bitemporal co-ordinates to stop at (exclusive, default unbounded)
 
 [source,clj]
 ----
@@ -195,7 +198,8 @@ curl -X GET $nodeURL/history/:ivan
   :crux.db/content-hash "c28f6d258397651106b7cb24bb0d3be234dc8bd1",
   :crux.db/valid-time #inst "2019-01-07T14:57:08.462-00:00",
   :crux.tx/tx-id 14,
-  :crux.tx/tx-time #inst "2019-01-07T16:51:55.185-00:00"}
+  :crux.tx/tx-time #inst "2019-01-07T16:51:55.185-00:00"
+  :crux.db/doc {...}}
 
  {...}]
 ----


### PR DESCRIPTION
resolves #830 

This PR depends on #840 - to see the change on top, see the most recent two commits: https://github.com/juxt/crux/pull/841/files/91e517a66f5d22564eea3acf4a2e731d54bcfb7e..4fa9f0ed7e85bbf2eb7f681ce7eb27fcdfb624fc

I implemented it first on the node as suggested, and it worked fine, passed tests, etc. Trouble is - allowing the user to specify arbitrary maximum tx-times means that the result of calling the function with the same parameters at two different times is subject to what transactions the node has indexed in the meantime - and it's _this_ that I now think is the real value of the DB as a separate entity: not just a store of a bitemporal co-ordinate, but a bound on what transactions can possibly influence the result of any functions you call on it.

The way I've implemented now is to have the entity-history on the DB, but to allow the user to also specify min/max vt/tt to the function itself. Perfectly fine to elide max on the call and use the value from the DB; the semantics in that case are unambiguous. RFC?

This also demo's a pattern I'm considering to consolidate the Java APIs:
- The node object that the Java and Clojure API's use should both be the _same_ object - so that extensions can be written in either Java or Clojure. (with crux.api.alpha, we wrap the Clojure node, which means that extensions written by Java authors won't work in Clojure applications)
- The Java API uses strongly typed objects where possible (in this case, `HistoryOptions`), so that IDEs can auto-complete the various options. Particularly, they don't use any Clojure-specific data structures - either as parameters or return values.
- The Clojure node then implements the Java API directly (no change here), using the strong types - with the trade-off that this is quite an interop-heavy implementation.
- The Clojure protocol exposes Clojure data-types instead - the `extend-protocol` definition between the Clojure protocol and the Java interface is where we adapt both parameters and return values.
- This may mean that we do our computation in Clojure data types, convert to Java in the interface, and back to Clojure in the protocol, which may turn out to be an intolerable overhead.

TODO:
* [ ] docstrings/javadocs/etc