### PR TITLE
AVs are shared between entities - we shouldn't evict them if another E is still using them

### DIFF
--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -802,3 +802,13 @@
       (t/is (thrown-with-msg? Exception #"Transaction consumer aborted"
                               (deref !fut 1000 ::timeout)))
       (future-cancel !fut))))
+
+(t/deftest test-evict-documents-with-common-attributes
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :count 1}]
+                        [:crux.tx/put {:crux.db/id :bar, :count 1}]])
+
+  (fix/submit+await-tx [[:crux.tx/evict :foo]])
+
+  (t/is (= #{[:bar]}
+           (api/q (api/db *api*) '{:find [?e]
+                                   :where [[?e :count 1]]}))))


### PR DESCRIPTION
Entries in the AV index aren't necessarily unique to one entity - we were including them in evictions without checking whether they were still used.

When we evict, we now count references to see whether another E is still using the AV in question before evicting it.