### PR TITLE
bringing submit-docs back before index-entity-txs to hopefully fix test-adding-back-evicted-document

### DIFF
--- a/crux-core/src/crux/tx/consumer.clj
+++ b/crux-core/src/crux/tx/consumer.clj
@@ -36,9 +36,7 @@
 
                                   (doseq [{:keys [::txe/tx-events] :as tx} tx-log-entry
                                           :let [tx (select-keys tx [::tx/tx-time ::tx/tx-id])]]
-                                    (when-let [{:keys [tombstones]} (tx/index-tx tx-consumer tx tx-events)]
-                                      (when (seq tombstones)
-                                        (db/submit-docs document-store tombstones)))
+                                    (tx/index-tx tx-consumer tx tx-events)
 
                                     (when (Thread/interrupted)
                                       (throw (InterruptedException.)))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -225,12 +225,7 @@
           submitted-tx (api/submit-tx *api* [[:crux.tx/evict :ivan]])]
       (t/is (api/await-tx *api* submitted-tx))
 
-      ;; actual removal of the document happens asynchronously after
-      ;; the transaction has been processed so waiting on the
-      ;; submitted transaction time is not enough
-      (while (api/entity (api/db *api*) :ivan)
-        (assert (< (- (.getTime (Date.)) (.getTime now)) 4000))
-        (Thread/sleep 500))
+      (t/is (nil? (api/entity (api/db *api*) :ivan)))
 
       (let [stats (api/attribute-stats *api*)]
         (t/is (= 0 (:name stats)))))))


### PR DESCRIPTION
Now that the Indexer's been split out from the tx-consuming code, the cycle between doc-store and indexer no longer exists, and the index-tx fn has access to both