### PR TITLE
Pull syntax

### DIFF
--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -12,7 +12,8 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [com.taoensso/encore "2.114.0"]
                  [org.agrona/agrona "1.0.7"]
-                 [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]]
+                 [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
+                 [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}
              :test {:dependencies [[juxt/crux-test "crux-git-version" :scope "test"]
                                    [org.clojure/test.check "0.10.0"]]}}

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -16,9 +16,10 @@
             [crux.api :as api]
             [crux.tx :as tx]
             [crux.tx.conform :as txc]
-            [crux.kv-indexer :as kvi]
-            [taoensso.nippy :as nippy])
-  (:import [clojure.lang Box ExceptionInfo]
+            [taoensso.nippy :as nippy]
+            [edn-query-language.core :as eql]
+            [clojure.string :as string])
+  (:import [clojure.lang Box ExceptionInfo MapEntry]
            (crux.api ICruxDatasource HistoryOptions HistoryOptions$SortOrder NodeOutOfSyncException)
            crux.codec.EntityTx
            crux.index.IndexStoreIndexState
@@ -117,7 +118,14 @@
                     :rule ::rule
                     :pred ::pred))
 
-(s/def ::find ::args-list)
+(s/def ::find-arg
+  (s/or :logic-var logic-var?
+        :pull (s/spec (s/cat :pull #{'pull}
+                             :logic-var logic-var?
+                             :pull-spec ::eql/query))))
+
+(s/def ::find (s/coll-of ::find-arg :kind vector? :min-count 1))
+
 (s/def ::where (s/coll-of ::term :kind vector? :min-count 1))
 
 (s/def ::arg-tuple (s/map-of (some-fn logic-var? keyword?) any?))
@@ -634,8 +642,8 @@
                                  true)}))]})
        (apply merge-with into {})))
 
-(defn- bound-result-for-var [index-store ^VarBinding var-binding ^List join-keys]
-  (db/decode-value index-store (.get join-keys (.result-index var-binding))))
+(defn- bound-result-for-var [^VarBinding var-binding ^List join-keys]
+  (.get join-keys (.result-index var-binding)))
 
 (defn- validate-existing-vars [var->bindings clause vars]
   (doseq [var vars
@@ -684,7 +692,8 @@
   (fn pred-constraint [index-store db idx-id->idx join-keys]
     (let [[pred-fn & args] (for [arg-binding arg-bindings]
                              (if (instance? VarBinding arg-binding)
-                               (bound-result-for-var index-store arg-binding join-keys)
+                               (->> (bound-result-for-var arg-binding join-keys)
+                                    (db/decode-value index-store))
                                arg-binding))]
       (let [pred-result (apply pred-fn args)]
         (if return
@@ -752,7 +761,8 @@
          (fn or-constraint [index-store db idx-id->idx join-keys]
            (let [args (when (seq bound-vars)
                         [(->> (for [var-binding bound-var-bindings]
-                                (bound-result-for-var index-store var-binding join-keys))
+                                (->> (bound-result-for-var var-binding join-keys)
+                                     (db/decode-value index-store)))
                               (zipmap bound-vars))])
                  branch-results (for [[branch-index {:keys [where
                                                             single-e-var-triple?] :as or-branch}] (map-indexed vector or-branches)
@@ -785,7 +795,8 @@
                                               (if has-free-vars?
                                                 (vec (for [join-keys idx-seq]
                                                        (vec (for [var-binding free-vars-in-join-order-bindings]
-                                                              (bound-result-for-var index-store var-binding join-keys)))))
+                                                              (->> (bound-result-for-var var-binding join-keys)
+                                                                   (db/decode-value index-store))))))
                                                 []))))))))]
              (when (seq (remove nil? branch-results))
                (when has-free-vars?
@@ -814,7 +825,8 @@
              (let [db (assoc db :index-store index-store)
                    args (when (seq not-vars)
                           [(->> (for [var-binding not-var-bindings]
-                                  (bound-result-for-var index-store var-binding join-keys))
+                                  (->> (bound-result-for-var var-binding join-keys)
+                                       (db/decode-value index-store)))
                                 (zipmap not-vars))])
                    {:keys [n-ary-join]} (build-sub-query index-store db not-clause args rule-name->rules stats)]
                (empty? (idx/layered-idx->seq n-ary-join)))))})))
@@ -1197,8 +1209,74 @@
                (get content-hash))
            value))))
 
-(defn- query [{:keys [valid-time transact-time indexer options index-store entity-resolver-fn] :as db}
-              ^ConformedQuery conformed-q]
+
+(defn- pull-child-fns [{:keys [children] :as pull-spec}]
+  (let [{special :special, props :prop, joins :join} (->> (:children pull-spec)
+                                                          (group-by (some-fn :type (constantly :special))))
+        {forward-joins false, reverse-joins true}
+        (group-by (comp #(string/starts-with? % "_") name :dispatch-key) joins)]
+
+    (into [(let [join-child-fns (into {} (map (juxt :dispatch-key pull-child-fns)) forward-joins)]
+             (fn [bound-result {:keys [document-store index-store entity-resolver-fn] :as db}]
+               (let [prop-dispatch-keys (into #{} (map :dispatch-key) props)
+                     special-dispatch-keys (into #{} (map :dispatch-key) special)]
+                 (when-not (and (empty? prop-dispatch-keys)
+                                (empty? special-dispatch-keys)
+                                (empty? join-child-fns))
+                   (let [content-hash (entity-resolver-fn (c/->id-buffer (db/decode-value index-store bound-result)))
+                         doc (-> (db/fetch-docs document-store #{content-hash})
+                                 (get content-hash))]
+                     (into (if (contains? special-dispatch-keys '*)
+                             doc
+                             (select-keys doc prop-dispatch-keys))
+                           (map (fn [[dispatch-key child-fns]]
+                                  (let [v (get doc dispatch-key)]
+                                    (letfn [(pull-value [v]
+                                              (into {}
+                                                    (mapcat (fn [f]
+                                                              (f (db/encode-value index-store v) db)))
+                                                    child-fns))]
+                                      (MapEntry/create dispatch-key (if (or (vector? v) (set? v))
+                                                                      (into (empty v) (map pull-value) v)
+                                                                      (pull-value v)))))))
+                           join-child-fns))))))]
+
+          (for [{:keys [dispatch-key] :as join} reverse-joins]
+            (let [child-fns (pull-child-fns join)
+                  forward-key (keyword (namespace dispatch-key)
+                                       (subs (name dispatch-key) 1))
+                  one? (= :one (get-in join [:params :crux/cardinality]))]
+              (fn [bound-result {:keys [document-store index-store entity-resolver-fn] :as db}]
+                [(MapEntry/create dispatch-key
+                                  (cond->> (for [v (cond->> (db/ave index-store (c/->id-buffer forward-key) bound-result nil entity-resolver-fn)
+                                                     one? (take 1)
+                                                     :always vec)]
+                                             (into {}
+                                                   (mapcat (fn [f]
+                                                             (f v db)))
+                                                   child-fns))
+                                    one? first))]))))))
+
+(defn- compile-pull-spec [pull-spec]
+  (let [root-fns (pull-child-fns (eql/query->ast pull-spec))]
+    (fn [bound-result db]
+      (into {}
+            (mapcat (fn [f]
+                      (f bound-result db)))
+            root-fns))))
+
+(defn- compile-find [conformed-find {:keys [var->bindings]}]
+  (for [[var-type arg] conformed-find]
+    (case var-type
+      :logic-var {:logic-var arg
+                  :var-binding (var->bindings arg)
+                  :->result (fn [bound-result {:keys [index-store]}]
+                              (db/decode-value index-store bound-result))}
+      :pull {:logic-var (:logic-var arg)
+             :var-binding (var->bindings (:logic-var arg))
+             :->result (compile-pull-spec (s/unform ::eql/query (:pull-spec arg)))})))
+
+(defn query [{:keys [valid-time transact-time document-store indexer options index-store] :as db} ^ConformedQuery conformed-q]
   (let [q (.q-normalized conformed-q)
         q-conformed (.q-conformed conformed-q)
         {:keys [find where args rules offset limit order-by full-results?]} q-conformed
@@ -1208,32 +1286,39 @@
                                           (dissoc :args))))
     (validate-args args)
     (let [rule-name->rules (rule-name->rules rules)
-          {:keys [n-ary-join var->bindings]} (build-sub-query index-store db where args rule-name->rules stats)
-          find-var-bindings (map var->bindings find)]
-      (doseq [var find
-              :when (not (contains? var->bindings var))]
-        (throw (IllegalArgumentException. (str "Find refers to unknown variable: " var))))
+          db (assoc db :index-store index-store)
+          entity-resolver-fn (or (:entity-resolver-fn db)
+                                 (new-entity-resolver-fn db))
+          db (assoc db :entity-resolver-fn entity-resolver-fn)
+          {:keys [n-ary-join var->bindings]
+           :as built-query} (build-sub-query index-store db where args rule-name->rules stats)
+          find (compile-find find built-query)
+          find-logic-vars (mapv :logic-var find)]
+      (doseq [{:keys [logic-var var-binding]} find
+              :when (nil? var-binding)]
+        (throw (IllegalArgumentException.
+                (str "Find refers to unknown variable: " logic-var))))
       (doseq [{:keys [var]} order-by
               :when (not (contains? var->bindings var))]
-        (throw (IllegalArgumentException. (str "Order by refers to unknown variable: " var))))
+        (throw (IllegalArgumentException.
+                (str "Order by refers to unknown variable: " var))))
       (doseq [{:keys [var]} order-by
-              :when (not (some #{var} find))]
-        (throw (IllegalArgumentException. (str "Order by requires a var from :find. unreturned var: " var))))
+              :when (not (some #{var} find-logic-vars))]
+        (throw (IllegalArgumentException.
+                (str "Order by requires a var from :find. unreturned var: " var))))
 
-      (cond->> (if full-results?
-                 (for [join-keys (idx/layered-idx->seq n-ary-join)]
-                   (->> find-var-bindings
-                        (mapv #(bound-result-for-var index-store % join-keys))
-                        (build-full-results db)))
-                 (for [join-keys (idx/layered-idx->seq n-ary-join)]
-                   (->> find-var-bindings
-                        (mapv #(bound-result-for-var index-store % join-keys)))))
+      (cond->> (for [join-keys (idx/layered-idx->seq n-ary-join)
+                     :let [bound-result-tuple (for [{:keys [var-binding ->result]} find]
+                                                (->result (bound-result-for-var var-binding join-keys) db))]]
+                 (if full-results?
+                   (build-full-results db bound-result-tuple)
+                   (vec bound-result-tuple)))
 
-        order-by (cio/external-sort (order-by-comparator find order-by))
+        order-by (cio/external-sort (order-by-comparator find-logic-vars order-by))
         offset (drop offset)
         limit (take limit)))))
 
-(defn- entity-tx [{:keys [valid-time transact-time] :as db} index-store eid]
+(defn entity-tx [{:keys [valid-time transact-time] :as db} index-store eid]
   (some-> (db/entity-as-of index-store eid valid-time transact-time)
           (c/entity-tx->edn)))
 

--- a/docs/nav.adoc
+++ b/docs/nav.adoc
@@ -19,6 +19,8 @@ include::{path}/transactions.adoc[leveloffset=+1]
 
 include::{path}/queries.adoc[leveloffset=+1]
 
+include::{path}/pull.adoc[leveloffset=+1]
+
 include::{path}/speculative.adoc[leveloffset=+1]
 
 include::{path}/sql.adoc[leveloffset=+1]

--- a/docs/nav.adoc
+++ b/docs/nav.adoc
@@ -19,6 +19,8 @@ include::{path}/transactions.adoc[leveloffset=+1]
 
 include::{path}/queries.adoc[leveloffset=+1]
 
+include::{path}/speculative.adoc[leveloffset=+1]
+
 include::{path}/sql.adoc[leveloffset=+1]
 
 include::{path}/api.adoc[leveloffset=+1]

--- a/docs/pull.adoc
+++ b/docs/pull.adoc
@@ -1,0 +1,73 @@
+= 'Pull' syntax
+
+Crux queries support a 'pull' syntax, allowing you to decouple specifying which entities you want from what data you'd like about those entities in your queries.
+Crux's support is based on the excellent https://edn-query-language.org/eql/1.0.0/what-is-eql.html[EDN Query Language (EQL)^] library.
+
+To specify what data you'd like about each entity, include a `(pull ?logic-var pull-spec)` entry in the `:find` clause of your query:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [?uid ?name ?profession]
+ :where [[?user :user/id ?uid]
+         [?user :user/name ?name]
+         [?user :user/profession ?profession]}
+;; => [[1 "Ivan" :doctor] [2 "Sergei" :lawyer], [3 "Petr" :doctor]]
+
+;; using `pull`:
+{:find [(pull ?user [:user/name :user/profession]
+ :where [[?user :user/id ?uid]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession :doctor},
+;;     {:user/id 2, :user/name "Sergei", :user/profession :lawyer},
+;;     {:user/id 3, :user/name "Petr", :user/profession :doctor}]
+----
+
+We can navigate to other entities (and hence build up nested results) using 'joins'.
+Joins are specified in `{}` braces in the pull-spec - each one maps one join key to its nested spec:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [?uid ?name ?profession-name]
+ :where [[?user :user/id ?uid]
+         [?user :user/name ?name]
+         [?user :user/profession ?profession]
+         [?profession :profession/name ?profession-name]}
+;; => [[1 "Ivan" "Doctor"] [2 "Sergei" "Lawyer"], [3 "Petr" "Doctor"]]
+
+{:find [(pull ?user [:user/name {:user/profession [:profession/name]}]
+ :where [[?user :user/id ?uid]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession {:profession/name "Doctor"}},
+;;     {:user/id 2, :user/name "Sergei", :user/profession {:profession/name "Lawyer"}}
+;;     {:user/id 3, :user/name "Petr", :user/profession {:profession/name "Doctor"}}]
+----
+
+We can also navigate in the reverse direction, looking for entities that refer to this one, by prepending `_` to the attribute name:
+
+[source,clojure]
+----
+{:find [(pull ?profession [:profession/name {:user/_profession [:user/id :user/name]}]
+ :where [[?profession :profession/name]]}
+
+;; => [{:profession/name "Doctor",
+;;      :user/_profession [{:user/id 1, :user/name "Ivan"},
+;;                         {:user/id 3, :user/name "Petr"}]},
+;;     {:profession/name "Lawyer",
+;;      :user/_profession [{:user/id 2, :user/name "Sergei"}]}]
+----
+
+You can quickly grab the whole document by specifying `*` in the pull spec:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [(pull ?user [*]
+ :where [[?user :user/id 1]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession :doctor, ...}]
+----
+
+For full details on what's supported in the pull-spec, see the https://edn-query-language.org/eql/1.0.0/specification.html[EQL specification^]
+Crux does not (yet) support union queries or recursive queries.

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -411,38 +411,6 @@ block) will result in undefined behaviour.
 include::./src/docs/examples.clj[tags=streaming-query]
 ----
 
-== Speculative transactions
-
-You can submit speculative transactions to Crux, to see what the results of your queries would be if a new transaction were to be applied.
-This is particularly useful for forecasting/projections, but also
-
-You'll receive a new database value, against which you can make queries and entity requests as you would any normal database value.
-Only you will see the effect of these transactions - they're not submitted to the cluster, and they're not visible to any other database value in your application.
-
-We submit these transactions to a database value using `with-tx`:
-
-[source,clojure]
-----
-(let [real-tx (crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
-      _ (crux/await-tx node real-tx)
-      all-names '{:find [?name], :where [[?e :name ?name]]}
-      db (crux/db node)]
-
-  (crux/q db all-names) ; => #{["Ivan"]}
-
-  (let [speculative-db (crux/with-tx db
-                         [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
-    (crux/q speculative-db all-names) ; => #{["Petr"] ["Ivan"]}
-    )
-
-  ;; we haven't impacted the original db value, nor the node
-  (crux/q db all-names) ; => #{["Ivan"]}
-  (crux/q (crux/db node) all-names) ; => #{["Ivan"]}
-  )
-----
-
-The entities submitted by the speculative `:crux.tx/put` take their valid time (if not explicitly specified) from the valid time of the `db` they were forked from.
-
 [#queries_history_api]
 == History API
 

--- a/docs/speculative.adoc
+++ b/docs/speculative.adoc
@@ -1,0 +1,31 @@
+= Speculative transactions
+
+You can submit speculative transactions to Crux, to see what the results of your queries would be if a new transaction were to be applied.
+This is particularly useful for forecasting/projections, but also
+
+You'll receive a new database value, against which you can make queries and entity requests as you would any normal database value.
+Only you will see the effect of these transactions - they're not submitted to the cluster, and they're not visible to any other database value in your application.
+
+We submit these transactions to a database value using `with-tx`:
+
+[source,clojure]
+----
+(let [real-tx (crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
+      _ (crux/await-tx node real-tx)
+      all-names '{:find [?name], :where [[?e :name ?name]]}
+      db (crux/db node)]
+
+  (crux/q db all-names) ; => #{["Ivan"]}
+
+  (let [speculative-db (crux/with-tx db
+                         [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
+    (crux/q speculative-db all-names) ; => #{["Petr"] ["Ivan"]}
+    )
+
+  ;; we haven't impacted the original db value, nor the node
+  (crux/q db all-names) ; => #{["Ivan"]}
+  (crux/q (crux/db node) all-names) ; => #{["Ivan"]}
+  )
+----
+
+The entities submitted by the speculative `:crux.tx/put` take their valid time (if not explicitly specified) from the valid time of the `db` they were forked from.


### PR DESCRIPTION
#849 

Allows users to decouple specifying which entities they want from what data they'd like about those entities in their queries.

We add a `(pull logic-var pull-spec)` option to the `:find` part of queries, see the change to `query_test.clj` or `pull.adoc` in the PR for the syntax and usage.

Implementation notes:
* Like the rest of the query engine, we split the pull engine up into 'conform', 'plan' and 'execute'.
  * 'Conform' is handled by EQL (thanks!) 
  * 'Plan' builds up a tree of functions, each of which accepts the runtime value and the db instance (mainly for doc-store + index-store)
  * 'Execute' then runs those functions.
* The 'plan' part is cached in the same query cache as the rest of the query plan.
* `bound-result-for-var` no longer decodes values - for `pull` we need bytes.

TODO:
* [ ] RFC: we don't yet implement union/recursive queries - do we need to before release?
* [ ] Still makes one request at a time of the document-store - we could batch these for performance (at a cost of some complexity)
* [ ] RFC: do we want an independent `pull` function, taking `eid`