### PR TITLE
Clarify index store boundary

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -28,8 +28,10 @@
 
 ;; tag::IndexStore[]
 (defprotocol IndexStore
-  (new-attribute-value-entity-index-pair [this a entity-resolver])
-  (new-attribute-entity-value-index-pair [this a entity-resolver])
+  (av [this a min-v entity-resolver-fn])
+  (ave [this a v min-e entity-resolver-fn])
+  (ae [this a min-e entity-resolver-fn])
+  (aev [this a e min-v entity-resolver-fn])
   (entity-as-of [this eid valid-time transact-time])
   (entity-history-range [this eid valid-time-start transaction-time-start valid-time-end transaction-time-end])
   (open-entity-history ^crux.api.ICursor [this eid sort-order opts])

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -1,6 +1,7 @@
 (ns ^:no-doc crux.index
   (:require [crux.codec :as c]
             [crux.db :as db]
+            [crux.io :as cio]
             [crux.kv :as kv]
             [crux.memory :as mem]
             [crux.morton :as morton]
@@ -166,12 +167,17 @@
                                          entity-tx)
                         (lazy-seq (step (kv/next i))))))))))
 
+(defn- recycle-nested-index-store [index-store ^BinaryJoinLayeredVirtualIndexPeekState peek-state]
+  (cio/try-close (.-nestedIndexStore peek-state))
+  (doto (db/open-nested-index-store index-store)
+    (->> (set! (.-nestedIndexStore peek-state)))))
+
 ;; AVE
 
 (defrecord DocAttributeValueEntityValueIndex [index-store ^DirectBuffer attr entity-resolver ^BinaryJoinLayeredVirtualIndexPeekState peek-state]
   db/Index
   (seek-values [this k]
-    (let [[v & vs] (db/av index-store attr k entity-resolver)]
+    (let [[v & vs] (db/av (recycle-nested-index-store index-store peek-state) attr k entity-resolver)]
       (set! (.-seq peek-state) vs)
       (set! (.-key peek-state) (first v))
       v))
@@ -183,14 +189,14 @@
       v)))
 
 (defn new-doc-attribute-value-entity-value-index [index-store attr entity-resolver]
-  (->DocAttributeValueEntityValueIndex index-store (c/->id-buffer attr) entity-resolver (BinaryJoinLayeredVirtualIndexPeekState. nil nil)))
+  (->DocAttributeValueEntityValueIndex index-store (c/->id-buffer attr) entity-resolver (BinaryJoinLayeredVirtualIndexPeekState. nil nil nil)))
 
 (defrecord DocAttributeValueEntityEntityIndex [index-store ^DirectBuffer attr ^DocAttributeValueEntityValueIndex value-entity-value-idx entity-resolver-fn ^BinaryJoinLayeredVirtualIndexPeekState peek-state]
   db/Index
   (seek-values [this k]
     (when (c/valid-id? k)
       (let [value-buffer (.-key ^BinaryJoinLayeredVirtualIndexPeekState (.peek-state value-entity-value-idx))
-            [v & vs] (db/ave index-store attr value-buffer k entity-resolver-fn)]
+            [v & vs] (db/ave (recycle-nested-index-store index-store peek-state) attr value-buffer k entity-resolver-fn)]
         (set! (.-seq peek-state) vs)
         (set! (.-key peek-state) (first v))
         v)))
@@ -202,7 +208,7 @@
       v)))
 
 (defn new-doc-attribute-value-entity-entity-index [index-store attr value-entity-value-idx entity-resolver-fn]
-  (->DocAttributeValueEntityEntityIndex index-store (c/->id-buffer attr) value-entity-value-idx entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil)))
+  (->DocAttributeValueEntityEntityIndex index-store (c/->id-buffer attr) value-entity-value-idx entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil nil)))
 
 ;; AEV
 
@@ -210,7 +216,7 @@
   db/Index
   (seek-values [this k]
     (when (c/valid-id? k)
-      (let [[v & vs] (db/ae index-store attr k entity-resolver)]
+      (let [[v & vs] (db/ae (recycle-nested-index-store index-store peek-state) attr k entity-resolver)]
         (set! (.-seq peek-state) vs)
         (set! (.-key peek-state) (first v))
         v)))
@@ -222,13 +228,13 @@
       v)))
 
 (defn new-doc-attribute-entity-value-entity-index [index-store attr entity-resolver-fn]
-  (->DocAttributeEntityValueEntityIndex index-store (c/->id-buffer attr) entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil)))
+  (->DocAttributeEntityValueEntityIndex index-store (c/->id-buffer attr) entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil nil)))
 
 (defrecord DocAttributeEntityValueValueIndex [index-store ^DirectBuffer attr ^DocAttributeEntityValueEntityIndex entity-value-entity-idx entity-resolver-fn ^BinaryJoinLayeredVirtualIndexPeekState peek-state]
   db/Index
   (seek-values [this k]
     (let [eid-buffer (.-key ^BinaryJoinLayeredVirtualIndexPeekState (.peek-state entity-value-entity-idx))
-          [v & vs] (db/aev index-store attr eid-buffer k entity-resolver-fn)]
+          [v & vs] (db/aev (recycle-nested-index-store index-store peek-state) attr eid-buffer k entity-resolver-fn)]
       (set! (.-seq peek-state) vs)
       (set! (.-key peek-state) (first v))
       v))
@@ -240,7 +246,7 @@
       v)))
 
 (defn new-doc-attribute-entity-value-value-index [index-store attr entity-value-entity-idx entity-resolver-fn]
-  (->DocAttributeEntityValueValueIndex index-store (c/->id-buffer attr) entity-value-entity-idx entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil)))
+  (->DocAttributeEntityValueValueIndex index-store (c/->id-buffer attr) entity-value-entity-idx entity-resolver-fn (BinaryJoinLayeredVirtualIndexPeekState. nil nil nil)))
 
 ;; Range Constraints
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -1,7 +1,6 @@
 (ns ^:no-doc crux.index
   (:require [crux.codec :as c]
             [crux.db :as db]
-            [crux.io :as cio]
             [crux.kv :as kv]
             [crux.memory :as mem]
             [crux.morton :as morton]
@@ -91,9 +90,7 @@
                         (let [prefix-size (- (.capacity k) c/id-size c/id-size)]
                           (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k prefix-size (.get seek-buffer-tl)) prefix-size))
                                                 (kv/seek i))]
-                            (lazy-seq (step k))))))))
-             (cio/->cursor #(cio/try-close i))
-             (iterator-seq))))
+                            (lazy-seq (step k)))))))))))
 
 (defn ave [index-store a v min-e entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)
@@ -123,9 +120,7 @@
                          (let [limit (- (.capacity k) c/id-size)]
                            (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
                                                  (kv/seek i))]
-                             (lazy-seq (step k)))))))))))
-             (cio/->cursor #(cio/try-close i))
-             (iterator-seq))))
+                             (lazy-seq (step k))))))))))))))
 
 (defn ae [index-store a min-e entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)
@@ -146,9 +141,7 @@
                      (let [limit (- (.capacity k) c/id-size c/id-size)]
                        (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
                                              (kv/seek i))]
-                         (lazy-seq (step k)))))))))
-             (cio/->cursor #(cio/try-close i))
-             (iterator-seq))))
+                         (lazy-seq (step k))))))))))))
 
 (defn aev [index-store a e min-v entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)
@@ -168,9 +161,7 @@
                 (when k
                   (cons (MapEntry/create (.value (c/decode-aecv-key->evc-from k))
                                          entity-tx)
-                        (lazy-seq (step (kv/next i)))))))
-             (cio/->cursor #(cio/try-close i))
-             (iterator-seq))))
+                        (lazy-seq (step (kv/next i))))))))))
 
 ;; AVE
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -87,10 +87,11 @@
                 (when k
                   (cons (MapEntry/create (.value (c/decode-avec-key->evc-from k))
                                          :crux.index.binary-placeholder/value)
-                        (let [prefix-size (- (.capacity k) c/id-size c/id-size)]
-                          (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k prefix-size (.get seek-buffer-tl)) prefix-size))
-                                                (kv/seek i))]
-                            (lazy-seq (step k)))))))))))
+                        (lazy-seq
+                         (let [prefix-size (- (.capacity k) c/id-size c/id-size)]
+                           (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k prefix-size (.get seek-buffer-tl)) prefix-size))
+                                                 (kv/seek i))]
+                             (step k)))))))))))
 
 (defn ave [index-store a v min-e entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)
@@ -117,10 +118,11 @@
                         (concat
                          (when (kv/get-value index-store version-k)
                            [(MapEntry/create eid-buffer entity-tx)])
-                         (let [limit (- (.capacity k) c/id-size)]
-                           (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
-                                                 (kv/seek i))]
-                             (lazy-seq (step k))))))))))))))
+                         (lazy-seq
+                          (let [limit (- (.capacity k) c/id-size)]
+                            (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
+                                                  (kv/seek i))]
+                              (step k))))))))))))))
 
 (defn ae [index-store a min-e entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)
@@ -138,10 +140,11 @@
                     (concat
                      (when (entity-resolver-fn eid-buffer)
                        [(MapEntry/create eid-buffer :crux.index.binary-placeholder/entity)])
-                     (let [limit (- (.capacity k) c/id-size c/id-size)]
-                       (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
-                                             (kv/seek i))]
-                         (lazy-seq (step k))))))))))))
+                     (lazy-seq
+                      (let [limit (- (.capacity k) c/id-size c/id-size)]
+                        (when-let [k (some->> (mem/inc-unsigned-buffer! (mem/limit-buffer (mem/copy-buffer k limit (.get seek-buffer-tl)) limit))
+                                              (kv/seek i))]
+                          (step k))))))))))))
 
 (defn aev [index-store a e min-v entity-resolver-fn]
   (let [attr-buffer (c/->id-buffer a)

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -747,9 +747,9 @@
               (when-let [result (->> new-results
                                      (apply merge-with
                                             (fn [x y]
-                                              (if (or (= :crux.index.binary-placeholder/entity y)
-                                                      (= :crux.index.binary-placeholder/value y))
-                                                x y))))]
+                                              (if (map? y)
+                                                y
+                                                x))))]
                 (MapEntry/create max-k result)))
             (recur))))))
 

--- a/crux-core/src/crux/index/BinaryJoinLayeredVirtualIndexPeekState.java
+++ b/crux-core/src/crux/index/BinaryJoinLayeredVirtualIndexPeekState.java
@@ -3,9 +3,11 @@ package crux.index;
 public class BinaryJoinLayeredVirtualIndexPeekState {
     public Object seq;
     public Object key;
+    public Object nestedIndexStore;
 
-    public BinaryJoinLayeredVirtualIndexPeekState(Object seq, Object key) {
+    public BinaryJoinLayeredVirtualIndexPeekState(Object seq, Object key, Object nestedIndexStore) {
         this.seq = seq;
         this.key = key;
+        this.nestedIndexStore = nestedIndexStore;
     }
 }

--- a/crux-core/src/crux/index/BinaryJoinLayeredVirtualIndexPeekState.java
+++ b/crux-core/src/crux/index/BinaryJoinLayeredVirtualIndexPeekState.java
@@ -1,0 +1,11 @@
+package crux.index;
+
+public class BinaryJoinLayeredVirtualIndexPeekState {
+    public Object seq;
+    public Object key;
+
+    public BinaryJoinLayeredVirtualIndexPeekState(Object seq, Object key) {
+        this.seq = seq;
+        this.key = key;
+    }
+}

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -46,15 +46,17 @@
     (kv/get-value snapshot k))
 
   db/IndexStore
-  (new-attribute-value-entity-index-pair [this a entity-resolver-fn]
-    (let [v-idx (idx/new-doc-attribute-value-entity-value-index snapshot a)
-          e-idx (idx/new-doc-attribute-value-entity-entity-index snapshot a v-idx entity-resolver-fn)]
-      [v-idx e-idx]))
+  (av [this a min-v entity-resolver-fn]
+    (idx/av this a min-v entity-resolver-fn))
 
-  (new-attribute-entity-value-index-pair [this a entity-resolver-fn]
-    (let [e-idx (idx/new-doc-attribute-entity-value-entity-index snapshot a entity-resolver-fn)
-          v-idx (idx/new-doc-attribute-entity-value-value-index snapshot a e-idx)]
-      [e-idx v-idx]))
+  (ave [this a v min-e entity-resolver-fn]
+    (idx/ave this a v min-e entity-resolver-fn))
+
+  (ae [this a min-e entity-resolver-fn]
+    (idx/ae this a min-e entity-resolver-fn))
+
+  (aev [this a e min-v entity-resolver-fn]
+    (idx/aev this a e min-v entity-resolver-fn))
 
   (entity-as-of [this valid-time transact-time eid]
     (with-open [i (kv/new-iterator snapshot)]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -279,12 +279,14 @@
         v-range-constraints (get var->range-constraints v)
         e-range-constraints (get var->range-constraints e)]
     (if (= (:v names) (first order))
-      (let [[v-idx e-idx] (db/new-attribute-value-entity-index-pair index-store a entity-resolver-fn)]
+      (let [v-idx (idx/new-doc-attribute-value-entity-value-index index-store a entity-resolver-fn)
+            e-idx (idx/new-doc-attribute-value-entity-entity-index index-store a v-idx entity-resolver-fn)]
         (log/debug :join-order :ave (cio/pr-edn-str v) e (cio/pr-edn-str clause))
         (idx/update-binary-join-order! binary-idx
                                        (idx/wrap-with-range-constraints v-idx v-range-constraints)
                                        (idx/wrap-with-range-constraints e-idx e-range-constraints)))
-      (let [[e-idx v-idx] (db/new-attribute-entity-value-index-pair index-store a entity-resolver-fn)]
+      (let [e-idx (idx/new-doc-attribute-entity-value-entity-index index-store a entity-resolver-fn)
+            v-idx (idx/new-doc-attribute-entity-value-value-index index-store a e-idx entity-resolver-fn)]
         (log/debug :join-order :aev e (cio/pr-edn-str v) (cio/pr-edn-str clause))
         (idx/update-binary-join-order! binary-idx
                                        (idx/wrap-with-range-constraints e-idx e-range-constraints)


### PR DESCRIPTION
This changes the IndexStore protocol to not return `db/Index` instances, but instead provide lower level methods returning seqs:

```
  (av [this a min-v entity-resolver-fn])
  (ave [this a v min-e entity-resolver-fn])
  (ae [this a min-e entity-resolver-fn])
  (aev [this a e min-v entity-resolver-fn])
```

The join engine has been refactored to deal with this. The above methods are taking in the entity-resolver-fn, but could instead take the bitemporal coordinates and let the IndexStore create a cached resolver internally for them.

The methods could be renamed and consolidated down to 2 or even 1, taking some form of options map.