### PR TITLE
Data browser - Create root endpoints

### DIFF
--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -290,7 +290,7 @@
                            :->jwt-token ->jwt-token}))))
 
   (status [_]
-    (api-request-sync url
+    (api-request-sync (str url "/_crux/status")
                       {:http-opts {:method :get}
                        :->jwt-token ->jwt-token}))
 

--- a/crux-http-server/src-cljs/crux/ui/common.cljs
+++ b/crux-http-server/src-cljs/crux/ui/common.cljs
@@ -10,7 +10,7 @@
 
 (defn route->url
   "k: page handler i.e. :entity
-  params: path-params map i.e. {:eid ':hello'}
+  params: path-params map
   query: query-params map i.e. {:find '[?eid]'}"
   ([k]
    (route->url k nil nil))
@@ -20,7 +20,7 @@
    (rfe/href k params query)))
 
 (defn url->route
-  "url: abosolute string path i.e. '/_entity/:eid?tt=...'"
+  "url: abosolute string path i.e. '/_entity?eid=...'"
   [url]
   (reitit/match-by-path (navigation/router) url))
 

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -24,6 +24,12 @@
        (js/console.warn "Metadata not found")))))
 
 (rf/reg-event-db
+ ::navigate-to-root-view
+ (fn [db [_ view]]
+   (-> (assoc-in db [:left-pane :visible?] true)
+       (assoc-in [:left-pane :view] view))))
+
+(rf/reg-event-db
  ::toggle-left-pane
  (fn [db _]
    (update-in db [:left-pane :visible?] not)))

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -64,20 +64,18 @@
 (rf/reg-event-fx
  ::set-entity-right-pane-document
  (fn [{:keys [db]} _]
-   (let [eid (get-in db [:current-route :path-params :eid])
-         query-params (-> (get-in db [:current-route :query-params])
-                          (select-keys [:valid-time :transaction-time]))]
-     {:dispatch [:navigate :entity {:eid eid} query-params]})))
+   (let [query-params (-> (get-in db [:current-route :query-params])
+                          (select-keys [:valid-time :transaction-time :eid]))]
+     {:dispatch [:navigate :entity nil query-params]})))
 
 (rf/reg-event-fx
  ::set-entity-right-pane-history
  (fn [{:keys [db]} _]
-   (let [eid (get-in db [:current-route :path-params :eid])
-         query-params (-> (get-in db [:current-route :query-params])
+   (let [query-params (-> (get-in db [:current-route :query-params])
                           (assoc :history true)
                           (assoc :with-docs true)
                           (assoc :sort-order "desc"))]
-     {:dispatch [:navigate :entity {:eid eid} query-params]})))
+     {:dispatch [:navigate :entity nil query-params]})))
 
 
 (rf/reg-event-db
@@ -90,11 +88,12 @@
  (fn [{:keys [db]} [_ {{:strs [eid vtd vtt ttd ttt]} :values}]]
    (let [query-params (->>
                        {:valid-time (common/date-time->datetime vtd vtt)
-                        :transaction-time (common/date-time->datetime ttd ttt)}
+                        :transaction-time (common/date-time->datetime ttd ttt)
+                        :eid eid}
                        (remove #(nil? (second %)))
                        (into {}))]
      {:db db
-      :dispatch [:navigate :entity {:eid (string/trim eid)} query-params]})))
+      :dispatch [:navigate :entity nil query-params]})))
 
 (rf/reg-event-db
  ::entity-right-pane-document-error

--- a/crux-http-server/src-cljs/crux/ui/http.cljs
+++ b/crux-http-server/src-cljs/crux/ui/http.cljs
@@ -38,13 +38,11 @@
 (rf/reg-event-fx
  ::fetch-entity
  (fn [{:keys [db]} _]
-   (let [eid (get-in db [:current-route :path-params :eid])
-         query-params (assoc (get-in db [:current-route :query-params])
-                             :link-entities? true)]
+   (let [query-params (assoc (get-in db [:current-route :query-params]) :link-entities? true)]
      {:dispatch-n [[:crux.ui.events/entity-right-pane-document-error nil]
                    [:crux.ui.events/set-entity-right-pane-loading true]]
       :http-xhrio {:method :get
-                   :uri (common/route->url :entity {:eid eid} query-params)
+                   :uri (common/route->url :entity nil query-params)
                    :response-format (ajax-edn/edn-response-format)
                    :on-success [::success-fetch-entity]
                    :on-failure [::fail-fetch-entity]}})))

--- a/crux-http-server/src-cljs/crux/ui/routes.cljs
+++ b/crux-http-server/src-cljs/crux/ui/routes.cljs
@@ -17,7 +17,7 @@
      [{:identity #(gensym)
        :start #(rf/dispatch [:crux.ui.http/fetch-query-table])
        :stop (fn [& params])}]}]
-   ["/_crux/entity/:eid"
+   ["/_crux/entity"
     {:name :entity
      :link-text "Entity"
      :controllers

--- a/crux-http-server/src-cljs/crux/ui/routes.cljs
+++ b/crux-http-server/src-cljs/crux/ui/routes.cljs
@@ -4,7 +4,7 @@
 
 (def routes
   [""
-   ["/"
+   ["/_crux/index"
     {:name :homepage
      :link-text "Home"
      :controllers

--- a/crux-http-server/src-cljs/crux/ui/routes.cljs
+++ b/crux-http-server/src-cljs/crux/ui/routes.cljs
@@ -10,14 +10,14 @@
      :controllers
      [{:start (fn [& params])
        :stop (fn [& params])}]}]
-   ["/_query"
+   ["/_crux/query"
     {:name :query
      :link-text "Query"
      :controllers
      [{:identity #(gensym)
        :start #(rf/dispatch [:crux.ui.http/fetch-query-table])
        :stop (fn [& params])}]}]
-   ["/_entity/:eid"
+   ["/_crux/entity/:eid"
     {:name :entity
      :link-text "Entity"
      :controllers

--- a/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
+++ b/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
@@ -82,7 +82,9 @@
 (rf/reg-sub
  ::query-right-pane-view
  (fn [db _]
-   (or (get-in db [:query :right-pane :view]) :table)))
+   (if (empty? (get-in db [:current-route :query-params]))
+     :query-root
+     (or (get-in db [:query :right-pane :view]) :table))))
 
 (rf/reg-sub
  ::query-right-pane-loading?
@@ -97,7 +99,10 @@
 (rf/reg-sub
  ::entity-right-pane-view
  (fn [db _]
-   (if (get-in db [:current-route :query-params :history]) :history :document)))
+   (cond
+     (nil? (get-in db [:current-route :query-params :eid])) :entity-root
+     (get-in db [:current-route :query-params :history]) :history
+     :else :document)))
 
 (rf/reg-sub
  ::entity-right-pane-document

--- a/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
+++ b/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
@@ -42,7 +42,7 @@
          transaction-time (common/datetime->date-time
                            (:transaction-time query-params))]
      (when (= :entity handler)
-       {"eid" (get-in db [:current-route :path-params :eid])
+       {"eid" (:eid query-params)
         "vtd" (:date valid-time)
         "vtt" (:time valid-time)
         "ttd" (:date transaction-time)
@@ -106,7 +106,7 @@
      {:error error}
      (let [query-params (get-in db [:current-route :query-params])
          document (get-in db [:entity :http :document "entity"])]
-     {:eid (get-in db [:current-route :path-params :eid])
+     {:eid (:eid query-params)
       :vt (or (:valid-time query-params) (str (t/now)))
       :tt (or (:transaction-time query-params) "Not Specified")
       :document document
@@ -126,7 +126,7 @@
 (rf/reg-sub
  ::entity-right-pane-history
  (fn [db _]
-   (let [eid (get-in db [:current-route :path-params :eid])
+   (let [eid (get-in db [:current-route :query-params :eid])
          history (get-in db [:entity :http :history])]
      {:eid eid
       :entity-history history})))
@@ -145,7 +145,7 @@
 (rf/reg-sub
  ::entity-right-pane-history-diffs
  (fn [db _]
-   (let [ eid (get-in db [:current-route :path-params :eid])
+   (let [eid (get-in db [:current-route :query-params :eid])
          history (get-in db [:entity :http :history])
          entity-history (history-docs->diffs history)]
      {:eid eid

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -164,20 +164,29 @@
 (defn query-right-pane
   []
   (let [right-pane-view @(rf/subscribe [::sub/query-right-pane-view])]
-    [:<>
-     [:div.pane-nav
-      [:div.pane-nav__tab
-       "Table"]
-      #_[:div.pane-nav__tab
-       {:class (if (= right-pane-view :graph)
-                 "pane-nav__tab--active"
-                 "pane-nav__tab--hover")
-        :on-click #(rf/dispatch [::events/set-query-right-pane-view :graph])}
-         "Graph"]]
-     (case right-pane-view
-       :table [query-table]
-       :graph [:div "this is graph"]
-       nil)]))
+    (if (= right-pane-view :query-root)
+      [:div.query-root
+       [:div.query-root__title
+        "Getting Started"]
+       [:p "To perform a query:"]
+       [:ul
+        [:li "Enter the desired query into the query editor."]
+        [:li "Select a " [:b "valid time"] " and a " [:b "transaction time"] " (if needed)"]
+        [:li "Click " [:b "submit query"] " to perform the query and get the results in a table."]]]
+      [:<>
+       [:div.pane-nav
+        [:div.pane-nav__tab
+         "Table"]
+        #_[:div.pane-nav__tab
+           {:class (if (= right-pane-view :graph)
+                     "pane-nav__tab--active"
+                     "pane-nav__tab--hover")
+            :on-click #(rf/dispatch [::events/set-query-right-pane-view :graph])}
+           "Graph"]]
+       (case right-pane-view
+         :table [query-table]
+         :graph [:div "this is graph"]
+         nil)])))
 
 (defn- entity->hiccup
   [links edn]
@@ -297,24 +306,33 @@
 
 (defn entity-right-pane []
   (let [right-pane-view @(rf/subscribe [::sub/entity-right-pane-view])]
-    [:<>
-     [:div.pane-nav
-      [:div.pane-nav__tab
-       {:class (if (= right-pane-view :document)
-                 "pane-nav__tab--active"
-                 "pane-nav__tab--hover")
-        :on-click #(rf/dispatch [::events/set-entity-right-pane-document])}
-       "Document"]
-      [:div.pane-nav__tab
-       {:class (if (= right-pane-view :history)
-                 "pane-nav__tab--active"
-                 "pane-nav__tab--hover")
-        :on-click #(rf/dispatch [::events/set-entity-right-pane-history])}
-       "History"]]
-     (case right-pane-view
-       :document [entity-document]
-       :history [entity-history-document]
-       nil)]))
+    (if (= right-pane-view :entity-root)
+      [:div.entity-root
+       [:div.entity-root__title
+        "Getting Started"]
+       [:p "To look for a particular entity:"]
+       [:ul
+        [:li "Enter the name of the entity to search for in the search box (for example, " [:i ":bar"] ")"]
+        [:li "Select a " [:b "valid time"] " and a " [:b "transaction time"] " (if needed)"]
+        [:li "Click " [:b "submit entity"] " to go to the entity's page"]]]
+      [:<>
+       [:div.pane-nav
+        [:div.pane-nav__tab
+         {:class (if (= right-pane-view :document)
+                   "pane-nav__tab--active"
+                   "pane-nav__tab--hover")
+          :on-click #(rf/dispatch [::events/set-entity-right-pane-document])}
+         "Document"]
+        [:div.pane-nav__tab
+         {:class (if (= right-pane-view :history)
+                   "pane-nav__tab--active"
+                   "pane-nav__tab--hover")
+          :on-click #(rf/dispatch [::events/set-entity-right-pane-history])}
+         "History"]]
+       (case right-pane-view
+         :document [entity-document]
+         :history [entity-history-document]
+         nil)])))
 
 (defn left-pane
   []
@@ -350,19 +368,29 @@
       [query-form]
       [entity-form]]]))
 
+(defn root-page
+  []
+  [:div.root-contents
+   [:p "Welcome to the Crux Console! Get started below:"]
+   [:p [:a {:href "/_crux/query" :on-click #(rf/dispatch [::events/navigate-to-root-view :query])} "Performing a query"]]
+   [:p [:a {:href "/_crux/entity" :on-click #(rf/dispatch [::events/navigate-to-root-view :entity])} "Searching for an entity"]]])
+
 (defn view []
   (let [{{:keys [name]} :data} @(rf/subscribe [::sub/current-route])]
     [:<>
      #_[:pre (with-out-str (pprint/pprint (dissoc @(rf/subscribe [:db]) :query)))]
      [:div.container.page-pane
-      (when name [left-pane])
-      [:div.right-pane
-       [:div.back-button
-        [:a
-         {:on-click common/back-page}
-         [:i.fas.fa-chevron-left]
-         [:span.back-button__text "Back"]]]
-       (case name
-         :query [query-right-pane]
-         :entity [entity-right-pane]
-         [:div "no matching"])]]]))
+      (if (= name :homepage)
+        [root-page]
+        [:<>
+         (when name [left-pane])
+         [:div.right-pane
+          [:div.back-button
+           [:a
+            {:on-click common/back-page}
+            [:i.fas.fa-chevron-left]
+            [:span.back-button__text "Back"]]]
+          (case name
+            :query [query-right-pane]
+            :entity [entity-right-pane]
+            [:div "no matching"])]])]]))

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -31,6 +31,7 @@
            [java.io Closeable IOException OutputStream]
            java.time.Duration
            java.util.Date
+           java.text.SimpleDateFormat
            [java.net URLDecoder URLEncoder]
            org.eclipse.jetty.server.Server
            [com.nimbusds.jose.jwk JWK JWKSet KeyType RSAKey ECKey]
@@ -90,6 +91,10 @@
    {:status status
     :headers headers
     :body body}))
+
+(defn- redirect-response [url]
+  {:status 302
+   :headers {"Location" url}})
 
 (defn- success-response [m]
   (response (if (some? m) 200 404)
@@ -393,6 +398,9 @@
 (defn- handler [request {:keys [crux-node ::read-only?]}]
   (condp check-path request
     [#"^/$" [:get]]
+    (redirect-response "/_crux/index")
+
+    [#"^/_crux/status" [:get]]
     (status crux-node)
 
     [#"^/document/.+$" [:get :post]]
@@ -469,20 +477,71 @@
       ((resolve 'crux.sparql.protocol/sparql-query) crux-node request)
       nil)))
 
+(defn html-request? [request]
+  (= (get-in request [:muuntaja/response :format]) "text/html"))
+
+(defn- root-page []
+  [:div.root-contents
+   [:p "Welcome to the Crux Console! Get started below:"]
+   [:p [:a {:href "/_crux/query"} "Performing a query"]]
+   [:p [:a {:href "/_crux/entity"} "Searching for an entity"]]])
+
+(defn- root-handler [^ICruxAPI crux-node options request]
+  {:status 200
+   :headers {"Content-Location" "/_crux/index.html"}
+   :body (when (html-request? request)
+           (raw-html
+            {:body (root-page)
+             :title "/_crux"
+             :options options}))})
+
+(def ^SimpleDateFormat default-date-formatter (SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss.SSS"))
+
+(defn- entity-root-html []
+  [:div.entity-root
+   [:div.entity-root__title
+    "Getting Started"]
+   [:p "To look for a particular entity, simply use the entity search below:"]
+   [:div.entity-root__contents
+    [:div.entity-editor__title
+     "Entity selector"]
+    [:div.entity-editor__contents
+     [:form
+      {:action "/_crux/entity"}
+      [:textarea.textarea
+       {:name "eid"
+        :rows 1}]
+      [:div.entity-editor-datetime
+       [:b "Valid Time"]
+       [:input.input.input-time
+        {:type "datetime-local"
+         :name "valid-time"
+         :step "0.01"
+         :value (.format default-date-formatter (Date.))}]
+       [:b "Transaction Time"]
+       [:input.input.input-time
+        {:type "datetime-local"
+         :name "transaction-time"
+         :step "0.01"}]]
+      [:button.button
+       {:type "submit"}
+       "Submit Query"]]]]])
+
 (defn link-all-entities
   [db path result]
   (letfn [(recur-on-result [result links]
-             (if (and (c/valid-id? result)
-                      (api/entity db result))
-               (let [query-params (format "?valid-time=%s&transaction-time=%s"
-                                          (.toInstant ^Date (api/valid-time db))
-                                          (.toInstant ^Date (api/transaction-time db)))
-                     encoded-eid (URLEncoder/encode (str result) "UTF-8")]
-                 (assoc links result (str path "/" encoded-eid query-params)))
-               (cond
-                 (map? result) (apply merge (map #(recur-on-result % links) (vals result)))
-                 (sequential? result) (apply merge (map #(recur-on-result % links) result))
-                 :else links)))]
+            (if (and (c/valid-id? result)
+                     (api/entity db result))
+              (let [encoded-eid (URLEncoder/encode (str result) "UTF-8")
+                    query-params (format "?eid=%s&valid-time=%s&transaction-time=%s"
+                                         encoded-eid
+                                         (.toInstant ^Date (api/valid-time db))
+                                         (.toInstant ^Date (api/transaction-time db)))]
+                (assoc links result (str path query-params)))
+              (cond
+                (map? result) (apply merge (map #(recur-on-result % links) (vals result)))
+                (sequential? result) (apply merge (map #(recur-on-result % links) result))
+                :else links)))]
     (recur-on-result result {})))
 
 (defn resolve-entity-map [linked-entities entity-map]
@@ -548,56 +607,88 @@
       [:div.entity-histories
        [:strong (str eid)] " entity not found"])]])
 
-(defn html-request? [request]
-  (= (get-in request [:muuntaja/response :format]) "text/html"))
-
-(defn- entity-state [^ICruxAPI crux-node options {{:strs [history sort-order
+(defn- entity-state [^ICruxAPI crux-node options {{:strs [eid history sort-order
                                                           valid-time transaction-time
                                                           start-valid-time start-transaction-time
                                                           end-valid-time end-transaction-time
                                                           with-corrections with-docs link-entities?]} :query-params
                                                   :as request}]
-  (let [[_ encoded-eid] (re-find #"^/_crux/entity/(.+)$" (req/path-info request))
-        eid (or (some-> encoded-eid URLDecoder/decode c/id-edn-reader)
-                (throw (IllegalArgumentException. "missing eid")))
-        vt (some-> valid-time
-                   (instant/read-instant-date))
-        tt (some-> transaction-time
-                   (instant/read-instant-date))
-        db (db-for-request crux-node {:valid-time vt
-                                      :transact-time tt})
-        html? (html-request? request)]
-    (if history
-      (let [sort-order (or (some-> sort-order keyword)
-                           (throw (IllegalArgumentException. "missing sort-order query parameter")))
-            history-opts {:with-corrections? (some-> ^String with-corrections Boolean/valueOf)
-                          :with-docs? (or html? (some-> ^String with-docs Boolean/valueOf))
-                          :start {:crux.db/valid-time (some-> start-valid-time (instant/read-instant-date))
-                                  :crux.tx/tx-time (some-> start-transaction-time (instant/read-instant-date))}
-                          :end {:crux.db/valid-time (some-> end-valid-time (instant/read-instant-date))
-                                :crux.tx/tx-time (some-> end-transaction-time (instant/read-instant-date))}}
-            entity-history (api/entity-history db eid sort-order history-opts)]
-        {:status (if (not-empty entity-history) 200 404)
-         :body  (if html?
-                  (raw-html
-                   {:body (entity-history->html encoded-eid entity-history)
-                    :title "/entity?history=true"
-                    :options options})
-                  ;; Stringifying #crux/id values, caused issues with AJAX
-                  (map #(update % :crux.db/content-hash str) entity-history))})
-      (let [entity-map (api/entity db eid)
-            linked-entities #(link-all-entities db  "/_crux/entity" entity-map)]
-        {:status (if (some? entity-map) 200 404)
-         :body (cond
-                 html? (raw-html
-                        {:body (entity->html encoded-eid linked-entities entity-map vt tt)
-                         :title "/entity"
-                         :options options})
+  (let [html? (html-request? request)]
+    (if (nil? eid)
+      (if html?
+        {:status 200
+         :body (raw-html
+                {:body (entity-root-html)
+                 :title "/entity"
+                 :options options})}
+        (throw (IllegalArgumentException. "missing eid")))
+      (let [decoded-eid (-> eid URLDecoder/decode c/id-edn-reader)
+            vt (when-not (str/blank? valid-time) (instant/read-instant-date valid-time))
+            tt (when-not (str/blank? transaction-time) (instant/read-instant-date transaction-time))
+            db (db-for-request crux-node {:valid-time vt
+                                          :transact-time tt})]
+        (if history
+          (let [sort-order (or (some-> sort-order keyword)
+                               (throw (IllegalArgumentException. "missing sort-order query parameter")))
+                history-opts {:with-corrections? (some-> ^String with-corrections Boolean/valueOf)
+                              :with-docs? (or html? (some-> ^String with-docs Boolean/valueOf))
+                              :start {:crux.db/valid-time (some-> start-valid-time (instant/read-instant-date))
+                                      :crux.tx/tx-time (some-> start-transaction-time (instant/read-instant-date))}
+                              :end {:crux.db/valid-time (some-> end-valid-time (instant/read-instant-date))
+                                    :crux.tx/tx-time (some-> end-transaction-time (instant/read-instant-date))}}
+                entity-history (api/entity-history db decoded-eid sort-order history-opts)]
+            {:status (if (not-empty entity-history) 200 404)
+             :body  (if html?
+                      (raw-html
+                       {:body (entity-history->html eid entity-history)
+                        :title "/entity?history=true"
+                        :options options})
+                      ;; Stringifying #crux/id values, caused issues with AJAX
+                      (map #(update % :crux.db/content-hash str) entity-history))})
+          (let [entity-map (api/entity db decoded-eid)
+                linked-entities #(link-all-entities db  "/_crux/entity" entity-map)]
+            {:status (if (some? entity-map) 200 404)
+             :body (cond
+                     html? (raw-html
+                            {:body (entity->html eid linked-entities entity-map vt tt)
+                             :title "/entity"
+                             :options options})
 
-                 link-entities? {"linked-entities" (linked-entities)
-                                 "entity" entity-map}
+                     link-entities? {"linked-entities" (linked-entities)
+                                     "entity" entity-map}
 
-                 :else entity-map)}))))
+                     :else entity-map)}))))))
+
+(defn- query-root-html []
+  [:div.query-root
+   [:div.query-root__title
+    "Getting Started"]
+   [:div.query-root__contents
+    [:p "To perform a query, use the editor below:"]
+    [:div.query-editor__title
+     "Query editor"]
+    [:div.query-editor__contents
+     [:form
+      {:action "/_crux/query"}
+      [:textarea.textarea
+       {:name "q"
+        :rows 10
+        :cols 40}]
+      [:div.query-editor-datetime
+       [:b "Valid Time"]
+       [:input.input.input-time
+        {:type "datetime-local"
+         :name "valid-time"
+         :step "0.01"
+         :value (.format default-date-formatter (Date.))}]
+       [:b "Transaction Time"]
+       [:input.input.input-time
+        {:type "datetime-local"
+         :name "transaction-time"
+         :step "0.01"}]]
+      [:button.button
+       {:type "submit"}
+       "Submit Query"]]]]])
 
 (defn- vectorize-param [param]
   (if (vector? param) param [param]))
@@ -619,11 +710,12 @@
   (->> (apply concat results)
        (filter (every-pred c/valid-id? #(api/entity db %)))
        (map (fn [id]
-              (let [query-params (format "?valid-time=%s&transaction-time=%s"
+              (let [encoded-eid (URLEncoder/encode (str id) "UTF-8")
+                    query-params (format "?eid=%s&valid-time=%s&transaction-time=%s"
+                                         encoded-eid
                                          (.toInstant ^Date (api/valid-time db))
-                                         (.toInstant ^Date (api/transaction-time db)))
-                    encoded-eid (URLEncoder/encode (str id) "UTF-8")]
-                [id (str path "/" encoded-eid query-params)])))
+                                         (.toInstant ^Date (api/transaction-time db)))]
+                [id (str path query-params)])))
        (into {})))
 
 (defn resolve-prev-next-offset
@@ -665,7 +757,7 @@
                "Nothing to show"]]])]]
     [:table.table__foot]]])
 
-(defn data-browser-query [^ICruxAPI crux-node options request]
+(defn data-browser-query [^ICruxAPI crux-node options {{:strs [valid-time transaction-time q]} :query-params :as request}]
   (let [query-params (:query-params request)
         link-entities? (get query-params "link-entities?")
         html? (html-request? request)]
@@ -674,17 +766,7 @@
       (if html?
         {:status 200
          :body (raw-html
-                {:body [:form
-                        {:action "/_crux/query"}
-                        [:textarea.textarea
-                         {:name "q"
-                          :cols 40
-                          :rows 10}]
-                        [:br]
-                        [:br]
-                        [:button.button
-                         {:type "submit"}
-                         "Submit Query"]]
+                {:body (query-root-html)
                  :title "/query"
                  :options options})}
         {:status 400
@@ -692,14 +774,13 @@
 
       :else
       (try
-        (let [query (cond-> (or (some-> (get query-params "q")
-                                        (edn/read-string))
+        (let [query (cond-> (or (some-> q (edn/read-string))
                                 (build-query query-params))
                       html? (dissoc :full-results?))
-              db (db-for-request crux-node {:valid-time (some-> (get query-params "valid-time")
-                                                                (instant/read-instant-date))
-                                            :transact-time (some-> (get query-params "transaction-time")
-                                                                   (instant/read-instant-date))})
+              vt (when-not (str/blank? valid-time) (instant/read-instant-date valid-time))
+              tt (when-not (str/blank? transaction-time) (instant/read-instant-date transaction-time))
+              db (db-for-request crux-node {:valid-time vt
+                                            :transact-time tt})
               results (api/q db query)]
           {:status 200
            :body (cond
@@ -723,8 +804,13 @@
 
 (defn- data-browser-handler [crux-node options request]
   (condp check-path request
+    [#"^/_crux/index$" [:get]]
+    (root-handler crux-node options request)
 
-    [#"^/_crux/entity/.*$" [:get]]
+    [#"^/_crux/index.html$" [:get]]
+    (root-handler crux-node options (assoc-in request [:muuntaja/response :format] "text/html"))
+
+    [#"^/_crux/entity$" [:get]]
     (entity-state crux-node options request)
 
     [#"^/_crux/query" [:get]]
@@ -802,7 +888,6 @@
                                        (-> (some-fn (-> #(handler % {:crux-node node, ::read-only? read-only?})
                                                         (p/wrap-params)
                                                         (wrap-exception-handling))
-
                                                     (-> (partial data-browser-handler node options)
                                                         (p/wrap-params)
                                                         (wrap-resource "public")


### PR DESCRIPTION
Includes a few notable changes to the http-server API:
- Replacing `/` with a redirect to `_crux/index` - moving `/` to `/_crux/status`
- Switching the routes from `_route` to `_crux/route`
- Switching `entity` route from passing in entity id's as path params to passing them in as a query param, `eid`.
- Adding in datetime-local inputs to the `query` form (alongside adding a form for the root version of `entity`)

These changes are also similarly reflected within the CLJs.

Currently a draft, as I believe there is further work to do - especially on the *contents* and styling of the root pages. 
- Index page needs some content to serve as a proper welcome page to the crux console.
- Both of the `query` and `entity` root pages need a proper tutorial, links to explanations, etc.
