### PR TITLE
docs: remove references to broken links

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -257,7 +257,7 @@ include::./src/docs/examples.clj[tags=ek-close]
 JDBC Nodes use https://github.com/seancorfield/next-jdbc/[`next.jdbc`]
 internally and pass through the relevant configuration options that
 you can find
-https://github.com/seancorfield/next-jdbc/blob/master/doc/all-the-options.md[here].
+https://github.com/seancorfield/next-jdbc/blob/develop/doc/all-the-options.md[here].
 
 image::jdbc-modes.svg?sanitize=true[Local Cluster Mode,width=70%,align="center"]
 

--- a/docs/example/backup-restore/README.md
+++ b/docs/example/backup-restore/README.md
@@ -3,7 +3,3 @@
 Try running `restore.sh` then `backup.sh`.
 Has to be run on a stopped node.
 
-See also
-[standalone-webservice example](https://github.com/juxt/crux/tree/master/example/standalone_webservice),
-for an example of backup with upload to S3.
-

--- a/docs/rest.adoc
+++ b/docs/rest.adoc
@@ -30,8 +30,7 @@ other RDF features are available.
 == Using the HTTP API
 
 The HTTP interface is provided as a Ring middleware in a Clojure namespace,
-located at `crux/crux-http-server/src/crux/http_server.clj`. There is an example of using this
-middleware in a https://github.com/juxt/crux/tree/master/docs/example/standalone_webservice[full example HTTP server configuration].
+located at `crux/crux-http-server/src/crux/http_server.clj`.
 
 Whilst CORS may be easily configured for use while prototyping a Single Page
 Application that uses Crux directly from a web browser, it is currently NOT


### PR DESCRIPTION
## Broken links
- https://github.com/seancorfield/next-jdbc/blob/master/doc/all-the-options.md
- https://github.com/juxt/crux/tree/master/docs/example/standalone_webservice

## Sources of breakages
- branch name changed from `master` to `develop` in seancorfield/next-jdbc
- example `standalone_webservice` was removed in 89671f1adcf0ec3ec01dae16a37729f72c865951