### PR TITLE
Ensure that if a tx-fn fails with a compilation error, the tx consumption doesn't stop

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -211,7 +211,6 @@
                                        {:keys [index-store query-engine], :as tx-consumer}]
   (let [fn-id (c/new-id k)
         db (api/db query-engine tx-time)
-        tx-fn (->tx-fn (q/entity db index-store fn-id))
         {args-doc-id :crux.db/id, :crux.db.fn/keys [args tx-events failed?]} args-doc
         args-content-hash (c/new-id args-doc)
 
@@ -228,7 +227,7 @@
 
               :else (try
                       (let [ctx (->TxFnContext query-engine tx)
-                            res (apply tx-fn ctx args)]
+                            res (apply (->tx-fn (q/entity db index-store fn-id)) ctx args)]
                         (if (false? res)
                           {:failed? true}
 


### PR DESCRIPTION
Sorry folks :disappointed: will release 1.9.1.

I moved the `tx-fn` local into the wrong `let` block, outside of the try-catch, and the tests that I thought covered this case didn't.

:raised_hands: 