### PR TITLE
Tx-fn in-tx query fixes

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -300,6 +300,7 @@
 
                                    (do
                                      (doto forked-indexer
+                                       (db/index-docs docs)
                                        (db/unindex-eids evict-eids)
                                        (db/index-entity-txs tx etxs))
                                      {:new-tx-events tx-events}))))]

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -168,65 +168,49 @@
         {args-doc-id :crux.db/id, :crux.db.fn/keys [args tx-events failed?]} args-doc
         args-content-hash (c/new-id args-doc)
 
-        res (cond
-              tx-events {:tx-events tx-events}
+        {:keys [tx-events docs failed?]}
+        (cond
+          tx-events {:tx-events tx-events}
 
-              failed? (do
-                        (log/warn "Transaction function failed when originally evaluated:"
-                                  fn-id args-doc-id
-                                  (pr-str (select-keys args-doc [:crux.db.fn/exception
-                                                                 :crux.db.fn/message
-                                                                 :crux.db.fn/ex-data])))
-                        {:failed? true})
+          failed? (do
+                    (log/warn "Transaction function failed when originally evaluated:"
+                              fn-id args-doc-id
+                              (pr-str (select-keys args-doc [:crux.db.fn/exception
+                                                             :crux.db.fn/message
+                                                             :crux.db.fn/ex-data])))
+                    {:failed? true})
 
-              :else (try
-                      (let [ctx (->TxFnContext query-engine tx)
-                            db (api/db query-engine tx-time)
-                            res (apply (->tx-fn (api/entity db fn-id)) ctx args)]
-                        (if (false? res)
-                          {:failed? true}
+          :else (try
+                  (let [ctx (->TxFnContext query-engine tx)
+                        db (api/db query-engine tx-time)
+                        res (apply (->tx-fn (api/entity db fn-id)) ctx args)]
+                    (if (false? res)
+                      {:failed? true}
 
-                          (let [conformed-tx-ops (mapv txc/conform-tx-op res)
-                                tx-events (mapv txc/->tx-event conformed-tx-ops)]
-                            {:tx-events tx-events
-                             :docs (into {args-content-hash {:crux.db/id args-doc-id
-                                                             :crux.db.fn/tx-events tx-events}}
-                                         (mapcat :docs)
-                                         conformed-tx-ops)})))
+                      (let [conformed-tx-ops (mapv txc/conform-tx-op res)
+                            tx-events (mapv txc/->tx-event conformed-tx-ops)]
+                        {:tx-events tx-events
+                         :docs (into {args-content-hash {:crux.db/id args-doc-id
+                                                         :crux.db.fn/tx-events tx-events}}
+                                     (mapcat :docs)
+                                     conformed-tx-ops)})))
 
-                      (catch Throwable t
-                        (reset! !last-tx-fn-error t)
-                        (log/warn t "Transaction function failure:" fn-id args-doc-id)
+                  (catch Throwable t
+                    (reset! !last-tx-fn-error t)
+                    (log/warn t "Transaction function failure:" fn-id args-doc-id)
 
-                        {:failed? true
-                         :fn-error t
-                         :docs {args-content-hash {:crux.db.fn/failed? true
-                                                   :crux.db.fn/exception (symbol (.getName (class t)))
-                                                   :crux.db.fn/message (ex-message t)
-                                                   :crux.db.fn/ex-data (ex-data t)}}})))
-
-        {:keys [tx-events docs failed?]} res]
-
+                    {:failed? true
+                     :fn-error t
+                     :docs {args-content-hash {:crux.db.fn/failed? true
+                                               :crux.db.fn/exception (symbol (.getName (class t)))
+                                               :crux.db.fn/message (ex-message t)
+                                               :crux.db.fn/ex-data (ex-data t)}}})))]
     (if failed?
       {:pre-commit-fn (constantly false)
        :docs docs}
 
-      (let [op-results (vec (for [[op & args :as tx-event] tx-events]
-                              (index-tx-event (case op
-                                                :crux.tx/fn (let [[fn-eid args-doc-id] args]
-                                                              (cond-> [op fn-eid]
-                                                                args-doc-id (conj (get docs args-doc-id))))
-                                                tx-event)
-                                              tx
-                                              tx-ingester)))]
-        {:pre-commit-fn #(every? true? (for [{:keys [pre-commit-fn]} op-results
-                                             :when pre-commit-fn]
-                                         (pre-commit-fn)))
-         :etxs (mapcat :etxs op-results)
-
-         :docs (into docs (mapcat :docs op-results))
-
-         :evict-eids (into #{} (mapcat :evict-eids) op-results)}))))
+      {:tx-events tx-events
+       :docs docs})))
 
 (defmethod index-tx-event :default [[op & _] tx tx-ingester]
   (throw (IllegalArgumentException. (str "Unknown tx-op: " op))))
@@ -296,34 +280,35 @@
 
     (try
       (index-docs this (txc/tx-events->docs forked-document-store tx-events))
-
       (let [forked-deps {:indexer forked-indexer
                          :document-store forked-document-store
                          :query-engine (assoc query-engine :indexer forked-indexer)}
-            res (reduce (fn [_ tx-event]
-                          (with-open [index-store (db/open-index-store forked-indexer)]
-                            (let [{:keys [pre-commit-fn evict-eids etxs docs]}
-                                  (index-tx-event (-> tx-event
-                                                      (with-tx-fn-args this))
-                                                  tx
-                                                  (-> forked-deps
-                                                      (assoc :index-store index-store)))]
-                              (db/submit-docs forked-document-store docs)
+            abort? (loop [[tx-event & more-tx-events] tx-events]
+                     (when tx-event
+                       (let [{:keys [new-tx-events abort?]}
+                             (with-open [index-store (db/open-index-store forked-indexer)]
+                               (let [{:keys [pre-commit-fn tx-events evict-eids etxs docs]}
+                                     (index-tx-event (-> tx-event
+                                                         (with-tx-fn-args forked-deps))
+                                                     tx
+                                                     (-> forked-deps
+                                                         (assoc :index-store index-store)))]
+                                 (db/submit-docs forked-document-store docs)
 
-                              (if (and pre-commit-fn (not (pre-commit-fn)))
-                                (reduced false)
+                                 (if (and pre-commit-fn (not (pre-commit-fn)))
+                                   {:abort? true}
 
-                                (do
-                                  (doto forked-indexer
-                                    (db/unindex-eids evict-eids)
-                                    (db/index-entity-txs tx etxs))
-                                  true)))))
-                        true
-                        tx-events)]
-        (when-not res
+                                   (do
+                                     (doto forked-indexer
+                                       (db/unindex-eids evict-eids)
+                                       (db/index-entity-txs tx etxs))
+                                     {:new-tx-events tx-events}))))]
+                         (or abort?
+                             (recur (concat new-tx-events more-tx-events))))))]
+        (when abort?
           (reset! !state :abort-only))
 
-        res)
+        (not abort?))
 
       (catch Throwable e
         (reset! !error e)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -674,6 +674,34 @@
                       :crux.tx/current-tx submitted-tx}
                      (api/entity (api/db *api*) :tx-metadata)))))))))
 
+(t/deftest tx-fn-sees-in-tx-query-results
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :foo 1}]])
+  (let [tx (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :foo 2}]
+                                 [:crux.tx/put {:crux.db/id :put
+                                                :crux.db/fn '(fn [ctx doc]
+                                                               [[:crux.tx/put doc]])}]
+                                 [:crux.tx/fn :put {:crux.db/id :bar, :ref :foo}]
+                                 [:crux.tx/put {:crux.db/id :doubling-fn
+                                                :crux.db/fn '(fn [ctx]
+                                                               (let [db (crux.api/db ctx)]
+
+                                                                 [[:crux.tx/put {:crux.db/id :prn-out
+                                                                                 :e (crux.api/entity db :bar)
+                                                                                 :q (first (crux.api/q db {:find '[e v]
+                                                                                                           :where '[[e :crux.db/id :bar]
+                                                                                                                    [e :ref v]]}))}]
+                                                                  [:crux.tx/put (-> (crux.api/entity db :foo)
+                                                                                    (update :foo * 2))]]))}]
+                                 [:crux.tx/fn :doubling-fn]])]
+
+    (t/is (crux/tx-committed? *api* tx))
+    (t/is (= {:crux.db/id :foo, :foo 4}
+             (crux/entity (crux/db *api*) :foo)))
+    (t/is (= {:crux.db/id :prn-out
+              :e {:crux.db/id :bar :ref :foo}
+              :q [:bar :foo]}
+             (crux/entity (crux/db *api*) :prn-out)))))
+
 (t/deftest tx-log-evict-454 []
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :to-evict}]])
   (fix/submit+await-tx [[:crux.tx/cas {:crux.db/id :to-evict} {:crux.db/id :to-evict :test "test"}]])


### PR DESCRIPTION
Couple of bugfixes for issues raised by @refset over the weekend (cheers :smile:)

Nested tx-fns weren't able to see the forked ctx, so they weren't seeing in-tx values for entities changes earlier in the tx (top-level tx-fns were) - fixed by taking responsibility for indexing the tx-events generated by tx-fns away from the tx-fn handling, and back into the general index-tx loop (which is now a work-queue rather than a `reduce`)

Also, ensuring that in-tx documents are put into both the document store and the indexer, so that they can be seen from queries.