### PR TITLE
Speculative transactions, #904

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -281,7 +281,10 @@
   (transaction-time [db]
     "returns the time of the latest transaction applied to this db value.
   If a tx time was specified when db value was acquired then returns
-  the specified time."))
+  the specified time.")
+
+  (with-tx [db tx-ops]
+    (.withTx db tx-ops)))
 
 (let [arglists '(^crux.api.ICursor
                  [db eid sort-order]
@@ -309,7 +312,9 @@
     ([this eid sort-order opts] (.openEntityHistory this eid (->HistoryOptions sort-order opts))))
 
   (valid-time [this] (.validTime this))
-  (transaction-time [this] (.transactionTime this)))
+  (transaction-time [this] (.transactionTime this))
+
+  (with-tx [this tx-ops] (.withTx this tx-ops)))
 
 (defprotocol PCruxAsyncIngestClient
   "Provides API access to Crux async ingestion."

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -93,4 +93,6 @@ public interface ICruxDatasource extends Closeable {
      * the specified time.
      */
     public Date transactionTime();
+
+    public ICruxDatasource withTx(List<List<?>> txOps);
 }

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -33,7 +33,7 @@
   (ae [this a min-e entity-resolver-fn])
   (aev [this a e min-v entity-resolver-fn])
   (entity-as-of-resolver [this eid valid-time transact-time])
-  (entity-as-of [this eid valid-time transact-time])
+  (entity-as-of ^crux.codec.EntityTx [this eid valid-time transact-time])
   (entity-history [this eid sort-order opts])
   (decode-value [this value-buffer])
   (encode-value [this value])

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -1,0 +1,178 @@
+(ns ^:no-doc crux.fork
+  (:require [clojure.set :as set]
+            [crux.api :as api]
+            [crux.codec :as c]
+            [crux.db :as db]
+            [crux.io :as cio]
+            [crux.memory :as mem])
+  (:import crux.codec.EntityTx
+           java.util.Date))
+
+(defn- merge-seqs
+  ([inner mem] (merge-seqs inner mem #(.compare mem/buffer-comparator %1 %2)))
+  ([inner mem compare]
+   (letfn [(merge-seqs* [inner mem]
+             (lazy-seq
+              (let [[i1 & more-inner] inner
+                    [m1 & more-mem] mem]
+                (cond
+                  (empty? inner) mem
+                  (empty? mem) inner
+                  :else (let [cmp (compare i1 m1)]
+                          (cond
+                            (neg? cmp) (cons i1 (merge-seqs* more-inner mem))
+                            (zero? cmp) (cons m1 (merge-seqs* more-inner more-mem))
+                            :else (cons m1 (merge-seqs* inner more-mem))))))))]
+     (merge-seqs* inner mem))))
+
+(defn- date-min [^Date d1, ^Date d2]
+  (if (and d1 d2)
+    (Date. (min (.getTime d1) (.getTime d2)))
+    (or d1 d2)))
+
+(defn- inc-date [^Date d1]
+  (Date. (inc (.getTime d1))))
+
+(defrecord ForkedIndexStore [inner-index-store mem-index-store
+                             evicted-eids
+                             capped-valid-time capped-transact-time]
+  db/IndexStore
+  (av [this a min-v entity-resolver-fn]
+    (merge-seqs (db/av inner-index-store a min-v entity-resolver-fn)
+                (db/av mem-index-store a min-v entity-resolver-fn)))
+
+  (ave [this a v min-e entity-resolver-fn]
+    (merge-seqs (db/ave inner-index-store a v min-e entity-resolver-fn)
+                (db/ave mem-index-store a v min-e entity-resolver-fn)))
+
+  (ae [this a min-e entity-resolver-fn]
+    (merge-seqs (db/ae inner-index-store a min-e entity-resolver-fn)
+                (db/ae mem-index-store a min-e entity-resolver-fn)))
+
+  (aev [this a e min-v entity-resolver-fn]
+    (merge-seqs (db/aev inner-index-store a e min-v entity-resolver-fn)
+                (db/aev mem-index-store a e min-v entity-resolver-fn)))
+
+  (entity-as-of-resolver [this eid valid-time transact-time]
+    (some-> ^EntityTx (db/entity-as-of this eid valid-time transact-time)
+            (.content-hash)
+            c/->id-buffer))
+
+  (entity-as-of [this eid valid-time transact-time]
+    (->> [(when-not (contains? (into #{} (map #(db/encode-value inner-index-store %)) evicted-eids) eid)
+            (db/entity-as-of inner-index-store eid
+                             (date-min valid-time capped-valid-time)
+                             (date-min transact-time capped-transact-time)))
+          (db/entity-as-of mem-index-store eid valid-time transact-time)]
+         (remove nil?)
+         (sort-by (juxt #(.vt ^EntityTx %) #(.tx-id ^EntityTx %)))
+         last))
+
+  (entity-history [this eid sort-order opts]
+    (merge-seqs (when-not (contains? evicted-eids eid)
+                  (db/entity-history inner-index-store eid sort-order
+                                     (case sort-order
+                                       :asc (-> opts
+                                                (update-in [:end :crux.db/valid-time] date-min (inc-date capped-valid-time))
+                                                (update-in [:end :crux.tx/tx-time] date-min (inc-date capped-transact-time)))
+                                       :desc (-> opts
+                                                 (update-in [:start :crux.db/valid-time] date-min capped-valid-time)
+                                                 (update-in [:start :crux.tx/tx-time] date-min capped-transact-time)))))
+                (db/entity-history mem-index-store eid sort-order opts)
+
+                (case [sort-order (boolean (:with-corrections? opts))]
+                  [:asc false] #(compare (.vt ^EntityTx %1) (.vt ^EntityTx %2))
+                  [:asc true] #(compare [(.vt ^EntityTx %1) (.tx-id ^EntityTx %1)]
+                                        [(.vt ^EntityTx %2) (.tx-id ^EntityTx %2)])
+                  [:desc false] #(compare (.vt ^EntityTx %2) (.vt ^EntityTx %1))
+                  [:desc true] #(compare [(.vt ^EntityTx %2) (.tx-id ^EntityTx %2)]
+                                         [(.vt ^EntityTx %1) (.tx-id ^EntityTx %1)]))))
+
+  (decode-value [this value-buffer]
+    (or (db/decode-value mem-index-store value-buffer)
+        (db/decode-value inner-index-store value-buffer)))
+
+  (encode-value [this value]
+    (db/encode-value mem-index-store value))
+
+  (open-nested-index-store ^java.io.Closeable [this]
+    (->ForkedIndexStore (db/open-nested-index-store inner-index-store)
+                        (db/open-nested-index-store mem-index-store)
+                        evicted-eids
+                        capped-valid-time
+                        capped-transact-time))
+
+  java.io.Closeable
+  (close [_]
+    (cio/try-close mem-index-store)
+    (cio/try-close inner-index-store)))
+
+(defrecord ForkedIndexer [inner-indexer mem-indexer !evicted-eids capped-valid-time capped-transact-time]
+  db/Indexer
+  (index-docs [this docs]
+    (db/index-docs mem-indexer docs))
+
+  (unindex-eids [this eids]
+    (swap! !evicted-eids set/union (set eids))
+    (db/unindex-eids mem-indexer eids)
+
+    (with-open [inner-index-store (db/open-index-store inner-indexer)
+                mem-index-store (db/open-index-store mem-indexer)]
+      (let [tombstones (->> (for [eid eids
+                                  etx (concat (db/entity-history inner-index-store eid :asc
+                                                                 {:with-corrections? true})
+                                              (db/entity-history mem-index-store eid :asc
+                                                                 {:with-corrections? true}))
+                                  :let [content-hash (.content-hash ^EntityTx etx)]
+                                  :when content-hash]
+                              [content-hash {:crux.db/id eid, :crux.db/evicted? true}])
+                            (into {}))]
+        {:tombstones tombstones})))
+
+  (index-entity-txs [this tx entity-txs]
+    (db/index-entity-txs mem-indexer tx entity-txs))
+
+  (store-index-meta [this k v]
+    (db/store-index-meta mem-indexer k v))
+
+  (read-index-meta [this k]
+    (db/read-index-meta this k nil))
+
+  (read-index-meta [this k not-found]
+    (let [v (db/read-index-meta mem-indexer k ::not-found)]
+      (if (not= v ::not-found)
+        v
+        (db/read-index-meta inner-indexer k not-found))))
+
+  (latest-completed-tx [this]
+    (or (db/latest-completed-tx mem-indexer)
+        (db/latest-completed-tx inner-indexer)))
+
+  (mark-tx-as-failed [this tx]
+    (db/mark-tx-as-failed mem-indexer tx))
+
+  (tx-failed? [this tx-id]
+    (or (db/tx-failed? mem-indexer tx-id)
+        (db/tx-failed? inner-indexer tx-id)))
+
+  (open-index-store ^java.io.Closeable [this]
+    (->ForkedIndexStore (db/open-index-store inner-indexer)
+                        (db/open-index-store mem-indexer)
+                        @!evicted-eids
+                        capped-valid-time
+                        capped-transact-time)))
+
+(defn ->forked-indexer [inner-indexer mem-indexer
+                        capped-valid-time capped-transact-time]
+  (->ForkedIndexer inner-indexer mem-indexer
+                   (atom #{})
+                   capped-valid-time capped-transact-time))
+
+(defrecord ForkedDocumentStore [doc-store !docs]
+  db/DocumentStore
+  (submit-docs [_ docs]
+    (swap! !docs merge docs))
+
+  (fetch-docs [_ ids]
+    (let [overridden-docs (select-keys @!docs ids)]
+      (into overridden-docs (db/fetch-docs doc-store (set/difference (set ids) (set (keys overridden-docs))))))))

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -6,8 +6,7 @@
             [crux.memory :as mem]
             [crux.status :as status]
             [crux.morton :as morton]
-            [crux.kv.memdb :as memdb]
-            [crux.tx :as tx])
+            [crux.kv.memdb :as memdb])
   (:import (crux.codec Id EntityTx)
            crux.api.IndexVersionOutOfSyncException
            java.io.Closeable

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1039,12 +1039,11 @@
                                                     logic-var+range-constraint)))))
     compiled-query))
 
-(defn- build-sub-query [index-store {:keys [query-engine] :as db} where args rule-name->rules stats]
+(defn- build-sub-query [index-store {:keys [query-cache] :as db} where args rule-name->rules stats]
   ;; NOTE: this implies argument sets with different vars get compiled
   ;; differently.
   (let [arg-vars (arg-vars args)
         encode-value-fn (partial db/encode-value index-store)
-        {:keys [query-cache]} query-engine
         {:keys [depth->constraints
                 vars-in-join-order
                 var->range-constraints
@@ -1134,7 +1133,7 @@
   (let [{:keys [where args rules]} (s/conform ::query q)]
     (compile-sub-query encode-value-fn where (arg-vars args) (rule-name->rules rules) stats)))
 
-(defn- build-full-results [{:keys [entity-resolver-fn index-store], {:keys [document-store]} :query-engine, :as db} bound-result-tuple]
+(defn- build-full-results [{:keys [entity-resolver-fn index-store document-store] :as db} bound-result-tuple]
   (vec (for [value bound-result-tuple]
          (if-let [content-hash (and (c/valid-id? value)
                                     (c/new-id (entity-resolver-fn (db/encode-value index-store value))))]
@@ -1142,10 +1141,10 @@
                (get content-hash))
            value))))
 
-(defn open-index-store ^java.io.Closeable [{:keys [query-engine index-store] :as db}]
+(defn open-index-store ^java.io.Closeable [{:keys [indexer index-store] :as db}]
   (if index-store
     (db/open-nested-index-store index-store)
-    (db/open-index-store (:indexer query-engine))))
+    (db/open-index-store indexer)))
 
 (defrecord ConformedQuery [q-normalized q-conformed])
 
@@ -1179,15 +1178,13 @@
     (fn [k]
       (lru/compute-if-absent entity-cache k mem/copy-to-unpooled-buffer entity-resolver-fn))))
 
-(defn new-entity-resolver-fn [{:keys [valid-time transact-time query-engine index-store] :as db}]
-  (let [{:keys [options]} query-engine]
-    (cond-> #(db/entity-as-of-resolver index-store % valid-time transact-time)
-      (::entity-cache? options) (with-entity-resolver-cache options))))
+(defn new-entity-resolver-fn [{:keys [valid-time transact-time index-store options] :as db}]
+  (cond-> #(db/entity-as-of-resolver index-store % valid-time transact-time)
+    (::entity-cache? options) (with-entity-resolver-cache options)))
 
 (defn query
-  ([{:keys [valid-time transact-time query-engine] :as db} ^ConformedQuery conformed-q]
-   (let [{:keys [^ExecutorService query-executor indexer options]} query-engine
-         start-time (System/currentTimeMillis)
+  ([{:keys [valid-time transact-time ^ExecutorService query-executor indexer options] :as db} ^ConformedQuery conformed-q]
+   (let [start-time (System/currentTimeMillis)
          q (.q-normalized conformed-q)
          query-future (.submit query-executor
                                ^Callable
@@ -1220,10 +1217,8 @@
        (throw result)
        result)))
 
-  ([{:keys [valid-time transact-time query-engine] :as db} index-store ^ConformedQuery conformed-q]
-   (let [{:keys [indexer options]} query-engine
-         db (assoc db :index-store index-store)
-         q (.q-normalized conformed-q)
+  ([{:keys [valid-time transact-time indexer options] :as db} index-store ^ConformedQuery conformed-q]
+   (let [q (.q-normalized conformed-q)
          q-conformed (.q-conformed conformed-q)
          {:keys [find where args rules offset limit order-by full-results?]} q-conformed
          stats (db/read-index-meta indexer :crux.kv/stats)]
@@ -1232,6 +1227,7 @@
                                            (dissoc :args))))
      (validate-args args)
      (let [rule-name->rules (rule-name->rules rules)
+           db (assoc db :index-store index-store)
            db (assoc db :entity-resolver-fn (or (:entity-resolver-fn db)
                                                 (new-entity-resolver-fn db)))
            {:keys [n-ary-join
@@ -1268,18 +1264,21 @@
   (some-> (db/entity-as-of index-store eid valid-time transact-time)
           (c/entity-tx->edn)))
 
-(defn entity [{{:keys [document-store]} :query-engine, :as db} index-store eid]
+(defn entity [{:keys [document-store] :as db} index-store eid]
   (when-let [content-hash (some-> (entity-tx db index-store eid)
                                   :crux.db/content-hash)]
     (-> (db/fetch-docs document-store #{content-hash})
         (get content-hash)
         (c/keep-non-evicted-doc))))
 
-(defrecord QueryDatasource [query-engine
-                            ^Date valid-time
-                            ^Date transact-time
+
+
+(defrecord QueryDatasource [document-store indexer bus
+                            ^Date valid-time ^Date transact-time
+                            query-executor conform-cache query-cache
                             index-store
-                            entity-resolver-fn]
+                            entity-resolver-fn
+                            options]
   Closeable
   (close [_]
     (when index-store
@@ -1296,8 +1295,7 @@
 
   (query [this query]
     ;; TODO in theory this should 'just' be a call to openQuery that eagerly eval's the results
-    (let [{:keys [conform-cache bus]} query-engine
-          conformed-query (normalize-and-conform-query conform-cache query)
+    (let [conformed-query (normalize-and-conform-query conform-cache query)
           query-id (str (UUID/randomUUID))
           safe-query (-> conformed-query .q-normalized (dissoc :args))]
       (when bus
@@ -1313,7 +1311,6 @@
 
   (openQuery [this query]
     (let [index-store (open-index-store this)
-          {:keys [bus conform-cache]} query-engine
           conformed-query (normalize-and-conform-query conform-cache query)
           query-id (str (UUID/randomUUID))
           safe-query (-> conformed-query .q-normalized (dissoc :args))]
@@ -1341,7 +1338,7 @@
                          HistoryOptions$SortOrder/ASC :asc
                          HistoryOptions$SortOrder/DESC :desc)
             with-docs? (.withDocs opts)
-            index-store (db/open-index-store (:indexer query-engine))
+            index-store (db/open-index-store indexer)
 
             opts (cond-> {:with-corrections? (.withCorrections opts)
                           :with-docs? with-docs?
@@ -1368,7 +1365,7 @@
                                            :crux.tx/tx-id (.tx-id etx)
                                            :crux.db/valid-time (.vt etx)
                                            :crux.db/content-hash (.content-hash etx)}
-                                    with-docs? (assoc :crux.db/doc (-> (db/fetch-docs (:document-store query-engine) #{(.content-hash etx)})
+                                    with-docs? (assoc :crux.db/doc (-> (db/fetch-docs document-store #{(.content-hash etx)})
                                                                        (get (.content-hash etx))))))))))))
 
   (validTime [_] valid-time)
@@ -1390,11 +1387,9 @@
           valid-time (or valid-time (cio/next-monotonic-date))
           tx-time (or tx-time latest-tx-time valid-time)]
 
-      (->QueryDatasource this
-                         valid-time
-                         tx-time
-                         nil
-                         nil)))
+      (map->QueryDatasource (merge this
+                                   {:valid-time valid-time
+                                    :transact-time tx-time}))))
 
   (open-db [this] (api/open-db this nil nil))
   (open-db [this valid-time] (api/open-db this valid-time nil))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1383,7 +1383,7 @@
                                            ::tx/tx-id 0})
           conformed-tx-ops (map txc/conform-tx-op tx-ops)
           docs (into {} (mapcat :docs) conformed-tx-ops)
-          document-store (doto (fork/->ForkedDocumentStore document-store (atom {}))
+          document-store (doto (fork/->forked-document-store document-store)
                            (db/submit-docs docs))
           indexer (doto (fork/->forked-indexer indexer (kvi/->KvIndexer (mem-kv/->mem-kv))
                                                valid-time transact-time)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -8,7 +8,10 @@
             [crux.io :as cio]
             [crux.tx.conform :as txc]
             [crux.tx.event :as txe]
-            [crux.api :as api])
+            [crux.api :as api]
+            [crux.fork :as fork]
+            [crux.kv-indexer :as kvi]
+            [crux.kv.memdb :as mem-kv])
   (:import crux.codec.EntityTx
            java.io.Closeable
            java.time.Duration
@@ -32,67 +35,15 @@
 (defmethod bus/event-spec ::indexing-tx [_] (s/keys :req [::submitted-tx]))
 (defmethod bus/event-spec ::indexed-tx [_] (s/keys :req [::submitted-tx ::txe/tx-events], :req-un [::committed?]))
 
-(defprotocol EntityHistory
-  (entity-history-seq-ascending [_ eid valid-time])
-  (entity-history-seq-descending [_ eid valid-time])
-  (entity-at [_ eid valid-time tx-time])
-  (with-etxs [_ etxs]))
-
 (defn- etx->vt [^EntityTx etx]
   (.vt etx))
-
-(defn- merge-histories [keyfn compare left right]
-  (lazy-seq
-   (cond
-     (nil? (seq left)) right
-     (nil? (seq right)) left
-     :else (let [[l & more-left] left
-                 [r & more-right] right]
-             (case (Integer/signum (compare (keyfn l) (keyfn r)))
-               -1 (cons l (merge-histories keyfn compare more-left right))
-               0 (cons r (merge-histories keyfn compare more-left more-right))
-               1 (cons r (merge-histories keyfn compare left more-right)))))))
-
-(defrecord IndexStore+NewETXs [index-store etxs]
-  EntityHistory
-  (entity-history-seq-ascending [_ eid valid-time]
-    (merge-histories etx->vt compare
-                     (db/entity-history index-store eid :asc
-                                        {:start {:crux.db/valid-time valid-time}})
-                     (->> (get etxs eid)
-                          (drop-while (comp neg? #(compare % valid-time) etx->vt)))))
-
-  (entity-history-seq-descending [_ eid valid-time]
-    (merge-histories etx->vt #(compare %2 %1)
-                     (db/entity-history index-store eid :desc
-                                        {:start {:crux.db/valid-time valid-time}})
-                     (->> (reverse (get etxs eid))
-                          (drop-while (comp pos? #(compare % valid-time) etx->vt)))))
-
-  (entity-at [_ eid valid-time tx-time]
-    (->> (merge-histories etx->vt #(compare %2 %1)
-                          (some->> (db/entity-as-of index-store eid valid-time tx-time)
-                                   vector)
-                          (some->> (reverse (get etxs eid))
-                                   (drop-while (comp pos? #(compare % valid-time) etx->vt))
-                                   first
-                                   vector))
-         first))
-
-  (with-etxs [_ new-etxs]
-    (->IndexStore+NewETXs index-store
-                          (merge-with #(merge-histories etx->vt compare %1 %2)
-                                      etxs
-                                      (->> new-etxs (group-by #(.eid ^EntityTx %)))))))
-
-
 
 (defmulti index-tx-event
   (fn [[op :as tx-event] tx tx-consumer]
     op))
 
 (defn- put-delete-etxs [k start-valid-time end-valid-time content-hash
-                        {::keys [tx-time tx-id], :keys [crux.db/valid-time]} {:keys [history]}]
+                        {::keys [tx-time tx-id], :keys [crux.db/valid-time]} {:keys [index-store]}]
   (let [eid (c/new-id k)
         ->new-entity-tx (fn [vt]
                           (c/->EntityTx eid vt tx-time tx-id content-hash))
@@ -101,7 +52,7 @@
 
     (if end-valid-time
       (when-not (= start-valid-time end-valid-time)
-        (let [entity-history (entity-history-seq-descending history eid end-valid-time)]
+        (let [entity-history (db/entity-history index-store eid :desc {:start {:crux.db/valid-time end-valid-time}})]
           (into (->> (cons start-valid-time
                            (->> (map etx->vt entity-history)
                                 (take-while #(neg? (compare start-valid-time %)))))
@@ -115,10 +66,11 @@
                    (c/->EntityTx eid end-valid-time tx-time tx-id c/nil-id-buffer))])))
 
       (->> (cons start-valid-time
-                 (when-let [visible-entity (some-> (entity-at history eid start-valid-time tx-time)
+                 (when-let [visible-entity (some-> (db/entity-as-of index-store eid start-valid-time tx-time)
+
                                                    (select-keys [:tx-time :tx-id :content-hash]))]
-                   (->> (entity-history-seq-ascending history eid start-valid-time)
-                        (remove #{start-valid-time})
+                   (->> (db/entity-history index-store eid :asc {:start {:crux.db/valid-time start-valid-time}})
+                        (remove (comp #{start-valid-time} :valid-time))
                         (take-while #(= visible-entity (select-keys % [:tx-time :tx-id :content-hash])))
                         (mapv etx->vt))))
 
@@ -132,21 +84,21 @@
 
 (defmethod index-tx-event :crux.tx/match [[op k v at-valid-time :as match-op]
                                           {::keys [tx-time tx-id], :keys [crux.db/valid-time], :as tx}
-                                          {:keys [history] :as tx-consumer}]
-  {:pre-commit-fn #(let [{:keys [content-hash] :as entity} (entity-at history
-                                                                      (c/new-id k)
-                                                                      (or at-valid-time valid-time tx-time)
-                                                                      tx-time)]
+                                          {:keys [index-store] :as tx-consumer}]
+  {:pre-commit-fn #(let [content-hash (db/entity-as-of-resolver index-store
+                                                                (c/new-id k)
+                                                                (or at-valid-time valid-time tx-time)
+                                                                tx-time)]
                      (or (= (c/new-id content-hash) (c/new-id v))
                          (log/debug "crux.tx/match failure:" (cio/pr-edn-str match-op) "was:" (c/new-id content-hash))))})
 
 (defmethod index-tx-event :crux.tx/cas [[op k old-v new-v at-valid-time :as cas-op]
                                         {::keys [tx-time tx-id], :keys [crux.db/valid-time] :as tx}
-                                        {:keys [history document-store] :as tx-consumer}]
+                                        {:keys [index-store document-store] :as tx-consumer}]
   (let [eid (c/new-id k)
         valid-time (or at-valid-time valid-time tx-time)]
 
-    {:pre-commit-fn #(let [{:keys [content-hash] :as entity} (entity-at history eid valid-time tx-time)
+    {:pre-commit-fn #(let [content-hash (db/entity-as-of-resolver index-store eid valid-time tx-time)
                            current-id (c/new-id content-hash)
                            expected-id (c/new-id old-v)]
                        ;; see juxt/crux#362 - we'd like to just compare content hashes here, but
@@ -162,7 +114,7 @@
 (def evict-time-ranges-env-var "CRUX_EVICT_TIME_RANGES")
 (def ^:dynamic *evict-all-on-legacy-time-ranges?* (= (System/getenv evict-time-ranges-env-var) "EVICT_ALL"))
 
-(defmethod index-tx-event :crux.tx/evict [[op k & legacy-args] tx {:keys [history] :as tx-consumer}]
+(defmethod index-tx-event :crux.tx/evict [[op k & legacy-args] tx _]
   (let [eid (c/new-id k)]
     {:pre-commit-fn #(cond
                        (empty? legacy-args) true
@@ -208,10 +160,8 @@
 
 (defmethod index-tx-event :crux.tx/fn [[op k args-doc :as tx-op]
                                        {:crux.tx/keys [tx-time tx-id] :as tx}
-                                       {:keys [query-engine], :as tx-consumer}]
+                                       {:keys [query-engine index-store], :as tx-consumer}]
   (let [fn-id (c/new-id k)
-        db (api/db query-engine tx-time)
-        tx-fn (->tx-fn (api/entity db fn-id))
         {args-doc-id :crux.db/id, :crux.db.fn/keys [args tx-events failed?]} args-doc
         args-content-hash (c/new-id args-doc)
 
@@ -228,7 +178,8 @@
 
               :else (try
                       (let [ctx (->TxFnContext query-engine tx)
-                            res (apply (->tx-fn (api/entity db index-store fn-id)) ctx args)]
+                            db (api/db query-engine tx-time)
+                            res (apply (->tx-fn (api/entity db fn-id)) ctx args)]
                         (if (false? res)
                           {:failed? true}
 
@@ -307,51 +258,55 @@
                      :av-count (->> (vals indexed-docs) (apply concat) (count))
                      :bytes-indexed bytes-indexed}))))
 
-(defn index-tx [{:keys [indexer document-store] :as tx-consumer} tx tx-events]
-  (let [res (with-open [index-store (db/open-index-store indexer)]
-              (let [tx-consumer (assoc tx-consumer :index-store index-store)]
-                (reduce (fn [{:keys [history] :as acc} tx-event]
-                          (let [tx-consumer (assoc tx-consumer :history history)
-                                {:keys [pre-commit-fn etxs evict-eids docs]} (index-tx-event tx-event tx tx-consumer)]
-                            (if (and pre-commit-fn (not (pre-commit-fn)))
-                              (reduced {::aborted? true
-                                        :docs (merge (:docs acc) docs)})
-                              (-> acc
-                                  (update :history with-etxs etxs)
-                                  (update :evict-eids set/union evict-eids)
-                                  (update :docs merge docs)))))
+(defn index-tx [{:keys [indexer document-store] :as tx-consumer} {::keys [tx-time] :as tx} tx-events]
+  (let [forked-indexer (fork/->forked-indexer indexer (kvi/->KvIndexer (mem-kv/->mem-kv)) nil tx-time)
+        forked-document-store (fork/->forked-document-store document-store)
+        forked-tx-consumer (-> tx-consumer
+                               (assoc :indexer forked-indexer
+                                      :document-store forked-document-store)
+                               (assoc-in [:query-engine :indexer] forked-indexer))
+        committed? (reduce (fn [_ tx-event]
+                             (with-open [index-store (db/open-index-store forked-indexer)]
+                               (let [{:keys [pre-commit-fn evict-eids etxs docs]} (index-tx-event tx-event tx (-> forked-tx-consumer (assoc :index-store index-store)))]
+                                 (doto forked-document-store
+                                   (db/submit-docs docs))
 
-                        {:history (->IndexStore+NewETXs index-store {})
-                         :evict-eids #{}
-                         :docs {}}
+                                 (if (and pre-commit-fn (not (pre-commit-fn)))
+                                   (reduced false)
 
-                        tx-events)))
-        committed? (not (::aborted? res))]
+                                   (do
+                                     (doto forked-indexer
+                                       (db/unindex-eids evict-eids)
+                                       (db/index-entity-txs tx etxs))
+                                     true)))))
+                           nil
+                           tx-events)
+        new-docs (fork/new-docs forked-document-store)]
 
     (db/submit-docs document-store
-                    (cond->> (:docs res)
+                    (cond->> new-docs
                       (not committed?) (into {} (filter (comp :crux.db.fn/failed? val)))))
 
     (if committed?
       (do
-        (when-let [evict-eids (not-empty (:evict-eids res))]
+        (when-let [evict-eids (not-empty (fork/newly-evicted-eids forked-indexer))]
           (let [{:keys [tombstones]} (db/unindex-eids indexer evict-eids)]
             (db/submit-docs document-store tombstones)))
 
-        (when-let [docs (not-empty (:docs res))]
-          (db/index-docs indexer docs)
-          (update-stats tx-consumer (->> (vals docs)
+        (when (not-empty new-docs)
+          (db/index-docs indexer new-docs)
+          (update-stats tx-consumer (->> (vals new-docs)
                                          (map doc-predicate-stats)))
 
-          (db/submit-docs document-store docs))
+          (db/submit-docs document-store new-docs))
 
-        (db/index-entity-txs indexer tx (->> (get-in res [:history :etxs]) (mapcat val))))
+        (db/index-entity-txs indexer tx (fork/new-etxs forked-indexer)))
 
       (do
         (log/warn "Transaction aborted:" (pr-str tx-events) (pr-str tx))
         (db/mark-tx-as-failed indexer tx)))
 
-    {:committed committed}))
+    {:committed? committed?}))
 
 (defn with-tx-fn-args [[op & args :as evt] {:keys [document-store]}]
   (case op

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -6,7 +6,6 @@
             [crux.codec :as c]
             [crux.db :as db]
             [crux.io :as cio]
-            [crux.query :as q]
             [crux.tx.conform :as txc]
             [crux.tx.event :as txe]
             [crux.api :as api])
@@ -208,9 +207,10 @@
 
 (defmethod index-tx-event :crux.tx/fn [[op k args-doc :as tx-op]
                                        {:crux.tx/keys [tx-time tx-id] :as tx}
-                                       {:keys [index-store query-engine], :as tx-consumer}]
+                                       {:keys [query-engine], :as tx-consumer}]
   (let [fn-id (c/new-id k)
         db (api/db query-engine tx-time)
+        tx-fn (->tx-fn (api/entity db fn-id))
         {args-doc-id :crux.db/id, :crux.db.fn/keys [args tx-events failed?]} args-doc
         args-content-hash (c/new-id args-doc)
 
@@ -227,7 +227,7 @@
 
               :else (try
                       (let [ctx (->TxFnContext query-engine tx)
-                            res (apply (->tx-fn (q/entity db index-store fn-id)) ctx args)]
+                            res (apply (->tx-fn (api/entity db index-store fn-id)) ctx args)]
                         (if (false? res)
                           {:failed? true}
 

--- a/crux-core/test/crux/fork_test.clj
+++ b/crux-core/test/crux/fork_test.clj
@@ -1,0 +1,139 @@
+(ns crux.fork-test
+  (:require [crux.fork :as fork]
+            [clojure.test :as t]
+            [crux.fixtures :as fix :refer [*api*]]
+            [crux.api :as crux]
+            [crux.tx :as tx]
+            [crux.db :as db])
+  (:import [java.util Date]))
+
+(t/use-fixtures :each fix/with-standalone-topology fix/with-node)
+
+(t/deftest test-simple-fork
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan, :name "Ivna"}]])
+
+  (let [all-names-query '{:find [?name]
+                          :where [[?e :name ?name]]}
+        db (crux/db *api*)
+        _ (Thread/sleep 10)    ; to ensure these two txs are at a different ms
+        db2 (crux/with-tx db
+              [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])]
+
+    (t/is (= (crux/valid-time db) (crux/valid-time db2)))
+
+    (t/is (= #{["Ivna"]}
+             (crux/q db all-names-query)))
+    (t/is (= #{["Ivan"]}
+             (crux/q db2 all-names-query)))
+
+    (t/testing "can delete an entity"
+      (t/is (= #{}
+               (crux/q (crux/with-tx db [[:crux.tx/delete :ivan]])
+                       all-names-query)))
+      (t/is (= #{["Petr"]}
+               (crux/q (crux/with-tx db [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]
+                                         [:crux.tx/delete :ivan]])
+                       all-names-query))))))
+
+(t/deftest test-history
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan, :name "Ivna"}]])
+
+  (let [db (crux/db *api*)
+        history (crux/entity-history (crux/with-tx db
+                                       [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
+                                     :ivan
+                                     :asc
+                                     {:with-docs? true
+                                      :with-corrections? true})]
+
+    (t/is (= (crux/valid-time db)
+             (:crux.db/valid-time (last history))))
+
+    (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc {:crux.db/id :ivan, :name "Ivna"}}
+              {:crux.tx/tx-id 1, :crux.db/doc {:crux.db/id :ivan, :name "Ivan"}}]
+
+             (->> history
+                  (mapv #(select-keys % [::tx/tx-id :crux.db/doc])))))))
+
+(t/deftest test-speculative-from-point-in-past
+  (let [ivan0 {:crux.db/id :ivan, :name "Ivan0"}
+        tt0 (::tx/tx-time (fix/submit+await-tx [[:crux.tx/put ivan0]]))
+        _ (Thread/sleep 10)      ; to ensure these two txs are at a different ms
+        tt1 (::tx/tx-time (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan1"}]]))
+
+        db0 (crux/db *api* tt0 tt0)]
+
+
+    (t/testing "doesn't include original data after the original db cutoff"
+      (let [db1 (crux/with-tx db0
+                  [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
+
+        (t/is (= (crux/valid-time db0) (crux/valid-time db1)))
+        (t/is (= ivan0 (crux/entity db1 :ivan)))))
+
+    (t/testing "doesn't include original data after the original db cutoff in history"
+      (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc {:crux.db/id :ivan, :name "Ivan0"}}
+                {:crux.tx/tx-id 2, :crux.db/doc {:crux.db/id :ivan, :name "Ivan2"}}]
+               (->> (crux/entity-history (crux/with-tx db0 [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan2"}]])
+                                         :ivan
+                                         :asc
+                                         {:with-docs? true
+                                          :with-corrections? true})
+                    (mapv #(select-keys % [::tx/tx-id :crux.db/doc]))))))))
+
+(t/deftest test-speculative-from-point-in-future
+  (let [ivan0 {:crux.db/id :ivan, :name "Ivan0"}
+        present-tx (fix/submit+await-tx [[:crux.tx/put ivan0]])
+        _ (Thread/sleep 10) ; to ensure these two txs are at a different ms
+
+        now+10m (Date. (+ (.getTime (Date.)) (* 10 60 1000)))
+        future-ivan {:crux.db/id :ivan, :name "Future Ivan"}
+        now+10m-tx (fix/submit+await-tx [[:crux.tx/put future-ivan now+10m]])
+        future-db (crux/db *api* now+10m)
+
+        now+5m (Date. (+ (.getTime (Date.)) (* 5 60 1000)))
+        db (crux/with-tx future-db
+             [[:crux.tx/put {:crux.db/id :ivan, :name "Future Ivan 2"}]
+              [:crux.tx/put {:crux.db/id :ivan, :name "5m Future Ivan"} now+5m]])]
+
+    (t/is (= now+10m (crux/valid-time db)))
+
+    (t/is (= [{:crux.tx/tx-id 0,
+               :crux.db/valid-time (::tx/tx-time present-tx),
+               :crux.db/doc ivan0}
+              {:crux.tx/tx-id 2,
+               :crux.db/valid-time now+5m,
+               :crux.db/doc {:crux.db/id :ivan, :name "5m Future Ivan"}}
+              {:crux.tx/tx-id 1,
+               :crux.db/valid-time now+10m,
+               :crux.db/doc {:crux.db/id :ivan, :name "Future Ivan"}}
+              {:crux.tx/tx-id 2,
+               :crux.db/valid-time now+10m,
+               :crux.db/doc {:crux.db/id :ivan, :name "Future Ivan 2"}}]
+             (->> (crux/entity-history db
+                                       :ivan
+                                       :asc
+                                       {:with-docs? true
+                                        :with-corrections? true})
+                  (mapv #(select-keys % [::tx/tx-id :crux.db/valid-time :crux.db/doc])))))))
+
+(t/deftest test-evict
+  (let [ivan {:crux.db/id :ivan, :name "Ivan"}
+        petr {:crux.db/id :petr, :name "Petr"}
+        tx (fix/submit+await-tx [[:crux.tx/put ivan]
+                                 [:crux.tx/put petr]])
+        db (crux/db *api*)
+        db+evict (crux/with-tx db
+                   [[:crux.tx/evict :petr]])]
+
+    (letfn [(entity-history [db eid]
+              (->> (crux/entity-history db eid :asc {:with-docs? true})
+                   (map #(select-keys % [::tx/tx-id ::db/doc]))))]
+      (t/is (= [{::tx/tx-id 0, ::db/doc ivan}] (entity-history db :ivan)))
+      (t/is (= [{::tx/tx-id 0, ::db/doc petr}] (entity-history db :petr)))
+      (t/is (= [{::tx/tx-id 0, ::db/doc ivan}] (entity-history db+evict :ivan)))
+      (t/is (empty? (entity-history db+evict :petr)))
+
+      (t/is (= #{["Ivan"]}
+               (crux/q db+evict '{:find [?name]
+                                  :where [[_ :name ?name]]}))))))

--- a/crux-test/test/crux/kv_indexer_test.clj
+++ b/crux-test/test/crux/kv_indexer_test.clj
@@ -87,12 +87,9 @@
 
                       (write-etxs (vals vt+tt->etx))
                       (with-open [index-store (db/open-index-store *indexer*)]
-                        (->> (for [[vt tt] (concat txs queries)
-                                   :let [expected (entity-as-of vt+tt->etx vt tt)
-                                         expected-or-deleted (when-not (= (c/new-id nil)
-                                                                          (c/new-id (some-> expected .content-hash)))
-                                                               expected)]]
-                               (= expected-or-deleted (db/entity-as-of index-store eid vt tt)))
+                        (->> (for [[vt tt] (concat txs queries)]
+                               (= (entity-as-of vt+tt->etx vt tt)
+                                  (db/entity-as-of index-store eid vt tt)))
                              (every? true?))))))))
 
 (tcct/defspec test-generative-stress-bitemporal-range-test 50

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -17,7 +17,8 @@
             [clojure.string :as string]
             [crux.tx.conform :as txc])
   (:import [java.util Date]
-           [java.time Duration]))
+           [java.time Duration]
+           [crux.codec EntityTx]))
 
 (t/use-fixtures :each fix/with-standalone-topology fix/with-kv-dir fix/with-node fix/with-silent-test-check
   (fn [f]
@@ -134,7 +135,7 @@
                  new-tx-id   :crux.tx/tx-id}
                 (fix/submit+await-tx [[:crux.tx/delete :http://dbpedia.org/resource/Pablo_Picasso new-valid-time]])]
             (with-open [index-store (db/open-index-store (:indexer *api*))]
-              (t/is (nil? (db/entity-as-of index-store :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-time)))
+              (t/is (nil? (.content-hash (db/entity-as-of index-store :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-time))))
               (t/testing "first version of entity is still visible in the past"
                 (t/is (= tx-id (:tx-id (db/entity-as-of index-store :http://dbpedia.org/resource/Pablo_Picasso valid-time new-tx-time))))))))))
 

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -205,7 +205,6 @@ Result:
 include::./src/docs/examples.clj[tags=query-with-pred-1-r]
 ----
 
-
 [#queries_valid_time_travel]
 == Valid time travel
 
@@ -411,6 +410,38 @@ block) will result in undefined behaviour.
 ----
 include::./src/docs/examples.clj[tags=streaming-query]
 ----
+
+== Speculative transactions
+
+You can submit speculative transactions to Crux, to see what the results of your queries would be if a new transaction were to be applied.
+This is particularly useful for forecasting/projections, but also
+
+You'll receive a new database value, against which you can make queries and entity requests as you would any normal database value.
+Only you will see the effect of these transactions - they're not submitted to the cluster, and they're not visible to any other database value in your application.
+
+We submit these transactions to a database value using `with-tx`:
+
+[source,clojure]
+----
+(let [real-tx (crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
+      _ (crux/await-tx node real-tx)
+      all-names '{:find [?name], :where [[?e :name ?name]]}
+      db (crux/db node)]
+
+  (crux/q db all-names) ; => #{["Ivan"]}
+
+  (let [speculative-db (crux/with-tx db
+                         [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
+    (crux/q speculative-db all-names) ; => #{["Petr"] ["Ivan"]}
+    )
+
+  ;; we haven't impacted the original db value, nor the node
+  (crux/q db all-names) ; => #{["Ivan"]}
+  (crux/q (crux/db node) all-names) ; => #{["Ivan"]}
+  )
+----
+
+The entities submitted by the speculative `:crux.tx/put` take their valid time (if not explicitly specified) from the valid time of the `db` they were forked from.
 
 [#queries_history_api]
 == History API


### PR DESCRIPTION
resolves #904

This adds `with-tx` to database values, accepting a list of transaction operations.

See [crux.fork-test](https://github.com/jarohen/crux/blob/speculative-txs-904/crux-core/test/crux/fork_test.clj) for example usage.

Implementation notes:
* This is implemented by forking the indexer, yielding an indexer where any novelty is stored in an in-memory index - both the underlying indexer/index-store and the in-memory indexer/index-store are consulted for queries.
* This implementation is also used within the tx processing - we had a similar implementation here anyway (from #434) but this now uses the same forking code. 
* As a result, transaction functions can now easily see the in-transaction state of any entity they wish to.
* `IndexStore`'s `entity-as-of` now returns an `EntityTx` for deleted entities - previously it just returned `nil`. This is so that we can distinguish between the forked `IndexStore` knowing that an entity's explicitly been deleted since the fork or whether there's been nothing to affect that entity

To do:

* [x] Moar tests, particularly around the bitemporality implementation - history bounds, future transactions, etc
* [x] Squash down the commit history
* [x] Document up for opencrux.com