### PR TITLE
Bench - Edit Default Behaviours

### DIFF
--- a/crux-bench/bin/run-stress.sh
+++ b/crux-bench/bin/run-stress.sh
@@ -9,7 +9,7 @@ while [[ "$#" -gt 0 ]]; do
         -r|--rev)
             REV="$2";
             shift 2;;
-        --tpch-query-count|--tpch-field-count)
+        --nodes|--tpch-query-count|--tpch-field-count)
             COMMAND+=", \"$1\", \"$2\""
             shift 2;;
         *) echo "Unknown parameter passed: $1"; exit 1;;

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -259,8 +259,8 @@
         :crux.kafka/doc-topic (str "kafka-rocksdb-doc-" uuid)
         :crux.kafka/tx-topic (str "kafka-rocksdb-tx-" uuid)
         :crux.kv/db-dir (str (io/file data-dir "kv/embedded-kafka-rocksdb"))}))
-   #_"standalone-lmdb"
-   #_(fn [data-dir]
+   "standalone-lmdb"
+   (fn [data-dir]
        {:crux.node/topology '[crux.standalone/topology
                               crux.metrics.dropwizard.cloudwatch/reporter
                               crux.kv.lmdb/kv-store]
@@ -268,8 +268,8 @@
         :crux.standalone/event-log-kv-store 'crux.kv.lmdb/kv
         :crux.standalone/event-log-dir (str (io/file data-dir "eventlog/lmdb"))})
 
-   #_"kafka-lmdb"
-   #_(fn [data-dir]
+   "kafka-lmdb"
+   (fn [data-dir]
        (let [uuid (UUID/randomUUID)]
          {:crux.node/topology '[crux.kafka/topology
                                 crux.metrics.dropwizard.cloudwatch/reporter

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -57,17 +57,17 @@
 
                          [nil "--tests test1,test2" "Tests to run"
                           :id :selected-tests
-                          :default (set (keys bench-tests))
+                          :default (set (keys (dissoc bench-tests :tpch-stress)))
                           :parse-fn #(into #{} (map keyword (set (string/split % #","))))]
 
                          [nil "--tpch-query-count 20" "Number of queries to run on TPCH stress"
                           :id :tpch-query-count
-                          :default 20
+                          :default 35
                           :parse-fn #(Long/parseLong %)]
 
                          [nil "--tpch-field-count 10" "Number of fields to run queries with on TPCH stress"
                           :id :tpch-field-count
-                          :default 10
+                          :default (count tpch-stress/fields)
                           :parse-fn #(Long/parseLong %)]])]
     (if errors
       (binding [*out* *err*]

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -41,7 +41,7 @@
                      (bench/with-comparison-times)
                      (doto post-to-slack)))))
    :tpch-stress (fn [nodes {:keys [tpch-query-count tpch-field-count] :as opts}]
-                  (bench/with-nodes [node (select-keys nodes #{"standalone-rocksdb"})]
+                  (bench/with-nodes [node nodes]
                     (-> (bench/with-comparison-times
                           (tpch-stress/run-tpch-stress-test node {:query-count tpch-query-count
                                                                   :field-count tpch-field-count}))

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -52,7 +52,7 @@
         (cli/parse-opts args
                         [[nil "--nodes node1,node2" "Node types"
                           :id :selected-nodes
-                          :default (set (keys bench/nodes))
+                          :default (set (keys (dissoc bench/nodes "standalone-lmdb" "kafka-lmdb")))
                           :parse-fn #(set (string/split % #","))]
 
                          [nil "--tests test1,test2" "Tests to run"


### PR DESCRIPTION
Changed a few of the default behaviours on crux-bench:
- The two `lmdb` nodes are now uncommented, and explicitly not used (so you can explicitly trigger a run against those)
- Changed default counts on tpch-stress test.

Also changed the `run-stress` script so you can pass which node you run it on (rather than just standalone-rocksdb, as before)