### PR TITLE
Fix falsy unbound args #882

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -417,7 +417,7 @@
     (UnaryJoinIteratorState.
      idx
      (or value c/empty-buffer)
-     (when (and result-name results)
+     (when (and result-name value)
        {result-name results}))))
 
 (defrecord UnaryJoinVirtualIndex [indexes ^UnaryJoinIteratorsThunkFnState state]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2828,3 +2828,21 @@
            (api/q (api/db *api*)
                   '{:find [?name flag?], :where [[?id :name ?name] [?id :flag? flag?]],
                     :args [{flag? nil}]}))))
+
+(t/deftest test-unused-args-still-binding-882
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :name "foo"}]])
+
+  (t/is (= #{["foo" false]}
+           (api/q (api/db *api*)
+                  '{:find [?name foo], :where [[?id :name ?name]],
+                    :args [{foo false}]})))
+
+  (t/is (= #{["foo" true]}
+           (api/q (api/db *api*)
+                  '{:find [?name foo], :where [[?id :name ?name]],
+                    :args [{foo true}]})))
+
+  (t/is (= #{["foo" nil]}
+           (api/q (api/db *api*)
+                  '{:find [?name foo], :where [[?id :name ?name]],
+                    :args [{foo nil}]}))))


### PR DESCRIPTION
based on #885, will merge that first. resolves #882.

In this case, the unary index wasn't passing through tuples from the inner index where the value was falsy - by checking whether the _buffer_ is nil instead, we ensure false/nil values are passed through correctly.