### PR TITLE
Removing the doc index, #868

### DIFF
--- a/crux-bench/test/crux/bench/rocksdb_microbench_test.clj
+++ b/crux-bench/test/crux/bench/rocksdb_microbench_test.clj
@@ -30,7 +30,4 @@
             (time
              (doseq [doc-batch (->> (take 10000 condition-docs)
                                     (partition-all 100))]
-               (db/index-docs (:indexer node) (->> doc-batch (into {} (map (juxt c/new-id identity)))))))
-
-            (with-open [snapshot (kv/new-snapshot (:kv-store node))]
-              (t/is (= first-doc (db/get-single-object (:object-store node) snapshot (c/new-id first-doc)))))))))))
+               (db/index-docs (:indexer node) (->> doc-batch (into {} (map (juxt c/new-id identity)))))))))))))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -26,7 +26,7 @@
 
 (def ^:const index-id-size Byte/BYTES)
 
-;; index for actual document store
+;; index for object store
 (def ^:const ^:private content-hash->doc-index-id 0)
 
 (def ^:const ave-index-id 1)
@@ -34,22 +34,20 @@
 (def ^:const hash-cache-index-id 3)
 
 ;; main bitemp index [reverse]
-(def ^:const ^:private entity+vt+tt+tx-id->content-hash-index-id 4)
-
-;; for crux own needs
-(def ^:const ^:private meta-key->value-index-id 5)
-
-;; Repurpose old id from internal tx-log used for testing for failed tx
-;; ids.
-(def ^:const ^:private failed-tx-id-index-id 6)
-
-;; to allow crux upgrades. rebuild indexes from kafka on backward incompatible
-(def ^:const ^:private index-version-index-id 7)
+(def ^:const entity+vt+tt+tx-id->content-hash-index-id 4)
 
 ;; second bitemp index [also reverse]
 ;; z combines vt and tt
 ;; used when a lookup by the first index fails
-(def ^:const ^:private entity+z+tx-id->content-hash-index-id 8)
+(def ^:const entity+z+tx-id->content-hash-index-id 5)
+
+;; for crux own needs
+(def ^:const ^:private meta-key->value-index-id 6)
+
+(def ^:const failed-tx-id-index-id 7)
+
+;; to allow crux upgrades. rebuild indexes from kafka on backward incompatible
+(def ^:const ^:private index-version-index-id 8)
 
 ;; used in standalone TxLog
 (def ^:const ^:private tx-events-index-id 9)
@@ -559,6 +557,7 @@
   (let [index-id (.getByte k 0)]
     (assert (= content-hash->doc-index-id index-id))
     (Id. (mem/slice-buffer k index-id-size id-size) 0)))
+
 (defn encode-meta-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b ^DirectBuffer k]
   (assert (= id-size (.capacity k)) (mem/buffer->hex k))
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (+ index-id-size id-size)))]
@@ -568,7 +567,7 @@
        (.putBytes index-id-size k 0 (.capacity k)))
      (+ index-id-size id-size))))
 
-(defn- descending-long ^long [^long l]
+(defn descending-long ^long [^long l]
   (bit-xor (bit-not l) Long/MIN_VALUE))
 
 (defn date->reverse-time-ms ^long [^Date date]
@@ -577,97 +576,15 @@
 (defn reverse-time-ms->date ^java.util.Date [^long reverse-time-ms]
   (Date. (descending-long reverse-time-ms)))
 
-(defn- maybe-long-size ^long [x]
+(defn maybe-long-size ^long [x]
   (if x
     Long/BYTES
     0))
-
-(defn encode-entity+vt+tt+tx-id-key-to
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
-   (encode-entity+vt+tt+tx-id-key-to b empty-buffer nil nil nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b entity]
-   (encode-entity+vt+tt+tx-id-key-to b entity nil nil nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b entity valid-time]
-   (encode-entity+vt+tt+tx-id-key-to b entity valid-time nil nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b ^DirectBuffer entity ^Date valid-time ^Date transact-time ^Long tx-id]
-   (assert (or (= id-size (.capacity entity))
-               (zero? (.capacity entity))) (mem/buffer->hex entity))
-   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (cond-> (+ index-id-size (.capacity entity))
-                                                             valid-time (+ Long/BYTES)
-                                                             transact-time (+ Long/BYTES)
-                                                             tx-id (+ Long/BYTES))))]
-     (.putByte b 0 entity+vt+tt+tx-id->content-hash-index-id)
-     (.putBytes b index-id-size entity 0 (.capacity entity))
-     (when valid-time
-       (.putLong b (+ index-id-size id-size) (date->reverse-time-ms valid-time) ByteOrder/BIG_ENDIAN))
-     (when transact-time
-       (.putLong b (+ index-id-size id-size Long/BYTES) (date->reverse-time-ms transact-time) ByteOrder/BIG_ENDIAN))
-     (when tx-id
-       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) (descending-long tx-id) ByteOrder/BIG_ENDIAN))
-     (->> (+ index-id-size (.capacity entity)
-             (maybe-long-size valid-time) (maybe-long-size transact-time) (maybe-long-size tx-id))
-          (mem/limit-buffer b)))))
 
 (defrecord EntityTx [^Id eid ^Date vt ^Date tt ^long tx-id ^Id content-hash]
   IdToBuffer
   (id->buffer [this to]
     (id->buffer eid to)))
-
-(defn decode-entity+vt+tt+tx-id-key-from ^crux.codec.EntityTx [^DirectBuffer k]
-  (assert (= (+ index-id-size id-size Long/BYTES Long/BYTES Long/BYTES) (.capacity k)) (mem/buffer->hex k))
-  (let [index-id (.getByte k 0)]
-    (assert (= entity+vt+tt+tx-id->content-hash-index-id index-id))
-    (let [entity (Id. (mem/slice-buffer k index-id-size id-size) 0)
-          valid-time (reverse-time-ms->date (.getLong k (+ index-id-size id-size) ByteOrder/BIG_ENDIAN))
-          transact-time (reverse-time-ms->date (.getLong k (+ index-id-size id-size Long/BYTES) ByteOrder/BIG_ENDIAN))
-          tx-id (descending-long (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN))]
-      (->EntityTx entity valid-time transact-time tx-id nil))))
-
-(defn encode-entity-tx-z-number [valid-time transaction-time]
-  (morton/longs->morton-number (date->reverse-time-ms valid-time)
-                               (date->reverse-time-ms transaction-time)))
-
-(defn encode-entity+z+tx-id-key-to
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
-   (encode-entity+z+tx-id-key-to b empty-buffer nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b entity]
-   (encode-entity+z+tx-id-key-to b entity nil nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b entity z]
-   (encode-entity+z+tx-id-key-to b entity z nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b ^DirectBuffer entity z ^Long tx-id]
-   (assert (or (= id-size (.capacity entity))
-               (zero? (.capacity entity))) (mem/buffer->hex entity))
-   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (cond-> (+ index-id-size (.capacity entity))
-                                                             z (+ (* 2 Long/BYTES))
-                                                             tx-id (+ Long/BYTES))))
-         [upper-morton lower-morton] (when z
-                                       (morton/morton-number->interleaved-longs z))]
-     (.putByte b 0 entity+z+tx-id->content-hash-index-id)
-     (.putBytes b index-id-size entity 0 (.capacity entity))
-     (when z
-       (.putLong b (+ index-id-size id-size) upper-morton ByteOrder/BIG_ENDIAN)
-       (.putLong b (+ index-id-size id-size Long/BYTES) lower-morton ByteOrder/BIG_ENDIAN))
-     (when tx-id
-       (.putLong b (+ index-id-size id-size Long/BYTES Long/BYTES) (descending-long tx-id) ByteOrder/BIG_ENDIAN))
-     (->> (+ index-id-size (.capacity entity) (if z (* 2 Long/BYTES) 0) (maybe-long-size tx-id))
-          (mem/limit-buffer b)))))
-
-(defn decode-entity+z+tx-id-key-as-z-number-from [^DirectBuffer k]
-  (assert (= (+ index-id-size id-size Long/BYTES Long/BYTES Long/BYTES) (.capacity k)) (mem/buffer->hex k))
-  (let [index-id (.getByte k 0)]
-    (assert (= entity+z+tx-id->content-hash-index-id index-id))
-    (morton/interleaved-longs->morton-number
-     (.getLong k (+ index-id-size id-size) ByteOrder/BIG_ENDIAN)
-     (.getLong k (+ index-id-size id-size Long/BYTES) ByteOrder/BIG_ENDIAN))))
-
-(defn decode-entity+z+tx-id-key-from ^crux.codec.EntityTx [^DirectBuffer k]
-  (assert (= (+ index-id-size id-size Long/BYTES Long/BYTES Long/BYTES) (.capacity k)) (mem/buffer->hex k))
-  (let [index-id (.getByte k 0)]
-    (assert (= entity+z+tx-id->content-hash-index-id index-id))
-    (let [entity (Id. (mem/slice-buffer k index-id-size id-size) 0)
-          [valid-time transaction-time] (morton/morton-number->longs (decode-entity+z+tx-id-key-as-z-number-from k))
-          tx-id (descending-long (.getLong k (+ index-id-size id-size Long/BYTES Long/BYTES) ByteOrder/BIG_ENDIAN))]
-      (->EntityTx entity (reverse-time-ms->date valid-time) (reverse-time-ms->date transaction-time) tx-id nil))))
 
 (defn entity-tx->edn [^EntityTx entity-tx]
   (when entity-tx
@@ -676,22 +593,6 @@
      :crux.db/valid-time (.vt entity-tx)
      :crux.tx/tx-time (.tt entity-tx)
      :crux.tx/tx-id (.tx-id entity-tx)}))
-
-(defn encode-failed-tx-id-key-to
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
-   (encode-failed-tx-id-key-to b nil))
-  (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b tx-id]
-   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (+ index-id-size (maybe-long-size tx-id))))]
-     (.putByte b 0 failed-tx-id-index-id)
-     (when tx-id
-       (.putLong b index-id-size (descending-long tx-id) ByteOrder/BIG_ENDIAN))
-     (mem/limit-buffer b (+ index-id-size (maybe-long-size tx-id))))))
-
-(defn decode-failed-tx-id-key-from [^DirectBuffer k]
-  (assert (= (+ index-id-size Long/BYTES) (.capacity k)) (mem/buffer->hex k))
-  (let [index-id (.getByte k 0)]
-    (assert (= failed-tx-id-index-id index-id))
-    (descending-long (.getLong k index-id-size ByteOrder/BIG_ENDIAN))))
 
 (defn encode-index-version-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer index-id-size))]

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -31,27 +31,28 @@
 
 (def ^:const ave-index-id 1)
 (def ^:const aecv-index-id 2)
+(def ^:const hash-cache-index-id 3)
 
 ;; main bitemp index [reverse]
-(def ^:const ^:private entity+vt+tt+tx-id->content-hash-index-id 3)
+(def ^:const ^:private entity+vt+tt+tx-id->content-hash-index-id 4)
 
 ;; for crux own needs
-(def ^:const ^:private meta-key->value-index-id 4)
+(def ^:const ^:private meta-key->value-index-id 5)
 
 ;; Repurpose old id from internal tx-log used for testing for failed tx
 ;; ids.
-(def ^:const ^:private failed-tx-id-index-id 5)
+(def ^:const ^:private failed-tx-id-index-id 6)
 
 ;; to allow crux upgrades. rebuild indexes from kafka on backward incompatible
-(def ^:const ^:private index-version-index-id 6)
+(def ^:const ^:private index-version-index-id 7)
 
 ;; second bitemp index [also reverse]
 ;; z combines vt and tt
 ;; used when a lookup by the first index fails
-(def ^:const ^:private entity+z+tx-id->content-hash-index-id 7)
+(def ^:const ^:private entity+z+tx-id->content-hash-index-id 8)
 
 ;; used in standalone TxLog
-(def ^:const ^:private tx-events-index-id 8)
+(def ^:const ^:private tx-events-index-id 9)
 
 (def ^:const ^:private value-type-id-size Byte/BYTES)
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -37,7 +37,6 @@
   (all-content-hashes [this eid])
   (decode-value [this a content-hash value-buffer])
   (encode-value [this value])
-  (get-document [this content-hash])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -35,7 +35,7 @@
   (entity-as-of [this eid valid-time transact-time])
   (open-entity-history ^crux.api.ICursor [this eid sort-order opts])
   (all-content-hashes [this eid])
-  (decode-value [this a content-hash value-buffer])
+  (decode-value [this value-buffer eid-buffer])
   (encode-value [this value])
   (open-nested-index-store ^java.io.Closeable [this]))
 ;; end::IndexStore[]

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -16,7 +16,7 @@
 ;; tag::Indexer[]
 (defprotocol Indexer
   (index-docs [this docs])
-  (unindex-docs [this docs])
+  (unindex-eids [this eids])
   (index-entity-txs [this tx entity-txs])
   (mark-tx-as-failed [this tx])
   (store-index-meta [this k v])
@@ -34,7 +34,6 @@
   (aev [this a e min-v entity-resolver-fn])
   (entity-as-of [this eid valid-time transact-time])
   (open-entity-history ^crux.api.ICursor [this eid sort-order opts])
-  (all-content-hashes [this eid])
   (decode-value [this value-buffer eid-buffer])
   (encode-value [this value])
   (open-nested-index-store ^java.io.Closeable [this]))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -227,9 +227,9 @@
     (not (multiple-values? v))
     (vector)))
 
-(defn doc-predicate-stats [doc evicted?]
+(defn doc-predicate-stats [doc]
   (->> (for [[k v] doc]
-         [k (cond-> (count (vectorize-value v)) evicted? -)])
+         [k (count (vectorize-value v))])
        (into {})))
 
 ;; Utils

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -8,7 +8,6 @@
             [taoensso.nippy :as nippy])
   (:import [clojure.lang IReduceInit MapEntry Seqable Sequential]
            crux.api.IndexVersionOutOfSyncException
-           [crux.codec EntityValueContentHash EntityTx]
            [crux.index BinaryJoinLayeredVirtualIndexPeekState BinaryJoinLayeredVirtualIndexState DocAttributeValueEntityEntityIndexState EntityHistoryRangeState EntityValueEntityPeekState NAryJoinLayeredVirtualIndexState NAryWalkState RelationIteratorsState RelationNestedIndexState SortedVirtualIndexState UnaryJoinIteratorState UnaryJoinIteratorsThunkFnState UnaryJoinIteratorsThunkState ValueEntityValuePeekState]
            [java.io Closeable DataInputStream]
            [java.util Collections Comparator Date]

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -335,7 +335,7 @@
     (assert (some? value-buffer) (str a))
     (if (c/can-decode-value-buffer? value-buffer)
       (c/decode-value-buffer value-buffer)
-      (let [doc (db/get-document this content-hash)
+      (let [doc (db/get-single-object object-store snapshot content-hash)
             value-or-values (get doc a)]
         (if-not (idx/multiple-values? value-or-values)
           value-or-values
@@ -347,9 +347,6 @@
 
   (encode-value [this value]
     (c/->value-buffer value))
-
-  (get-document [this content-hash]
-    (db/get-single-object object-store snapshot content-hash))
 
   (open-nested-index-store [this]
     (->KvIndexStore object-store (lru/new-cached-snapshot snapshot false))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -546,11 +546,13 @@
        (into {})))
 
 (defn- bound-result-for-var [index-store var->bindings join-keys join-results var]
-  (let [binding ^VarBinding (get var->bindings var)]
-    (if (.value? binding)
-      (get join-results (.result-name binding))
-      (when-let [^EntityTx entity-tx (get join-results (.e-var binding))]
-        (db/decode-value index-store (.attr binding) (.content-hash entity-tx) (get join-keys (.result-index binding)))))))
+  (let [var-binding ^VarBinding (get var->bindings var)]
+    (if (.value? var-binding)
+      (get join-results (.result-name var-binding))
+      (when-let [etx ^EntityTx (get join-results (.e-var var-binding))]
+        (db/decode-value index-store
+                         (get join-keys (.result-index var-binding))
+                         (c/->id-buffer (.eid etx)))))))
 
 (declare build-sub-query)
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -605,8 +605,9 @@
 (defn- or-single-e-var-triple-fast-path [index-store {:keys [entity-resolver-fn] :as db} {:keys [e a v] :as clause} args]
   (let [eid (get (first args) e)]
     (when-let [^EntityTx entity-tx (entity-resolver-fn eid)]
-      (let [doc (db/get-document index-store (.content-hash entity-tx))]
-        (when (contains? (set (idx/vectorize-value (get doc a))) v)
+      (let [v (c/->value-buffer v)
+            [[found-v _]] (db/aev index-store (c/->id-buffer a) eid v entity-resolver-fn)]
+        (when (and found-v (mem/buffers=? v found-v))
           [])))))
 
 (def ^:private ^:dynamic *recursion-table* {})
@@ -1049,11 +1050,13 @@
   (let [{:keys [where args rules]} (s/conform ::query q)]
     (compile-sub-query encode-value-fn where (arg-vars args) (rule-name->rules rules) stats)))
 
-(defn- build-full-results [{:keys [entity-resolver-fn index-store] :as db} bound-result-tuple]
+(defn- build-full-results [{:keys [entity-resolver-fn index-store], {:keys [document-store]} :query-engine, :as db} bound-result-tuple]
   (vec (for [value bound-result-tuple]
-         (if-let [entity-tx (and (c/valid-id? value)
-                                 (entity-resolver-fn value))]
-           (db/get-document index-store (.content-hash ^EntityTx entity-tx))
+         (if-let [^EntityTx entity-tx (and (c/valid-id? value)
+                                           (entity-resolver-fn value))]
+           (let [content-hash (.content-hash entity-tx)]
+             (-> (db/fetch-docs document-store #{content-hash})
+                 (get content-hash)))
            value))))
 
 (defn open-index-store ^java.io.Closeable [{:keys [query-engine index-store] :as db}]
@@ -1175,9 +1178,11 @@
   (some-> (db/entity-as-of index-store eid valid-time transact-time)
           (c/entity-tx->edn)))
 
-(defn entity [db index-store eid]
-  (let [entity-tx (entity-tx db index-store eid)]
-    (-> (db/get-document index-store (:crux.db/content-hash entity-tx))
+(defn entity [{{:keys [document-store]} :query-engine, :as db} index-store eid]
+  (when-let [content-hash (some-> (entity-tx db index-store eid)
+                                  :crux.db/content-hash)]
+    (-> (db/fetch-docs document-store #{content-hash})
+        (get content-hash)
         (idx/keep-non-evicted-doc))))
 
 (defrecord QueryDatasource [query-engine
@@ -1276,7 +1281,8 @@
                               :crux.tx/tx-id (.tx-id etx)
                               :crux.db/valid-time (.vt etx)
                               :crux.db/content-hash (.content-hash etx)}
-                       with-docs? (assoc :crux.db/doc (db/get-document index-store (.content-hash etx)))))))))))
+                       with-docs? (assoc :crux.db/doc (-> (db/fetch-docs (:document-store query-engine) #{(.content-hash etx)})
+                                                          (get (.content-hash etx))))))))))))
 
   (validTime [_] valid-time)
   (transactionTime [_] transact-time))
@@ -1293,16 +1299,17 @@
         (.awaitTermination 60000 TimeUnit/MILLISECONDS)))))
 
 (def query-engine
-  {:start-fn (fn [{:crux.node/keys [indexer bus]} {::keys [query-pool-size query-cache-size conform-cache-size] :as args}]
+  {:start-fn (fn [{:crux.node/keys [indexer bus document-store]} {::keys [query-pool-size query-cache-size conform-cache-size] :as args}]
                (let [query-executor (Executors/newFixedThreadPool query-pool-size (cio/thread-factory "crux.query.query-pool-thread"))]
                  (map->QueryEngine
                   {:indexer indexer
                    :conform-cache (lru/new-cache conform-cache-size)
                    :query-cache (lru/new-cache query-cache-size)
+                   :document-store document-store
                    :bus bus
                    :query-executor query-executor
                    :options args})))
-   :deps [:crux.node/indexer :crux.node/bus]
+   :deps [:crux.node/indexer :crux.node/bus :crux.node/document-store]
    :args {::query-pool-size {:doc "Query Pool Size"
                              :default 32
                              :crux.config/type :crux.config/nat-int}

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -1,16 +1,15 @@
 (ns ^:no-doc crux.tx
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.set :as set]
+            [clojure.spec.alpha :as s]
             [clojure.tools.logging :as log]
             [crux.bus :as bus]
             [crux.codec :as c]
             [crux.db :as db]
             [crux.index :as idx]
             [crux.io :as cio]
-            [crux.kv :as kv]
             [crux.query :as q]
             [crux.tx.conform :as txc]
-            [crux.tx.event :as txe]
-            [clojure.set :as set])
+            [crux.tx.event :as txe])
   (:import crux.codec.EntityTx
            java.io.Closeable
            java.time.Duration

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -214,17 +214,7 @@
       (t/is (true? (api/tx-committed? *api* submitted-tx))))
 
     (let [stats (api/attribute-stats *api*)]
-      (t/is (= 2 (:name stats)))))
-
-  (t/testing "reflect evicted documents"
-    (let [now (Date.)
-          submitted-tx (api/submit-tx *api* [[:crux.tx/evict :ivan]])]
-      (t/is (api/await-tx *api* submitted-tx))
-
-      (t/is (nil? (api/entity (api/db *api*) :ivan)))
-
-      (let [stats (api/attribute-stats *api*)]
-        (t/is (= 0 (:name stats)))))))
+      (t/is (= 2 (:name stats))))))
 
 (t/deftest test-adding-back-evicted-document
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])

--- a/crux-test/test/crux/kv_indexer_test.clj
+++ b/crux-test/test/crux/kv_indexer_test.clj
@@ -8,7 +8,6 @@
             [crux.fixtures :as f]
             [crux.fixtures.kv-only :as fkv :refer [*kv*]]
             [crux.kv-indexer :as kvi]
-            [crux.object-store :as os]
             [crux.tx :as tx])
   (:import crux.codec.EntityTx
            java.util.Date))
@@ -20,7 +19,7 @@
 (defmacro with-fresh-indexer [& body]
   `(fkv/with-kv-store
      (fn []
-       (binding [*indexer* (kvi/->KvIndexer *kv* (os/->KvObjectStore *kv*))]
+       (binding [*indexer* (kvi/->KvIndexer *kv*)]
          ~@body))))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2730,7 +2730,7 @@
         _ (fix/transact! *api* [ivan])
         db (api/db *api*)]
     (with-open [shared-db (api/open-db *api*)]
-      (t/is (= (api/entity db :ivan) (api/entity shared-db :ivan) ivan))
+      (t/is (= ivan (api/entity shared-db :ivan)))
       (let [n 1000
              ;; TODO: was 1.4, introduced a bug?
             acceptable-snapshot-speedup 1.1

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -671,9 +671,7 @@
   (fix/submit+await-tx [[:crux.tx/evict :to-evict]])
 
   (with-open [log-iterator (api/open-tx-log *api* nil true)]
-    (t/is (= (->> (iterator-seq log-iterator)
-                  (map :crux.api/tx-ops))
-             [[[:crux.tx/put
+    (t/is (= [[[:crux.tx/put
                 #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
                           :evicted? true}]]
               [[:crux.tx/cas
@@ -682,7 +680,9 @@
                 #:crux.db{:id #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0",
                           :evicted? true}]]
               [[:crux.tx/evict
-                #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0"]]]))))
+                #crux/id "6abe906510aa2263737167c12c252245bdcf6fb0"]]]
+             (->> (iterator-seq log-iterator)
+                  (map :crux.api/tx-ops))))))
 
 (t/deftest nil-transaction-fn-457
   (with-redefs [tx/tx-fns-enabled? true]


### PR DESCRIPTION
resolves #868, see that card for details of the new indices

* The kv-indexer no longer uses the object store. For most operations, this was relatively straightforward
  * For `decode-value` we go to the hash-cache
  * For eviction we go through all the attributes, find all the content hashes for all of the entities, and then evict using those. NB that we can't go to the doc-store during eviction because, in the case of multiple nodes, one node could have tombstoned the document before another node has had chance to read from it.
* We no longer include eviction in attribute stats
* We don't need `all-commit-hashes` any more, not going to miss it hugely
* I've moved some of codec (encoding/decoding content-index keys) to kv-indexer, given it's an implementation detail of the kv-indexer
* [ ] Do we want to refactor the standalone/Kafka doc store so that they don't explicitly depend on a kv-store?