### PR TITLE
ability to open HTTP nodes in read-only mode, #854

### DIFF
--- a/crux-test/test/crux/http_server_test.clj
+++ b/crux-test/test/crux/http_server_test.clj
@@ -1,0 +1,14 @@
+(ns crux.http-server-test
+  (:require [crux.fixtures :as fix :refer [*api*]]
+            [clojure.test :as t]
+            [crux.api :as crux]
+            [crux.fixtures.http-server :as fh]))
+
+(t/use-fixtures :each
+  fix/with-standalone-topology
+  #(fix/with-opts {:crux.http-server/read-only? true} %)
+  fh/with-http-server fix/with-node fh/with-http-client)
+
+(t/deftest test-read-only-node
+  (t/is (thrown-with-msg? UnsupportedOperationException #"read-only"
+                          (crux/submit-tx *api* [[:crux.tx/put {:crux.db/id :foo}]]))))

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -29,7 +29,9 @@
 (defn start-standalone-http-node [port storage-dir]
   (crux/start-node {:crux.node/topology '[crux.standalone/topology crux.http-server/module]
                     :crux.kv/db-dir (str (io/file storage-dir "db"))
-                    :crux.http-server/port port}))
+                    :crux.http-server/port port
+                    ;; by default, the HTTP server is read-write - set this flag to make it read-only
+                    :crux.http-server/read-only? false}))
 ;; end::start-standalone-http-node[]
 
 ;; tag::ek-example[]


### PR DESCRIPTION
resolves #854 

supply `:crux.http-server/read-only?` to the server-side topology to prevent submitting transactions via the HTTP node