### PR TITLE
Remove public document API

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -61,14 +61,6 @@
   be `.close`d when you've finished using it (for example, in a `with-open`
   block)")
 
-  (document [node content-hash]
-    "Reads a document from the document store based on its
-  content hash.")
-
-  (documents [node content-hashes-set]
-    "Reads the set of documents from the document store based on their
-  respective content hashes. Returns a map content-hash->document")
-
   (history [node eid]
     "Returns the transaction history of an entity, in reverse
   chronological order. Includes corrections, but does not include
@@ -188,9 +180,6 @@
     ([this] (.openDB this))
     ([this ^Date valid-time] (.openDB this valid-time))
     ([this ^Date valid-time ^Date transaction-time] (.openDB this valid-time transaction-time)))
-
-  (document [this content-hash] (.document this content-hash))
-  (documents [this content-hash-set] (.documents this content-hash-set))
 
   (history [this eid] (.history this eid))
 

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -65,26 +65,6 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
     public ICruxDatasource openDB(Date validTime, Date transactionTime) throws NodeOutOfSyncException;
 
     /**
-     *  Reads a document from the document store based on its
-     *  content hash.
-     *
-     * @param contentHash an object that can be coerced into a content
-     * hash.
-     * @return            the document map.
-     */
-    public Map<Keyword, Object> document(Object contentHash);
-
-    /**
-     *  Reads a document from the document store based on its
-     *  content hash.
-     *
-     * @param contentHashSet a set of objects that can be coerced into a content
-     * hashes.
-     * @return            a map from hashable objects to the corresponding documents.
-     */
-    public Map<String,Map<Keyword,?>> documents(Set<?> contentHashSet);
-
-    /**
      * Returns the transaction history of an entity, in reverse
      * chronological order. Includes corrections, but does not include
      * the actual documents.

--- a/crux-core/src/crux/api/alpha/CruxNode.java
+++ b/crux-core/src/crux/api/alpha/CruxNode.java
@@ -87,24 +87,6 @@ public class CruxNode implements AutoCloseable {
         return database(node, validTime, transactionTime);
     }
 
-    private Document document(Object contentHash) {
-        Map<Keyword, Object> doc = node.document(contentHash);
-        return Document.document(doc);
-    }
-
-    /**
-     * Returns the transaction history of an entity, in reverse chronological order. Includes corrections, but does not include the actual documents
-     * @param id Id of the entity to get the history for
-     * @return Iterable set of Documents containing transaction information
-     */
-    public Iterable<Document> history(CruxId id) {
-        @SuppressWarnings("deprecation")
-        List<Map<Keyword,Object>> history = node.history(id.toEdn());
-        return history.stream()
-            .map(this::document)
-            .collect(Collectors.toList());
-    }
-
     /**
      * Blocks until the node has caught up indexing. Will throw an exception on timeout
      * @param timeout Max time to wait, can be null for the default

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -62,20 +62,6 @@
     (let [db (.db this valid-time tx-time)]
       (assoc db :index-store (q/open-index-store db))))
 
-  (document [this content-hash]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (with-open [index-store (db/open-index-store indexer)]
-        (-> (db/get-single-object object-store index-store (c/new-id content-hash))
-            (idx/keep-non-evicted-doc)))))
-
-  (documents [this content-hash-set]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (with-open [index-store (db/open-index-store indexer)]
-        (->> (db/get-objects object-store index-store (map c/new-id content-hash-set))
-             (into {} (remove (comp idx/evicted-doc? val)))))))
-
   (history [this eid]
     (reverse (.historyRange this eid nil nil nil nil)))
 

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -237,12 +237,6 @@
   (openDB [this valid-time] (.db this valid-time))
   (openDB [this valid-time tx-time] (.db this valid-time tx-time))
 
-  (document [_ content-hash]
-    (api-request-sync (str url "/document/" content-hash) nil {:method :get}))
-
-  (documents [_ content-hash-set]
-    (api-request-sync (str url "/documents") content-hash-set {:method :post}))
-
   (history [_ eid]
     (api-request-sync (str url "/history/" (str (c/new-id eid))) nil {:method :get}))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -129,27 +129,6 @@
                 {"Content-Type" "application/edn"}
                 (cio/pr-edn-str status-map)))))
 
-(defn- document [^ICruxAPI crux-node request]
-  (let [[_ content-hash] (re-find #"^/document/(.+)$" (req/path-info request))]
-    (success-response
-     (.document crux-node (c/new-id content-hash)))))
-
-(defn- stringify-keys [m]
-  (persistent!
-    (reduce-kv
-      (fn [m k v] (assoc! m (str k) v))
-      (transient {})
-      m)))
-
-(defn- documents [^ICruxAPI crux-node  {:keys [query-params] :as request}]
-  ; TODO support for GET
-  (let [preserve-ids? (Boolean/parseBoolean (get query-params "preserve-crux-ids" "false"))
-        content-hashes-set (body->edn request)
-        ids-set (set (map c/new-id content-hashes-set))]
-    (success-response
-      (cond-> (.documents crux-node ids-set)
-              (not preserve-ids?) stringify-keys))))
-
 (defn- history [^ICruxAPI crux-node request]
   (let [[_ eid] (re-find #"^/history/(.+)$" (req/path-info request))
         history (.history crux-node (c/new-id (URLDecoder/decode eid)))]
@@ -390,12 +369,6 @@
   (condp check-path request
     [#"^/$" [:get]]
     (status crux-node)
-
-    [#"^/document/.+$" [:get :post]]
-    (document crux-node request)
-
-    [#"^/documents" [:post]]
-    (documents crux-node request)
 
     [#"^/entity/.+$" [:get]]
     (entity crux-node request)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -157,12 +157,9 @@
                            :crux.db/content-hash (str ivan-crux-id)
                            :crux.db/valid-time valid-time})
                    entity-tx))
-          (t/is (= ivan (.document *api* (:crux.db/content-hash entity-tx))))
-          (t/is (= {ivan-crux-id ivan} (api/documents *api* #{(:crux.db/content-hash entity-tx)})))
           (t/is (= [entity-tx] (api/history *api* :ivan)))
           (t/is (= [entity-tx] (api/history-range *api* :ivan #inst "1990" #inst "1990" tx-time tx-time)))
 
-          (t/is (nil? (api/document *api* (c/new-id :does-not-exist))))
           (t/is (nil? (api/entity-tx (api/db *api* #inst "1999") :ivan))))))))
 
 (t/deftest test-can-write-entity-using-map-as-id
@@ -239,22 +236,6 @@
 
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
   (t/is (api/entity (api/db *api*) :foo)))
-
-(t/deftest test-document-bug-123
-  (let [version-1-submitted-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 1}]])]
-    (.awaitTx *api* version-1-submitted-tx nil)
-    (t/is (true? (.hasTxCommitted *api* version-1-submitted-tx))))
-
-  (let [version-2-submitted-tx (.submitTx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan" :version 2}]])]
-    (.awaitTx *api* version-2-submitted-tx nil)
-    (t/is (true? (.hasTxCommitted *api* version-2-submitted-tx))))
-
-  (let [history (.history *api* :ivan)]
-    (t/is (= 2 (count history)))
-    (t/is (= [{:crux.db/id :ivan :name "Ivan" :version 2}
-              {:crux.db/id :ivan :name "Ivan" :version 1}]
-             (for [content-hash (map :crux.db/content-hash history)]
-               (.document *api* content-hash))))))
 
 (t/deftest test-tx-log
   (let [valid-time (Date.)

--- a/docs/example/backup-restore/src/example_backup_restore/main.clj
+++ b/docs/example/backup-restore/src/example_backup_restore/main.clj
@@ -24,8 +24,6 @@
 
   (api/entity (api/db syst) :id/jeff)
 
-  (api/document syst "48ea7b320721dbdbd09c5e6be1486b0e76369b6a")
-
   (api/submit-tx
            syst
            [[:crux.tx/put
@@ -36,9 +34,5 @@
               :person/name "Lia"}]])
 
   (api/transaction-time
-    (api/db syst #inst "2019-02-02"
-            #inst "2019-04-16T12:35:05.042-00:00"))
-
-  (api/document
     (api/db syst #inst "2019-02-02"
             #inst "2019-04-16T12:35:05.042-00:00")))


### PR DESCRIPTION
as discussed on Slack - too low level to expose as a public API now that open-tx-log and history both return docs on request