### PR TITLE
Support falsey values in query :args

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -269,8 +269,9 @@
          (into {}))))
 
 (defn- arg-for-var [arg var]
-  (or (get arg (symbol (name var)))
-      (get arg (keyword (name var)))))
+  (second
+    (or (find arg (symbol (name var)))
+        (find arg (keyword (name var))))))
 
 (defn- update-binary-index! [index-store {:keys [entity-resolver-fn]} binary-idx vars-in-join-order var->range-constraints]
   (let [{:keys [clause names]} (meta binary-idx)

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2808,3 +2808,23 @@
                                   {})
                 :vars-in-join-order
                 (filter #{'m 'e})))))
+
+(t/deftest test-binds-against-false-arg-885
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :name "foo", :flag? false}]
+                        [:crux.tx/put {:crux.db/id :bar, :name "bar", :flag? true}]
+                        [:crux.tx/put {:crux.db/id :baz, :name "baz", :flag? nil}]])
+
+  (t/is (= #{["foo" false]}
+           (api/q (api/db *api*)
+                  '{:find [?name flag?], :where [[?id :name ?name] [?id :flag? flag?]],
+                    :args [{flag? false}]})))
+
+  (t/is (= #{["bar" true]}
+           (api/q (api/db *api*)
+                  '{:find [?name flag?], :where [[?id :name ?name] [?id :flag? flag?]],
+                    :args [{flag? true}]})))
+
+  (t/is (= #{["baz" nil]}
+           (api/q (api/db *api*)
+                  '{:find [?name flag?], :where [[?id :name ?name] [?id :flag? flag?]],
+                    :args [{flag? nil}]}))))


### PR DESCRIPTION
This allows for things like :args [{'c false}], which currently don't
match anything.

This is related to #882 which is about 'c being unused (but _doesn't_ fix it).  This only
fixes what @Vaelatern actually intended, which is to match when `:cross`
was false.