### PR TITLE
LMDB Segfaults

### DIFF
--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -710,7 +710,7 @@
                                               av-i (kv/new-iterator snapshot)]
                                     (->> (for [eid eids
                                                ecav-key (all-keys-in-prefix ecav-i
-                                                                            (encode-ecav-key-to (.get seek-buffer-tl)
+                                                                            (encode-ecav-key-to nil
                                                                                                 (c/->id-buffer eid)))]
                                            ecav-key)
 

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -687,8 +687,8 @@
 (defrecord KvIndexer [kv-store]
   db/Indexer
   (index-docs [this docs]
-    (with-open [snapshot (kv/new-snapshot kv-store)]
-      (let [docs (->> docs
+    (let [docs (with-open [snapshot (kv/new-snapshot kv-store)]
+                 (->> docs
                       (into {} (remove (let [crux-db-id (c/->id-buffer :crux.db/id)]
                                          (fn [[k doc]]
                                            (let [eid (c/->id-buffer (:crux.db/id doc))]
@@ -697,21 +697,21 @@
                                                                                         (c/->id-buffer k)
                                                                                         crux-db-id
                                                                                         eid)))))))
-                      not-empty)
+                      not-empty))
+          content-idx-kvs (->content-idx-kvs docs)]
 
-            content-idx-kvs (->content-idx-kvs docs)]
-
-        (some->> (seq content-idx-kvs) (kv/store kv-store))
-
-        {:bytes-indexed (->> content-idx-kvs (transduce (comp (mapcat seq) (map mem/capacity)) +))
-         :indexed-docs docs})))
+      (some->> (seq content-idx-kvs) (kv/store kv-store))
+      {:bytes-indexed (->> content-idx-kvs (transduce (comp (mapcat seq) (map mem/capacity)) +))
+       :indexed-docs docs}))
 
   (unindex-eids [this eids]
-    (with-open [snapshot (kv/new-snapshot kv-store)
-                ecav-i (kv/new-iterator snapshot)
-                av-i (kv/new-iterator snapshot)]
-      (let [{:keys [tombstones ks]} (->> (for [eid eids
-                                               ecav-key (all-keys-in-prefix ecav-i (encode-ecav-key-to nil (c/->id-buffer eid)))]
+    (let [{:keys [tombstones ks]} (with-open [snapshot (kv/new-snapshot kv-store)
+                                              ecav-i (kv/new-iterator snapshot)
+                                              av-i (kv/new-iterator snapshot)]
+                                    (->> (for [eid eids
+                                               ecav-key (all-keys-in-prefix ecav-i
+                                                                            (encode-ecav-key-to (.get seek-buffer-tl)
+                                                                                                (c/->id-buffer eid)))]
                                            ecav-key)
 
                                          (reduce (fn [acc ecav-key]
@@ -742,10 +742,10 @@
                                                        (not (c/can-decode-value-buffer? value-buffer))
                                                        (update :ks conj (encode-hash-cache-key-to nil value-buffer eid-buffer)))))
                                                  {:tombstones {}
-                                                  :ks #{}}))]
+                                                  :ks #{}})))]
 
-        (kv/delete kv-store ks)
-        {:tombstones tombstones})))
+      (kv/delete kv-store ks)
+      {:tombstones tombstones}))
 
   (mark-tx-as-failed [this {:crux.tx/keys [tx-id] :as tx}]
     (kv/store kv-store [(meta-kv ::latest-completed-tx tx)

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -94,7 +94,6 @@
 
         (let [latest-completed-tx-id (::tx/tx-id (api/latest-completed-tx this))
               tx-log-iterator (db/open-tx-log tx-log after-tx-id)
-              index-store (db/open-index-store indexer)
               tx-log (-> (iterator-seq tx-log-iterator)
                          (->> (remove #(db/tx-failed? indexer (:crux.tx/tx-id %)))
                               (take-while (comp #(<= % latest-completed-tx-id) ::tx/tx-id)))
@@ -105,7 +104,6 @@
                                                        (assoc :crux.api/tx-ops (txc/tx-events->tx-ops document-store tx-events)))))))]
 
           (cio/->cursor (fn []
-                          (.close index-store)
                           (.close tx-log-iterator))
                         tx-log)))))
 
@@ -136,8 +134,7 @@
                                     (select-keys ev [:committed?])
                                     (select-keys submitted-tx [::tx/tx-time ::tx/tx-id])
                                     (when (:with-tx-ops? event-opts)
-                                      (with-open [index-store (db/open-index-store indexer)]
-                                        {:crux/tx-ops (txc/tx-events->tx-ops document-store tx-events)}))))))))
+                                      {:crux/tx-ops (txc/tx-events->tx-ops document-store tx-events)})))))))
 
   (latestCompletedTx [this]
     (db/latest-completed-tx indexer))

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -71,20 +71,26 @@
       {::tx/tx-id tx-id}))
 
   (open-tx-log [this after-tx-id]
-    (let [snapshot (kv/new-snapshot event-log-kv-store)
-          iterator (kv/new-iterator snapshot)]
-      (letfn [(tx-log [k]
-                (lazy-seq
-                 (when (some-> k (tx-event-key?))
-                   (cons (assoc (decode-tx-event-key-from k)
-                                :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
-                         (tx-log (kv/next iterator))))))]
+    (let [batch-fn (fn [after-tx-id]
+                     (with-open [snapshot (kv/new-snapshot event-log-kv-store)
+                                 iterator (kv/new-iterator snapshot)]
+                       (letfn [(tx-log [k]
+                                 (lazy-seq
+                                  (when (some-> k (tx-event-key?))
+                                    (cons (assoc (decode-tx-event-key-from k)
+                                                 :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
+                                          (tx-log (kv/next iterator))))))]
 
-        (let [k (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
-          (->> (when k (tx-log (if after-tx-id (kv/next iterator) k)))
-               (cio/->cursor (fn []
-                               (cio/try-close iterator)
-                               (cio/try-close snapshot))))))))
+                         (when-let [k (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
+                           (->> (tx-log (if after-tx-id (kv/next iterator) k))
+                                (take 100)
+                                (vec))))))]
+      (cio/->cursor
+       (fn [])
+       (lazy-seq
+        (when-let [batch (seq (batch-fn after-tx-id))]
+          (concat batch (when-let [next-after-tx-id (:crux.tx/id (last batch))]
+                          (batch-fn next-after-tx-id))))))))
 
   Closeable
   (close [_]

--- a/crux-lmdb/src/crux/kv/lmdb.clj
+++ b/crux-lmdb/src/crux/kv/lmdb.clj
@@ -28,7 +28,7 @@
   (success? (LMDB/mdb_env_set_mapsize env size)))
 
 (defn- acquire-write-lock ^long [^StampedLock mapsize-lock]
-  (let [stamp (.tryWriteLock mapsize-lock 10 TimeUnit/SECONDS)]
+  (let [stamp (.tryWriteLock mapsize-lock 120 TimeUnit/SECONDS)]
     (assert (pos? stamp) "LMDB write lock timeout")
     stamp))
 

--- a/crux-lmdb/src/crux/kv/lmdb/jnr.clj
+++ b/crux-lmdb/src/crux/kv/lmdb/jnr.clj
@@ -3,9 +3,11 @@
   (:require [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [clojure.spec.alpha :as s]
+            [crux.io :as cio]
             [crux.kv :as kv]
             [crux.memory :as mem])
   (:import java.io.Closeable
+           java.util.concurrent.locks.StampedLock
            org.agrona.ExpandableDirectByteBuffer
            [org.lmdbjava CopyFlags Cursor Dbi DbiFlags DirectBufferProxy Env EnvFlags Env$MapFullException GetOp PutFlags Txn]))
 
@@ -27,7 +29,7 @@
   (close [_]
     (.close cursor)))
 
-(defrecord LMDBJNRSnapshot [^Dbi dbi ^Txn tx]
+(defrecord LMDBJNRSnapshot [^Dbi dbi ^Txn tx close-fn]
   kv/KvSnapshot
   (new-iterator [_]
     (->LMDBJNRIterator tx (.openCursor dbi tx) (ExpandableDirectByteBuffer.)))
@@ -37,7 +39,10 @@
 
   Closeable
   (close [_]
-    (.close tx)))
+    (try
+      (.close tx)
+      (finally
+        (close-fn)))))
 
 (def ^:dynamic ^{:tag 'long} *mapsize-increase-factor* 1)
 (def ^:const max-mapsize-increase-factor 32)
@@ -49,43 +54,51 @@
                                   EnvFlags/MDB_NOSYNC
                                   EnvFlags/MDB_NOMETASYNC])
 
-(defn- increase-mapsize [^Env env ^long factor]
-  (let [new-mapsize (* factor (.mapSize (.info env)))]
-    (log/debug "Increasing mapsize to:" new-mapsize)
-    (.setMapSize env new-mapsize)))
+(defn- increase-mapsize [^StampedLock mapsize-lock ^Env env ^long factor]
+  (cio/with-write-lock mapsize-lock
+    (let [new-mapsize (* factor (.mapSize (.info env)))]
+      (log/debug "Increasing mapsize to:" new-mapsize)
+      (.setMapSize env new-mapsize))))
 
-(defrecord LMDBJNRKv [db-dir ^Env env ^Dbi dbi]
+(defrecord LMDBJNRKv [db-dir ^Env env ^Dbi dbi ^StampedLock mapsize-lock]
   kv/KvStore
   (new-snapshot [_]
-    (->LMDBJNRSnapshot dbi (.txnRead env)))
+    (let [txn-stamp (.readLock mapsize-lock)]
+      (try
+        (->LMDBJNRSnapshot dbi (.txnRead env) #(.unlock mapsize-lock txn-stamp))
+        (catch Throwable t
+          (.unlock mapsize-lock txn-stamp)
+          (throw t)))))
 
   (store [this kvs]
     (try
-      (with-open [tx (.txnWrite env)]
-        (let [kb (ExpandableDirectByteBuffer.)
-              vb (ExpandableDirectByteBuffer.)]
-          (doseq [[k v] kvs]
-            (.put dbi tx (mem/ensure-off-heap k kb) (mem/ensure-off-heap v vb) (make-array PutFlags 0)))
-          (.commit tx)))
+      (cio/with-read-lock mapsize-lock
+        (with-open [tx (.txnWrite env)]
+          (let [kb (ExpandableDirectByteBuffer.)
+                vb (ExpandableDirectByteBuffer.)]
+            (doseq [[k v] kvs]
+              (.put dbi tx (mem/ensure-off-heap k kb) (mem/ensure-off-heap v vb) (make-array PutFlags 0)))
+            (.commit tx))))
       (catch Env$MapFullException e
         (binding [*mapsize-increase-factor* (* 2 *mapsize-increase-factor*)]
           (when (> *mapsize-increase-factor* max-mapsize-increase-factor)
             (throw (IllegalStateException. "Too large size of keys to store at once.")))
-          (increase-mapsize env *mapsize-increase-factor*)
+          (increase-mapsize mapsize-lock env *mapsize-increase-factor*)
           (kv/store this kvs)))))
 
   (delete [this ks]
     (try
-      (with-open [tx (.txnWrite env)]
-        (let [kb (ExpandableDirectByteBuffer.)]
-          (doseq [k ks]
-            (.delete dbi tx (mem/ensure-off-heap k kb)))
-          (.commit tx)))
+      (cio/with-read-lock mapsize-lock
+        (with-open [tx (.txnWrite env)]
+          (let [kb (ExpandableDirectByteBuffer.)]
+            (doseq [k ks]
+              (.delete dbi tx (mem/ensure-off-heap k kb)))
+            (.commit tx))))
       (catch Env$MapFullException e
         (binding [*mapsize-increase-factor* (* 2 *mapsize-increase-factor*)]
           (when (> *mapsize-increase-factor* max-mapsize-increase-factor)
             (throw (IllegalStateException. "Too large size of keys to delete at once.")))
-          (increase-mapsize env *mapsize-increase-factor*)
+          (increase-mapsize mapsize-lock env *mapsize-increase-factor*)
           (kv/delete this ks)))))
 
   (fsync [this]
@@ -101,8 +114,9 @@
       (.copy env file (make-array CopyFlags 0))) )
 
   (count-keys [_]
-    (with-open [tx (.txnRead env)]
-      (.entries (.stat dbi tx))))
+    (cio/with-read-lock mapsize-lock
+      (with-open [tx (.txnRead env)]
+        (.entries (.stat dbi tx)))))
 
   (db-dir [this]
     (str db-dir))
@@ -112,9 +126,10 @@
 
   Closeable
   (close [_]
-    (.close env)))
+    (cio/with-write-lock mapsize-lock
+      (.close env))))
 
-(def kv {:start-fn (fn [_ {:keys [::kv/db-dir ::kv/sync? ::env-flags]
+(def kv {:start-fn (fn [_ {:keys [::kv/db-dir ::kv/sync? ::env-flags ::env-mapsize]
                            :as options}]
                      (let [env (.open (Env/create DirectBufferProxy/PROXY_DB)
                                       (io/file db-dir)
@@ -122,14 +137,19 @@
                                                              (not sync?) (concat no-sync-env-flags))))
                            ^String db-name nil]
                        (try
+                         (when env-mapsize
+                           (.setMapSize env env-mapsize))
                          (-> (map->LMDBJNRKv {:db-dir db-dir
                                               :env env
-                                              :dbi (.openDbi env db-name ^"[Lorg.lmdbjava.DbiFlags;" (make-array DbiFlags 0))}))
+                                              :dbi (.openDbi env db-name ^"[Lorg.lmdbjava.DbiFlags;" (make-array DbiFlags 0))
+                                              :mapsize-lock (StampedLock.)}))
                          (catch Throwable t
                            (.close env)
                            (throw t)))))
          :args (merge kv/options
                       {::env-flags {:doc "LMDB Flags"
-                                    :crux.config/type [any? identity]}})})
+                                    :crux.config/type [any? identity]}
+                       ::env-mapsize {:doc "LMDB Map size"
+                                      :crux.config/type :crux.config/nat-int}})})
 
 (def kv-store {:crux.node/kv-store kv})

--- a/crux-test/test/crux/fixtures/kv_only.clj
+++ b/crux-test/test/crux/fixtures/kv_only.clj
@@ -7,16 +7,19 @@
 
 (def ^:dynamic *kv*)
 (def ^:dynamic *kv-module* 'crux.kv.rocksdb/kv)
-(def ^:dynamic *sync* false)
+(def ^:dynamic *kv-opts* {})
 
 (defn ^Closeable start-kv-store [opts]
   (topo/start-component *kv-module* nil opts))
 
+(defn with-kv-opts [opts f]
+  (binding [*kv-opts* opts]
+    (f)))
+
 (defn with-kv-store [f]
   (let [db-dir (cio/create-tmpdir "kv-store")]
     (try
-      (with-open [kv (start-kv-store {:crux.kv/db-dir (str db-dir)
-                                      :crux.kv/sync? *sync*})]
+      (with-open [kv (start-kv-store (assoc *kv-opts* :crux.kv/db-dir (str db-dir)))]
         (binding [*kv* kv]
           (f)))
       (finally


### PR DESCRIPTION
Adding a stamped lock that has its write lock taken out when increasing the LMDB mapsize, and read lock while transactions are running, to avoid changing the underlying mmap while txs are running, causing seg faults.