### PR TITLE
Add 'current-queries' to the API.

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -123,7 +123,10 @@
     "Returns the latest transaction to have been submitted to this cluster")
 
   (attribute-stats [node]
-    "Returns frequencies map for indexed attributes"))
+    "Returns frequencies map for indexed attributes")
+
+  (current-queries [node]
+    "Returns a list of currently running/recently finished queries"))
 
 (defprotocol PCruxIngestClient
   "Provides API access to Crux ingestion."
@@ -200,7 +203,8 @@
   (latest-completed-tx [node] (.latestCompletedTx node))
   (latest-submitted-tx [node] (.latestSubmittedTx node))
 
-  (attribute-stats [this] (.attributeStats this)))
+  (attribute-stats [this] (.attributeStats this))
+  (current-queries [this] (.currentQueries this)))
 
 (extend-protocol PCruxIngestClient
   ICruxIngestAPI

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -125,8 +125,11 @@
   (attribute-stats [node]
     "Returns frequencies map for indexed attributes")
 
-  (current-queries [node]
-    "Returns a list of currently running/recently finished queries"))
+  (active-queries [node]
+    "Returns a list of currently running queries")
+
+  (recent-queries [node]
+    "Returns a list of recently completed/failed queries"))
 
 (defprotocol PCruxIngestClient
   "Provides API access to Crux ingestion."
@@ -204,7 +207,8 @@
   (latest-submitted-tx [node] (.latestSubmittedTx node))
 
   (attribute-stats [this] (.attributeStats this))
-  (current-queries [this] (.currentQueries this)))
+  (active-queries [this] (.activeQueries this))
+  (recent-queries [this] (.recentQueries this)))
 
 (extend-protocol PCruxIngestClient
   ICruxIngestAPI

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -3,11 +3,11 @@
   (:refer-clojure :exclude [sync])
   (:require [clojure.spec.alpha :as s]
             [crux.codec :as c]
+            [crux.query-state :as qs]
             [clojure.tools.logging :as log])
-  (:import [crux.api Crux ICruxAPI ICruxIngestAPI
-            ICruxAsyncIngestAPI ICruxDatasource ICursor
-            HistoryOptions HistoryOptions$SortOrder
-            RemoteClientOptions]
+  (:import (crux.api Crux ICruxAPI ICruxIngestAPI
+                     ICruxAsyncIngestAPI ICruxDatasource ICursor
+                     HistoryOptions HistoryOptions$SortOrder RemoteClientOptions)
            java.io.Closeable
            java.util.Date
            java.time.Duration
@@ -207,8 +207,12 @@
   (latest-submitted-tx [node] (.latestSubmittedTx node))
 
   (attribute-stats [this] (.attributeStats this))
-  (active-queries [this] (.activeQueries this))
-  (recent-queries [this] (.recentQueries this)))
+
+  (active-queries [this]
+    (map qs/<-QueryState (.activeQueries this)))
+
+  (recent-queries [this]
+    (map qs/<-QueryState (.recentQueries this))))
 
 (extend-protocol PCruxIngestClient
   ICruxIngestAPI

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -156,9 +156,16 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
 
 
     /**
-     * Returns a list of currently running/recently finished queries.
+     * Returns a list of currently running queries.
      *
      * @return List containing maps with query information.
      */
-    public List<Map <Keyword, ?>> currentQueries();
+    public List<Map <Keyword, ?>> activeQueries();
+
+    /**
+     * Returns a list of recently completed/failed queries
+     *
+     * @return List containing maps with query information.
+     */
+    public List<Map <Keyword, ?>> recentQueries();
 }

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -153,4 +153,12 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      * @return         Map containing attribute freqencies.
      */
     public Map<Keyword, Long> attributeStats();
+
+
+    /**
+     * Returns a list of currently running/recently finished queries.
+     *
+     * @return List containing maps with query information.
+     */
+    public List<Map <Keyword, ?>> currentQueries();
 }

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -1,11 +1,8 @@
 package crux.api;
 
 import java.io.Closeable;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.time.Duration;
-import java.util.Set;
 import java.util.function.Consumer;
 import clojure.lang.Keyword;
 import clojure.lang.PersistentArrayMap;
@@ -154,18 +151,17 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      */
     public Map<Keyword, Long> attributeStats();
 
-
     /**
      * Returns a list of currently running queries.
      *
      * @return List containing maps with query information.
      */
-    public List<Map <Keyword, ?>> activeQueries();
+    public List<QueryState> activeQueries();
 
     /**
      * Returns a list of recently completed/failed queries
      *
      * @return List containing maps with query information.
      */
-    public List<Map <Keyword, ?>> recentQueries();
+    public List<QueryState> recentQueries();
 }

--- a/crux-core/src/crux/api/QueryState.java
+++ b/crux-core/src/crux/api/QueryState.java
@@ -1,0 +1,38 @@
+package crux.api;
+
+import clojure.lang.Keyword;
+
+import java.util.Date;
+import java.util.Map;
+
+public class QueryState {
+    public enum QueryStatus {
+        IN_PROGRESS, COMPLETED, FAILED
+    }
+
+    public static class QueryError {
+        public final String errorClass;
+        public final String errorMessage;
+
+        public QueryError(String errorClass, String errorMessage) {
+            this.errorClass = errorClass;
+            this.errorMessage = errorMessage;
+        }
+    }
+
+    public final Object queryId;
+    public final Date startedAt;
+    public final Date finishedAt;
+    public final QueryStatus status;
+    public final Map<Keyword, ?> query;
+    public final QueryError error;
+
+    public QueryState(Object queryId, Date startedAt, Date finishedAt, QueryStatus status, Map<Keyword, ?> query, QueryError error) {
+        this.queryId = queryId;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+        this.status = status;
+        this.query = query;
+        this.error = error;
+    }
+}

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1431,7 +1431,6 @@
         (bus/send bus {:crux/event-type ::submitted-query
                        ::query safe-query
                        ::query-id query-id}))
-
       (->> (crux.query/query db conformed-query)
            (cio/->cursor (fn []
                            (cio/try-close index-store)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1438,7 +1438,7 @@
                  (bus/send bus {:crux/event-type ::failed-query
                                 ::query safe-query
                                 ::query-id query-id
-                                ::error {:type (type e)
+                                ::error {:type (pr-str (type e))
                                          :message (.getMessage e)}}))
                (throw e)))
            (cio/->cursor (fn []

--- a/crux-core/src/crux/query_state.clj
+++ b/crux-core/src/crux/query_state.clj
@@ -1,4 +1,4 @@
-(ns crux.query-state
+(ns ^:no-doc crux.query-state
   (:import (crux.api QueryState QueryState$QueryStatus QueryState$QueryError)))
 
 (defn <-QueryState [^QueryState query-state]

--- a/crux-core/src/crux/query_state.clj
+++ b/crux-core/src/crux/query_state.clj
@@ -1,0 +1,28 @@
+(ns crux.query-state
+  (:import (crux.api QueryState QueryState$QueryStatus QueryState$QueryError)))
+
+(defn <-QueryState [^QueryState query-state]
+  {:status (case (str (.status query-state))
+             "FAILED" :failed
+             "COMPLETED" :completed
+             "IN_PROGRESS" :in-progress)
+   :query-id (.queryId query-state)
+   :query (.query query-state)
+   :started-at (.startedAt query-state)
+   :finished-at (.finishedAt query-state)
+   :error (when-let [error (.error query-state)]
+            {:type (.errorClass error)
+             :message (.errorMessage error)})})
+
+(defn ->QueryState [{:keys [query-id started-at finished-at status error query] :as query-state}]
+  (QueryState. query-id
+               started-at
+               finished-at
+               (case status
+                 :failed QueryState$QueryStatus/FAILED
+                 :completed QueryState$QueryStatus/COMPLETED
+                 :in-progress QueryState$QueryStatus/IN_PROGRESS)
+               query
+               (when error
+                 (let [{:keys [type message]} error]
+                   (QueryState$QueryError. type message)))))

--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -33,7 +33,7 @@
 (defmethod bus/event-spec ::baz [_] (s/keys))
 
 (t/deftest test-await
-  (let [bus (bus/->bus)]
+  (let [bus (bus/->bus {})]
     (t/testing "ready already"
       (t/is (= ::ready (bus/await bus {:crux/event-types #{::foo}
                                        :->result (fn [] ::ready)}))))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -131,7 +131,7 @@
 
   (query [this q]
     (with-open [res (.openQuery this q)]
-      (if (:order-by q)
+      (if (some q [:order-by :limit :offset])
         (vec (iterator-seq res))
         (set (iterator-seq res)))))
 

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -269,6 +269,11 @@
                       {:http-opts {:method :get}
                        :->jwt-token ->jwt-token}))
 
+  (currentQueries [_]
+    (api-request-sync (str url "/current-queries")
+                      {:http-opts {:method :get}
+                       :->jwt-token ->jwt-token}))
+
   Closeable
   (close [_]))
 

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -4,6 +4,7 @@
             [crux.io :as cio]
             [crux.db :as db]
             [crux.codec :as c]
+            [crux.query-state :as qs]
             [crux.query :as q]
             [clojure.string :as string])
   (:import (java.io Closeable InputStreamReader IOException PushbackReader)
@@ -270,14 +271,16 @@
                        :->jwt-token ->jwt-token}))
 
   (activeQueries [_]
-    (api-request-sync (str url "/active-queries")
-                      {:http-opts {:method :get}
-                       :->jwt-token ->jwt-token}))
+    (->> (api-request-sync (str url "/active-queries")
+                           {:http-opts {:method :get}
+                            :->jwt-token ->jwt-token})
+         (map qs/->QueryState)))
 
   (recentQueries [_]
-    (api-request-sync (str url "/recent-queries")
-                      {:http-opts {:method :get}
-                       :->jwt-token ->jwt-token}))
+    (->> (api-request-sync (str url "/recent-queries")
+                           {:http-opts {:method :get}
+                            :->jwt-token ->jwt-token})
+         (map qs/->QueryState)))
 
   Closeable
   (close [_]))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -269,8 +269,13 @@
                       {:http-opts {:method :get}
                        :->jwt-token ->jwt-token}))
 
-  (currentQueries [_]
-    (api-request-sync (str url "/current-queries")
+  (activeQueries [_]
+    (api-request-sync (str url "/active-queries")
+                      {:http-opts {:method :get}
+                       :->jwt-token ->jwt-token}))
+
+  (recentQueries [_]
+    (api-request-sync (str url "/recent-queries")
                       {:http-opts {:method :get}
                        :->jwt-token ->jwt-token}))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -324,8 +324,11 @@
 (defn latest-submitted-tx [^ICruxAPI crux-node]
   (success-response (.latestSubmittedTx crux-node)))
 
-(defn current-queries [^ICruxAPI crux-node]
-  (success-response (.currentQueries crux-node)))
+(defn active-queries [^ICruxAPI crux-node]
+  (success-response (.activeQueries crux-node)))
+
+(defn recent-queries [^ICruxAPI crux-node]
+  (success-response (.recentQueries crux-node)))
 
 (def ^:private sparql-available?
   (try ; you can change it back to require when clojure.core fixes it to be thread-safe
@@ -390,8 +393,11 @@
     [#"^/latest-submitted-tx" [:get]]
     (latest-submitted-tx crux-node)
 
-    [#"^/current-queries" [:get]]
-    (current-queries crux-node)
+    [#"^/active-queries" [:get]]
+    (active-queries crux-node)
+
+    [#"^/recent-queries" [:get]]
+    (recent-queries crux-node)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
              sparql-available?)

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -325,10 +325,10 @@
   (success-response (.latestSubmittedTx crux-node)))
 
 (defn active-queries [^ICruxAPI crux-node]
-  (success-response (.activeQueries crux-node)))
+  (success-response (api/active-queries crux-node)))
 
 (defn recent-queries [^ICruxAPI crux-node]
-  (success-response (.recentQueries crux-node)))
+  (success-response (api/recent-queries crux-node)))
 
 (def ^:private sparql-available?
   (try ; you can change it back to require when clojure.core fixes it to be thread-safe

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -324,6 +324,9 @@
 (defn latest-submitted-tx [^ICruxAPI crux-node]
   (success-response (.latestSubmittedTx crux-node)))
 
+(defn current-queries [^ICruxAPI crux-node]
+  (success-response (.currentQueries crux-node)))
+
 (def ^:private sparql-available?
   (try ; you can change it back to require when clojure.core fixes it to be thread-safe
     (requiring-resolve 'crux.sparql.protocol/sparql-query)
@@ -386,6 +389,9 @@
 
     [#"^/latest-submitted-tx" [:get]]
     (latest-submitted-tx crux-node)
+
+    [#"^/current-queries" [:get]]
+    (current-queries crux-node)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
              sparql-available?)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -85,6 +85,7 @@
       (t/is (= #{[:ivan]} (api/q (api/db *api*)
                                  '{:find [e]
                                    :where [[e :name "Ivan"]]})))
+
       (t/is (= #{} (api/q (api/db *api* #inst "1999")
                           '{:find [e]
                             :where [[e :name "Ivan"]]})))
@@ -437,3 +438,39 @@
                    (-> (db/fetch-docs (:document-store *server-api*) #{arg-doc-id})
                        (get arg-doc-id)
                        (dissoc :crux.db/id)))))))))
+
+(t/deftest test-current-queries
+  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
+    (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
+    (t/is (true? (api/tx-committed? *api* submitted-tx)))
+    (let [db (api/db *api*)]
+      (t/is (api/q (api/db *api*)
+                   '{:find [e]
+                     :where [[e :name "Ivan"]]}))
+
+      (t/testing "test current-query - post successful query"
+        (let [current-queries (api/current-queries *api*)]
+          (t/is (= :completed (:status (first current-queries))))))
+
+      (t/is (thrown-with-msg? Exception
+                              #"Find refers to unknown variable: f"
+                              (api/q db '{:find [f], :where [[e :crux.db/id _]]})))
+
+      (t/testing "test current-query - post failed query"
+        (let [malformed-query (first (api/current-queries *api*))]
+          (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
+          (t/is (= :failed (:status malformed-query)))))
+
+      (t/testing "test current-query - streaming query"
+        (with-open [res (api/open-q db '{:find [e]
+                                         :where [[e :name "Ivan"]]})]
+
+          (t/testing "test current-query - streaming query (not realized)"
+            (let [streaming-query (first (api/current-queries *api*))]
+              (= '{:find [e] :where [[e :name "Ivan"]]} (:query streaming-query))
+              (= :in-progress (:status streaming-query))))
+
+          (t/is (iterator-seq res))
+
+          (t/testing "test current-query - streaming query (result realized)"
+            (= :complete (:status (first (api/current-queries *api*))))))))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -438,39 +438,3 @@
                    (-> (db/fetch-docs (:document-store *server-api*) #{arg-doc-id})
                        (get arg-doc-id)
                        (dissoc :crux.db/id)))))))))
-
-(t/deftest test-current-queries
-  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
-    (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
-    (t/is (true? (api/tx-committed? *api* submitted-tx)))
-    (let [db (api/db *api*)]
-      (t/is (api/q (api/db *api*)
-                   '{:find [e]
-                     :where [[e :name "Ivan"]]}))
-
-      (t/testing "test current-query - post successful query"
-        (let [current-queries (api/current-queries *api*)]
-          (t/is (= :completed (:status (first current-queries))))))
-
-      (t/is (thrown-with-msg? Exception
-                              #"Find refers to unknown variable: f"
-                              (api/q db '{:find [f], :where [[e :crux.db/id _]]})))
-
-      (t/testing "test current-query - post failed query"
-        (let [malformed-query (first (api/current-queries *api*))]
-          (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
-          (t/is (= :failed (:status malformed-query)))))
-
-      (t/testing "test current-query - streaming query"
-        (with-open [res (api/open-q db '{:find [e]
-                                         :where [[e :name "Ivan"]]})]
-
-          (t/testing "test current-query - streaming query (not realized)"
-            (let [streaming-query (first (api/current-queries *api*))]
-              (= '{:find [e] :where [[e :name "Ivan"]]} (:query streaming-query))
-              (= :in-progress (:status streaming-query))))
-
-          (t/is (iterator-seq res))
-
-          (t/testing "test current-query - streaming query (result realized)"
-            (= :complete (:status (first (api/current-queries *api*))))))))))

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -82,4 +82,4 @@
 
       (t/testing "test active-queries & recent-queries - streaming query (result realized)"
         (t/is (empty? (api/active-queries *api*)))
-        (= :complete (:status (first (api/recent-queries *api*))))))))
+        (t/is (= :completed (:status (first (api/recent-queries *api*)))))))))

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -1,0 +1,44 @@
+(ns crux.current-queries-test
+  (:require [clojure.test :as t]
+            [crux.api :as api]
+            [crux.fixtures :as fix :refer [*api*]]
+            [crux.fixtures.every-api :as every-api]))
+
+(t/use-fixtures :once every-api/with-embedded-kafka-cluster)
+(t/use-fixtures :each (partial fix/with-opts {:crux.bus/sync? true}) every-api/with-each-api-implementation)
+
+(t/deftest test-current-queries
+  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
+    (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
+    (t/is (true? (api/tx-committed? *api* submitted-tx)))
+    (let [db (api/db *api*)]
+      (t/is (api/q (api/db *api*)
+                   '{:find [e]
+                     :where [[e :name "Ivan"]]}))
+
+      (t/testing "test current-query - post successful query"
+        (let [current-queries (api/current-queries *api*)]
+          (t/is (= :completed (:status (first current-queries))))))
+
+      (t/is (thrown-with-msg? Exception
+                              #"Find refers to unknown variable: f"
+                              (api/q db '{:find [f], :where [[e :crux.db/id _]]})))
+
+      (t/testing "test current-query - post failed query"
+        (let [malformed-query (first (api/current-queries *api*))]
+          (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
+          (t/is (= :failed (:status malformed-query)))))
+
+      (t/testing "test current-query - streaming query"
+        (with-open [res (api/open-q db '{:find [e]
+                                         :where [[e :name "Ivan"]]})]
+
+          (t/testing "test current-query - streaming query (not realized)"
+            (let [streaming-query (first (api/current-queries *api*))]
+              (= '{:find [e] :where [[e :name "Ivan"]]} (:query streaming-query))
+              (= :in-progress (:status streaming-query))))
+
+          (t/is (iterator-seq res))
+
+          (t/testing "test current-query - streaming query (result realized)"
+            (= :complete (:status (first (api/current-queries *api*))))))))))

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -2,43 +2,62 @@
   (:require [clojure.test :as t]
             [crux.api :as api]
             [crux.fixtures :as fix :refer [*api*]]
-            [crux.fixtures.every-api :as every-api]))
+            [crux.fixtures.every-api :as every-api])
+  (:import java.time.Duration))
 
 (t/use-fixtures :once every-api/with-embedded-kafka-cluster)
-(t/use-fixtures :each (partial fix/with-opts {:crux.bus/sync? true}) every-api/with-each-api-implementation)
+(t/use-fixtures :each (partial fix/with-opts {:crux.bus/sync? true
+                                              :crux.node/finished-queries-max-age (Duration/ofSeconds 1)
+                                              :crux.node/finished-queries-max-count 1})
+  every-api/with-each-api-implementation)
 
 (t/deftest test-current-queries
-  (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
-    (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
-    (t/is (true? (api/tx-committed? *api* submitted-tx)))
-    (let [db (api/db *api*)]
-      (t/is (api/q (api/db *api*)
-                   '{:find [e]
-                     :where [[e :name "Ivan"]]}))
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])
+  (let [db (api/db *api*)]
+    (api/q (api/db *api*)
+           '{:find [e]
+             :where [[e :name "Ivan"]]})
 
-      (t/testing "test current-query - post successful query"
-        (let [current-queries (api/current-queries *api*)]
-          (t/is (= :completed (:status (first current-queries))))))
+    (t/testing "test current-query - post successful query"
+      (let [current-queries (api/current-queries *api*)]
+        (t/is (= :completed (:status (first current-queries))))))
 
-      (t/is (thrown-with-msg? Exception
-                              #"Find refers to unknown variable: f"
-                              (api/q db '{:find [f], :where [[e :crux.db/id _]]})))
+    (t/is (thrown-with-msg? Exception
+                            #"Find refers to unknown variable: f"
+                            (api/q db '{:find [f], :where [[e :crux.db/id _]]})))
 
-      (t/testing "test current-query - post failed query"
-        (let [malformed-query (first (api/current-queries *api*))]
-          (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
-          (t/is (= :failed (:status malformed-query)))))
+    (t/testing "test current-query - post failed query"
+      (let [malformed-query (first (api/current-queries *api*))]
+        (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
+        (t/is (= :failed (:status malformed-query)))))
 
-      (t/testing "test current-query - streaming query"
-        (with-open [res (api/open-q db '{:find [e]
-                                         :where [[e :name "Ivan"]]})]
+    (t/testing "test current-query - streaming query"
+      (with-open [res (api/open-q db '{:find [e]
+                                       :where [[e :name "Ivan"]]})]
 
-          (t/testing "test current-query - streaming query (not realized)"
-            (let [streaming-query (first (api/current-queries *api*))]
-              (= '{:find [e] :where [[e :name "Ivan"]]} (:query streaming-query))
-              (= :in-progress (:status streaming-query))))
+        (t/testing "test current-query - streaming query (not realized)"
+          (let [streaming-query (first (api/current-queries *api*))]
+            (= '{:find [e] :where [[e :name "Ivan"]]} (:query streaming-query))
+            (= :in-progress (:status streaming-query))))
 
-          (t/is (iterator-seq res))
+        (doall (iterator-seq res))
 
-          (t/testing "test current-query - streaming query (result realized)"
-            (= :complete (:status (first (api/current-queries *api*))))))))))
+        (t/testing "test current-query - streaming query (result realized)"
+          (= :complete (:status (first (api/current-queries *api*)))))))
+
+    (api/q (api/db *api*)
+           '{:find [e]
+             :where [[e :name "Ivan"]]})
+    (api/q (api/db *api*)
+           '{:find [e]
+             :where [[e :name "Iva"]]})
+    (t/testing "test current-query - check max count expiration"
+      (t/is (= '{:find [e]
+                 :where [[e :name "Iva"]]}
+               (:query (first (api/current-queries *api*))))))
+    (t/is (api/q (api/db *api*)
+                 '{:find [e]
+                   :where [[e :name "Ivan"]]}))
+    (Thread/sleep 1000)
+    (t/testing "test current-query - check time expiration"
+      (t/is (empty? (api/current-queries *api*))))))

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -131,7 +131,7 @@
      ~@body))
 
 (t/deftest test-await-tx
-  (let [bus (bus/->bus)
+  (let [bus (bus/->bus {})
         await-tx (fn [tx timeout]
                    (#'n/await-tx {:bus bus} ::tx/tx-id tx timeout))
         tx1 {::tx/tx-id 1

--- a/docs/clojure_api.adoc
+++ b/docs/clojure_api.adoc
@@ -180,6 +180,21 @@ toc::[]
     "Returns frequencies of indexed attributes")
 ----
 
+=== active-queries
+
+[source,clojure]
+----
+  (active-queries [node]
+    "Returns a list of currently running queries")
+----
+
+=== recent-queries
+
+[source,clojure]
+----
+  (recent-queries [node]
+    "Returns a list of recently completed/failed queries")
+----
 
 [#clojure-api-icruxdatasource]
 == ICruxDatasource

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,13 @@
    [juxt/crux-cli "crux-git-version-beta"]
 
    [org.apache.kafka/connect-api "2.3.0" :scope "provided"]
+
    [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]
+   [com.h2database/h2 "1.4.199"]
+   [com.opentable.components/otj-pg-embedded "0.13.1"]
+   [org.xerial/sqlite-jdbc "3.28.0"]
+   [mysql/mysql-connector-java "8.0.17"]
+   [com.microsoft.sqlserver/mssql-jdbc "8.2.2.jre8"]
 
    [integrant "0.8.0"]
    [integrant/repl "0.3.1"]
@@ -55,11 +61,14 @@
    [com.google.code.findbugs/jsr305 "3.0.2"]
    [org.apache.commons/commons-lang3 "3.9"]
    [org.apache.commons/commons-text "1.7"]
+   [org.apache.commons/commons-compress "1.19"]
    [org.javassist/javassist "3.22.0-GA"]
    [commons-codec "1.12"]
    [joda-time "2.9.9"]
    [org.eclipse.jetty/jetty-util "9.4.22.v20191022"]
    [org.eclipse.jetty/jetty-http "9.4.22.v20191022"]
+   [org.tukaani/xz "1.8"]
+   [com.github.spotbugs/spotbugs-annotations "3.1.9"]
 
    ;; crux metrics dependencies
    ;; tag::MetricsJMXDeps[]


### PR DESCRIPTION
Resolves #493 

**TODO**:
- Add tests to API test.

A small sample of what you get back:
```clojure
user> (crux/current-queries (crux-node))
({:query-id "f5783cf7-a713-4a58-aebb-b711cf1193fb",
  :started-at
  #object[java.time.Instant 0x5e3771ce "2020-08-03T15:11:33.205Z"],
  :query {:find [e], :where [[e :crux.db/id _]]},
  :finished-at
  #object[java.time.Instant 0x5557d318 "2020-08-03T15:11:33.206Z"],
  :time-taken #object[java.time.Duration 0x654a582 "PT0.001S"],
  :status :completed}
 {:query-id "60a862ab-431b-4305-802c-b83d08e61823",
  :started-at
  #object[java.time.Instant 0x3b3a7353 "2020-08-03T15:11:31.597Z"],
  :query {:find [e], :where [[e :crux.db/id _]]},
  :finished-at
  #object[java.time.Instant 0x7579c524 "2020-08-03T15:11:31.601Z"],
  :time-taken #object[java.time.Duration 0x8d031e "PT0.004S"],
  :status :completed}
 {:query-id "451e71a7-521f-4865-bb41-f830ef1f72d9",
  :started-at
  #object[java.time.Instant 0x63cbbc46 "2020-08-03T15:09:36.831Z"],
  :query {:find [f], :where [[e :crux.db/id _]]},
  :finished-at
  #object[java.time.Instant 0x27e46745 "2020-08-03T15:09:36.858Z"],
  :time-taken #object[java.time.Duration 0x49fcb933 "PT0.027S"],
  :status :failed,
  :error
  {:type java.lang.IllegalArgumentException,
   :message "Find refers to unknown variable: f"}})
```