### PR TITLE
Accept java.io.File for filepaths

### DIFF
--- a/crux-core/src/crux/config.clj
+++ b/crux-core/src/crux/config.clj
@@ -4,6 +4,7 @@
             [clojure.edn :as edn]
             [clojure.string :as str])
   (:import java.util.Properties
+           (java.io File)
            (java.time Duration)
            (java.util.concurrent TimeUnit)))
 
@@ -12,6 +13,13 @@
          boolean?))
 
 (s/def ::string string?)
+
+(s/def ::file-path
+  (s/and (s/conformer (fn [fp]
+                        (cond
+                          (instance? File fp) (str fp)
+                          (string? fp) fp)))
+         string?))
 
 (s/def ::int
   (s/and (s/conformer (fn [x] (cond (int? x) x, (string? x) (Integer/parseInt x), :else x)))

--- a/crux-core/src/crux/config.clj
+++ b/crux-core/src/crux/config.clj
@@ -5,6 +5,7 @@
             [clojure.string :as str])
   (:import java.util.Properties
            (java.io File)
+           (java.nio.file Path Paths)
            (java.time Duration)
            (java.util.concurrent TimeUnit)))
 
@@ -14,12 +15,13 @@
 
 (s/def ::string string?)
 
-(s/def ::file-path
+(s/def ::path
   (s/and (s/conformer (fn [fp]
                         (cond
-                          (instance? File fp) (str fp)
-                          (string? fp) fp)))
-         string?))
+                          (instance? Path fp) fp
+                          (instance? File fp) (.toPath ^File fp)
+                          (string? fp) (Paths/get fp (make-array String 0)))))
+         #(instance? Path %)))
 
 (s/def ::int
   (s/and (s/conformer (fn [x] (cond (int? x) x, (string? x) (Integer/parseInt x), :else x)))

--- a/crux-core/src/crux/kv.clj
+++ b/crux-core/src/crux/kv.clj
@@ -33,7 +33,7 @@
   {:crux.kv/db-dir
    {:doc "Directory to store K/V files"
     :required? false
-    :crux.config/type :crux.config/string}
+    :crux.config/type :crux.config/file-path}
    :crux.kv/sync?
    {:doc "Sync the KV store to disk after every write."
     :default false

--- a/crux-core/src/crux/kv.clj
+++ b/crux-core/src/crux/kv.clj
@@ -33,7 +33,7 @@
   {:crux.kv/db-dir
    {:doc "Directory to store K/V files"
     :required? false
-    :crux.config/type :crux.config/file-path}
+    :crux.config/type :crux.config/path}
    :crux.kv/sync?
    {:doc "Sync the KV store to disk after every write."
     :default false

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -122,7 +122,7 @@
 
    ::event-log-dir {:doc "The directory to persist the standalone event log to"
                     :required? false
-                    :crux.config/type :crux.config/file-path}
+                    :crux.config/type :crux.config/path}
 
    ::event-log-sync? {:doc "Sync the event-log backed KV store to disk after every write."
                       :default true

--- a/crux-core/src/crux/standalone.clj
+++ b/crux-core/src/crux/standalone.clj
@@ -122,7 +122,7 @@
 
    ::event-log-dir {:doc "The directory to persist the standalone event log to"
                     :required? false
-                    :crux.config/type :crux.config/string}
+                    :crux.config/type :crux.config/file-path}
 
    ::event-log-sync? {:doc "Sync the event-log backed KV store to disk after every write."
                       :default true

--- a/crux-kafka-embedded/src/crux/kafka/embedded.clj
+++ b/crux-kafka-embedded/src/crux/kafka/embedded.clj
@@ -71,9 +71,9 @@
     (stop-kafka-broker kafka)
     (stop-zookeeper zookeeper)))
 
-(s/def ::zookeeper-data-dir string?)
+(s/def ::zookeeper-data-dir :crux.config/file-path)
 (s/def ::zookeeper-port :crux.io/port)
-(s/def ::kafka-log-dir string?)
+(s/def ::kafka-log-dir :crux.config/file-path)
 (s/def ::kafka-port :crux.io/port)
 (s/def ::broker-config (s/map-of string? string?))
 

--- a/crux-lmdb/src/crux/kv/lmdb.clj
+++ b/crux-lmdb/src/crux/kv/lmdb.clj
@@ -12,6 +12,8 @@
            java.util.concurrent.TimeUnit
            [org.agrona DirectBuffer MutableDirectBuffer ExpandableDirectByteBuffer]
            org.agrona.concurrent.UnsafeBuffer
+           (java.nio.file Files Path)
+           java.nio.file.attribute.FileAttribute
            [org.lwjgl.system MemoryStack MemoryUtil]
            [org.lwjgl.util.lmdb LMDB MDBEnvInfo MDBStat MDBVal]))
 
@@ -80,8 +82,9 @@
 
 (defn- env-open [^long env dir ^long flags]
   (success? (LMDB/mdb_env_open env
-                               (.getAbsolutePath (doto (io/file dir)
-                                                   (.mkdirs)))
+                               (-> (Files/createDirectories ^Path dir (make-array FileAttribute 0))
+                                   (.toAbsolutePath)
+                                   (str))
                                flags
                                0664)))
 

--- a/crux-lmdb/src/crux/kv/lmdb/jnr.clj
+++ b/crux-lmdb/src/crux/kv/lmdb/jnr.clj
@@ -7,6 +7,7 @@
             [crux.kv :as kv]
             [crux.memory :as mem])
   (:import java.io.Closeable
+           java.nio.file.Path
            java.util.concurrent.locks.StampedLock
            org.agrona.ExpandableDirectByteBuffer
            [org.lmdbjava CopyFlags Cursor Dbi DbiFlags DirectBufferProxy Env EnvFlags Env$MapFullException GetOp PutFlags Txn]))
@@ -131,7 +132,8 @@
 
 (def kv {:start-fn (fn [_ {:keys [::kv/db-dir ::kv/sync? ::env-flags ::env-mapsize]
                            :as options}]
-                     (let [env (.open (Env/create DirectBufferProxy/PROXY_DB)
+                     (let [db-dir (.toFile ^Path db-dir)
+                           env (.open (Env/create DirectBufferProxy/PROXY_DB)
                                       (io/file db-dir)
                                       (into-array EnvFlags (cond-> default-env-flags
                                                              (not sync?) (concat no-sync-env-flags))))

--- a/crux-rocksdb/src/crux/kv/rocksdb.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb.clj
@@ -7,6 +7,8 @@
             [crux.memory :as mem])
   (:import java.io.Closeable
            java.nio.ByteBuffer
+           (java.nio.file Files Path)
+           java.nio.file.attribute.FileAttribute
            java.util.function.ToIntFunction
            (org.rocksdb Checkpoint CompressionType FlushOptions LRUCache
                         Options ReadOptions RocksDB RocksIterator
@@ -141,8 +143,9 @@
                             (.setBottommostCompressionType CompressionType/ZSTD_COMPRESSION)
                             (.setCreateIfMissing true))
                      db (try
-                          (RocksDB/open opts (.getAbsolutePath (doto (io/file db-dir)
-                                                                 (.mkdirs))))
+                          (RocksDB/open opts (-> (Files/createDirectories ^Path db-dir (make-array FileAttribute 0))
+                                                 (.toAbsolutePath)
+                                                 (str)))
                           (catch Throwable t
                             (.close opts)
                             (throw t)))

--- a/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
+++ b/crux-rocksdb/src/crux/kv/rocksdb/jnr.clj
@@ -10,6 +10,7 @@
   (:import java.io.Closeable
            [org.agrona DirectBuffer MutableDirectBuffer ExpandableDirectByteBuffer]
            org.agrona.concurrent.UnsafeBuffer
+           java.nio.file.Path
            [jnr.ffi LibraryLoader Memory NativeType Pointer]))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -276,6 +277,7 @@
                      _ (.rocksdb_options_set_create_if_missing rocksdb opts 1)
                      _ (.rocksdb_options_set_compression rocksdb opts rocksdb_lz4_compression)
                      errptr-out (make-array String 1)
+                     db-dir (.toFile ^Path db-dir)
                      db (try
                           (let [db (.rocksdb_open rocksdb
                                                   opts

--- a/crux-test/src/crux/fixtures.clj
+++ b/crux-test/src/crux/fixtures.clj
@@ -46,7 +46,7 @@
 
 (defn with-kv-dir [f]
   (with-tmp-dir "kv-store" [db-dir]
-    (with-opts {:crux.kv/db-dir (str db-dir)}
+    (with-opts {:crux.kv/db-dir db-dir}
       f)))
 
 (defn with-node [f]

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -30,15 +30,15 @@
   {:node {:crux.node/topology ['crux.standalone/topology
                                'crux.kv.rocksdb/kv-store
                                'crux.http-server/module]
-          :crux.kv/db-dir (str (io/file dev-node-dir "db"))
+          :crux.kv/db-dir (io/file dev-node-dir "db")
           :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv
-          :crux.standalone/event-log-dir (str (io/file dev-node-dir "event-log"))
+          :crux.standalone/event-log-dir (io/file dev-node-dir "event-log")
           :crux.kv/sync? true}})
 
 (defmethod i/init-key :embedded-kafka [_ {:keys [kafka-port kafka-dir]}]
-  (ek/start-embedded-kafka #::ek{:zookeeper-data-dir (str (io/file kafka-dir "zk-data"))
+  (ek/start-embedded-kafka #::ek{:zookeeper-data-dir (io/file kafka-dir "zk-data")
                                  :zookeeper-port (cio/free-port)
-                                 :kafka-log-dir (str (io/file kafka-dir "kafka-log"))
+                                 :kafka-log-dir (io/file kafka-dir "kafka-log")
                                  :kafka-port kafka-port}))
 
 (defmethod i/halt-key! :embedded-kafka [_ ^Closeable embedded-kafka]
@@ -51,8 +51,8 @@
      :node {:crux.node/topology ['crux.kafka/topology
                                  'crux.kv.rocksdb/kv-store]
             :crux.kafka/bootstrap-servers (str "localhost:" kafka-port)
-            :crux.kv/db-dir (str (io/file dev-node-dir "ek-db"))
-            :crux.standalone/event-log-dir (str (io/file dev-node-dir "ek-event-log"))
+            :crux.kv/db-dir (io/file dev-node-dir "ek-db")
+            :crux.standalone/event-log-dir (io/file dev-node-dir "ek-event-log")
             :crux.kv/sync? true}}))
 
 

--- a/docs/src/docs/examples.clj
+++ b/docs/src/docs/examples.clj
@@ -13,7 +13,7 @@
 ;; tag::start-standalone-node[]
 (defn start-standalone-node ^crux.api.ICruxAPI [storage-dir]
   (crux/start-node {:crux.node/topology '[crux.standalone/topology]
-                    :crux.kv/db-dir (str (io/file storage-dir "db"))}))
+                    :crux.kv/db-dir (io/file storage-dir "db")}))
 
 (comment ; which can be used as
   (def node (start-standalone-node "crux-store")))
@@ -28,7 +28,7 @@
 ;; tag::start-standalone-http-node[]
 (defn start-standalone-http-node [port storage-dir]
   (crux/start-node {:crux.node/topology '[crux.standalone/topology crux.http-server/module]
-                    :crux.kv/db-dir (str (io/file storage-dir "db"))
+                    :crux.kv/db-dir (io/file storage-dir "db")
                     :crux.http-server/port port
                     ;; by default, the HTTP server is read-write - set this flag to make it read-only
                     :crux.http-server/read-only? false}))
@@ -36,8 +36,8 @@
 
 ;; tag::ek-example[]
 (defn start-embedded-kafka [kafka-port storage-dir]
-  (ek/start-embedded-kafka {:crux.kafka.embedded/zookeeper-data-dir (str (io/file storage-dir "zk-data"))
-                            :crux.kafka.embedded/kafka-log-dir (str (io/file storage-dir "kafka-log"))
+  (ek/start-embedded-kafka {:crux.kafka.embedded/zookeeper-data-dir (io/file storage-dir "zk-data")
+                            :crux.kafka.embedded/kafka-log-dir (io/file storage-dir "kafka-log")
                             :crux.kafka.embedded/kafka-port kafka-port}))
 ;; end::ek-example[]
 
@@ -51,7 +51,7 @@
 (defn start-cluster [kafka-port storage-dir]
   (crux/start-node {:crux.node/topology '[crux.kafka/topology crux.kv.rocksdb/kv-store]
                     :crux.kafka/bootstrap-servers (str "localhost:" kafka-port)
-                    :crux.kv/db-dir (str (io/file storage-dir "db"))}))
+                    :crux.kv/db-dir (io/file storage-dir "db")}))
 ;; end::start-cluster-node[]
 
 ;; tag::start-standalone-with-rocks[]
@@ -65,7 +65,7 @@
 (defn start-lmdb-node [storage-dir]
   (crux/start-node {:crux.node/topology '[crux.standalone/topology
                                           crux.kv.lmdb/kv-store]
-                    :crux.kv/db-dir (str (io/file storage-dir "db"))}))
+                    :crux.kv/db-dir (io/file storage-dir "db")}))
 ;; end::start-standalone-with-lmdb[]
 
 ;; tag::start-jdbc-node[]


### PR DESCRIPTION
Resolves #985, also replacing a few usages in the codebase of now unnecessary conversions to string (and leaving some untouched, to check both work fine). 