### PR TITLE
TPCH stress-test changes

### DIFF
--- a/crux-bench/bin/run-stress.sh
+++ b/crux-bench/bin/run-stress.sh
@@ -2,14 +2,14 @@
 set -e
 
 # COMMAND = '["crux.bench.main", "foo", "bar"]'
-COMMAND='["crux.bench.main"'
+COMMAND='["crux.bench.main", "--tests", "tpch-stress"'
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -r|--rev)
             REV="$2";
             shift 2;;
-        --nodes|--tests|--tpch-query-count|--tpch-field-count)
+        --tpch-query-count|--tpch-field-count)
             COMMAND+=", \"$1\", \"$2\""
             shift 2;;
         *) echo "Unknown parameter passed: $1"; exit 1;;
@@ -29,33 +29,13 @@ TASKDEF_ARN=$(aws ecs register-task-definition\
                   --network-mode "awsvpc" \
                   --container-definitions \
                   '[{
-                      "name":"zookeeper-container",
-                      "cpu":1024,
-                      "memory":2048,
-                      "image":"confluentinc/cp-zookeeper:5.3.1",
-                      "essential":true,
-                      "environment":[{"name":"ZOOKEEPER_CLIENT_PORT", "value":"2181"},{"name":"ZOOKEEPER_TICK_TIME", "value":"2000"}],
-                      "portMappings":[{"containerPort":2181}]
-                    }, {
-                      "name":"broker-container",
-                      "cpu":1024,
-                      "memory":2048,
-                      "image":"confluentinc/cp-enterprise-kafka:5.3.1",
-                      "dependsOn":[{"condition":"START","containerName":"zookeeper-container"}],
-                      "essential":true,
-                      "environment":[{"name":"KAFKA_BROKER_ID","value":"1"},
-                                     {"name":"KAFKA_ZOOKEEPER_CONNECT","value":"localhost:2181"},
-                                     {"name":"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR","value":"1"},
-                                     {"name":"KAFKA_ADVERTISED_LISTENERS","value":"PLAINTEXT://localhost:9092"}],
-                      "portMappings":[{"containerPort":9092}]
-                    },{
                       "name":"bench-container",
                       "cpu":2048,
-                      "memory":8192,
+                      "memory":4092,
                       "image":"955308952094.dkr.ecr.eu-west-2.amazonaws.com/crux-bench:commit-'${SHA}'",
-                      "dependsOn":[{"condition":"START","containerName":"broker-container"}],
                       "essential":true,
                       "secrets":[{"name":"SLACK_URL","valueFrom":"arn:aws:secretsmanager:eu-west-2:955308952094:secret:bench/slack-url-uumMHQ"}],
+		      "entryPoint":["java","-cp","crux-bench-standalone.jar","-Xms1g","-Xmx1g","clojure.main", "-m"],
                       "logConfiguration":{
                         "logDriver":"awslogs",
                         "options": {
@@ -70,7 +50,7 @@ TASKDEF_ARN=$(aws ecs register-task-definition\
 echo "Starting ECS task @ ${SHA:0:8}. Failures:"
 aws ecs run-task \
     --task-definition "$TASKDEF_ARN" \
-    --cluster crux-bench \
+    --cluster crux-bench-stress \
     --launch-type FARGATE \
     --count 1 \
     --network-configuration "awsvpcConfiguration={subnets=[subnet-5140ba2b],assignPublicIp=\"ENABLED\"}" \

--- a/crux-bench/src/crux/bench/tpch_stress_test.clj
+++ b/crux-bench/src/crux/bench/tpch_stress_test.clj
@@ -9,31 +9,43 @@
    (bench/with-additional-index-metrics node
      (tpch/load-docs! node))))
 
-(defn run-stress-queries [node {:keys [query-count field-count] :as opts}]
-  (bench/run-bench :query-stress
-    (dotimes [n query-count]
-      (log/info (format "Starting query #%s" n))
-      {:count (count (crux/q (crux/db node)
-                             {:find '[l_orderkey],
-                              :where (vec
-                                      (take field-count '[[e :l_orderkey l_orderkey]
-                                                          [e :l_partkey l_partkey]
-                                                          [e :l_suppkey l_suppkey]
-                                                          [e :l_linenumber l_linenumber]
-                                                          [e :l_quantity l_quantity]
-                                                          [e :l_extendedprice l_extendedprice]
-                                                          [e :l_discount l_discount]
-                                                          [e :l_tax l_tax]
-                                                          [e :l_returnflag l_returnflag]
-                                                          [e :l_linestatus l_linestatus]
-                                                          [e :l_shipdate l_shipdate]
-                                                          [e :l_commitdate l_commitdate]
-                                                          [e :l_receiptdate l_receiptdate]
-                                                          [e :l_shipinstruct l_shipinstruct]
-                                                          [e :l_shipmode l_shipmode]
-                                                          [e :l_comment l_comment]]))
-                              :timeout 1000000}))})
-    {:run-success? true}))
+(def fields '{:l_orderkey l_orderkey
+              :l_partkey l_partkey
+              :l_suppkey l_suppkey
+              :l_linenumber l_linenumber
+              :l_quantity l_quantity
+              :l_extendedprice l_extendedprice
+              :l_discount l_discount
+              :l_tax l_tax
+              :l_returnflag l_returnflag
+              :l_linestatus l_linestatus
+              :l_shipdate l_shipdate
+              :l_commitdate l_commitdate
+              :l_receiptdate l_receiptdate
+              :l_shipinstruct l_shipinstruct
+              :l_shipmode l_shipmode
+              :l_comment l_comment})
+
+(defn run-stress-queries [node {:keys [query-count field-count] :or {query-count 50 field-count (count fields)} :as opts}]
+  (let [q {:find '[e],
+           :where (->> fields
+                       (take field-count)
+                       (mapcat (fn [[a v]] [['e a v] [(list 'identity v) (gensym)]]))
+                       vec)
+           :timeout 1000000}]
+    (log/infof "Stressing query: %s" (prn-str q))
+    (bench/run-bench :query-stress
+      (bench/with-thread-pool
+        opts
+        (fn [{:keys [idx q]}]
+          (log/info (format "Starting query #%s" idx))
+          {:count (count (crux/q (crux/db node) q))})
+        (->> q
+             (repeat query-count)
+             (map-indexed (fn [idx q] {:idx idx, :q q}))))
+      {:run-success? true
+       :num-queries query-count
+       :num-fields field-count})))
 
 (defn run-tpch-stress-test [node {:keys [query-count field-count] :as opts}]
   (bench/with-bench-ns :tpch-stress
@@ -44,5 +56,5 @@
 (comment
   (let [node (user/crux-node)]
     (bench/with-bench-ns :tpch-stress
-      #_(load-tpch-docs node)
-      #_(run-stress-queries node {:query-count 15, :field-count 10}))))
+      (load-tpch-docs node)
+      (run-stress-queries node {}))))


### PR DESCRIPTION
Add `run-stress` script, run tpch-stress queries with thread pool.

`run-stress` is based off of `run-bench`, running on the tpch-stress
with a 4GB bench container.