### PR TITLE
Encode values

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -34,7 +34,8 @@
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end])
   (entity-history ^crux.api.ICursor [this eid sort-order opts])
   (all-content-hashes [this eid])
-  (decode-value [this a content-hash value])
+  (decode-value [this a content-hash value-buffer])
+  (encode-value [this value])
   (get-document [this content-hash])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -236,7 +236,7 @@
        (and value (compare-pred (mem/compare-buffers value compare-v max-length))))
      (constantly true))))
 
-(defn- new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
+(defn new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
   (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (.capacity prefix-v))
         pred (value-comparsion-predicate zero? prefix-v (.capacity prefix-v))]
     (->PredicateVirtualIndex idx pred (fn [k]
@@ -244,26 +244,20 @@
                                           k
                                           prefix-v)))))
 
-;; TODO: Get rid of assumption that value-buffer-type-id is always one
-;; byte. Later, move construction or handling of ranges to the
-;; IndexStore and remove the need for type id completely.
 (defn new-less-than-equal-virtual-index [idx ^DirectBuffer max-v]
   (let [pred (value-comparsion-predicate (comp not pos?) max-v)]
-    (-> (->PredicateVirtualIndex idx pred identity)
-        (new-prefix-equal-virtual-index (c/value-buffer-type-id max-v)))))
+    (->PredicateVirtualIndex idx pred identity)))
 
 (defn new-less-than-virtual-index [idx ^DirectBuffer max-v]
   (let [pred (value-comparsion-predicate neg? max-v)]
-    (-> (->PredicateVirtualIndex idx pred identity)
-        (new-prefix-equal-virtual-index (c/value-buffer-type-id max-v)))))
+    (->PredicateVirtualIndex idx pred identity)))
 
 (defn new-greater-than-equal-virtual-index [idx ^DirectBuffer min-v]
   (let [pred (value-comparsion-predicate (comp not neg?) min-v)]
-    (-> (->PredicateVirtualIndex idx pred (fn [k]
-                                            (if (pred k)
-                                              k
-                                              min-v)))
-        (new-prefix-equal-virtual-index (c/value-buffer-type-id min-v)))))
+    (->PredicateVirtualIndex idx pred (fn [k]
+                                        (if (pred k)
+                                          k
+                                          min-v)))))
 
 (defrecord GreaterThanVirtualIndex [idx]
   db/Index
@@ -280,8 +274,7 @@
                                                 (if (pred k)
                                                   k
                                                   min-v)))]
-    (-> (->GreaterThanVirtualIndex idx)
-        (new-prefix-equal-virtual-index (c/value-buffer-type-id min-v)))))
+    (->GreaterThanVirtualIndex idx)))
 
 (defn new-equals-virtual-index [idx ^DirectBuffer v]
   (let [pred (value-comparsion-predicate zero? v)]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -236,21 +236,34 @@
        (and value (compare-pred (mem/compare-buffers value compare-v max-length))))
      (constantly true))))
 
-(defn new-less-than-equal-virtual-index [idx max-v]
-  (let [pred (value-comparsion-predicate (comp not pos?) (c/->value-buffer max-v))]
-    (->PredicateVirtualIndex idx pred identity)))
-
-(defn new-less-than-virtual-index [idx max-v]
-  (let [pred (value-comparsion-predicate neg? (c/->value-buffer max-v))]
-    (->PredicateVirtualIndex idx pred identity)))
-
-(defn new-greater-than-equal-virtual-index [idx min-v]
-  (let [min-v (c/->value-buffer min-v)
-        pred (value-comparsion-predicate (comp not neg?) min-v)]
+(defn- new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
+  (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (.capacity prefix-v))
+        pred (value-comparsion-predicate zero? prefix-v (.capacity prefix-v))]
     (->PredicateVirtualIndex idx pred (fn [k]
-                                        (if (pred k)
+                                        (if (seek-k-pred k)
                                           k
-                                          min-v)))))
+                                          prefix-v)))))
+
+;; TODO: Get rid of assumption that value-buffer-type-id is always one
+;; byte. Later, move construction or handling of ranges to the
+;; IndexStore and remove the need for type id completely.
+(defn new-less-than-equal-virtual-index [idx ^DirectBuffer max-v]
+  (let [pred (value-comparsion-predicate (comp not pos?) max-v)]
+    (-> (->PredicateVirtualIndex idx pred identity)
+        (new-prefix-equal-virtual-index (c/value-buffer-type-id max-v)))))
+
+(defn new-less-than-virtual-index [idx ^DirectBuffer max-v]
+  (let [pred (value-comparsion-predicate neg? max-v)]
+    (-> (->PredicateVirtualIndex idx pred identity)
+        (new-prefix-equal-virtual-index (c/value-buffer-type-id max-v)))))
+
+(defn new-greater-than-equal-virtual-index [idx ^DirectBuffer min-v]
+  (let [pred (value-comparsion-predicate (comp not neg?) min-v)]
+    (-> (->PredicateVirtualIndex idx pred (fn [k]
+                                            (if (pred k)
+                                              k
+                                              min-v)))
+        (new-prefix-equal-virtual-index (c/value-buffer-type-id min-v)))))
 
 (defrecord GreaterThanVirtualIndex [idx]
   db/Index
@@ -261,30 +274,21 @@
   (next-values [this]
     (db/next-values idx)))
 
-(defn new-greater-than-virtual-index [idx min-v]
-  (let [min-v (c/->value-buffer min-v)
-        pred (value-comparsion-predicate pos? min-v)
+(defn new-greater-than-virtual-index [idx ^DirectBuffer min-v]
+  (let [pred (value-comparsion-predicate pos? min-v)
         idx (->PredicateVirtualIndex idx pred (fn [k]
                                                 (if (pred k)
                                                   k
                                                   min-v)))]
-    (->GreaterThanVirtualIndex idx)))
+    (-> (->GreaterThanVirtualIndex idx)
+        (new-prefix-equal-virtual-index (c/value-buffer-type-id min-v)))))
 
-(defn new-equals-virtual-index [idx v]
-  (let [v (c/->value-buffer v)
-        pred (value-comparsion-predicate zero? v)]
+(defn new-equals-virtual-index [idx ^DirectBuffer v]
+  (let [pred (value-comparsion-predicate zero? v)]
     (->PredicateVirtualIndex idx pred (fn [k]
                                         (if (pred k)
                                           k
                                           v)))))
-
-(defn new-prefix-equal-virtual-index [idx ^DirectBuffer prefix-v]
-  (let [seek-k-pred (value-comparsion-predicate (comp not neg?) prefix-v (.capacity prefix-v))
-        pred (value-comparsion-predicate zero? prefix-v (.capacity prefix-v))]
-    (->PredicateVirtualIndex idx pred (fn [k]
-                                        (if (seek-k-pred k)
-                                          k
-                                          prefix-v)))))
 
 (defn wrap-with-range-constraints [idx range-constraints]
   (if range-constraints
@@ -625,8 +629,8 @@
 (def ^:private sorted-virtual-index-key-comparator
   (reify Comparator
     (compare [_ [a] [b]]
-      (mem/compare-buffers (or a c/nil-id-buffer)
-                           (or b c/nil-id-buffer)))))
+      (mem/compare-buffers (or a c/empty-buffer)
+                           (or b c/empty-buffer)))))
 
 (defrecord SortedVirtualIndex [values ^SortedVirtualIndexState state]
   db/Index
@@ -683,7 +687,7 @@
   (let [result-name (:name idx)]
     (UnaryJoinIteratorState.
      idx
-     (or value c/nil-id-buffer)
+     (or value c/empty-buffer)
      (when (and result-name results)
        {result-name results}))))
 
@@ -886,7 +890,7 @@
 (defn- relation-virtual-index-depth ^long [^RelationIteratorsState iterators-state]
   (dec (count (.indexes iterators-state))))
 
-(defrecord RelationVirtualIndex [relation-name max-depth layered-range-constraints ^RelationIteratorsState state]
+(defrecord RelationVirtualIndex [relation-name max-depth layered-range-constraints encode-value-fn ^RelationIteratorsState state]
   db/Index
   (seek-values [this k]
     (when-let [idx (last (.indexes state))]
@@ -925,15 +929,15 @@
   (max-depth [this]
     max-depth))
 
-(defn- build-nested-index [tuples [range-constraints & next-range-constraints]]
+(defn- build-nested-index [encode-value-fn tuples [range-constraints & next-range-constraints]]
   (-> (new-sorted-virtual-index
        (for [prefix (vals (group-by first tuples))
              :let [value (ffirst prefix)]]
-         [(c/->value-buffer value)
+         [(encode-value-fn value)
           (RelationNestedIndexState.
            value
            (when (seq (next (first prefix)))
-             (build-nested-index (map next prefix) next-range-constraints)))]))
+             (build-nested-index encode-value-fn (map next prefix) next-range-constraints)))]))
       (wrap-with-range-constraints range-constraints)))
 
 (defn update-relation-virtual-index!
@@ -942,14 +946,14 @@
   ([^RelationVirtualIndex relation tuples layered-range-constraints]
    (let [state ^RelationIteratorsState (.state relation)]
      (set! (.indexes state) [(binding [nippy/*freeze-fallback* :write-unfreezable]
-                               (build-nested-index tuples layered-range-constraints))])
+                               (build-nested-index (.encode-value-fn relation) tuples layered-range-constraints))])
      (set! (.child-idx state) nil)
      (set! (.needs-seek? state) false))
    relation))
 
 (defn new-relation-virtual-index
-  ([relation-name tuples max-depth]
-   (new-relation-virtual-index relation-name tuples max-depth nil))
-  ([relation-name tuples max-depth layered-range-constraints]
+  ([relation-name tuples max-depth encode-value-fn]
+   (new-relation-virtual-index relation-name tuples max-depth encode-value-fn nil))
+  ([relation-name tuples max-depth encode-value-fn layered-range-constraints]
    (let [iterators-state (RelationIteratorsState. nil nil false)]
-     (update-relation-virtual-index! (->RelationVirtualIndex relation-name max-depth layered-range-constraints iterators-state) tuples))))
+     (update-relation-virtual-index! (->RelationVirtualIndex relation-name max-depth layered-range-constraints encode-value-fn iterators-state) tuples))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -239,7 +239,7 @@
                                   arg))
                            or-join-vars)}))
 
-(defn- build-var-range-constraints [e-vars range-clauses]
+(defn- build-var-range-constraints [encode-value-fn e-vars range-clauses]
   (let [var->range-clauses (->> (for [{:keys [op sym] :as clause} range-clauses]
                                   (if (and (contains? e-vars sym)
                                            (not= '= op))
@@ -250,18 +250,13 @@
                                 (group-by :sym))]
     (->> (for [[var clauses] var->range-clauses]
            [var (->> (for [{:keys [op val sym]} clauses
-                           :let [type-prefix (c/value-buffer-type-id (c/->value-buffer val))]]
+                           :let [val (encode-value-fn val)]]
                        (case op
-                         = #(-> (idx/new-equals-virtual-index % val)
-                                (idx/new-prefix-equal-virtual-index type-prefix))
-                         < #(-> (idx/new-less-than-virtual-index % val)
-                                (idx/new-prefix-equal-virtual-index type-prefix))
-                         <= #(-> (idx/new-less-than-equal-virtual-index % val)
-                                 (idx/new-prefix-equal-virtual-index type-prefix))
-                         > #(-> (idx/new-greater-than-virtual-index % val)
-                                (idx/new-prefix-equal-virtual-index type-prefix))
-                         >= #(-> (idx/new-greater-than-equal-virtual-index % val)
-                                 (idx/new-prefix-equal-virtual-index type-prefix))))
+                         = #(idx/new-equals-virtual-index % val)
+                         < #(idx/new-less-than-virtual-index % val)
+                         <= #(idx/new-less-than-equal-virtual-index % val)
+                         > #(idx/new-greater-than-virtual-index % val)
+                         >= #(idx/new-greater-than-equal-virtual-index % val)))
                      (apply comp))])
          (into {}))))
 
@@ -348,17 +343,22 @@
                            (get literal->var v))
                    join {:id (gensym "triple")
                          :name e-var
-                         :idx-fn #(-> (idx/new-binary-join-virtual-index)
-                                      (with-meta {:clause clause
-                                                  :names {:e e-var
-                                                          :v v-var}}))}
+                         :idx-fn (fn [_]
+                                   (-> (idx/new-binary-join-virtual-index)
+                                       (with-meta {:clause clause
+                                                   :names {:e e-var
+                                                           :v v-var}})))}
                    var->joins (merge-with into var->joins {v-var [join]
                                                            e-var [join]})
                    var->joins (if (literal? e)
-                                (merge-with into var->joins {e-var [{:idx-fn #(idx/new-relation-virtual-index e-var [[e]] 1)}]})
+                                (merge-with into var->joins {e-var [{:idx-fn
+                                                                     (fn [encode-value-fn]
+                                                                       (idx/new-relation-virtual-index e-var [[e]] 1 encode-value-fn))}]})
                                 var->joins)
                    var->joins (if (literal? v)
-                                (merge-with into var->joins {v-var [{:idx-fn #(idx/new-relation-virtual-index v-var [[v]] 1)}]})
+                                (merge-with into var->joins {v-var [{:idx-fn
+                                                                     (fn [encode-value-fn]
+                                                                       (idx/new-relation-virtual-index v-var [[v]] 1 encode-value-fn))}]})
                                 var->joins)]
                var->joins))
            var->joins))]))
@@ -375,13 +375,16 @@
     (set (for [k ks]
            (symbol (name k))))))
 
-(defn- arg-joins [arg-vars e-vars var->joins]
+(defn- arg-joins [encode-value-fn arg-vars e-vars var->joins]
   (if (seq arg-vars)
     (let [idx-id (gensym "args")
           join {:id idx-id
-                :idx-fn #(idx/new-relation-virtual-index idx-id
-                                                         []
-                                                         (count arg-vars))}]
+                :idx-fn
+                (fn [encode-value-fn]
+                  (idx/new-relation-virtual-index idx-id
+                                                  []
+                                                  (count arg-vars)
+                                                  encode-value-fn))}]
       [idx-id
        (->> arg-vars
             (reduce
@@ -399,10 +402,13 @@
           (if return
             (let [idx-id (gensym "pred-return")
                   join {:id idx-id
-                        :idx-fn #(idx/new-relation-virtual-index idx-id
-                                                                 []
-                                                                 1
-                                                                 [(get var->range-constraints return)])
+                        :idx-fn
+                        (fn [encode-value-fn]
+                          (idx/new-relation-virtual-index idx-id
+                                                          []
+                                                          1
+                                                          encode-value-fn
+                                                          [(get var->range-constraints return)]))
                         :name (symbol "crux.query.value" (name return))}]
               [(conj pred-clause+idx-ids [pred-clause idx-id])
                (merge-with into var->joins {return [join]})])
@@ -456,9 +462,12 @@
                 idx-id (gensym "or-free-vars")
                 join (when (seq free-vars)
                        {:id idx-id
-                        :idx-fn #(idx/new-relation-virtual-index idx-id
-                                                                 []
-                                                                 (count free-vars))})]
+                        :idx-fn
+                        (fn [encode-value-fn]
+                          (idx/new-relation-virtual-index idx-id
+                                                          []
+                                                          (count free-vars)
+                                                          encode-value-fn))})]
             (when (not (apply = (map :or-vars or-branches)))
               (throw (IllegalArgumentException.
                       (str "Or requires same logic variables: " (cio/pr-edn-str clause)))))
@@ -581,7 +590,7 @@
 ;; parent, which is what will be used when walking the tree. Due to
 ;; the way or-join (and rules) work, they likely have to stay as sub
 ;; queries. Recursive rules always have to be sub queries.
-(defn- or-single-e-var-triple-fast-path [index-store {:keys [query-engine entity-as-of-idx] :as db} {:keys [e a v] :as clause} args]
+(defn- or-single-e-var-triple-fast-path [index-store {:keys [entity-as-of-idx] :as db} {:keys [e a v] :as clause} args]
   (let [eid (get (first args) e)]
     (when-let [^EntityTx entity-tx (idx/entity-at entity-as-of-idx eid)]
       (let [doc (db/get-document index-store (.content-hash entity-tx))]
@@ -657,7 +666,7 @@
 ;; propagating knowledge from the first var to the next. Currently
 ;; unification has to scan the values and check them as they get bound
 ;; and doesn't fully carry its weight compared to normal predicates.
-(defn- build-unification-constraints [unify-clauses var->bindings]
+(defn- build-unification-constraints [encode-value-fn unify-clauses var->bindings]
   (for [{:keys [op args]
          :as clause} unify-clauses
         :let [unification-vars (filter logic-var? args)
@@ -665,7 +674,7 @@
               args (vec (for [arg args]
                           (if (logic-var? arg)
                             arg
-                            (->> (map c/->value-buffer (idx/vectorize-value arg))
+                            (->> (map encode-value-fn (idx/vectorize-value arg))
                                  (into (sorted-set-by mem/buffer-comparator))))))]]
     (do (validate-existing-vars var->bindings clause unification-vars)
         {:join-depth unification-join-depth
@@ -835,7 +844,7 @@
        (sort-by (comp var->values-result-index second))
        (into {})))
 
-(defn- compile-sub-query [where arg-vars rule-name->rules stats]
+(defn- compile-sub-query [encode-value-fn where arg-vars rule-name->rules stats]
   (let [where (expand-rules where rule-name->rules {})
         {triple-clauses :triple
          range-clauses :range
@@ -852,13 +861,14 @@
                 pred-vars
                 pred-return-vars]} (collect-vars type->clauses)
         var->joins {}
-        var->range-constraints (build-var-range-constraints e-vars range-clauses)
+        var->range-constraints (build-var-range-constraints encode-value-fn e-vars range-clauses)
         [triple-join-deps var->joins] (triple-joins triple-clauses
                                                     range-clauses
                                                     var->joins
                                                     arg-vars
                                                     stats)
-        [args-idx-id var->joins] (arg-joins arg-vars
+        [args-idx-id var->joins] (arg-joins encode-value-fn
+                                            arg-vars
                                             e-vars
                                             var->joins)
         [pred-clause+idx-ids var->joins] (pred-joins pred-clauses var->range-constraints var->joins)
@@ -898,7 +908,7 @@
                                                  var->values-result-index
                                                  join-depth
                                                  (keys var->attr)))
-        unification-constraints (build-unification-constraints unify-clauses var->bindings)
+        unification-constraints (build-unification-constraints encode-value-fn unify-clauses var->bindings)
         not-constraints (build-not-constraints rule-name->rules :not not-clauses var->bindings stats)
         not-join-constraints (build-not-constraints rule-name->rules :not-join not-join-clauses var->bindings stats)
         pred-constraints (build-pred-constraints pred-clause+idx-ids var->bindings)
@@ -922,7 +932,7 @@
      :args-idx-id args-idx-id
      :attr-stats (select-keys stats (vals var->attr))}))
 
-(defn- build-idx-id->idx [var->joins]
+(defn- build-idx-id->idx [encode-value-fn var->joins]
   (->> (for [[_ joins] var->joins
              {:keys [id idx-fn] :as join} joins
              :when id]
@@ -931,13 +941,14 @@
         (fn [acc [id idx-fn]]
           (if (contains? acc id)
             acc
-            (assoc acc id (idx-fn))))
+            (assoc acc id (idx-fn encode-value-fn))))
         {})))
 
 (defn- build-sub-query [index-store {:keys [query-engine] :as db} where args rule-name->rules stats]
   ;; NOTE: this implies argument sets with different vars get compiled
   ;; differently.
   (let [arg-vars (arg-vars args)
+        encode-value-fn (partial db/encode-value index-store)
         {:keys [query-cache]} query-engine
         {:keys [depth->constraints
                 vars-in-join-order
@@ -951,13 +962,13 @@
                               [where arg-vars rule-name->rules]
                               identity
                               (fn [_]
-                                (compile-sub-query where arg-vars rule-name->rules stats)))
-        idx-id->idx (build-idx-id->idx var->joins)
+                                (compile-sub-query encode-value-fn where arg-vars rule-name->rules stats)))
+        idx-id->idx (build-idx-id->idx encode-value-fn var->joins)
         constrain-result-fn (fn [join-keys join-results]
                               (constrain-join-result-by-constraints index-store db idx-id->idx depth->constraints join-keys join-results))
         unary-join-index-groups (for [v vars-in-join-order]
                                   (for [{:keys [id idx-fn name] :as join} (get var->joins v)]
-                                    (assoc (or (get idx-id->idx id) (idx-fn)) :name name)))]
+                                    (assoc (or (get idx-id->idx id) (idx-fn encode-value-fn)) :name name)))]
     (doseq [[_ idx] idx-id->idx
             :when (instance? BinaryJoinLayeredVirtualIndex idx)]
       (update-binary-index! index-store db idx vars-in-join-order var->range-constraints))
@@ -1021,13 +1032,10 @@
     :else
     q))
 
-(defn query-plan-for
-  ([q]
-   (query-plan-for q {}))
-  ([q stats]
-   (s/assert ::query q)
-   (let [{:keys [where args rules]} (s/conform ::query q)]
-     (compile-sub-query where (arg-vars args) (rule-name->rules rules) stats))))
+(defn query-plan-for [q encode-value-fn stats]
+  (s/assert ::query q)
+  (let [{:keys [where args rules]} (s/conform ::query q)]
+    (compile-sub-query encode-value-fn where (arg-vars args) (rule-name->rules rules) stats)))
 
 (defn- build-full-results [{:keys [entity-as-of-idx index-store] :as db} bound-result-tuple]
   (vec (for [value bound-result-tuple]
@@ -1152,7 +1160,7 @@
           (idx/entity-at eid)
           (c/entity-tx->edn)))
 
-(defn entity [{:keys [query-engine] :as db} index-store eid]
+(defn entity [db index-store eid]
   (let [entity-tx (entity-tx db index-store eid)]
     (-> (db/get-document index-store (:crux.db/content-hash entity-tx))
         (idx/keep-non-evicted-doc))))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -389,6 +389,9 @@
               (when xs
                 (recur xs))))))))
 
+  (encode-value [this value]
+    (c/->value-buffer value))
+
   (get-document [this content-hash]
     (db/get-single-object object-store snapshot content-hash))
 

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -43,7 +43,7 @@
                                 (apply [_ resp e]
                                   (if e
                                     (try
-                                      (throw (.getCause e))
+                                      (throw (.getCause ^Throwable e))
                                       (catch NoSuchKeyException e
                                         (log/warn "S3 key not found: " s3-key))
                                       (catch Exception e

--- a/crux-test/test/crux/index_test.clj
+++ b/crux-test/test/crux/index_test.clj
@@ -211,7 +211,8 @@
                                                [9]
                                                [11]
                                                [12]]
-                                              1)
+                                              1
+                                              c/->value-buffer)
         b-idx (idx/new-relation-virtual-index :b
                                               [[0]
                                                [2]
@@ -220,7 +221,8 @@
                                                [8]
                                                [9]
                                                [12]]
-                                              1)
+                                              1
+                                              c/->value-buffer)
         c-idx (idx/new-relation-virtual-index :c
                                               [[2]
                                                [4]
@@ -228,7 +230,8 @@
                                                [8]
                                                [10]
                                                [12]]
-                                              1)]
+                                              1
+                                              c/->value-buffer)]
 
     (t/is (= [{:x 8}
               {:x 12}]
@@ -254,7 +257,8 @@
                                            [1 4]
                                            [1 5]
                                            [3 5]]
-                                          2)
+                                          2
+                                          c/->value-buffer)
         s (idx/new-relation-virtual-index :s
                                           [[3 4]
                                            [3 5]
@@ -262,7 +266,8 @@
                                            [4 8]
                                            [4 9]
                                            [5 2]]
-                                          2)
+                                          2
+                                          c/->value-buffer)
         t (idx/new-relation-virtual-index :t
                                           [[1 4]
                                            [1 5]
@@ -271,7 +276,8 @@
                                            [1 9]
                                            [1 2]
                                            [3 2]]
-                                          2)]
+                                          2
+                                          c/->value-buffer)]
     (t/testing "n-ary join"
       (let [index-groups [[(assoc r :name :a) (assoc t :name :a)]
                           [(assoc r :name :b) (assoc s :name :b)]
@@ -313,7 +319,8 @@
                                            [3]
                                            [4]
                                            [5]]
-                                          1)]
+                                          1
+                                          c/->value-buffer)]
 
     (t/is (= [1 2 3 4 5]
              (->> (idx/idx->seq r)
@@ -325,41 +332,41 @@
                    (idx/idx->series r))))
 
     (t/is (= [1 2 3]
-             (->> (idx/idx->seq (idx/new-less-than-virtual-index r 4))
+             (->> (idx/idx->seq (idx/new-less-than-virtual-index r (c/->value-buffer 4)))
                   (map second))))
 
     (t/is (= [1 2 3 4]
-             (->> (idx/idx->seq (idx/new-less-than-equal-virtual-index r 4))
+             (->> (idx/idx->seq (idx/new-less-than-equal-virtual-index r (c/->value-buffer 4)))
                   (map second))))
 
     (t/is (= [3 4 5]
-             (->> (idx/idx->seq (idx/new-greater-than-virtual-index r 2))
+             (->> (idx/idx->seq (idx/new-greater-than-virtual-index r (c/->value-buffer 2)))
                   (map second))))
 
     (t/is (= [2 3 4 5]
-             (->> (idx/idx->seq (idx/new-greater-than-equal-virtual-index r 2))
+             (->> (idx/idx->seq (idx/new-greater-than-equal-virtual-index r (c/->value-buffer 2)))
                   (map second))))
 
     (t/is (= [2]
-             (->> (idx/idx->seq (idx/new-equals-virtual-index r 2))
+             (->> (idx/idx->seq (idx/new-equals-virtual-index r (c/->value-buffer 2)))
                   (map second))))
 
-    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r 0))))
-    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r 6))))
+    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r (c/->value-buffer 0)))))
+    (t/is (empty? (idx/idx->seq (idx/new-equals-virtual-index r (c/->value-buffer 6)))))
 
     (t/testing "seek skips to lower range"
-      (t/is (= 2 (second (db/seek-values (idx/new-greater-than-equal-virtual-index r 2) (c/->value-buffer nil)))))
-      (t/is (= 3 (second (db/seek-values (idx/new-greater-than-virtual-index r 2) (c/->value-buffer 1))))))
+      (t/is (= 2 (second (db/seek-values (idx/new-greater-than-equal-virtual-index r (c/->value-buffer 2)) (c/->value-buffer nil)))))
+      (t/is (= 3 (second (db/seek-values (idx/new-greater-than-virtual-index r (c/->value-buffer 2)) (c/->value-buffer 1))))))
 
     (t/testing "combining indexes"
       (t/is (= [2 3 4]
                (->> (idx/idx->seq (-> r
-                                      (idx/new-greater-than-equal-virtual-index 2)
-                                      (idx/new-less-than-virtual-index 5)))
+                                      (idx/new-greater-than-equal-virtual-index (c/->value-buffer 2))
+                                      (idx/new-less-than-virtual-index (c/->value-buffer 5))))
                     (map second)))))
 
     (t/testing "incompatible type"
-      (t/is (empty? (->> (idx/idx->seq (-> (idx/new-greater-than-equal-virtual-index r "foo")))
+      (t/is (empty? (->> (idx/idx->seq (-> (idx/new-greater-than-equal-virtual-index r (c/->value-buffer "foo"))))
                          (map second)))))))
 
 (t/deftest test-or-virtual-index
@@ -425,20 +432,23 @@
                                               [[7 4]
                                                ;; extra sanity check
                                                [8 4]]
-                                              2)
+                                              2
+                                              c/->value-buffer)
         s-idx (idx/new-relation-virtual-index :s
                                               [[4 0]
                                                [4 1]
                                                [4 2]
                                                [4 3]]
-                                              2)
+                                              2
+                                              c/->value-buffer)
         t-idx (idx/new-relation-virtual-index :t
                                               [[7 0]
                                                [7 1]
                                                [7 2]
                                                [8 1]
                                                [8 2]]
-                                              2)
+                                              2
+                                              c/->value-buffer)
         index-groups [[(assoc r-idx :name :a)
                        (assoc t-idx :name :a)]
                       [(assoc r-idx :name :b)
@@ -462,17 +472,20 @@
                                               [[1]
                                                [2]
                                                [3]]
-                                              1)
+                                              1
+                                              c/->value-buffer)
         q-idx (idx/new-relation-virtual-index :q
                                               [[2]
                                                [3]
                                                [4]]
-                                              1)
+                                              1
+                                              c/->value-buffer)
         r-idx (idx/new-relation-virtual-index :r
                                               [[3]
                                                [4]
                                                [5]]
-                                              1)]
+                                              1
+                                              c/->value-buffer)]
     (t/testing "conjunction"
       (let [unary-and-idx (idx/new-unary-join-virtual-index [(assoc p-idx :name :x)
                                                              (assoc q-idx :name :x)
@@ -504,12 +517,14 @@
                                               [[1 3]
                                                [2 4]
                                                [2 20]]
-                                              2)
+                                              2
+                                              c/->value-buffer)
         q-idx (idx/new-relation-virtual-index :q
                                               [[1 10]
                                                [2 20]
                                                [3 30]]
-                                              2)
+                                              2
+                                              c/->value-buffer)
         index-groups [[(assoc p-idx :name :x)
                        (assoc q-idx :name :x)]
                       [(assoc p-idx :name :y)]
@@ -528,7 +543,8 @@
     (t/testing "disjunction"
       (let [zero-idx (idx/new-relation-virtual-index :zero
                                                      [[0]]
-                                                     1)
+                                                     1
+                                                     c/->value-buffer)
             lhs-index (idx/new-n-ary-join-layered-virtual-index
                        [(idx/new-unary-join-virtual-index [(assoc p-idx :name :x)])
                         (idx/new-unary-join-virtual-index [(assoc p-idx :name :y)])

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -4,6 +4,7 @@
             [clojure.walk :as w]
             [clojure.test :as t]
             [crux.api :as api]
+            [crux.codec :as c]
             [crux.db :as db]
             [crux.fixtures :as fix :refer [*api*]]
             [crux.query :as q]
@@ -2803,7 +2804,7 @@
                                    :where '[[e :foo/type "type"]
                                             [e :foo/id m]]
                                    :args [{'m 1}]}
-
+                                  c/->value-buffer
                                   {})
                 :vars-in-join-order
                 (filter #{'m 'e})))))


### PR DESCRIPTION
Moving the responsibility of encoding values to the `IndexStore`, so it can chose the internal representation. The query engine now makes two assumptions of the buffers returned from `encode-value`:

1. The byte representations are sortable as unsigned big endian, so range searches depend on this.
2. The first byte represents the type id. This id is only used as a prefix for range searches and its values is never inspected.

Naturally, the existing `IndexStore` `decode-value` method takes a buffer respecting the above and returns the corresponding Java object representation.

The range searches will likely be pushed down into the `IndexStore` itself later, then the second assumption around type ids will be removed.

Ids in the index are mainly treated as buffers to be joined on, so they don't have to be stored as hashes, but there might be some places that still makes this assumption. Externally, for content hashes and entity ids on the TxLog, the hashes will still be used.