### PR TITLE
Value ids

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -13,7 +13,7 @@
            java.time.Duration
            [java.util.function Supplier Consumer]))
 
-(s/def :crux.db/id (s/and (complement string?) c/valid-id?))
+(s/def :crux.db/id c/valid-id?)
 (s/def :crux.db/evicted? boolean?)
 (s/def :crux.db.fn/args (s/coll-of any? :kind vector?))
 

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -399,10 +399,6 @@
     (id-function to (binding [*sort-unordered-colls* true]
                       (nippy/fast-freeze this))))
 
-  Collection
-  (id->buffer [this to]
-    (throw (IllegalArgumentException. "Collections cannot be ids.")))
-
   Object
   (id->buffer [this to]
     (id-function to (nippy/fast-freeze this)))
@@ -546,7 +542,8 @@
 
 (defn valid-id? [x]
   (try
-    (= id-size (.capacity (->id-buffer x)))
+    (and (not (instance? Collection x))
+         (= id-size (.capacity (->id-buffer x))))
     (catch IllegalArgumentException _
       false)))
 

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -511,6 +511,10 @@
     (catch IllegalArgumentException _
       false)))
 
+(defn id-buffer? [^DirectBuffer buffer]
+  (and (= id-size (.capacity buffer))
+       (= id-value-type-id (.getByte buffer 0))))
+
 (nippy/extend-freeze
  Id
  :crux.codec/id

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -394,6 +394,11 @@
         (id->buffer id to)
         (id-function to (nippy/fast-freeze this)))))
 
+  Collection
+  (id->buffer [this to]
+    (id-function to (binding [*sort-unordered-colls* true]
+                      (nippy/fast-freeze this))))
+
   Map
   (id->buffer [this to]
     (id-function to (binding [*sort-unordered-colls* true]

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -325,19 +325,19 @@
 
   Keyword
   (id->buffer [this to]
-    (id-function to (.getBytes (subs (str this) 1))))
+    (id-function to (.getBytes (subs (str this) 1) StandardCharsets/UTF_8)))
 
   UUID
   (id->buffer [this to]
-    (id-function to (.getBytes (str this))))
+    (id-function to (.getBytes (str this) StandardCharsets/UTF_8)))
 
   URI
   (id->buffer [this to]
-    (id-function to (.getBytes (str (.normalize this)))))
+    (id-function to (.getBytes (str (.normalize this)) StandardCharsets/UTF_8)))
 
   URL
   (id->buffer [this to]
-    (id-function to (.getBytes (.toExternalForm this))))
+    (id-function to (.getBytes (.toExternalForm this) StandardCharsets/UTF_8)))
 
   String
   (id->buffer [this to]
@@ -351,9 +351,9 @@
                       (maybe-url-str this)
                       (maybe-map-str this))]
         (id->buffer id to)
-        (id-function to (nippy/fast-freeze this)))))
+        (id-function to (.getBytes this StandardCharsets/UTF_8)))))
 
-  Collection
+  Set
   (id->buffer [this to]
     (id-function to (binding [*sort-unordered-colls* true]
                       (nippy/fast-freeze this))))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -21,7 +21,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def ^:const index-version 8)
+(def ^:const index-version 9)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)
@@ -501,8 +501,6 @@
  :crux.codec/edn-id
  [data-input]
  (id-edn-reader (nippy/thaw-from-in! data-input)))
-
-(declare multiple-values?)
 
 (defn valid-id? [x]
   (try

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -386,7 +386,23 @@
                       (maybe-url-str this)
                       (maybe-map-str this))]
         (id->buffer id to)
-        (throw (IllegalArgumentException. (format "Not a %s hex, keyword, EDN map, URL or an UUID string: %s" hash/id-hash-algorithm this))))))
+        (id-function to (nippy/fast-freeze this)))))
+
+  Number
+  (id->buffer [this to]
+    (id-function to (nippy/fast-freeze this)))
+
+  Character
+  (id->buffer [this to]
+    (id-function to (nippy/fast-freeze this)))
+
+  Date
+  (id->buffer [this to]
+    (id-function to (nippy/fast-freeze this)))
+
+  Boolean
+  (id->buffer [this to]
+    (id-function to (nippy/fast-freeze this)))
 
   Map
   (id->buffer [this to]

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -79,8 +79,6 @@
 (def ^:private double-value-type-id 2)
 (def ^:private date-value-type-id 3)
 (def ^:private string-value-type-id 4)
-(def ^:private bytes-value-type-id 5)
-(def ^:private object-value-type-id 6)
 (def ^:private boolean-value-type-id 7)
 (def ^:private char-value-type-id 8)
 
@@ -202,8 +200,7 @@
   String
   (value->buffer [this ^MutableDirectBuffer to]
     (if (< max-string-index-length (count this))
-      (doto (id-function to (nippy/fast-freeze this))
-        (.putByte 0 (byte object-value-type-id)))
+      (id->buffer this to)
       (let [terminate-mark (byte 1)
             terminate-mark-size Byte/BYTES
             offset (byte 2)
@@ -218,51 +215,13 @@
               (.putByte to (inc idx) (byte (+ offset b)))
               (recur (inc idx))))))))
 
-  nil
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  Keyword
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  UUID
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  URI
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  URL
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  Map
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  DirectBuffer
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  ByteBuffer
-  (value->buffer [this to]
-    (id->buffer this to))
-
-  Collection
-  (value->buffer [this to]
-    (doto (id-function to (binding [*sort-unordered-colls* true]
-                            (nippy/fast-freeze this)))
-      (.putByte 0 (byte object-value-type-id))))
-
   Object
   (value->buffer [this ^MutableDirectBuffer to]
-    (if (satisfies? IdToBuffer this)
-      (id->buffer this to)
-      (doto (id-function to (binding [*sort-unordered-colls* true]
-                              (nippy/fast-freeze this)))
-        (.putByte 0 (byte object-value-type-id))))))
+    (id->buffer this to))
+
+  nil
+  (value->buffer [this to]
+    (id->buffer this to)))
 
 (defn ->value-buffer ^org.agrona.DirectBuffer [x]
   (value->buffer x (ExpandableDirectByteBuffer. 32)))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -357,7 +357,7 @@
                       (maybe-url-str this)
                       (maybe-map-str this))]
         (id->buffer id to)
-        (id-function to (.getBytes this StandardCharsets/UTF_8)))))
+        (id-function to (nippy/fast-freeze this)))))
 
   Boolean
   (id->buffer [this to]

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -680,7 +680,7 @@
                                               ecav-i (kv/new-iterator snapshot)
                                               av-i (kv/new-iterator snapshot)]
                                     (->> (for [eid eids
-                                               :let [eid-value-buffer (c/->value-buffer index-store eid)]
+                                               :let [eid-value-buffer (c/->value-buffer eid)]
                                                ecav-key (all-keys-in-prefix ecav-i
                                                                             (encode-ecav-key-to nil eid-value-buffer))]
                                            [eid eid-value-buffer ecav-key])

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -688,7 +688,6 @@
                                          (reduce (fn [acc [eid ^DirectBuffer eid-value-buffer ecav-key]]
                                                    (let [quad ^Quad (decode-ecav-key-from ecav-key (.capacity eid-value-buffer))
                                                          attr-buffer (c/->id-buffer (.attr quad))
-                                                         eid-buffer (value-buffer->id-buffer index-store (.eid quad))
                                                          value-buffer (.value quad)
                                                          shared-av? (> (->> (all-keys-in-prefix av-i (encode-ave-key-to nil
                                                                                                                         attr-buffer

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -710,9 +710,10 @@
                                     (let [av-i @(:level-1-iterator-delay index-store)
                                           ecav-i @(:level-2-iterator-delay index-store)]
                                       (->> (for [eid eids
-                                                 :let [eid-value-buffer (c/->value-buffer eid)]
+                                                 :let [eid-value-buffer (db/encode-value index-store eid)]
                                                  ecav-key (all-keys-in-prefix ecav-i
-                                                                              (encode-ecav-key-to nil (c/->id-buffer eid)))]
+                                                                              (encode-ecav-key-to nil
+                                                                                                  (c/->id-buffer eid)))]
                                              [eid-value-buffer ecav-key])
 
                                            (reduce (fn [acc [eid-value-buffer ecav-key]]
@@ -728,7 +729,8 @@
                                                                               count)
                                                                          1)]
                                                        (cond-> acc
-                                                         true (update :tombstones assoc (.content-hash quad) {:crux.db/id (.eid quad), :crux.db/evicted? true})
+                                                         true (update :tombstones assoc (.content-hash quad) {:crux.db/id (.eid quad)
+                                                                                                              :crux.db/evicted? true})
                                                          true (update :ks conj
                                                                       (encode-ave-key-to nil
                                                                                          attr-buffer

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -661,11 +661,12 @@
     (let [crux-db-id (c/->id-buffer :crux.db/id)
           docs (with-open [snapshot (kv/new-snapshot kv-store)]
                  (->> docs
-                      (into {} (remove (fn [[_ doc]]
-                                         (let [eid-value (c/->value-buffer (:crux.db/id doc))]
+                      (into {} (remove (fn [[k doc]]
+                                         (let [eid-value (c/->value-buffer (:crux.db/id doc))
+                                               content-hash (c/->id-buffer k)]
                                            (kv/get-value snapshot (encode-ecav-key-to (.get seek-buffer-tl)
                                                                                       eid-value
-                                                                                      (c/->id-buffer doc)
+                                                                                      content-hash
                                                                                       crux-db-id
                                                                                       eid-value))))))
                       not-empty))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1136,8 +1136,7 @@
 
 (defn- build-full-results [{:keys [entity-resolver-fn index-store], {:keys [document-store]} :query-engine, :as db} bound-result-tuple]
   (vec (for [value bound-result-tuple]
-         (if-let [content-hash (and (c/valid-id? value)
-                                    (c/new-id (entity-resolver-fn (db/encode-value index-store value))))]
+         (if-let [content-hash (some-> (entity-resolver-fn (c/->id-buffer value)) (c/new-id))]
            (-> (db/fetch-docs document-store #{content-hash})
                (get content-hash))
            value))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1256,8 +1256,8 @@
                     (build-full-results db bound-result-tuple)
                     (vec bound-result-tuple)))
 
-         true (dedupe)
          order-by (cio/external-sort (order-by-comparator find order-by))
+         true (dedupe)
          offset (drop offset)
          limit (take limit))))))
 

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -4,7 +4,7 @@
   (:import (java.util UUID)))
 
 (defn- check-eid [eid op]
-  (when-not (and eid (c/valid-id? eid) (not (string? eid)))
+  (when-not (and eid (c/valid-id? eid))
     (throw (ex-info "invalid entity id" {:eid eid, :op op}))))
 
 (defn- check-doc [doc op]

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -4,12 +4,12 @@
   (:import (java.util UUID)))
 
 (defn- check-eid [eid op]
-  (when-not (and eid (c/valid-id? eid))
+  (when-not (and (some? eid) (c/valid-id? eid))
     (throw (ex-info "invalid entity id" {:eid eid, :op op}))))
 
 (defn- check-doc [doc op]
   (when-not (and (map? doc)
-                 (every? keyword (keys doc)))
+                 (every? keyword? (keys doc)))
     (throw (ex-info "invalid doc" {:op op, :doc doc})))
 
   (check-eid (:crux.db/id doc) op))

--- a/crux-core/src/crux/tx/event.clj
+++ b/crux-core/src/crux/tx/event.clj
@@ -4,7 +4,7 @@
   (:import java.util.Date))
 
 (def ^:private date? (partial instance? Date))
-(def ^:private id? (partial satisfies? c/IdToBuffer))
+(def ^:private id? c/valid-id?)
 
 (defmulti tx-event first)
 

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -81,5 +81,5 @@
                       (= v (c/decode-value-buffer buffer)))
                     (and (string? v)
                          (> (count v) @#'c/max-string-index-length)
-                         (= @#'c/object-value-type-id
+                         (= @#'c/id-value-type-id
                             (.getByte (c/value-buffer-type-id buffer) 0)))))))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -81,5 +81,5 @@
                       (= v (c/decode-value-buffer buffer)))
                     (and (string? v)
                          (> (count v) @#'c/max-string-index-length)
-                         (= @#'c/id-value-type-id
+                         (= @#'c/clob-value-type-id
                             (.getByte (c/value-buffer-type-id buffer) 0)))))))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -7,7 +7,8 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop])
   (:import crux.codec.Id
-           java.util.Date))
+           java.util.Date
+           java.net.URL))
 
 (t/use-fixtures :each fix/with-silent-test-check)
 
@@ -42,7 +43,7 @@
 
 (t/deftest test-id-reader
   (t/testing "can read and convert to real id"
-    (t/is (= (c/new-id "http://google.com") #crux/id "http://google.com"))
+    (t/is (not= (c/new-id "http://google.com") #crux/id "http://google.com"))
     (t/is (= "234988566c9a0a9cf952cec82b143bf9c207ac16"
              (str #crux/id "http://google.com")))
     (t/is (instance? Id (c/new-id #crux/id "http://google.com"))))
@@ -51,20 +52,24 @@
     (t/is (= (c/new-id :foo) #crux/id ":foo"))
     (t/is (= (c/new-id #uuid "37c20bcd-eb5e-4ef7-b5dc-69fed7d87f28")
              #crux/id "37c20bcd-eb5e-4ef7-b5dc-69fed7d87f28"))
-    (t/is (= (c/new-id "234988566c9a0a9cf952cec82b143bf9c207ac16")
-             #crux/id "234988566c9a0a9cf952cec82b143bf9c207ac16")))
+    (t/is (not= #crux/id "234988566c9a0a9cf952cec82b143bf9c207ac16"
+                (c/new-id "234988566c9a0a9cf952cec82b143bf9c207ac16")))
+    (t/is (not= (c/new-id "234988566c9a0a9cf952cec82b143bf9c207ac16")
+                #crux/id "234988566c9a0a9cf952cec82b143bf9c207ac16")))
 
   (t/testing "can embed id in other forms"
-    (t/is (= {:find ['e]
-              :where [['e (c/new-id "http://xmlns.com/foaf/0.1/firstName") "Pablo"]]}
-             '{:find [e]
-               :where [[e #crux/id "http://xmlns.com/foaf/0.1/firstName" "Pablo"]]})))
+    (t/is (not= {:find ['e]
+                 :where [['e (c/new-id "http://xmlns.com/foaf/0.1/firstName") "Pablo"]]}
+                '{:find [e]
+                  :where [[e #crux/id "http://xmlns.com/foaf/0.1/firstName" "Pablo"]]})))
 
-  (t/testing "string form of URL and keyword are same id"
+  (t/testing "URL and keyword are same id"
     (t/is (= (c/new-id :http://xmlns.com/foaf/0.1/firstName)
              #crux/id "http://xmlns.com/foaf/0.1/firstName"))
-    (t/is (= (c/new-id "http://xmlns.com/foaf/0.1/firstName")
-             #crux/id ":http://xmlns.com/foaf/0.1/firstName"))))
+    (t/is (= (c/new-id (URL. "http://xmlns.com/foaf/0.1/firstName"))
+             #crux/id ":http://xmlns.com/foaf/0.1/firstName"))
+    (t/is (not= (c/new-id "http://xmlns.com/foaf/0.1/firstName")
+                #crux/id ":http://xmlns.com/foaf/0.1/firstName"))))
 
 (tcct/defspec test-generative-primitive-value-decoder 1000
   (prop/for-all [v (gen/one-of [(gen/return nil)

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -105,7 +105,7 @@
                                            (map str ids))
                                   {:builder-fn jdbcr/as-unqualified-lower-maps})]
            row)
-         (map (juxt (comp c/new-id :event_key) #(->v dbtype (:v %))))
+         (map (juxt (comp c/new-id c/hex->id-buffer :event_key) #(->v dbtype (:v %))))
          (into {}))))
 
 (defrecord JdbcTxLog [ds dbtype]

--- a/crux-kafka-connect/src/crux/kafka/connect.clj
+++ b/crux-kafka-connect/src/crux/kafka/connect.clj
@@ -82,7 +82,7 @@
 
 (defn- coerce-eid [id]
   (cond
-    (and id (c/valid-id? id))
+    (and (some? id) (c/valid-id? id))
     (c/id-edn-reader id)
 
     (string? id)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -90,7 +90,7 @@
     (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 8}
+  (t/is (= (merge {:crux.index/index-version 9}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -40,7 +40,7 @@
                                                      fix/with-kv-dir
                                                      fix/with-node])
                                    (with-meta {::embedded-kafka? true}))}
-      #_(select-keys [:local-standalone])
+      (select-keys [:local-standalone])
       #_(select-keys [:local-standalone :remote])
       #_(select-keys [:local-standalone :h2 :sqlite :remote])))
 
@@ -104,7 +104,7 @@
       (t/is (= submitted-tx (api/latest-completed-tx *api*))))))
 
 (t/deftest test-can-use-crux-ids
-  (let [id #crux/id :https://adam.com
+  (let [id #crux/id "https://adam.com"
         doc {:crux.db/id id, :name "Adam"}
         submitted-tx (.submitTx *api* [[:crux.tx/put doc]])]
     (.awaitTx *api* submitted-tx nil)

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2997,11 +2997,11 @@
 
     (t/testing "query with order-by returns distinct results"
       (t/is (= [[30] [25] [20]]
-               (api/q db '{:find [a] :where [[_ :age a]], :order-by [[a :desc]]}))))
+               (api/q db '{:find [a] :where [[e :age a]], :order-by [[a :desc]]}))))
 
-    (t/testing "lazy query returns distinct results"
+    (t/testing "lazy query does not return distinct results"
       (with-open [res (api/open-q db '{:find [a] :where [[_ :age a]]})]
-        (t/is (= [[20] [25] [30]]
+        (t/is (= [[20] [20] [25] [30]]
                  (sort (iterator-seq res))))))))
 
 (t/deftest test-unsorted-args-697

--- a/docs/Confluent-QuickStart.adoc
+++ b/docs/Confluent-QuickStart.adoc
@@ -53,7 +53,7 @@ Now, verify that this was transacted within your REPL:
 ----
 (crux/entity (crux/db node) "415c45c9-7cbe-4660-801b-dab9edc60c84")
 ==>
-{:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c84", :value "baz"}
+{:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c84", :value "baz"}
 ----
 
 == Source Connector
@@ -69,7 +69,7 @@ Within your REPL, transact an element into Crux:
 
 [source,clj]
 ----
-(crux/submit-tx node [[:crux.tx/put {:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"}]])
+(crux/submit-tx node [[:crux.tx/put {:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"}]])
 ----
 
 Check the contents of 'test.sink.txt' using the command below, and you should see that the transactions were outputted to the _'connect-test'_ topic:
@@ -77,5 +77,5 @@ Check the contents of 'test.sink.txt' using the command below, and you should se
 ----
 tail test.sink.txt
 ==>
-[[:crux.tx/put {:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"} #inst "2019-09-19T12:31:21.342-00:00"]]
+[[:crux.tx/put {:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"} #inst "2019-09-19T12:31:21.342-00:00"]]
 ----

--- a/docs/Kafka-QuickStart.adoc
+++ b/docs/Kafka-QuickStart.adoc
@@ -64,7 +64,7 @@ Now, verify that this was transacted within your REPL:
 ----
 (crux/entity (crux/db node) "415c45c9-7cbe-4660-801b-dab9edc60c84")
 ==>
-{:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c84", :value "baz"}
+{:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c84", :value "baz"}
 ----
 
 == Source Connector
@@ -80,7 +80,7 @@ Within your REPL, transact an element into Crux:
 
 [source,clj]
 ----
-(crux/submit-tx node [[:crux.tx/put {:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"}]])
+(crux/submit-tx node [[:crux.tx/put {:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"}]])
 ----
 
 Check the contents of 'test.sink.txt' using the command below, and you should see that the transactions were outputted to the _'connect-test'_ topic:
@@ -88,5 +88,5 @@ Check the contents of 'test.sink.txt' using the command below, and you should se
 ----
 tail test.sink.txt
 ==>
-[[:crux.tx/put {:crux.db/id #crux/id "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"} #inst "2019-09-19T12:31:21.342-00:00"]]
+[[:crux.tx/put {:crux.db/id #uuid "415c45c9-7cbe-4660-801b-dab9edc60c82", :value "baz-source"} #inst "2019-09-19T12:31:21.342-00:00"]]
 ----

--- a/docs/transactions.adoc
+++ b/docs/transactions.adoc
@@ -53,14 +53,14 @@ which enables later deletion of documents.
 The following types of `:crux.db/id` are allowed:
 
 * Keyword (e.g. `{:crux.db/id :my-id}` or `{:crux.db/id :dbpedia.resource/Pablo-Picasso}`)
-* UUID (e.g. `{:crux.db/id #uuid "6f0232d0-f3f9-4020-a75f-17b067f41203"}` or `{:crux.db/id #crux/id "6f0232d0-f3f9-4020-a75f-17b067f41203"}`)
+* String (e.g. `{:crux.db/id "my-id"}`)
+* Integers/Longs (e.g. `{:crux.db/id 42}`)
+* UUID (e.g. `{:crux.db/id #uuid "6f0232d0-f3f9-4020-a75f-17b067f41203"}`)
 * URI (e.g. `{:crux.db/id #crux/id "mailto:crux@juxt.pro"}`)
 * URL (e.g. `{:crux.db/id #crux/id "https://github.com/juxt/crux"}`), including `http`, `https`, `ftp` and `file` protocols
-* Maps (e.g. `{:crux.db/id #crux/id {:this :id-field}}`) (Note: see https://github.com/juxt/crux/issues/362[issue #362]).
+* Maps (e.g. `{:crux.db/id {:this :id-field}}`) (Note: see https://github.com/juxt/crux/issues/362[issue #362]).
 
-The `#crux/id` reader literal will take any string and attempt to coerce it
-into a valid ID. Use of `#crux/id` with a valid ID type will also work
-(e.g. `{:crux.db/id #crux/id :my-id}`).
+The `#crux/id` reader literal will take URI/URL strings and attempt to coerce them into valid IDs.
 
 URIs and URLs are interpreted using Java classes (java.net.URI and java.net.URL respectively) and therefore you can also use these directly.
 


### PR DESCRIPTION
Implementation allows any valid primitive value that can be decoded directly to also be an id. Also separates the id space from the value space totally, so a value is never encoded to an id buffer and vice versa.

The temporal indexes (and the hash cache) uses ids still, so there's a small dance to move between values and ids in the index store. This could be pushed behind the cache, as the entity-as-of methods could deal with this if they get a buffer that's not an id.

Strings are hashed based on their bytes. This means keywords, urls and uuids can hash to the same value as a string with the same representation. Up for discussion.

This PR also contains along-standing tweak to ensure our ids from string values (like keywords etc.) are calculated using UTF-8 and not the default charset (which would likely be UTF-8). This means that there's an unlikely scenario where someone has run their JVMs using a different charset which would now maybe hash differently. If someone has this issue, we have to either offer a replay tool for their log, or back out this behaviour.