### PR TITLE
await-tx no longer polls, #825

### DIFF
--- a/crux-core/src/crux/bus.clj
+++ b/crux-core/src/crux/bus.clj
@@ -1,16 +1,28 @@
 (ns ^:no-doc crux.bus
-  (:refer-clojure :exclude [send])
+  (:refer-clojure :exclude [send await])
   (:require [crux.io :as cio]
             [clojure.tools.logging :as log]
             [clojure.spec.alpha :as s])
   (:import [java.io Closeable]
-           [java.util.concurrent ExecutorService Executors TimeUnit]))
+           [java.util.concurrent ExecutorService Executors TimeUnit]
+           [java.time Duration]))
 
 (defprotocol EventSource
-  (listen ^java.io.Closeable [_ listen-ops f]))
+  (await [bus opts]
+    "opts :: {:crux/event-types, :->result, :timeout, :timeout-value}
+     (->result): if it returns a value, we'll return this immediately, otherwise, we'll listen for the events.
+     (->result event): if it returns a value, we'll yield that value and close the listener.
+
+     Use ->result to (thread-)safely determine whether to await or immediately return - we won't send through any events while this is determining whether to listen or not.")
+
+  (listen ^java.io.Closeable [bus listen-opts f]))
+
+(alter-meta! #'await assoc :arglists '([bus {:keys [crux/event-types ->result ^Duration timeout timeout-value]}]))
+(alter-meta! #'listen assoc :arglists '(^java.io.Closeable
+                                        [bus {:crux/keys [event-types], ::keys [executor]} f]))
 
 (defprotocol EventSink
-  (send [_ event]))
+  (send [bus event]))
 
 (s/def :crux/event-type keyword?)
 
@@ -29,11 +41,38 @@
     (catch Exception e
       (log/error e "error closing listener"))))
 
-(defrecord EventBus [!listeners]
+(defrecord EventBus [!listeners ^ExecutorService await-solo-pool]
   EventSource
-  (listen [this listen-opts f]
-    (let [{:crux/keys [event-types]} listen-opts
-          executor (Executors/newSingleThreadExecutor (cio/thread-factory "bus-listener"))
+  (await [this {:keys [crux/event-types ->result ^Duration timeout timeout-value]}]
+    (if-let [res (->result) ]
+      res ; fast path - don't serialise calls unless we need to
+      (let [!latch (promise)]
+        (with-open [^java.io.Closeable
+                    listener @(.submit await-solo-pool
+                                       ^Callable
+                                       (fn []
+                                         (let [listener (listen this {:crux/event-types event-types
+                                                                      ::executor await-solo-pool}
+                                                                (fn [evt]
+                                                                  (try
+                                                                    (when-let [res (->result evt)]
+                                                                      (deliver !latch {:res res}))
+                                                                    (catch Exception e
+                                                                      (deliver !latch {:error e})))))]
+                                           (try
+                                             (when-let [res (->result)]
+                                               (deliver !latch {:res res}))
+                                             (catch Exception e
+                                               (deliver !latch {:error e})))
+                                           listener)))]
+          (let [{:keys [res error]} (if timeout
+                                      (deref !latch (.toMillis timeout) {:res timeout-value})
+                                      (deref !latch))]
+            (or res (throw error)))))))
+
+  (listen [this {:crux/keys [event-types], ::keys [executor]} f]
+    (let [close-executor? (nil? executor)
+          executor (or executor (Executors/newSingleThreadExecutor (cio/thread-factory "bus-listener")))
           listener {:executor executor
                     :f f
                     :crux/event-types event-types}]
@@ -49,7 +88,8 @@
                                         (-> listeners (update event-type disj listener)))
                                       listeners
                                       event-types)))
-          (close-executor executor)))))
+          (when close-executor?
+            (close-executor executor))))))
 
   EventSink
   (send [_ {:crux/keys [event-type] :as event}]
@@ -60,9 +100,15 @@
 
   Closeable
   (close [_]
+    (close-executor await-solo-pool)
+
     (doseq [{:keys [executor]} (->> @!listeners (mapcat val))]
       (close-executor executor))))
 
+(defn ->bus []
+  (->EventBus (atom {})
+              (Executors/newSingleThreadExecutor (cio/thread-factory "crux-bus-await-thread"))))
+
 (def bus
   {:start-fn (fn [deps args]
-               (->EventBus (atom {})))})
+               (->bus))})

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -119,19 +119,6 @@
     (catch Throwable t
       (log/error t "Could not close:" c))))
 
-(defn wait-while [p ^Duration timeout]
-  (let [timeout-at (some-> timeout .toMillis (+ (System/currentTimeMillis)))]
-    (loop []
-      (when (Thread/interrupted)
-        (throw (InterruptedException.)))
-
-      (if (p)
-        (do (Thread/sleep 100)
-            (if (and timeout-at (>= (System/currentTimeMillis) timeout-at))
-              false
-              (recur)))
-        true))))
-
 (defn load-properties [^Reader in]
   (->> (doto (Properties.)
          (.load in))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -115,6 +115,7 @@
   (awaitTxTime [this tx-time timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
+      (bus/await bus {})
       (-> (tx/await-tx-time indexer tx-ingester tx-time (or timeout (:crux.tx-log/await-tx-timeout options)))
           :crux.tx/tx-time)))
 
@@ -127,7 +128,7 @@
     (case event-type
       :crux/indexed-tx
       (bus/listen bus
-                  (assoc event-opts :crux/event-type ::tx/indexed-tx)
+                  (assoc event-opts :crux/event-types #{::tx/indexed-tx})
                   (fn [{:keys [::tx/submitted-tx ::txe/tx-events] :as ev}]
                     (.accept ^Consumer consumer
                              (merge {:crux/event-type :crux/indexed-tx}

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -21,8 +21,9 @@
   (:import [crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException ICursor]
            java.io.Closeable
            java.util.function.Consumer
-           [java.util.concurrent Executors]
-           java.util.concurrent.locks.StampedLock))
+           [java.util.concurrent Executors TimeoutException]
+           java.util.concurrent.locks.StampedLock
+           java.time.Duration))
 
 (def crux-version
   (when-let [pom-file (io/resource "META-INF/maven/juxt/crux-core/pom.properties")]
@@ -34,6 +35,30 @@
 (defn- ensure-node-open [{:keys [closed?]}]
   (when @closed?
     (throw (IllegalStateException. "Crux node is closed"))))
+
+(defn- await-tx [{:keys [bus] :as node} tx-k tx ^Duration timeout]
+  (let [tx-v (get tx tx-k)
+
+        {:keys [timeout? ingester-error node-closed? tx] :as res}
+        (bus/await bus {:crux/event-types #{::tx/indexed-tx ::tx/ingester-error ::node-closed}
+                        :->result (letfn [(tx->result [tx]
+                                            (when (and tx (not (neg? (compare (get tx tx-k) tx-v))))
+                                              {:tx tx}))]
+                                    (fn
+                                      ([] (tx->result (api/latest-completed-tx node)))
+                                      ([{:keys [crux/event-type] :as ev}]
+                                       (case event-type
+                                         ::tx/indexed-tx (tx->result (::tx/submitted-tx ev))
+                                         ::tx/ingester-error {:ingester-error (::tx/ingester-error ev)}
+                                         ::node-closed {:node-closed? true}))))
+                        :timeout timeout
+                        :timeout-value {:timeout? true}})]
+    (cond
+      ingester-error (throw (Exception. "Transaction ingester aborted." ingester-error))
+      timeout? (throw (TimeoutException. (str "Timed out waiting for: " (pr-str tx)
+                                              ", index has: " (pr-str (api/latest-completed-tx node)))))
+      node-closed? (throw (InterruptedException. "Node closed."))
+      tx tx)))
 
 (defrecord CruxNode [kv-store tx-log document-store indexer tx-ingester bus query-engine
                      options close-fn status-fn closed? ^StampedLock lock]
@@ -113,16 +138,10 @@
           :crux.tx/tx-time)))
 
   (awaitTxTime [this tx-time timeout]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (bus/await bus {})
-      (-> (tx/await-tx-time indexer tx-ingester tx-time (or timeout (:crux.tx-log/await-tx-timeout options)))
-          :crux.tx/tx-time)))
+    (::tx/tx-time (await-tx this ::tx/tx-time {::tx/tx-time tx-time} timeout)))
 
   (awaitTx [this submitted-tx timeout]
-    (cio/with-read-lock lock
-      (ensure-node-open this)
-      (tx/await-tx indexer tx-ingester submitted-tx (or timeout (:crux.tx-log/await-tx-timeout options)))))
+    (await-tx this ::tx/tx-id submitted-tx timeout))
 
   (listen [this {:crux/keys [event-type] :as event-opts} consumer]
     (case event-type
@@ -138,7 +157,9 @@
                                       {:crux/tx-ops (txc/tx-events->tx-ops document-store tx-events)})))))))
 
   (latestCompletedTx [this]
-    (db/latest-completed-tx indexer))
+    (cio/with-read-lock lock
+      (ensure-node-open this)
+      (db/latest-completed-tx indexer)))
 
   (latestSubmittedTx [this]
     (db/latest-submitted-tx tx-log))
@@ -163,8 +184,10 @@
   Closeable
   (close [_]
     (cio/with-write-lock lock
-      (when (and (not @closed?) close-fn) (close-fn))
-      (reset! closed? true))))
+      (when (not @closed?)
+        (when close-fn (close-fn))
+        (bus/send bus {:crux/event-type ::node-closed})
+        (reset! closed? true)))))
 
 (def ^:private node-component
   {:start-fn (fn [{::keys [indexer tx-ingester document-store tx-log kv-store bus query-engine]} node-opts]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -35,6 +35,9 @@
 (defmethod bus/event-spec ::indexing-tx [_] (s/keys :req [::submitted-tx]))
 (defmethod bus/event-spec ::indexed-tx [_] (s/keys :req [::submitted-tx ::txe/tx-events], :req-un [::committed?]))
 
+(s/def ::ingester-error #(instance? Exception %))
+(defmethod bus/event-spec ::ingester-error [_] (s/keys :req [::ingester-error]))
+
 (defn- etx->vt [^EntityTx etx]
   (.vt etx))
 
@@ -326,6 +329,7 @@
       (catch Throwable e
         (reset! !error e)
         (reset! !state :abort-only)
+        (bus/send bus {:crux/event-type ::ingester-error, ::ingester-error e})
         (throw e))))
 
   (commit [this]

--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -9,9 +9,10 @@
     (with-open [bus ^Closeable (topo/start-component bus/bus {} {})]
       (bus/send bus {:crux/event-type :foo, :value 1})
 
-      (with-open [_ (bus/listen bus {:crux/event-type :foo} #(swap! !events conj %))]
+      (with-open [_ (bus/listen bus {:crux/event-types #{:foo :baz}} #(swap! !events conj %))]
         (bus/send bus {:crux/event-type :foo, :value 2})
-        (bus/send bus {:crux/event-type :bar, :value 1}))
+        (bus/send bus {:crux/event-type :bar, :value 1})
+        (bus/send bus {:crux/event-type :baz, :value 3}))
 
       (bus/send bus {:crux/event-type :foo, :value 3})
 
@@ -19,5 +20,6 @@
       ;; - we don't guarantee this if the node is shut down
       (Thread/sleep 100))
 
-    (t/is (= [{:crux/event-type :foo, :value 2}]
+    (t/is (= [{:crux/event-type :foo, :value 2}
+              {:crux/event-type :baz, :value 3}]
              @!events))))

--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -1,8 +1,12 @@
 (ns crux.bus-test
   (:require [crux.bus :as bus]
             [clojure.test :as t]
-            [crux.topology :as topo])
-  (:import (java.io Closeable)))
+            [crux.topology :as topo]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]
+            [crux.api :as crux])
+  (:import (java.io Closeable)
+           (java.time Duration)))
 
 (t/deftest test-bus
   (let [!events (atom [])]
@@ -23,3 +27,59 @@
     (t/is (= [{:crux/event-type :foo, :value 2}
               {:crux/event-type :baz, :value 3}]
              @!events))))
+
+(defmethod bus/event-spec ::foo [_] (s/keys))
+(defmethod bus/event-spec ::bar [_] (s/keys))
+(defmethod bus/event-spec ::baz [_] (s/keys))
+
+(t/deftest test-await
+  (let [bus (bus/->bus)]
+    (t/testing "ready already"
+      (t/is (= ::ready (bus/await bus {:crux/event-types #{::foo}
+                                       :->result (fn [] ::ready)}))))
+
+    (t/testing "times out"
+      (t/is (= ::timeout (bus/await bus {:crux/event-types #{::foo}
+                                         :->result (constantly nil)
+                                         :timeout (Duration/ofMillis 10)
+                                         :timeout-value ::timeout}))))
+
+    (t/testing "eventually works"
+      (future
+        (Thread/sleep 100)
+        (bus/send bus {:crux/event-type ::foo}))
+
+      (t/is (= ::done (bus/await bus {:crux/event-types #{::foo}
+                                      :->result (fn
+                                                  ([] nil)
+                                                  ([ev] ::done))}))))
+
+    (t/testing "times out if it's not quite ready"
+      (let [!latch (promise)]
+        (future
+          (Thread/sleep 100)
+          (bus/send bus {:crux/event-type ::bar}))
+
+        (t/is (= ::timeout (bus/await bus {:crux/event-types #{::bar}
+                                           :->result (fn
+                                                       ([] nil)
+                                                       ([ev] ::done))
+                                           :timeout (Duration/ofMillis 10)
+                                           :timeout-value ::timeout})))))
+
+    (t/testing "throws if ->result throws on the pool"
+      (t/is (thrown-with-msg? Exception #"boom"
+                              (bus/await bus {:crux/event-types #{::baz}
+                                              :->result (let [caller-thread (Thread/currentThread)]
+                                                          (fn []
+                                                            (when (not= caller-thread (Thread/currentThread))
+                                                              (throw (Exception. "boom")))))})))
+      (future
+        (Thread/sleep 100)
+        (bus/send bus {:crux/event-type ::baz}))
+
+      (t/is (thrown-with-msg? Exception #"boom"
+                              (bus/await bus {:crux/event-types #{::baz}
+                                              :->result (fn
+                                                          ([] nil)
+                                                          ([evt] (throw (Exception. "boom"))))}))))))

--- a/crux-metrics/src/crux/metrics/indexer.clj
+++ b/crux-metrics/src/crux/metrics/indexer.clj
@@ -15,7 +15,7 @@
 (defn assign-tx-latency-gauge [registry {:crux.node/keys [bus]}]
   (let [!last-tx-lag (atom 0)]
     (bus/listen bus
-                {:crux/event-type :crux.tx/indexed-tx}
+                {:crux/event-types #{:crux.tx/indexed-tx}}
                 (fn [{::tx/keys [submitted-tx]}]
                   (reset! !last-tx-lag (- (System/currentTimeMillis)
                                           (.getTime ^Date (::tx/tx-time submitted-tx))))))
@@ -27,7 +27,7 @@
 (defn assign-doc-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-docs"])]
     (bus/listen bus
-                {:crux/event-type :crux.tx/indexed-docs}
+                {:crux/event-types #{:crux.tx/indexed-docs}}
                 (fn [{:keys [doc-ids]}]
                   (dropwizard/mark! meter (count doc-ids))))
 
@@ -36,7 +36,7 @@
 (defn assign-av-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-avs"])]
     (bus/listen bus
-                {:crux/event-type :crux.tx/indexed-docs}
+                {:crux/event-types #{:crux.tx/indexed-docs}}
                 (fn [{:keys [av-count]}]
                   (dropwizard/mark! meter av-count)))
     meter))
@@ -44,7 +44,7 @@
 (defn assign-bytes-meter [registry {:crux.node/keys [bus]}]
   (let [meter (dropwizard/meter registry ["indexer" "indexed-bytes"])]
     (bus/listen bus
-                {:crux/event-types :crux.tx/indexed-docs}
+                {:crux/event-types #{:crux.tx/indexed-docs}}
                 (fn [{:keys [bytes-indexed]}]
                   (dropwizard/mark! meter bytes-indexed)))
 
@@ -54,12 +54,12 @@
   (let [timer (dropwizard/timer registry ["indexer" "indexed-txs"])
         !timer (atom nil)]
     (bus/listen bus
-                {:crux/event-type :crux.tx/indexing-tx}
+                {:crux/event-types #{:crux.tx/indexing-tx}}
                 (fn [_]
                   (reset! !timer (dropwizard/start timer))))
 
     (bus/listen bus
-                {:crux/event-type :crux.tx/indexed-tx}
+                {:crux/event-types #{:crux.tx/indexed-tx}}
                 (fn [_]
                   (let [[ctx _] (reset-vals! !timer nil)]
                     (dropwizard/stop ctx))))

--- a/crux-metrics/src/crux/metrics/query.clj
+++ b/crux-metrics/src/crux/metrics/query.clj
@@ -6,11 +6,11 @@
   [registry {:crux.node/keys [bus]}]
   (let [!timer-store (atom {})
         query-timer (dropwizard/timer registry ["query" "timer"])]
-    (bus/listen bus {:crux/event-type :crux.query/submitted-query}
+    (bus/listen bus {:crux/event-types #{:crux.query/submitted-query}}
               (fn [event]
                 (swap! !timer-store assoc (:crux.query/query-id event) (dropwizard/start query-timer))))
 
-    (bus/listen bus {:crux/event-type :crux.query/completed-query}
+    (bus/listen bus {:crux/event-types #{:crux.query/completed-query}}
               (fn [event]
                 (dropwizard/stop (get @!timer-store (:crux.query/query-id event)))
                 (swap! !timer-store dissoc (:crux.query/query-id event))))

--- a/crux-test/test/crux/compaction_test.clj
+++ b/crux-test/test/crux/compaction_test.clj
@@ -25,11 +25,9 @@
   (let [opts {:crux.node/topology 'crux.jdbc/topology
               :crux.jdbc/dbtype "h2"
               :crux.jdbc/dbname *db-name*}
-        api (Crux/startNode opts)
-        tx (api/submit-tx api [[:crux.tx/put {:crux.db/id :foo}]])]
-    (api/await-tx api tx)
-    (f/transact! api [{:crux.db/id :foo}])
-    (.close api)
+        tx (with-open [api (Crux/startNode opts)]
+             (api/submit-tx api [[:crux.tx/put {:crux.db/id :foo}]])
+             (api/submit-tx api [[:crux.tx/put {:crux.db/id :foo}]]))]
 
     (with-open [api2 (Crux/startNode opts)]
       (api/await-tx api2 tx nil)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -799,13 +799,12 @@
   (let [!events (atom [])
         !latch (promise)
         bus (get-in (meta *api*) [::n/topology ::n/bus])]
-    (doseq [event-type #{::tx/indexing-docs ::tx/indexed-docs
-                         ::tx/indexing-tx ::tx/indexed-tx}]
-      (bus/listen bus {:crux/event-type event-type}
-                  (fn [evt]
-                    (swap! !events conj evt)
-                    (when (= ::tx/indexed-tx (:crux/event-type evt))
-                      (deliver !latch @!events)))))
+    (bus/listen bus {:crux/event-types #{::tx/indexing-docs ::tx/indexed-docs
+                                         ::tx/indexing-tx ::tx/indexed-tx}}
+                (fn [evt]
+                  (swap! !events conj evt)
+                  (when (= ::tx/indexed-tx (:crux/event-type evt))
+                    (deliver !latch @!events))))
 
     (let [doc-1 {:crux.db/id :foo, :value 1}
           doc-2 {:crux.db/id :bar, :value 2}

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -830,12 +830,6 @@
                (-> (vec @!events)
                    (update 2 dissoc :bytes-indexed)))))))
 
-(t/deftest test-wait-while
-  (let [twice-no (let [!atom (atom 3)]
-                   #(pos? (swap! !atom dec)))]
-    (t/is (false? (cio/wait-while twice-no (Duration/ofMillis 100))))
-    (t/is (true? (cio/wait-while twice-no (Duration/ofMillis 400))))
-    (t/is (true? (cio/wait-while twice-no nil)))))
 
 (t/deftest await-fails-quickly-738
   (with-redefs [tx/index-tx-event (fn [_ _ _] (throw (ex-info "test error for await-fails-quickly-738" {})))]


### PR DESCRIPTION
Resolves #825 - see that issue for rationale.
Based on #969, will merge that first (first four commits of this branch are from there). Latter three commits are all self-contained.

* Adds `await` to the internal bus so that we can block on the calling thread, waiting for a message of a certain shape.
* Adds `::tx/ingester-error` and `::node/node-closed` events to the bus s.t. `await-tx` can throw if either happen