### PR TITLE
Revert reverting RocksDB version bump

### DIFF
--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -177,6 +177,12 @@
     b
     (UnsafeBuffer. (->off-heap b tmp) 0 (capacity b))))
 
+(defn direct-byte-buffer ^java.nio.ByteBuffer [b]
+  (let [b (->off-heap b)]
+    (-> (.byteBuffer b)
+        (.position 0)
+        (.limit (.capacity b)))))
+
 (defn on-heap-buffer ^org.agrona.DirectBuffer [^bytes b]
   (UnsafeBuffer. b))
 

--- a/crux-rocksdb/project.clj
+++ b/crux-rocksdb/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [juxt/crux-core "derived-from-git"]
                  [juxt/crux-metrics "derived-from-git" :scope "provided"]
-                 [org.rocksdb/rocksdbjni "6.5.3"]
+                 [org.rocksdb/rocksdbjni "6.8.1"]
                  [com.github.jnr/jnr-ffi "2.1.12"]]
   :middleware [leiningen.project-version/middleware]
   :pedantic? :warn)

--- a/crux-rocksdb/src/crux/kv/rocksdb.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb.clj
@@ -8,23 +8,40 @@
             [crux.memory :as mem]
             [crux.index :as idx])
   (:import java.io.Closeable
-           clojure.lang.MapEntry
-           (org.rocksdb Checkpoint CompressionType FlushOptions
+           java.nio.ByteBuffer
+           java.util.function.ToIntFunction
+           (org.rocksdb Checkpoint CompressionType FlushOptions LRUCache
                         Options ReadOptions RocksDB RocksIterator
                         WriteBatch WriteOptions Statistics StatsLevel)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
-;; NOTE: We're returning on-heap buffers simply wrapping arrays
-;; here. This may or may not work later down the line.
+(def ^:const ^:private initial-read-buffer-limit 128)
+
+(defn- read-value [^ToIntFunction f]
+  (loop [limit initial-read-buffer-limit]
+    (let [out (mem/direct-byte-buffer (mem/allocate-buffer limit))
+          result (.applyAsInt f out)]
+      (cond
+        (= result RocksDB/NOT_FOUND)
+        nil
+
+        (< limit result)
+        (recur result)
+
+        :else
+        (mem/as-buffer out)))))
+
 (defn- iterator->key [^RocksIterator i]
   (when (.isValid i)
-    (mem/on-heap-buffer (.key i))))
+    (read-value (reify ToIntFunction
+                  (applyAsInt [_ out]
+                    (.key i ^ByteBuffer out))))))
 
 (defrecord RocksKvIterator [^RocksIterator i]
   kv/KvIterator
   (seek [this k]
-    (.seek i (mem/->on-heap k))
+    (.seek i (mem/direct-byte-buffer k))
     (iterator->key i))
 
   (next [this]
@@ -36,7 +53,9 @@
     (iterator->key i))
 
   (value [this]
-    (mem/on-heap-buffer (.value i)))
+    (read-value (reify ToIntFunction
+                  (applyAsInt [_ out]
+                    (.value i ^ByteBuffer out)))))
 
   Closeable
   (close [this]
@@ -48,7 +67,9 @@
     (->RocksKvIterator (.newIterator db read-options)))
 
   (get-value [this k]
-    (some-> (.get db read-options (mem/->on-heap k)) (mem/on-heap-buffer)))
+    (read-value (reify ToIntFunction
+                  (applyAsInt [_ out]
+                    (.get db read-options (mem/direct-byte-buffer k) ^ByteBuffer out)))))
 
   Closeable
   (close [_]
@@ -70,13 +91,13 @@
   (store [{:keys [^RocksDB db ^WriteOptions write-options]} kvs]
     (with-open [wb (WriteBatch.)]
       (doseq [[k v] kvs]
-        (.put wb (mem/->on-heap k) (mem/->on-heap v)))
+        (.put wb (mem/direct-byte-buffer k) (mem/direct-byte-buffer v)))
       (.write db write-options wb)))
 
   (delete [{:keys [^RocksDB db ^WriteOptions write-options]} ks]
     (with-open [wb (WriteBatch.)]
       (doseq [k ks]
-        (.delete wb (mem/->on-heap k)))
+        (.remove wb (mem/direct-byte-buffer k)))
       (.write db write-options wb)))
 
   (compact [{:keys [^RocksDB db]}]

--- a/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
@@ -57,16 +57,6 @@
                                  ^{jnr.ffi.annotations.Out true :tag "[Ljava.lang.String;"} errptr])
   (^void rocksdb_close [^jnr.ffi.Pointer db])
 
-  (^jnr.ffi.Pointer rocksdb_get_pinned [^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} db
-                                        ^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} options
-                                        ^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} key
-                                        ^{jnr.ffi.types.size_t true  :tag long} keylen
-                                        ^{jnr.ffi.annotations.Out true :tag "[Ljava.lang.String;"} errptr])
-  (^jnr.ffi.Pointer rocksdb_pinnableslice_value [^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} v
-                                                 ^{jnr.ffi.annotations.Out true :tag jnr.ffi.Pointer} vlen])
-  (^void rocksdb_pinnableslice_destroy [^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} v])
-
-
   (^jnr.ffi.Pointer rocksdb_checkpoint_object_create [^jnr.ffi.Pointer db
                                                       ^"[Ljava.lang.String;" errptr])
   (^void rocksdb_checkpoint_create [^{jnr.ffi.annotations.In true :tag jnr.ffi.Pointer} checkpoint
@@ -174,7 +164,7 @@
   (close [this]
     (.rocksdb_iter_destroy rocksdb i)))
 
-(defrecord RocksJNRKvSnapshot [^Pointer db ^Pointer read-options ^Pointer snapshot pinned]
+(defrecord RocksJNRKvSnapshot [^Pointer db ^Pointer read-options ^Pointer snapshot len-out]
   kv/KvSnapshot
   (new-iterator [this]
     (->RocksJNRKvIterator (.rocksdb_create_iterator rocksdb db read-options)
@@ -184,22 +174,13 @@
   (get-value [this k]
     (let [k (mem/->off-heap k)
           errptr-out (make-array String 1)
-          p (.rocksdb_get_pinned rocksdb db read-options (buffer->pointer k) (.capacity k) errptr-out)]
-      (try
-        (check-error errptr-out)
-        (catch Throwable t
-          (some->> p (.rocksdb_pinnableslice_destroy rocksdb))
-          (throw t)))
-      (when p
-        (swap! pinned conj p)
-        (let [len-out (Memory/allocateTemporary rt NativeType/ULONG)]
-          (-> (.rocksdb_pinnableslice_value rocksdb p len-out)
-              (pointer+len->buffer len-out))))))
+          v (.rocksdb_get rocksdb db read-options (buffer->pointer k) (.capacity k) len-out errptr-out)]
+      (check-error errptr-out)
+      (when v
+        (pointer+len->buffer v len-out))))
 
   Closeable
   (close [_]
-    (doseq [p @pinned]
-      (.rocksdb_pinnableslice_destroy rocksdb p))
     (.rocksdb_readoptions_destroy rocksdb read-options)
     (.rocksdb_release_snapshot rocksdb db snapshot)))
 
@@ -215,7 +196,7 @@
       (->RocksJNRKvSnapshot db
                             read-options
                             snapshot
-                            (atom []))))
+                            (Memory/allocateTemporary rt NativeType/ULONG))))
 
   (store [{:keys [^Pointer db ^Pointer write-options]} kvs]
     (let [wb (.rocksdb_writebatch_create rocksdb)


### PR DESCRIPTION
Now that we've disabled pinning, let's try revert "Revert RocksDB version bump, #851"

Has run fine against bench, will run it against the stress test and then merge.

This reverts commit 253382ecedf6b8302c187d494fc168569a7116d6.