### PR TITLE
EQL project syntax, #849

### DIFF
--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -12,7 +12,8 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [com.taoensso/encore "2.114.0"]
                  [org.agrona/agrona "1.0.7"]
-                 [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]]
+                 [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
+                 [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}
              :test {:dependencies [[juxt/crux-test "crux-git-version" :scope "test"]]}}
   :middleware [leiningen.project-version/middleware]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3150,42 +3150,65 @@
   (fix/submit+await-tx (for [doc (read-string (slurp (io/resource "data/james-bond.edn")))]
                          [:crux.tx/put doc]))
 
-  (let [db (api/db *api*)]
-    (t/testing "simple props"
-      (t/is (= #{[{:vehicle/brand "Aston Martin", :vehicle/model "DB5"}]
-                 [{:vehicle/brand "Aston Martin", :vehicle/model "DB10"}]
-                 [{:vehicle/brand "Aston Martin", :vehicle/model "DBS"}]
-                 [{:vehicle/brand "Aston Martin", :vehicle/model "DBS V12"}]
-                 [{:vehicle/brand "Aston Martin", :vehicle/model "V8 Vantage Volante"}]
-                 [{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}]}
+  (let [->lookup-docs (let [f @#'q/lookup-docs]
+                        (fn [!lookup-counts]
+                          (fn [v db]
+                            (swap! !lookup-counts conj (count (::q/hashes (meta v))))
+                            (f v db))))
+        db (api/db *api*)]
 
-               (api/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
-                           :where [[?v :vehicle/brand "Aston Martin"]]}))))
+    (t/testing "simple props"
+      (let [expected #{[{:vehicle/brand "Aston Martin", :vehicle/model "DB5"}]
+                       [{:vehicle/brand "Aston Martin", :vehicle/model "DB10"}]
+                       [{:vehicle/brand "Aston Martin", :vehicle/model "DBS"}]
+                       [{:vehicle/brand "Aston Martin", :vehicle/model "DBS V12"}]
+                       [{:vehicle/brand "Aston Martin", :vehicle/model "V8 Vantage Volante"}]
+                       [{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}]}]
+        (let [!lookup-counts (atom [])]
+          (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+            (t/is (= expected
+                     (api/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
+                                 :where [[?v :vehicle/brand "Aston Martin"]]})))
+            (t/is (= [6] @!lookup-counts) "batching lookups")))
+
+        (let [!lookup-counts (atom [])]
+          (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+            (t/is (= expected
+                     (api/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
+                                 :where [[?v :vehicle/brand "Aston Martin"]]
+                                 :batch-size 3})))
+            (t/is (= [3 3] @!lookup-counts) "batching lookups")))))
 
     (t/testing "forward joins"
-      (t/is (= #{[{:film/year "2002",
-                   :film/name "Die Another Day"
-                   :film/bond {:person/name "Pierce Brosnan"},
-                   :film/director {:person/name "Lee Tamahori"},
-                   :film/vehicles #{{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}
-                                    {:vehicle/brand "Ford", :vehicle/model "Thunderbird"}
-                                    {:vehicle/brand "Ford", :vehicle/model "Fairlane"}
-                                    {:vehicle/brand "Jaguar", :vehicle/model "XKR"}}}]}
-               (api/q db '{:find [(eql/project ?f [{:film/bond [:person/name]}
-                                                   {:film/director [:person/name]}
-                                                   {:film/vehicles [:vehicle/brand :vehicle/model]}
-                                                   :film/name :film/year])]
-                           :where [[?f :film/name "Die Another Day"]]}))))
+      (let [!lookup-counts (atom [])]
+        (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+          (t/is (= #{[{:film/year "2002",
+                       :film/name "Die Another Day"
+                       :film/bond {:person/name "Pierce Brosnan"},
+                       :film/director {:person/name "Lee Tamahori"},
+                       :film/vehicles [{:vehicle/brand "Jaguar", :vehicle/model "XKR"}
+                                       {:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}
+                                       {:vehicle/brand "Ford", :vehicle/model "Thunderbird"}
+                                       {:vehicle/brand "Ford", :vehicle/model "Fairlane"}]}]}
+                   (api/q db '{:find [(eql/project ?f [{:film/bond [:person/name]}
+                                                       {:film/director [:person/name]}
+                                                       {:film/vehicles [:vehicle/brand :vehicle/model]}
+                                                       :film/name :film/year])]
+                               :where [[?f :film/name "Die Another Day"]]})))
+          (t/is (= [1 6] @!lookup-counts) "batching lookups"))))
 
     (t/testing "reverse joins"
-      (t/is (= #{[{:person/name "Daniel Craig",
-                   :film/_bond [{:film/name "Quantum of Solace", :film/year "2008"}
-                                {:film/name "Spectre", :film/year "2015"}
-                                {:film/name "Skyfall", :film/year "2012"}
-                                {:film/name "Casino Royale", :film/year "2006"}]}]}
-               (api/q db '{:find [(eql/project ?dc [:person/name
-                                                    {:film/_bond [:film/name :film/year]}])]
-                           :where [[?dc :person/name "Daniel Craig"]]}))))
+      (let [!lookup-counts (atom [])]
+        (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+          (t/is (= #{[{:person/name "Daniel Craig",
+                       :film/_bond [{:film/name "Quantum of Solace", :film/year "2008"}
+                                    {:film/name "Spectre", :film/year "2015"}
+                                    {:film/name "Skyfall", :film/year "2012"}
+                                    {:film/name "Casino Royale", :film/year "2006"}]}]}
+                   (api/q db '{:find [(eql/project ?dc [:person/name
+                                                        {:film/_bond [:film/name :film/year]}])]
+                               :where [[?dc :person/name "Daniel Craig"]]})))
+          (t/is (= [5] @!lookup-counts) "batching lookups"))))
 
     (t/testing "project *"
       (t/is (= #{[{:crux.db/id :daniel-craig

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -8,7 +8,9 @@
             [crux.db :as db]
             [crux.fixtures :as fix :refer [*api*]]
             [crux.query :as q]
-            [crux.index :as idx])
+            [crux.index :as idx]
+            [clojure.java.io :as io]
+            [edn-query-language.core :as eql])
   (:import java.util.UUID))
 
 (t/use-fixtures :each fix/with-kv-dir fix/with-standalone-topology fix/with-node)
@@ -3143,3 +3145,51 @@
                                              [e2 :x x]
                                              [e2 :y y]
                                              [(!= e1 e2)]]})))))
+
+(t/deftest test-project
+  (fix/submit+await-tx (for [doc (read-string (slurp (io/resource "data/james-bond.edn")))]
+                         [:crux.tx/put doc]))
+
+  (let [db (api/db *api*)]
+    (t/testing "simple props"
+      (t/is (= #{[{:vehicle/brand "Aston Martin", :vehicle/model "DB5"}]
+                 [{:vehicle/brand "Aston Martin", :vehicle/model "DB10"}]
+                 [{:vehicle/brand "Aston Martin", :vehicle/model "DBS"}]
+                 [{:vehicle/brand "Aston Martin", :vehicle/model "DBS V12"}]
+                 [{:vehicle/brand "Aston Martin", :vehicle/model "V8 Vantage Volante"}]
+                 [{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}]}
+
+               (api/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
+                           :where [[?v :vehicle/brand "Aston Martin"]]}))))
+
+    (t/testing "forward joins"
+      (t/is (= #{[{:film/year "2002",
+                   :film/name "Die Another Day"
+                   :film/bond {:person/name "Pierce Brosnan"},
+                   :film/director {:person/name "Lee Tamahori"},
+                   :film/vehicles #{{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}
+                                    {:vehicle/brand "Ford", :vehicle/model "Thunderbird"}
+                                    {:vehicle/brand "Ford", :vehicle/model "Fairlane"}
+                                    {:vehicle/brand "Jaguar", :vehicle/model "XKR"}}}]}
+               (api/q db '{:find [(eql/project ?f [{:film/bond [:person/name]}
+                                                   {:film/director [:person/name]}
+                                                   {:film/vehicles [:vehicle/brand :vehicle/model]}
+                                                   :film/name :film/year])]
+                           :where [[?f :film/name "Die Another Day"]]}))))
+
+    (t/testing "reverse joins"
+      (t/is (= #{[{:person/name "Daniel Craig",
+                   :film/_bond [{:film/name "Quantum of Solace", :film/year "2008"}
+                                {:film/name "Spectre", :film/year "2015"}
+                                {:film/name "Skyfall", :film/year "2012"}
+                                {:film/name "Casino Royale", :film/year "2006"}]}]}
+               (api/q db '{:find [(eql/project ?dc [:person/name
+                                                    {:film/_bond [:film/name :film/year]}])]
+                           :where [[?dc :person/name "Daniel Craig"]]}))))
+
+    (t/testing "project *"
+      (t/is (= #{[{:crux.db/id :daniel-craig
+                   :person/name "Daniel Craig",
+                   :type :person}]}
+               (api/q db '{:find [(eql/project ?dc [*])]
+                           :where [[?dc :person/name "Daniel Craig"]]}))))))

--- a/docs/nav.adoc
+++ b/docs/nav.adoc
@@ -19,6 +19,8 @@ include::{path}/transactions.adoc[leveloffset=+1]
 
 include::{path}/queries.adoc[leveloffset=+1]
 
+include::{path}/projections.adoc[leveloffset=+1]
+
 include::{path}/speculative.adoc[leveloffset=+1]
 
 include::{path}/sql.adoc[leveloffset=+1]

--- a/docs/nav.adoc
+++ b/docs/nav.adoc
@@ -19,6 +19,8 @@ include::{path}/transactions.adoc[leveloffset=+1]
 
 include::{path}/queries.adoc[leveloffset=+1]
 
+include::{path}/speculative.adoc[leveloffset=+1]
+
 include::{path}/sql.adoc[leveloffset=+1]
 
 include::{path}/api.adoc[leveloffset=+1]

--- a/docs/projections.adoc
+++ b/docs/projections.adoc
@@ -1,0 +1,75 @@
+= 'Projection' syntax
+
+*ALPHA* - subject to change without warning between releases.
+
+Crux queries support a 'projection' syntax, allowing you to decouple specifying which entities you want from what data you'd like about those entities in your queries.
+Crux's support is based on the excellent https://edn-query-language.org/eql/1.0.0/what-is-eql.html[EDN Query Language (EQL)^] library.
+
+To specify what data you'd like about each entity, include a `(eql/project ?logic-var projection-spec)` entry in the `:find` clause of your query:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [?uid ?name ?profession]
+ :where [[?user :user/id ?uid]
+         [?user :user/name ?name]
+         [?user :user/profession ?profession]}
+;; => [[1 "Ivan" :doctor] [2 "Sergei" :lawyer], [3 "Petr" :doctor]]
+
+;; using `eql/project`:
+{:find [(eql/project ?user [:user/name :user/profession]
+ :where [[?user :user/id ?uid]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession :doctor},
+;;     {:user/id 2, :user/name "Sergei", :user/profession :lawyer},
+;;     {:user/id 3, :user/name "Petr", :user/profession :doctor}]
+----
+
+We can navigate to other entities (and hence build up nested results) using 'joins'.
+Joins are specified in `{}` braces in the projection-spec - each one maps one join key to its nested spec:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [?uid ?name ?profession-name]
+ :where [[?user :user/id ?uid]
+         [?user :user/name ?name]
+         [?user :user/profession ?profession]
+         [?profession :profession/name ?profession-name]}
+;; => [[1 "Ivan" "Doctor"] [2 "Sergei" "Lawyer"], [3 "Petr" "Doctor"]]
+
+{:find [(eql/project ?user [:user/name {:user/profession [:profession/name]}]
+ :where [[?user :user/id ?uid]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession {:profession/name "Doctor"}},
+;;     {:user/id 2, :user/name "Sergei", :user/profession {:profession/name "Lawyer"}}
+;;     {:user/id 3, :user/name "Petr", :user/profession {:profession/name "Doctor"}}]
+----
+
+We can also navigate in the reverse direction, looking for entities that refer to this one, by prepending `_` to the attribute name:
+
+[source,clojure]
+----
+{:find [(eql/project ?profession [:profession/name {:user/_profession [:user/id :user/name]}]
+ :where [[?profession :profession/name]]}
+
+;; => [{:profession/name "Doctor",
+;;      :user/_profession [{:user/id 1, :user/name "Ivan"},
+;;                         {:user/id 3, :user/name "Petr"}]},
+;;     {:profession/name "Lawyer",
+;;      :user/_profession [{:user/id 2, :user/name "Sergei"}]}]
+----
+
+You can quickly grab the whole document by specifying `*` in the projection spec:
+
+[source,clojure]
+----
+;; with just 'query':
+{:find [(eql/project ?user [*])]
+ :where [[?user :user/id 1]]}
+
+;; => [{:user/id 1, :user/name "Ivan", :user/profession :doctor, ...}]
+----
+
+For full details on what's supported in the projection-spec, see the https://edn-query-language.org/eql/1.0.0/specification.html[EQL specification^]
+Crux does not (yet) support union queries or recursive queries.

--- a/docs/queries.adoc
+++ b/docs/queries.adoc
@@ -411,38 +411,6 @@ block) will result in undefined behaviour.
 include::./src/docs/examples.clj[tags=streaming-query]
 ----
 
-== Speculative transactions
-
-You can submit speculative transactions to Crux, to see what the results of your queries would be if a new transaction were to be applied.
-This is particularly useful for forecasting/projections, but also
-
-You'll receive a new database value, against which you can make queries and entity requests as you would any normal database value.
-Only you will see the effect of these transactions - they're not submitted to the cluster, and they're not visible to any other database value in your application.
-
-We submit these transactions to a database value using `with-tx`:
-
-[source,clojure]
-----
-(let [real-tx (crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
-      _ (crux/await-tx node real-tx)
-      all-names '{:find [?name], :where [[?e :name ?name]]}
-      db (crux/db node)]
-
-  (crux/q db all-names) ; => #{["Ivan"]}
-
-  (let [speculative-db (crux/with-tx db
-                         [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
-    (crux/q speculative-db all-names) ; => #{["Petr"] ["Ivan"]}
-    )
-
-  ;; we haven't impacted the original db value, nor the node
-  (crux/q db all-names) ; => #{["Ivan"]}
-  (crux/q (crux/db node) all-names) ; => #{["Ivan"]}
-  )
-----
-
-The entities submitted by the speculative `:crux.tx/put` take their valid time (if not explicitly specified) from the valid time of the `db` they were forked from.
-
 [#queries_history_api]
 == History API
 

--- a/docs/speculative.adoc
+++ b/docs/speculative.adoc
@@ -1,0 +1,31 @@
+= Speculative transactions
+
+You can submit speculative transactions to Crux, to see what the results of your queries would be if a new transaction were to be applied.
+This is particularly useful for forecasting/projections, but also
+
+You'll receive a new database value, against which you can make queries and entity requests as you would any normal database value.
+Only you will see the effect of these transactions - they're not submitted to the cluster, and they're not visible to any other database value in your application.
+
+We submit these transactions to a database value using `with-tx`:
+
+[source,clojure]
+----
+(let [real-tx (crux/submit-tx node [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan"}]])
+      _ (crux/await-tx node real-tx)
+      all-names '{:find [?name], :where [[?e :name ?name]]}
+      db (crux/db node)]
+
+  (crux/q db all-names) ; => #{["Ivan"]}
+
+  (let [speculative-db (crux/with-tx db
+                         [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
+    (crux/q speculative-db all-names) ; => #{["Petr"] ["Ivan"]}
+    )
+
+  ;; we haven't impacted the original db value, nor the node
+  (crux/q db all-names) ; => #{["Ivan"]}
+  (crux/q (crux/db node) all-names) ; => #{["Ivan"]}
+  )
+----
+
+The entities submitted by the speculative `:crux.tx/put` take their valid time (if not explicitly specified) from the valid time of the `db` they were forked from.


### PR DESCRIPTION
resolves #849

Allows users to decouple specifying which entities they want from what data they'd like about those entities in their queries.

We add an `(eql/project logic-var pull-spec)` option to the `:find` part of queries, see the change to `query_test.clj` or `projection.adoc` in the PR for the syntax and usage.

Implementation notes:

* Like the rest of the query engine, we split the pull engine up into 'conform', 'plan' and 'execute'.
  * 'Conform' is handled by EQL (thanks!)
  * 'Plan' builds up a tree of functions, each of which accepts the runtime value and the db instance (mainly for doc-store + index-store)
  * 'Execute' then runs those functions.
* We batch requests to the document store (just in case it's remote). 
  * Each level of the projection execution functions now either return a function or a plain old value (if they're fully realised). The function contains metadata detailing which hashes are required, and it expects to be passed a map of docs. It may then return a value or another function (if further docs are required).
  * We surface the document requests that each part of the nested structure requires in order to batch them up - this essentially means turning a list of potential functions into a single function (requesting all the hashes) that then returns the list. This is done recursively, so that we still batch up deeper levels of the projection tree - ideally, this means that we should only make as many doc-store requests as there are levels in the projection spec requested (rather than 1 batch at the top level, then n batches at level 2, etc etc - the 'n + 1 query problem')
* We apply both the projection and `full-results` _after_ the order-by/drop/take now - so that we don't eagerly project/fetch full results for the whole of a large result set if we don't need to.
* I've marked this as 'experimental, subject to change without warning between releases' in the docs.

TODO:

- [x] The 'plan' part should be cached, similarly to the rest of the query plan
- [x] Still makes one request at a time of the document-store - we could batch these for performance (at a cost of some complexity)
- [ ] RFC: do we want an independent `pull` function, taking `eid`?