### PR TITLE
Add crux.metrics to status

### DIFF
--- a/crux-http-server/src-cljs/crux/ui/common.cljs
+++ b/crux-http-server/src-cljs/crux/ui/common.cljs
@@ -8,6 +8,7 @@
    [reitit.frontend.easy :as rfe]
    [tick.alpha.api :as t]
    [tick.format :as tf]
+   [clojure.walk :as walk]
    [tick.locale-en-us]))
 
 (defn route->url
@@ -98,3 +99,9 @@
     :width "24"}
    [:g {:fill "#111111"}
     [:path {:d "M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"}]]])
+
+(defn sort-map [map]
+  (->> map
+       (walk/postwalk
+        (fn [map] (cond->> map
+                  (map? map) (into (sorted-map)))))))

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -18,7 +18,7 @@
    (let [result-meta (some-> (js/document.querySelector
                               (str "meta[title=" title "]"))
                              (.getAttribute "content"))
-         edn-content (reader/read-string result-meta)]
+         edn-content (reader/read-string {:readers {'object pr-str}} result-meta)]
      (if edn-content
        {:db (assoc db handler edn-content)}
        (js/console.warn "Metadata not found")))))

--- a/crux-http-server/src-cljs/crux/ui/routes.cljs
+++ b/crux-http-server/src-cljs/crux/ui/routes.cljs
@@ -14,7 +14,8 @@
     {:name :status
      :link-text "Status"
      :controllers
-     [{:start #(rf/dispatch [:crux.ui.http/fetch-node-status])
+     [{:identity #(gensym)
+       :start #(rf/dispatch [:crux.ui.http/fetch-node-status])
        :stop (fn [& params])}]}]
    ["/_crux/query"
     {:name :query

--- a/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
+++ b/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
@@ -259,4 +259,4 @@
 (rf/reg-sub
  ::node-options
  (fn [db _]
-   (doto (:options db) prn)))
+   (:options db)))

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -406,7 +406,15 @@
     (fn [[key value]]
       (when value
         [[:dt [:b (str key)]]
-         [:dd (with-out-str (pprint/pprint value))]]))
+         (cond
+           (map? value) [:dd (into
+                              [:dl]
+                              (mapcat
+                               (fn [[key value]]
+                                 [[:dt [:b (str key)]]
+                                  [:dd (with-out-str (pprint/pprint value))]])
+                               value))]
+           :else [:dd (with-out-str (pprint/pprint value))])]))
     status-map)))
 
 (defn status-page

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -415,7 +415,7 @@
                                   [:dd (with-out-str (pprint/pprint value))]])
                                value))]
            :else [:dd (with-out-str (pprint/pprint value))])]))
-    status-map)))
+    (common/sort-map status-map))))
 
 (defn status-page
   []

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -401,11 +401,12 @@
 
 (defn status-map->html-elements [status-map]
   (into
-   [:div.node-info__content]
-   (map
+   [:dl.node-info__content]
+   (mapcat
     (fn [[key value]]
       (when value
-        [:p [:b (str key)] ": " (str value)]))
+        [[:dt [:b (str key)]]
+         [:dd (with-out-str (pprint/pprint value))]]))
     status-map)))
 
 (defn status-page

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -418,7 +418,15 @@
     (fn [[key value]]
       (when value
         [[:dt [:b (str key)]]
-         [:dd (with-out-str (pp/pprint value))]]))
+         (cond
+           (map? value) [:dd (into
+                              [:dl]
+                              (mapcat
+                               (fn [[key value]]
+                                 [[:dt [:b (str key)]]
+                                  [:dd (with-out-str (pp/pprint value))]])
+                               value))]
+           :else [:dd (with-out-str (pp/pprint value))])]))
     status-map)))
 
 (defn- status [^ICruxAPI crux-node options request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -413,11 +413,12 @@
 
 (defn status-map->html-elements [status-map]
   (into
-   [:div.node-info__content]
-   (map
+   [:dl.node-info__content]
+   (mapcat
     (fn [[key value]]
       (when value
-        [:p [:b (str key)] ": " (str value)]))
+        [[:dt [:b (str key)]]
+         [:dd (with-out-str (pp/pprint value))]]))
     status-map)))
 
 (defn- status [^ICruxAPI crux-node options request]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -11,6 +11,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clojure.instant :as instant]
+            [clojure.walk :as walk]
             [crux.api :as api]
             [crux.codec :as c]
             [crux.io :as cio]
@@ -411,6 +412,12 @@
              :title "/_crux"
              :options options}))})
 
+(defn sort-map [map]
+  (->> map
+       (walk/postwalk
+        (fn [map] (cond->> map
+                  (map? map) (into (sorted-map)))))))
+
 (defn status-map->html-elements [status-map]
   (into
    [:dl.node-info__content]
@@ -427,7 +434,7 @@
                                   [:dd (with-out-str (pp/pprint value))]])
                                value))]
            :else [:dd (with-out-str (pp/pprint value))])]))
-    status-map)))
+    (sort-map status-map))))
 
 (defn- status [^ICruxAPI crux-node options request]
   (let [status-map (api/status crux-node)]

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -31,23 +31,23 @@
              (.getGauges registry))
             (mapcat
              (fn [[^String name ^Meter meter]]
-               {name {"1-min-rate" (.getOneMinuteRate meter)
-                      "5-min-rate" (.getFiveMinuteRate meter)
-                      "15-min-rate" (.getFifteenMinuteRate meter)}})
+               {name {"rate-1-min" (.getOneMinuteRate meter)
+                      "rate-5-min" (.getFiveMinuteRate meter)
+                      "rate-15-min" (.getFifteenMinuteRate meter)}})
              (.getMeters registry))
             (mapcat
              (fn [[^String name ^Timer timer]]
                (let [^Snapshot snapshot (.getSnapshot timer)]
-                 {name {"1-min-rate" (.getOneMinuteRate timer)
-                        "5-min-rate" (.getFiveMinuteRate timer)
-                        "15-min-rate" (.getFifteenMinuteRate timer)
+                 {name {"rate-1-min" (.getOneMinuteRate timer)
+                        "rate-5-min" (.getFiveMinuteRate timer)
+                        "rate-15-min" (.getFifteenMinuteRate timer)
                         "minimum" (.getMin snapshot)
                         "maximum" (.getMax snapshot)
                         "mean" (.getMean snapshot)
                         "std-dev" (.getStdDev snapshot)
-                        "75th-percentile" (.get75thPercentile snapshot)
-                        "99th-percentile" (.get99thPercentile snapshot)
-                        "99.9th percentile" (.get999thPercentile snapshot)}}))
+                        "percentile-75th" (.get75thPercentile snapshot)
+                        "percentile-99th" (.get99thPercentile snapshot)
+                        "percentile-99.9th" (.get999thPercentile snapshot)}}))
              (.getTimers registry))))}))
 
 (def all-metrics-loaded {:start-fn (fn [_ _])

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -31,15 +31,15 @@
              (.getGauges registry))
             (mapcat
              (fn [[^String name ^Meter meter]]
-               {(str name "/1-min-rate") (.getOneMinuteRate meter)
-                (str name "/5-min-rate") (.getFiveMinuteRate meter)
-                (str name "/15-min-rate") (.getFifteenMinuteRate meter)})
+               {name {"/1-min-rate" (.getOneMinuteRate meter)
+                      "/5-min-rate" (.getFiveMinuteRate meter)
+                      "/15-min-rate" (.getFifteenMinuteRate meter)}})
              (.getMeters registry))
             (mapcat
              (fn [[^String name ^Timer timer]]
-               {(str name "/1-min-rate") (.getOneMinuteRate timer)
-                (str name "/5-min-rate") (.getFiveMinuteRate timer)
-                (str name "/15-min-rate") (.getFifteenMinuteRate timer)})
+               {name {"/1-min-rate" (.getOneMinuteRate timer)
+                      "/5-min-rate" (.getFiveMinuteRate timer)
+                      "/15-min-rate" (.getFifteenMinuteRate timer)}})
              (.getTimers registry))))}))
 
 (def all-metrics-loaded {:start-fn (fn [_ _])

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -5,7 +5,7 @@
             [crux.status :as status])
   (:import [java.time Duration]
            [java.util.concurrent TimeUnit]
-           [com.codahale.metrics MetricRegistry Gauge]))
+           [com.codahale.metrics MetricRegistry Gauge Meter Timer]))
 
 (def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics?  with-query-metrics?]}]
                                   (cond-> (dropwizard/new-registry)
@@ -22,11 +22,25 @@
 (defrecord StatusReporter [^MetricRegistry registry]
   status/Status
   (status-map [this]
-    (into {}
-          (map
-           (fn [[^String name ^Gauge gauge]]
-             [(keyword name) (.getValue gauge)])
-           (.getGauges registry)))))
+    {:crux.metrics
+     (into (sorted-map)
+           (concat
+            (map
+             (fn [[^String name ^Gauge gauge]]
+               {name (.getValue gauge)})
+             (.getGauges registry))
+            (mapcat
+             (fn [[^String name ^Meter meter]]
+               {(str name "/1-min-rate") (.getOneMinuteRate meter)
+                (str name "/5-min-rate") (.getFiveMinuteRate meter)
+                (str name "/15-min-rate") (.getFifteenMinuteRate meter)})
+             (.getMeters registry))
+            (mapcat
+             (fn [[^String name ^Timer timer]]
+               {(str name "/1-min-rate") (.getOneMinuteRate timer)
+                (str name "/5-min-rate") (.getFiveMinuteRate timer)
+                (str name "/15-min-rate") (.getFifteenMinuteRate timer)})
+             (.getTimers registry))))}))
 
 (def all-metrics-loaded {:start-fn (fn [_ _])
                          :deps #{::registry}})

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -7,6 +7,9 @@
            [java.util.concurrent TimeUnit]
            [com.codahale.metrics MetricRegistry Gauge Meter Timer Snapshot]))
 
+(defn- ns->ms [time-ns]
+  (/ time-ns 1e6))
+
 (def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics?  with-query-metrics?]}]
                                   (cond-> (dropwizard/new-registry)
                                     with-indexer-metrics? (doto (indexer-metrics/assign-listeners deps))
@@ -41,13 +44,13 @@
                  {name {"rate-1-min" (.getOneMinuteRate timer)
                         "rate-5-min" (.getFiveMinuteRate timer)
                         "rate-15-min" (.getFifteenMinuteRate timer)
-                        "minimum" (.getMin snapshot)
-                        "maximum" (.getMax snapshot)
-                        "mean" (.getMean snapshot)
-                        "std-dev" (.getStdDev snapshot)
-                        "percentile-75th" (.get75thPercentile snapshot)
-                        "percentile-99th" (.get99thPercentile snapshot)
-                        "percentile-99.9th" (.get999thPercentile snapshot)}}))
+                        "minimum-ms" (ns->ms (.getMin snapshot))
+                        "maximum-ms" (ns->ms (.getMax snapshot))
+                        "mean-ms" (ns->ms (.getMean snapshot))
+                        "std-dev-ms" (ns->ms (.getStdDev snapshot))
+                        "percentile-75-ms" (ns->ms (.get75thPercentile snapshot))
+                        "percentile-99-ms" (ns->ms (.get99thPercentile snapshot))
+                        "percentile-99.9-ms" (ns->ms (.get999thPercentile snapshot))}}))
              (.getTimers registry))))}))
 
 (def all-metrics-loaded {:start-fn (fn [_ _])

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -29,13 +29,13 @@
              (fn [[^String name ^Gauge gauge]]
                {name (.getValue gauge)})
              (.getGauges registry))
-            (mapcat
+            (map
              (fn [[^String name ^Meter meter]]
                {name {"rate-1-min" (.getOneMinuteRate meter)
                       "rate-5-min" (.getFiveMinuteRate meter)
                       "rate-15-min" (.getFifteenMinuteRate meter)}})
              (.getMeters registry))
-            (mapcat
+            (map
              (fn [[^String name ^Timer timer]]
                (let [^Snapshot snapshot (.getSnapshot timer)]
                  {name {"rate-1-min" (.getOneMinuteRate timer)


### PR DESCRIPTION
These are added so long as the user has some dependency on `crux.metrics/registry`.