### PR TITLE
fix CLJS build failing when run from the root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,10 @@ jobs:
 
       - run:
           command: |
-            cd crux-http-server
             export LEIN_JVM_OPTS=-Xmx2G
-            lein build:cljs
+            lein sub install
 
-      - run: lein sub install
-      - run: lein deps
-      - run: lein do version, sub test, check
+      - run: lein do sub test, check
       - store_test_results:
           path: "crux-test/target/test-results"
 

--- a/crux-http-server/.gitignore
+++ b/crux-http-server/.gitignore
@@ -1,0 +1,1 @@
+/cljs-target/

--- a/crux-http-server/project.clj
+++ b/crux-http-server/project.clj
@@ -23,12 +23,17 @@
                              [day8.re-frame/http-fx "v0.2.0"]
                              [bidi "2.1.6"]
                              [tick "0.4.23-alpha"]
-                             [kibu/pushy "0.3.8"]]}}
+                             [kibu/pushy "0.3.8"]]}
+             :sass-from-root {:sass {:source "crux-http-server/resources/public/scss/"
+                                     :target "crux-http-server/cljs-target/public/css/"}}}
   :aliases {"fig" ["trampoline" "run" "-m" "figwheel.main"]
             "build:cljs" ["do"
                           ["clean"]
                           ["run" "-m" "figwheel.main" "-O" "advanced" "-bo" "dev"]
-                          ["sass"]]}
+                          ["sass"]]
+            "install" ["do"
+                       ["with-profiles" "+sass-from-root" "build:cljs"]
+                       "install"]}
   :plugins [[yogthos/lein-sass "0.1.10"]]
   :resource-paths ["resources" "cljs-target"]
   :sass {:source "resources/public/scss/" :target "cljs-target/public/css/"}


### PR DESCRIPTION
Have added an install alias to crux-http-server that alters the SASS paths for when we run `lein sub -s crux-http-server install` - trade-off is that `lein install` will no longer work from the sub-directory.