### PR TITLE
Fix #1016, consistent ID types

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1256,7 +1256,7 @@
                               (empty? join-child-fns))
                  (let [content-hash (entity-resolver-fn (c/->id-buffer value))]
                    (let-docs [docs #{content-hash}]
-                     (let [doc (get docs content-hash)]
+                     (let [doc (get docs (c/new-id content-hash))]
                        (->> (mapv (fn [[dispatch-key child-fns]]
                                     (let [v (get doc dispatch-key)]
                                       (->> (if (or (vector? v) (set? v))
@@ -1303,7 +1303,7 @@
                               (or (when full-results?
                                     (when-let [hash (some-> (entity-resolver-fn (c/->id-buffer value)) (c/new-id))]
                                       (let-docs [docs #{hash}]
-                                        (get docs hash))))
+                                        (get docs (c/new-id hash)))))
                                   value))}
       :project {:logic-var (:logic-var arg)
                 :var-binding (var->bindings (:logic-var arg))

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -103,7 +103,7 @@
     (->> (for [id-batch (partition-all 100 ids)
                row (jdbc/execute! ds (into [(format "SELECT EVENT_KEY, V FROM tx_events WHERE TOPIC = 'docs' AND EVENT_KEY IN (%s) AND COMPACTED = 0"
                                                     (->> (repeat (count id-batch) "?") (str/join ", ")))]
-                                           (map str id-batch))
+                                           (map (comp str c/new-id) id-batch))
                                   {:builder-fn jdbcr/as-unqualified-lower-maps})]
            row)
          (map (juxt (comp c/new-id c/hex->id-buffer :event_key) #(->v dbtype (:v %))))


### PR DESCRIPTION
Fix #1016, caused by not being consistent about the types of IDs we're passing to the doc store