### PR TITLE
Supporting non-polling transaction consumers

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -47,8 +47,14 @@
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
 
-(defprotocol TxConsumer
-  (consumer-error [this]))
+(defprotocol TxIngester
+  (begin-tx [tx-ingester tx])
+  (ingester-error [tx-ingester]))
+
+(defprotocol InFlightTx
+  (index-tx-events [in-flight-tx tx-events])
+  (commit [in-flight-tx])
+  (abort [in-flight-tx]))
 
 (defprotocol DocumentStore
   (submit-docs [this id-and-docs])

--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -449,7 +449,8 @@
 (defn- advance-iterator-to-hash-cache-value [i value-buffer]
   (let [hash-cache-prefix-key (encode-hash-cache-key-to (.get seek-buffer-tl) value-buffer)
         found-k (kv/seek i hash-cache-prefix-key)]
-    (mem/buffers=? found-k hash-cache-prefix-key (.capacity hash-cache-prefix-key))))
+    (and found-k
+         (mem/buffers=? found-k hash-cache-prefix-key (.capacity hash-cache-prefix-key)))))
 
 (defn- value-buffer->id-buffer [index-store ^DirectBuffer value-buffer]
   (c/->id-buffer (db/decode-value index-store value-buffer)))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -35,7 +35,7 @@
   (when @closed?
     (throw (IllegalStateException. "Crux node is closed"))))
 
-(defrecord CruxNode [kv-store tx-log document-store indexer tx-consumer bus query-engine
+(defrecord CruxNode [kv-store tx-log document-store indexer tx-ingester bus query-engine
                      options close-fn status-fn closed? ^StampedLock lock]
   ICruxAPI
   (db [this] (.db this nil nil))
@@ -115,13 +115,13 @@
   (awaitTxTime [this tx-time timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (-> (tx/await-tx-time indexer tx-consumer tx-time (or timeout (:crux.tx-log/await-tx-timeout options)))
+      (-> (tx/await-tx-time indexer tx-ingester tx-time (or timeout (:crux.tx-log/await-tx-timeout options)))
           :crux.tx/tx-time)))
 
   (awaitTx [this submitted-tx timeout]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (tx/await-tx indexer tx-consumer submitted-tx (or timeout (:crux.tx-log/await-tx-timeout options)))))
+      (tx/await-tx indexer tx-ingester submitted-tx (or timeout (:crux.tx-log/await-tx-timeout options)))))
 
   (listen [this {:crux/keys [event-type] :as event-opts} consumer]
     (case event-type
@@ -166,18 +166,18 @@
       (reset! closed? true))))
 
 (def ^:private node-component
-  {:start-fn (fn [{::keys [indexer tx-consumer document-store tx-log kv-store bus query-engine]} node-opts]
+  {:start-fn (fn [{::keys [indexer tx-ingester document-store tx-log kv-store bus query-engine]} node-opts]
                (map->CruxNode {:options node-opts
                                :kv-store kv-store
                                :tx-log tx-log
                                :indexer indexer
-                               :tx-consumer tx-consumer
+                               :tx-ingester tx-ingester
                                :document-store document-store
                                :bus bus
                                :query-engine query-engine
                                :closed? (atom false)
                                :lock (StampedLock.)}))
-   :deps #{::indexer ::tx-consumer ::kv-store ::bus ::document-store ::tx-log ::query-engine}
+   :deps #{::indexer ::tx-ingester ::kv-store ::bus ::document-store ::tx-log ::query-engine}
    :args {:crux.tx-log/await-tx-timeout {:doc "Default timeout for awaiting transactions being indexed."
                                          :default nil
                                          :crux.config/type :crux.config/duration}}})
@@ -185,7 +185,8 @@
 (def base-topology
   {::kv-store 'crux.kv.memdb/kv
    ::indexer 'crux.kv-indexer/kv-indexer
-   ::tx-consumer 'crux.tx/tx-consumer
+   ::tx-ingester 'crux.tx/tx-ingester
+   ::tx-consumer 'crux.tx/polling-tx-consumer
    ::bus 'crux.bus/bus
    ::query-engine 'crux.query/query-engine
    ::node 'crux.node/node-component})

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -186,7 +186,6 @@
   {::kv-store 'crux.kv.memdb/kv
    ::indexer 'crux.kv-indexer/kv-indexer
    ::tx-ingester 'crux.tx/tx-ingester
-   ::tx-consumer 'crux.tx/polling-tx-consumer
    ::bus 'crux.bus/bus
    ::query-engine 'crux.query/query-engine
    ::node 'crux.node/node-component})

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -121,7 +121,7 @@
     (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
     (t/is (true? (api/tx-committed? *api* submitted-tx)))
 
-    (t/testing "query"
+    (with-dbs [db (*api*)]
       (t/is (= #{[:ivan]} (api/q (api/db *api*)
                                  '{:find [e]
                                    :where [[e :name "Ivan"]]})))
@@ -129,31 +129,30 @@
                           '{:find [e]
                             :where [[e :name "Ivan"]]})))
 
-      (with-dbs [db (*api*)]
-        (t/testing "query string"
-          (t/is (= #{[:ivan]} (api/q db "{:find [e] :where [[e :name \"Ivan\"]]}"))))
+      (t/testing "query string"
+        (t/is (= #{[:ivan]} (api/q db "{:find [e] :where [[e :name \"Ivan\"]]}"))))
 
-        (t/testing "query vector"
-          (t/is (= #{[:ivan]} (api/q db '[:find e
-                                          :where [e :name "Ivan"]]))))
+      (t/testing "query vector"
+        (t/is (= #{[:ivan]} (api/q db '[:find e
+                                        :where [e :name "Ivan"]]))))
 
-        (t/testing "malformed query"
-          (t/is (thrown-with-msg? Exception
-                                  #"(status 400|Spec assertion failed)"
-                                  (api/q db '{:find [e]}))))
+      (t/testing "malformed query"
+        (t/is (thrown-with-msg? Exception
+                                #"(status 400|Spec assertion failed)"
+                                (api/q db '{:find [e]}))))
 
-        (t/testing "query with streaming result"
-          (with-open [res (api/open-q db '{:find [e]
-                                           :where [[e :name "Ivan"]]})]
-            (t/is (= '([:ivan])
-                     (iterator-seq res)))))
+      (t/testing "query with streaming result"
+        (with-open [res (api/open-q db '{:find [e]
+                                         :where [[e :name "Ivan"]]})]
+          (t/is (= '([:ivan])
+                   (iterator-seq res)))))
 
-        (t/testing "query returning full results"
-          (with-open [res (api/open-q db '{:find [e]
-                                           :where [[e :name "Ivan"]]
-                                           :full-results? true})]
-            (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}])
-                     (iterator-seq res)))))))))
+      (t/testing "query returning full results"
+        (with-open [res (api/open-q db '{:find [e]
+                                         :where [[e :name "Ivan"]]
+                                         :full-results? true})]
+          (t/is (= '([{:crux.db/id :ivan, :name "Ivan"}])
+                   (iterator-seq res))))))))
 
 (t/deftest test-history
   (t/testing "transaction"


### PR DESCRIPTION
Currently, our tx-consumer polls using the tx-log's `open-tx-log` implementation - users can plug in a new tx-log implementation. We have one built-in tx-consumer component in the topology that starts up this polling loop. This has all the usual properties of a polling solution - particularly, that it defaults to polling every 100ms, which (if you're unlucky) provides a lower bound to the end-to-end latency of transactions.

This PR allows users to meaningfully plug in their own tx-consumer.

* We provide a polling implementation that's easy to integrate - see the new JDBC implementation in the PR for how to preserve the current behaviour
* This PR allows users to implement a non-polling tx-consumer, for tx-logs that support it. The new Standalone implementation is an example of this - as soon as the transaction is submitted it can be
* Kafka is somewhere in between - we still need to poll, but because it's now pluggable it means we can reuse the Kafka consumer (rather than having to open up a new Kafka consumer every time `open-tx-log`'s called, because we don't know what the caller's going to do with it).

Indeed, we did have something similar, previously, before we split out the Indexer/IndexStore/DocumentStore protocols - we didn't have any non-polling consumers at the time so it made sense to centralise the polling logic. This PR goes slightly back in the previous direction - keeping the polling logic centralised but allowing it to be overridden.

We do this by breaking up the transaction ingest process. Previously, `index-tx` could be thought of as three stages: begin, index-tx-events, and commit/abort - this PR exposes these three stages to allow the user to consume transactions however they want.

Notably, `with-tx` is now a doddle - we begin the tx, index the events, but don't commit the transaction.