### PR TITLE
We also evict keys from bitemp indices on evict, fixes intermittent test failure

### DIFF
--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -678,6 +678,7 @@
 
   (unindex-eids [this eids]
     (let [{:keys [tombstones ks]} (with-open [snapshot (kv/new-snapshot kv-store)
+                                              bitemp-i (kv/new-iterator snapshot)
                                               ecav-i (kv/new-iterator snapshot)
                                               av-i (kv/new-iterator snapshot)]
                                     (->> (for [eid eids
@@ -715,7 +716,12 @@
                                                        (not (c/can-decode-value-buffer? value-buffer))
                                                        (update :ks conj (encode-hash-cache-key-to nil value-buffer eid-value-buffer)))))
                                                  {:tombstones {}
-                                                  :ks #{}})))]
+                                                  :ks (into #{}
+                                                            (mapcat (fn [eid]
+                                                                      (let [eid-id-buffer (c/->id-buffer eid)]
+                                                                        (into (set (all-keys-in-prefix bitemp-i (encode-entity+vt+tt+tx-id-key-to nil eid-id-buffer)))
+                                                                              (set (all-keys-in-prefix bitemp-i (encode-entity+z+tx-id-key-to nil eid-id-buffer)))))))
+                                                            eids)})))]
 
       (kv/delete kv-store ks)
       {:tombstones tombstones}))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -245,8 +245,8 @@
 
     (with-open [index-store (db/open-index-store (:indexer *api*))]
       (let [picasso-history (db/entity-history index-store picasso-id :desc {})]
-        (t/testing "eviction keeps tx history"
-          (t/is (= 1 (count (map :content-hash picasso-history)))))
+        (t/testing "eviction removes tx history"
+          (t/is (empty? picasso-history)))
         (t/testing "eviction removes docs"
           (t/is (empty? (->> (db/fetch-docs (:document-store *api*) (keep :content-hash picasso-history))
                              vals


### PR DESCRIPTION
Previously, we only evicted keys from the content indices when we evict entities, not the bitemp indices - this was mostly safe:
* in the query engine, we look at the content indices first - evicted entities are removed from here, no problem.
* when returning a document (via entity, or history) we check to see whether the document's a tombstone

With Kafka, though, submitting a doc to the doc-store is asynchronous, so there was a slight delay between the transaction committing and the tombstone making it into the doc-store. This, combined with `entity-tx` still returning ETxs for the evicted entity due to the bitemp index (seems relatively harmless - not much you can do with just a content-hash), means that you could still get hold of the entity for a short while after the transaction's committed. 

Side effect of this PR is that `entity-tx` now returns nil for evicted eids where previously it would return an ETx.

I suspect adding document-store caches to this made it more visible - if the ordering is 'submit-doc', 'fetch-doc', 'index-doc', the cache is invalidated on submit, re-seeded in fetch, and not re-invalidated after the doc's indexed.