### PR TITLE
Index version check wasn't failing when upgrading to 1.9.x

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -47,6 +47,7 @@
 (def ^:const failed-tx-id-index-id 7)
 
 ;; to allow crux upgrades. rebuild indexes from kafka on backward incompatible
+;; if you're going to shuffle index numbers around on a version bump, don't move this one.
 (def ^:const index-version-index-id 8)
 
 ;; used in standalone TxLog

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -317,6 +317,12 @@
 
 ;; Index Version
 
+;; TODO keep til index version > 8
+(defn- encode-legacy-index-version-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
+  (let [^MutableDirectBuffer b (or b (mem/allocate-buffer c/index-id-size))]
+    (.putByte b 0 6) ; index-version-index-id pre 1.9.0
+    (mem/limit-buffer b c/index-id-size)))
+
 (defn- encode-index-version-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer c/index-id-size))]
     (.putByte b 0 c/index-version-index-id)
@@ -333,7 +339,8 @@
 
 (defn- current-index-version [kv]
   (with-open [snapshot (kv/new-snapshot kv)]
-    (some->> (kv/get-value snapshot (encode-index-version-key-to (.get seek-buffer-tl)))
+    (some->> (or (kv/get-value snapshot (encode-index-version-key-to (.get seek-buffer-tl)))
+                 (kv/get-value snapshot (encode-legacy-index-version-key-to (.get seek-buffer-tl))))
              (decode-index-version-value-from))))
 
 (defn- check-and-store-index-version [kv]


### PR DESCRIPTION
I added indices before the index-version index, and renumbered the indices (thinking it was ok due to the version bump) - but this means the version check succeeds on upgrade to 1.9.x (due to it not being able to find the previous index number)