### PR TITLE
Decode primitive values

### DIFF
--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -13,7 +13,8 @@
                  [com.taoensso/encore "2.114.0"]
                  [org.agrona/agrona "1.0.7"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]]
-  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}}
+  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]
+                                  [org.clojure/test.check "0.10.0"]]}}
   :middleware [leiningen.project-version/middleware]
   :java-source-paths ["src"]
   :javac-options ["-source" "8" "-target" "8"

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -34,6 +34,7 @@
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end])
   (entity-history [this eid sort-order opts])
   (all-content-hashes [this eid])
+  (decode-value [this a content-hash value])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -35,6 +35,7 @@
   (entity-history [this eid sort-order opts])
   (all-content-hashes [this eid])
   (decode-value [this a content-hash value])
+  (get-document [this content-hash])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -28,12 +28,12 @@
   kv/KvIterator
   (seek [_ k]
     (when-let [k (kv/seek i k)]
-      (when (mem/buffers=? k prefix (mem/capacity prefix))
+      (when (mem/buffers=? k prefix (.capacity prefix))
         k)))
 
   (next [_]
     (when-let [k (kv/next i)]
-      (when (mem/buffers=? k prefix (mem/capacity prefix))
+      (when (mem/buffers=? k prefix (.capacity prefix))
         k)))
 
   (value [_]
@@ -72,7 +72,7 @@
 
   (next-values [this]
     (when-let [last-k (.last-k peek-state)]
-      (let [prefix-size (- (mem/capacity last-k) c/id-size c/id-size)]
+      (let [prefix-size (- (.capacity ^DirectBuffer last-k) c/id-size c/id-size)]
         (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer last-k prefix-size (.get seek-buffer-tl)) prefix-size))
                               (kv/seek i))]
           (attribute-value+placeholder k peek-state))))))
@@ -84,7 +84,7 @@
 
 (defn- attribute-value-entity-entity+value [snapshot i ^DirectBuffer current-k attr value entity-as-of-idx peek-eb ^DocAttributeValueEntityEntityIndexState peek-state]
   (loop [k current-k]
-    (let [limit (- (mem/capacity k) c/id-size)]
+    (let [limit (- (.capacity k) c/id-size)]
       (set! (.peek peek-state) (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit peek-eb) limit))))
     (or (let [eid (.eid (c/decode-avec-key->evc-from k))
               eid-buffer (c/->id-buffer eid)
@@ -279,8 +279,8 @@
                                           v)))))
 
 (defn new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
-  (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (mem/capacity prefix-v))
-        pred (value-comparsion-predicate zero? prefix-v (mem/capacity prefix-v))]
+  (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (.capacity prefix-v))
+        pred (value-comparsion-predicate zero? prefix-v (.capacity prefix-v))]
     (->PredicateVirtualIndex idx pred (fn [k]
                                         (if (seek-k-pred k)
                                           k
@@ -338,7 +338,7 @@
                :let [k (c/->id-buffer k)]
                v (vectorize-value v)
                :let [v (c/->value-buffer v)]
-               :when (pos? (mem/capacity v))]
+               :when (pos? (.capacity v))]
            [(c/encode-avec-key-to nil k v id content-hash)
             (c/encode-aecv-key-to nil k id content-hash v)])
          (apply concat))))
@@ -378,7 +378,7 @@
   ([i ^DirectBuffer prefix, ^DirectBuffer seek-k, {:keys [entries? reverse?]}]
    (letfn [(step [k]
              (lazy-seq
-              (when (and k (mem/buffers=? prefix k (mem/capacity prefix)))
+              (when (and k (mem/buffers=? prefix k (.capacity prefix)))
                 (cons (if entries?
                         [(mem/copy-to-unpooled-buffer k) (mem/copy-to-unpooled-buffer (kv/value i))]
                         (mem/copy-to-unpooled-buffer k))
@@ -415,7 +415,7 @@
 ;; Entities
 
 (defn- ^EntityTx enrich-entity-tx [entity-tx ^DirectBuffer content-hash]
-  (assoc entity-tx :content-hash (when (pos? (mem/capacity content-hash))
+  (assoc entity-tx :content-hash (when (pos? (.capacity content-hash))
                                    (c/safe-id (c/new-id content-hash)))))
 
 (defn- safe-entity-tx ^crux.codec.EntityTx [entity-tx]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -432,7 +432,7 @@
           (if (morton/morton-number-within-range? min max z)
             (let [entity-tx (safe-entity-tx (c/decode-entity+z+tx-id-key-from k))
                   v (kv/value i)]
-              (if-not (mem/buffers=? (c/nil-id-buffer) v)
+              (if-not (mem/buffers=? c/nil-id-buffer v)
                 [(c/->id-buffer (.eid entity-tx))
                  (enrich-entity-tx entity-tx v)
                  z]
@@ -480,7 +480,7 @@
           (let [entity-tx (safe-entity-tx (c/decode-entity+vt+tt+tx-id-key-from k))
                 v (kv/value i)]
             (if (<= (compare (.tt entity-tx) transact-time) 0)
-              (when-not (mem/buffers=? (c/nil-id-buffer) v)
+              (when-not (mem/buffers=? c/nil-id-buffer v)
                 [(c/->id-buffer (.eid entity-tx))
                  (enrich-entity-tx entity-tx v)])
               (if morton/*use-space-filling-curve-index?*
@@ -622,8 +622,8 @@
 (def ^:private sorted-virtual-index-key-comparator
   (reify Comparator
     (compare [_ [a] [b]]
-      (mem/compare-buffers (or a (c/nil-id-buffer))
-                           (or b (c/nil-id-buffer))))))
+      (mem/compare-buffers (or a c/nil-id-buffer)
+                           (or b c/nil-id-buffer)))))
 
 (defrecord SortedVirtualIndex [values ^SortedVirtualIndexState state]
   db/Index
@@ -680,7 +680,7 @@
   (let [result-name (:name idx)]
     (UnaryJoinIteratorState.
      idx
-     (or value (c/nil-id-buffer))
+     (or value c/nil-id-buffer)
      (when (and result-name results)
        {result-name results}))))
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -318,9 +318,12 @@
   (when-not (evicted-doc? doc)
     doc))
 
+(defn multiple-values? [v]
+  (or (vector? v) (set? v)))
+
 (defn vectorize-value [v]
   (cond-> v
-    (not (or (vector? v) (set? v)))
+    (not (multiple-values? v))
     (vector)))
 
 (defn doc-predicate-stats [doc evicted?]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -145,7 +145,7 @@
                                                        (dissoc :crux.tx.event/tx-events)
                                                        (assoc :crux.api/tx-ops
                                                               (->> tx-events
-                                                                   (mapv #(tx/tx-event->tx-op % index-store object-store)))))))))]
+                                                                   (mapv #(tx/tx-event->tx-op % index-store)))))))))]
 
           (cio/->cursor (fn []
                           (.close index-store)
@@ -179,8 +179,8 @@
                                     (select-keys ev [:committed?])
                                     (select-keys submitted-tx [::tx/tx-time ::tx/tx-id])
                                     (when (:with-tx-ops? event-opts)
-                                      (with-open [snapshot (kv/new-snapshot kv-store)]
-                                        {:crux/tx-ops (mapv #(tx/tx-event->tx-op % snapshot object-store) tx-events)}))))))))
+                                      (with-open [index-store (db/open-index-store indexer)]
+                                        {:crux/tx-ops (mapv #(tx/tx-event->tx-op % index-store) tx-events)}))))))))
 
   (latestCompletedTx [this]
     (db/latest-completed-tx indexer))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -174,7 +174,7 @@
                      (-> entity-to-restore
                          (assoc :vt end-valid-time))
 
-                     (c/->EntityTx eid end-valid-time tx-time tx-id (c/nil-id-buffer)))]))))
+                     (c/->EntityTx eid end-valid-time tx-time tx-id c/nil-id-buffer))]))))
 
       (->> (cons start-valid-time
                  (when-let [visible-entity (some-> (entity-at history eid start-valid-time tx-time)

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -68,12 +68,14 @@
 
 (tcct/defspec test-generative-primitive-value-decoder 1000
   (prop/for-all [v (gen/one-of [gen/large-integer
-                                (gen/double* {:NaN? false})
+                                gen/double
                                 (gen/fmap #(Date. (long %)) gen/large-integer)
                                 gen/string])]
                 (let [buffer (c/->value-buffer v)]
                   (if (c/can-decode-value-buffer? buffer)
-                    (t/is (= v (c/decode-value-buffer buffer))
+                    (t/is (if (and (double? v) (Double/isNaN v))
+                            (Double/isNaN (c/decode-value-buffer buffer))
+                            (= v (c/decode-value-buffer buffer)))
                           (str (pr-str v) " " (class v)))
                     (t/is (= @#'c/object-value-type-id
                              (.getByte (c/value-buffer-type-id buffer) 0)))))))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -2,14 +2,14 @@
   (:require [clojure.test :as t]
             [crux.codec :as c]
             [crux.memory :as mem]
+            [crux.fixtures :as fix]
             [clojure.test.check.clojure-test :as tcct]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop])
   (:import crux.codec.Id
            java.util.Date))
 
-(declare with-silent-test-check)
-(t/use-fixtures :each #'with-silent-test-check)
+(t/use-fixtures :each fix/with-silent-test-check)
 
 (t/deftest test-ordering-of-values
   (t/testing "longs"
@@ -83,7 +83,3 @@
                                (> (count v) @#'c/max-string-index-length)
                                (= @#'c/object-value-type-id
                                   (.getByte (c/value-buffer-type-id buffer) 0))))))))
-
-(defn with-silent-test-check [f]
-  (binding [tcct/*report-completion* false]
-    (f)))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -9,7 +9,7 @@
            java.util.Date))
 
 (declare with-silent-test-check)
-(t/use-fixtures :each with-silent-test-check)
+(t/use-fixtures :each #'with-silent-test-check)
 
 (t/deftest test-ordering-of-values
   (t/testing "longs"

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -70,7 +70,7 @@
   (prop/for-all [v (gen/one-of [gen/large-integer
                                 (gen/double* {:NaN? false})
                                 (gen/fmap #(Date. (long %)) gen/large-integer)
-                                gen/string-alphanumeric])]
+                                gen/string])]
                 (let [buffer (c/->value-buffer v)]
                   (if (c/can-decode-value-buffer? buffer)
                     (t/is (= v (c/decode-value-buffer buffer))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -1,8 +1,15 @@
 (ns crux.codec-test
   (:require [clojure.test :as t]
             [crux.codec :as c]
-            [crux.memory :as mem])
-  (:import crux.codec.Id))
+            [crux.memory :as mem]
+            [clojure.test.check.clojure-test :as tcct]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop])
+  (:import crux.codec.Id
+           java.util.Date))
+
+(declare with-silent-test-check)
+(t/use-fixtures :each with-silent-test-check)
 
 (t/deftest test-ordering-of-values
   (t/testing "longs"
@@ -58,3 +65,19 @@
              #crux/id "http://xmlns.com/foaf/0.1/firstName"))
     (t/is (= (c/new-id "http://xmlns.com/foaf/0.1/firstName")
              #crux/id ":http://xmlns.com/foaf/0.1/firstName"))))
+
+(tcct/defspec test-generative-primitive-value-decoder 1000
+  (prop/for-all [v (gen/one-of [gen/large-integer
+                                (gen/double* {:NaN? false})
+                                (gen/fmap #(Date. (long %)) gen/large-integer)
+                                gen/string-alphanumeric])]
+                (let [buffer (c/->value-buffer v)]
+                  (if (c/can-decode-value-buffer? buffer)
+                    (t/is (= v (c/decode-value-buffer buffer))
+                          (str (pr-str v) " " (class v)))
+                    (t/is (= @#'c/object-value-type-id
+                             (.getByte (c/value-buffer-type-id buffer) 0)))))))
+
+(defn with-silent-test-check [f]
+  (binding [tcct/*report-completion* false]
+    (f)))


### PR DESCRIPTION
Running `curx.query-test` and comparing the time it takes to use this decoder for primitive values where possible instead of going to the document is about 20% for these cases, which are about 1/3 of all value accesses in the test. This does not show in the total runtime of the test as it does much more. A more targeted query test would likely show the improvement better.

This PR is mainly to implement and test the decoder, but also plugs it in into `crux.query` in `bound-results-for-var`. It does not yet try to move this logic into the `IndexStore`. (This isn't true anymore, the latter commits do this.)