### PR TITLE
Ensuring we hash ids before they go on the tx-log

### DIFF
--- a/crux-core/src/crux/kv_indexer.clj
+++ b/crux-core/src/crux/kv_indexer.clj
@@ -691,7 +691,7 @@
                                                                             count)
                                                                        1)]
                                                      (cond-> acc
-                                                       true (update :tombstones assoc (.content-hash quad) {:crux.db/id eid
+                                                       true (update :tombstones assoc (.content-hash quad) {:crux.db/id (c/new-id eid)
                                                                                                             :crux.db/evicted? true})
                                                        true (update :ks conj
                                                                     (encode-ae-key-to nil

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -108,28 +108,28 @@
 (defmulti ->tx-event :op :default ::default)
 
 (defmethod ->tx-event :crux.tx/put [{:keys [op eid doc-id start-valid-time end-valid-time]}]
-  (cond-> [op eid doc-id]
+  (cond-> [op (c/new-id eid) doc-id]
     start-valid-time (conj start-valid-time)
     end-valid-time (conj end-valid-time)))
 
 (defmethod ->tx-event :crux.tx/delete [{:keys [op eid start-valid-time end-valid-time]}]
-  (cond-> [op eid]
+  (cond-> [op (c/new-id eid)]
     start-valid-time (conj start-valid-time)
     end-valid-time (conj end-valid-time)))
 
 (defmethod ->tx-event :crux.tx/match [{:keys [op eid doc-id at-valid-time]}]
-  (cond-> [op eid doc-id]
+  (cond-> [op (c/new-id eid) doc-id]
     at-valid-time (conj at-valid-time)))
 
 (defmethod ->tx-event :crux.tx/cas [{:keys [op eid old-doc-id new-doc-id at-valid-time]}]
-  (cond-> [op eid old-doc-id new-doc-id]
+  (cond-> [op (c/new-id eid) old-doc-id new-doc-id]
     at-valid-time (conj at-valid-time)))
 
 (defmethod ->tx-event :crux.tx/evict [{:keys [op eid]}]
   [op eid])
 
 (defmethod ->tx-event :crux.tx/fn [{:keys [op fn-eid arg-doc-id]}]
-  (cond-> [op fn-eid]
+  (cond-> [op (c/new-id fn-eid)]
     arg-doc-id (conj arg-doc-id)))
 
 (defmethod ->tx-event ::default [tx-op]

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -412,7 +412,7 @@
         (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *server-api*) nil)]
                            (-> (iterator-seq tx-log) last ::txe/tx-events first last))]
 
-          (t/is (= {:crux.db.fn/tx-events [[:crux.tx/put :ivan (c/new-id {:crux.db/id :ivan, :name "Ivan"})]]}
+          (t/is (= {:crux.db.fn/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan, :name "Ivan"})]]}
                    (-> (db/fetch-docs (:document-store *server-api*) #{arg-doc-id})
                        (get arg-doc-id)
                        (dissoc :crux.db/id))))))
@@ -441,12 +441,12 @@
                               (get sub-arg-doc-id))]
 
           (t/is (= {:crux.db/id (:crux.db/id arg-doc)
-                    :crux.db.fn/tx-events [[:crux.tx/put :bob (c/new-id {:crux.db/id :bob, :name "Bob"})]
-                                           [:crux.tx/fn :put-ivan sub-arg-doc-id]]}
+                    :crux.db.fn/tx-events [[:crux.tx/put (c/new-id :bob) (c/new-id {:crux.db/id :bob, :name "Bob"})]
+                                           [:crux.tx/fn (c/new-id :put-ivan) sub-arg-doc-id]]}
                    arg-doc))
 
           (t/is (= {:crux.db/id (:crux.db/id sub-arg-doc)
-                    :crux.db.fn/tx-events [[:crux.tx/put :ivan (c/new-id {:crux.db/id :ivan :name "Ivan2"})]]}
+                    :crux.db.fn/tx-events [[:crux.tx/put (c/new-id :ivan) (c/new-id {:crux.db/id :ivan :name "Ivan2"})]]}
                    sub-arg-doc))))
 
       (t/testing "copes with args doc having been replaced"


### PR DESCRIPTION
We want to make sure we hash ids before they go on the tx-log, because it may contain personally identifiable information if someone uses (eg) email addresses as entity ids.

Looks like it was a regression in ~1.8.3 when I migrated the tx-op conforming away from clojure.spec :disappointed: It didn't raise any test errors because Id's `equals` method conforms its parameter to Id if it implements `IdToBuffer` so, even though most of the tests were checking for hashes on the tx-log, they were passing when the tx-log returned keywords.

I've updated `openTxLog` to ensure that the eids returned are always hashed, for consistency. There'll still be tx-logs created in the meantime that'll still have plain-text eids, though - not ideal.

(edit: #1000 :tada: shame it's not something more exciting though)