### PR TITLE
All value representations in content indices

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -21,7 +21,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def ^:const index-version 12)
+(def ^:const index-version 13)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1279,7 +1279,7 @@
                                        (subs (name dispatch-key) 1))
                   one? (= :one (get-in join [:params :crux/cardinality]))]
               (fn [value {:keys [document-store index-store entity-resolver-fn] :as db}]
-                (->> (vec (for [v (cond->> (db/ave index-store (c/->id-buffer forward-key) (c/->value-buffer value) nil entity-resolver-fn)
+                (->> (vec (for [v (cond->> (db/ave index-store forward-key (c/->value-buffer value) nil entity-resolver-fn)
                                     one? (take 1)
                                     :always vec)]
                             (project-child (db/decode-value index-store v) child-fns db)))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -95,7 +95,7 @@
     (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 12}
+  (t/is (= (merge {:crux.index/index-version 13}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))


### PR DESCRIPTION
This PR brings the representation of attributes in content indices to use 'value buffers' rather than 'id buffers'. @hraberg made the initial change in #952 to migrate entities and values over to value buffers - this PR migrates attributes so that all of the constituent parts of the content index keys (AV, AVE, AE, ECAV) are value-buffers.

This means that we have the flexibility to allow more types of attributes (eg strings) without a further index bump. I deliberately haven't relaxed the spec in this PR as it deserves more consideration - this merely lowers the barrier to doing so. Regardless of opinions on that particular debate, this simplifies the content indices as all the components now have the same encoding/decoding.

When we initially discussed this we were concerned about having more than one unknown length component in the key - in practice (as Håkan found out) in the majority of usages we still only have one unknown length component (in `av` we have `a`, `ave` we have `a` and `v`, `ae` we have `a`, `aev` we have `a` and `e`). The exception to the rule is evicting an entity, where we want to use the ECAV index but only have `E` in hand - `C` is fixed-length but `A` and `V` are both variable. I've fixed this by adding explicit lengths to the entity and attribute components (but not the values, to preserve the lexicographical ordering properties of values). 

Out of scope of this PR, but another related change to consider: migrating the eids in the bitemp indices to value buffers - this would mean that _everything_ in the kv-store would be value buffers.
* Value would be that we could extract all serde implementation from the KVIndexer - it could both accept and return bytes without understanding what they mean (so long as they're lexicographically comparable, for value types that we want to order)
* All Indexers will share the same binary representation, which will lower the barrier to users creating their own Indexer implementations.
* This will allow us to fix the assumption in speculative transactions that KVIndexer is the only implementation of Indexer - again, because of the shared binary representation.
* This is significantly more involved, though - in the tx-log we frequently have eid hashes which would need to be converted to value buffers. AFAIK we already store these values in the hash-cache, so it's theoretically possible - but clearly not as straightforward.