### PR TITLE
Add "slowest queries" to the API.

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -129,7 +129,10 @@
     "Returns a list of currently running queries")
 
   (recent-queries [node]
-    "Returns a list of recently completed/failed queries"))
+    "Returns a list of recently completed/failed queries")
+
+  (slowest-queries [node]
+    "Returns a list of slowest completed/failed queries ran on the node"))
 
 (defprotocol PCruxIngestClient
   "Provides API access to Crux ingestion."
@@ -212,7 +215,10 @@
     (map qs/<-QueryState (.activeQueries this)))
 
   (recent-queries [this]
-    (map qs/<-QueryState (.recentQueries this))))
+    (map qs/<-QueryState (.recentQueries this)))
+
+  (slowest-queries [this]
+    (map qs/<-QueryState (.slowestQueries this))))
 
 (extend-protocol PCruxIngestClient
   ICruxIngestAPI

--- a/crux-core/src/crux/api/ICruxAPI.java
+++ b/crux-core/src/crux/api/ICruxAPI.java
@@ -164,4 +164,11 @@ public interface ICruxAPI extends ICruxIngestAPI, Closeable {
      * @return List containing maps with query information.
      */
     public List<QueryState> recentQueries();
+
+    /**
+     * Returns a list of slowest completed/failed queries ran on the node
+     *
+     * @return List containing maps with query information.
+     */
+    public List<QueryState> slowestQueries();
 }

--- a/crux-core/src/crux/config.clj
+++ b/crux-core/src/crux/config.clj
@@ -55,6 +55,8 @@
                    t
                    any?))))
 
+(s/def ::fn fn?)
+
 (s/def ::doc string?)
 (s/def ::default any?)
 (s/def ::required? boolean?)

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -68,7 +68,7 @@
     (let [time-since-query ^Duration (Duration/between (.toInstant ^Date finished-at) (Instant/now))]
       (neg? (.compareTo max-age time-since-query)))))
 
-(defn- slow-query? [{:keys [started-at finished-at] :as query} {::keys [^Duration slow-queries-min-threshold]}]
+(defn slow-query? [{:keys [started-at finished-at] :as query} {::keys [^Duration slow-queries-min-threshold]}]
   (let [time-taken (Duration/between (.toInstant ^Date started-at) (.toInstant ^Date finished-at))]
     (neg? (.compareTo slow-queries-min-threshold time-taken))))
 

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -230,10 +230,10 @@
 
 (defmethod print-method CruxNode [node ^Writer w] (.write w "#<CruxNode>"))
 
-(defn- add-and-clean-finished-queries [queries {:keys [query-id] :as query} {::keys [slow-query-callback-fn] :as node-opts}]
+(defn- add-and-clean-finished-queries [queries {:keys [query-id] :as query} {::keys [slow-queries-callback-fn] :as node-opts}]
   (let [slow-query? (slow-query? query node-opts)]
-    (when (and slow-query? slow-query-callback-fn)
-      (slow-query-callback-fn query))
+    (when (and slow-query? slow-queries-callback-fn)
+      (slow-queries-callback-fn query))
     (-> queries
         (update :in-progress dissoc query-id)
         (update :completed conj query)
@@ -300,9 +300,9 @@
           ::slow-queries-min-threshold {:doc "Minimum threshold for a query to be considered slow."
                                         :default (Duration/ofMinutes 1)
                                         :crux.config/type :crux.config/duration}
-          ::slow-query-callback-fn {:doc "Callback function to pass slow queries to"
-                                    :default nil
-                                    :crux.config/type :crux.config/fn}}})
+          ::slow-queries-callback-fn {:doc "Callback function to pass slow queries to"
+                                      :default nil
+                                      :crux.config/type :crux.config/fn}}})
 
 (def base-topology
   {::kv-store 'crux.kv.memdb/kv

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -282,6 +282,12 @@
                             :->jwt-token ->jwt-token})
          (map qs/->QueryState)))
 
+  (slowestQueries [_]
+    (->> (api-request-sync (str url "/slowest-queries")
+                           {:http-opts {:method :get}
+                            :->jwt-token ->jwt-token})
+         (map qs/->QueryState)))
+
   Closeable
   (close [_]))
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -266,6 +266,9 @@
 (defn recent-queries [^ICruxAPI crux-node]
   (success-response (api/recent-queries crux-node)))
 
+(defn slowest-queries [^ICruxAPI crux-node]
+  (success-response (api/slowest-queries crux-node)))
+
 (def ^:private sparql-available?
   (try ; you can change it back to require when clojure.core fixes it to be thread-safe
     (requiring-resolve 'crux.sparql.protocol/sparql-query)
@@ -334,6 +337,9 @@
 
     [#"^/recent-queries" [:get]]
     (recent-queries crux-node)
+
+    [#"^/slowest-queries" [:get]]
+    (slowest-queries crux-node)
 
     (if (and (check-path [#"^/sparql/?$" [:get :post]] request)
              sparql-available?)

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -10,7 +10,8 @@
 (defn- ns->ms [time-ns]
   (/ time-ns 1e6))
 
-(def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics?  with-query-metrics?]}]
+(def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics? with-query-metrics? slow-query-callback-fn] :as node-opts}]
+                                  (query-metrics/add-slow-query-listeners deps node-opts)
                                   (cond-> (dropwizard/new-registry)
                                     with-indexer-metrics? (doto (indexer-metrics/assign-listeners deps))
                                     with-query-metrics? (doto (query-metrics/assign-listeners deps))))
@@ -20,7 +21,10 @@
                                                       :crux.config/type :crux.config/boolean}
                              ::with-query-metrics? {:doc "Include metrics on queries"
                                                     :default true
-                                                    :crux.config/type :crux.config/boolean}}})
+                                                    :crux.config/type :crux.config/boolean}
+                             ::slow-query-callback-fn {:doc "Callback function to pass slow queries to"
+                                                       :default nil
+                                                       :crux.config/type :crux.config/fn}}})
 
 (defrecord StatusReporter [^MetricRegistry registry]
   status/Status

--- a/crux-metrics/src/crux/metrics.clj
+++ b/crux-metrics/src/crux/metrics.clj
@@ -10,8 +10,7 @@
 (defn- ns->ms [time-ns]
   (/ time-ns 1e6))
 
-(def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics? with-query-metrics? slow-query-callback-fn] :as node-opts}]
-                                  (query-metrics/add-slow-query-listeners deps node-opts)
+(def registry-module {:start-fn (fn [deps {::keys [with-indexer-metrics? with-query-metrics?]}]
                                   (cond-> (dropwizard/new-registry)
                                     with-indexer-metrics? (doto (indexer-metrics/assign-listeners deps))
                                     with-query-metrics? (doto (query-metrics/assign-listeners deps))))
@@ -21,10 +20,7 @@
                                                       :crux.config/type :crux.config/boolean}
                              ::with-query-metrics? {:doc "Include metrics on queries"
                                                     :default true
-                                                    :crux.config/type :crux.config/boolean}
-                             ::slow-query-callback-fn {:doc "Callback function to pass slow queries to"
-                                                       :default nil
-                                                       :crux.config/type :crux.config/fn}}})
+                                                    :crux.config/type :crux.config/boolean}}})
 
 (defrecord StatusReporter [^MetricRegistry registry]
   status/Status

--- a/crux-metrics/src/crux/metrics/query.clj
+++ b/crux-metrics/src/crux/metrics/query.clj
@@ -21,17 +21,3 @@
      :current-query-count (dropwizard/gauge registry
                                             ["query" "currently-running"]
                                             (fn [] (count @!timer-store)))}))
-
-(defn add-slow-query-listeners
-  [{:crux.node/keys [bus]} {:crux.metrics/keys [slow-query-callback-fn] :as node-opts}]
-  (let [!in-progress-queries (atom {})]
-    (bus/listen bus {:crux/event-types #{::q/submitted-query}}
-                (fn [{::q/keys [query-id] :as query}]
-                  (swap! !in-progress-queries assoc query-id {:started-at (Date.)})))
-    (bus/listen bus {:crux/event-types #{::q/completed-query ::q/failed-query}}
-                (fn [{::q/keys [query-id] :as query}]
-                  (let [started-at (get-in @!in-progress-queries [query-id :started-at])
-                        query (assoc query :started-at started-at :finished-at (Date.))]
-                    (swap! !in-progress-queries dissoc query-id)
-                    (when (node/slow-query? query node-opts)
-                      (slow-query-callback-fn query)))))))

--- a/crux-metrics/src/crux/metrics/query.clj
+++ b/crux-metrics/src/crux/metrics/query.clj
@@ -1,20 +1,37 @@
 (ns ^:no-doc crux.metrics.query
   (:require [crux.bus :as bus]
-            [crux.metrics.dropwizard :as dropwizard]))
+            [crux.node :as node]
+            [crux.query :as q]
+            [crux.metrics.dropwizard :as dropwizard])
+  (:import java.util.Date))
 
 (defn assign-listeners
   [registry {:crux.node/keys [bus]}]
   (let [!timer-store (atom {})
         query-timer (dropwizard/timer registry ["query" "timer"])]
     (bus/listen bus {:crux/event-types #{:crux.query/submitted-query}}
-              (fn [event]
-                (swap! !timer-store assoc (:crux.query/query-id event) (dropwizard/start query-timer))))
+                (fn [event]
+                  (swap! !timer-store assoc (:crux.query/query-id event) (dropwizard/start query-timer))))
 
     (bus/listen bus {:crux/event-types #{:crux.query/completed-query}}
-              (fn [event]
-                (dropwizard/stop (get @!timer-store (:crux.query/query-id event)))
-                (swap! !timer-store dissoc (:crux.query/query-id event))))
+                (fn [event]
+                  (dropwizard/stop (get @!timer-store (:crux.query/query-id event)))
+                  (swap! !timer-store dissoc (:crux.query/query-id event))))
     {:query-timer query-timer
      :current-query-count (dropwizard/gauge registry
                                             ["query" "currently-running"]
                                             (fn [] (count @!timer-store)))}))
+
+(defn add-slow-query-listeners
+  [{:crux.node/keys [bus]} {:crux.metrics/keys [slow-query-callback-fn] :as node-opts}]
+  (let [!in-progress-queries (atom {})]
+    (bus/listen bus {:crux/event-types #{::q/submitted-query}}
+                (fn [{::q/keys [query-id] :as query}]
+                  (swap! !in-progress-queries assoc query-id {:started-at (Date.)})))
+    (bus/listen bus {:crux/event-types #{::q/completed-query ::q/failed-query}}
+                (fn [{::q/keys [query-id] :as query}]
+                  (let [started-at (get-in @!in-progress-queries [query-id :started-at])
+                        query (assoc query :started-at started-at :finished-at (Date.))]
+                    (swap! !in-progress-queries dissoc query-id)
+                    (when (node/slow-query? query node-opts)
+                      (slow-query-callback-fn query)))))))

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -46,7 +46,9 @@
                (->> (clean-completed-queries queries
                                              {::n/recent-queries-max-age (Duration/ofSeconds 8)
                                               ::n/recent-queries-max-count 5})
-                    (map ::query-id))))))
+                    (map ::query-id)))))))
+
+(t/deftest test-cleaning-slowest-queries
   (let [clean-slowest-queries @#'n/clean-slowest-queries
         started-at (Date.)
         queries [{:started-at (Date/from (.minus (.toInstant started-at)

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -123,11 +123,10 @@
     (t/testing "test slowest-queries - post query (min threshold - 1 nanosecond)"
       (t/is (= :completed (:status (first (api/slowest-queries *api*))))))
 
-    (let [slow-query? @#'n/slow-query?
-          start (Instant/now)
+    (let [start (Instant/now)
           query-info {:started-at (Date/from start) :finished-at (Date/from (.plusSeconds start 2))}]
-      (t/is (slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 1)}))
-      (t/is (not (slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 10)}))))))
+      (t/is (n/slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 1)}))
+      (t/is (not (n/slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 10)}))))))
 
 (t/deftest test-active-queries
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]

--- a/crux-test/test/crux/current_queries_test.clj
+++ b/crux-test/test/crux/current_queries_test.clj
@@ -4,46 +4,91 @@
             [crux.fixtures :as fix :refer [*api*]]
             [crux.fixtures.every-api :as every-api]
             [crux.node :as n])
-  (:import java.time.Duration
+  (:import (java.time Instant Duration)
            java.util.Date))
 
 (t/use-fixtures :once every-api/with-embedded-kafka-cluster)
-(t/use-fixtures :each (partial fix/with-opts {:crux.bus/sync? true}) every-api/with-each-api-implementation)
+(t/use-fixtures :each
+  (partial fix/with-opts {:crux.bus/sync? true
+                          :crux.node/slow-queries-min-threshold (Duration/ofNanos 1)})
+  every-api/with-each-api-implementation)
 
 (t/deftest test-cleaning-recent-queries
-  (let [clean-expired-queries @#'n/clean-expired-queries
-        queries [{:finished-at (Date.)
-                  ::query-id 1}
-                 {:finished-at (Date/from (.minus (.toInstant (Date.))
-                                                  (Duration/ofSeconds 5)))
-                  ::query-id 2}
-                 {:finished-at (Date/from (.minus (.toInstant (Date.))
-                                                  (Duration/ofSeconds 10)))
-                  ::query-id 3}]]
-    (t/testing "test recent-queries - check max count expiration"
-      (t/is (= [1]
-               (->> (clean-expired-queries queries
-                                           {::n/recent-queries-max-age (Duration/ofSeconds 8)
-                                            ::n/recent-queries-max-count 1})
-                    (map ::query-id))))
+  (let [clean-running-queries @#'n/clean-running-queries]
+    (t/testing "test clean-running-queries cleans up completed queries"
+      (let [queries {:completed [{:finished-at (Date.)
+                                  ::query-id 1}
+                                 {:finished-at (Date/from (.minus (.toInstant (Date.))
+                                                                  (Duration/ofSeconds 5)))
+                                  ::query-id 2}
+                                 {:finished-at (Date/from (.minus (.toInstant (Date.))
+                                                                  (Duration/ofSeconds 10)))
+                                  ::query-id 3}]}]
+        (t/testing "test recent-queries - check max count expiration"
+          (t/is (= [1]
+                   (->> (clean-running-queries queries
+                                               {::n/recent-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/recent-queries-max-count 1})
+                        :completed
+                        (map ::query-id))))
 
-      (t/is (= [1 2]
-               (->> (clean-expired-queries queries
-                                           {::n/recent-queries-max-age (Duration/ofSeconds 8)
-                                            ::n/recent-queries-max-count 2})
-                    (map ::query-id)))))
+          (t/is (= [1 2]
+                   (->> (clean-running-queries queries
+                                               {::n/recent-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/recent-queries-max-count 2})
+                        :completed
+                        (map ::query-id)))))
 
-    (t/testing "test recent-queries - check time expiration"
-      (t/is (= [1]
-               (->> (clean-expired-queries queries
-                                           {::n/recent-queries-max-age (Duration/ofSeconds 4)
-                                            ::n/recent-queries-max-count 5})
-                    (map ::query-id))))
-      (t/is (= [1 2]
-               (->> (clean-expired-queries queries
-                                           {::n/recent-queries-max-age (Duration/ofSeconds 8)
-                                            ::n/recent-queries-max-count 5})
-                    (map ::query-id)))))))
+        (t/testing "test recent-queries - check time expiration"
+          (t/is (= [1]
+                   (->> (clean-running-queries queries
+                                               {::n/recent-queries-max-age (Duration/ofSeconds 4)
+                                                ::n/recent-queries-max-count 5})
+                        :completed
+                        (map ::query-id))))
+          (t/is (= [1 2]
+                   (->> (clean-running-queries queries
+                                               {::n/recent-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/recent-queries-max-count 5})
+                        :completed
+                        (map ::query-id)))))))
+    (t/testing "test clean-running-queries cleans up slowest queries"
+      (let [queries {:slowest [{:finished-at (Date.)
+                                ::query-id 1}
+                               {:finished-at (Date/from (.minus (.toInstant (Date.))
+                                                                (Duration/ofSeconds 5)))
+                                ::query-id 2}
+                               {:finished-at (Date/from (.minus (.toInstant (Date.))
+                                                                (Duration/ofSeconds 10)))
+                                ::query-id 3}]}]
+        (t/testing "test slowest-queries - check max count expiration"
+          (t/is (= [1]
+                   (->> (clean-running-queries queries
+                                               {::n/slow-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/slow-queries-max-count 1})
+                        :slowest
+                        (map ::query-id))))
+
+          (t/is (= [1 2]
+                   (->> (clean-running-queries queries
+                                               {::n/slow-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/slow-queries-max-count 2})
+                        :slowest
+                        (map ::query-id)))))
+
+        (t/testing "test slowest-queries - check time expiration"
+          (t/is (= [1]
+                   (->> (clean-running-queries queries
+                                               {::n/slow-queries-max-age (Duration/ofSeconds 4)
+                                                ::n/slow-queries-max-count 5})
+                        :slowest
+                        (map ::query-id))))
+          (t/is (= [1 2]
+                   (->> (clean-running-queries queries
+                                               {::n/slow-queries-max-age (Duration/ofSeconds 8)
+                                                ::n/slow-queries-max-count 5})
+                        :slowest
+                        (map ::query-id)))))))))
 
 (t/deftest test-recent-queries
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]
@@ -66,6 +111,23 @@
       (let [malformed-query (first (api/recent-queries *api*))]
         (t/is (= '{:find [f], :where [[e :crux.db/id _]]} (:query malformed-query)))
         (t/is (= :failed (:status malformed-query)))))))
+
+(t/deftest test-slowest-queries
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]
+                        [:crux.tx/put {:crux.db/id :petr :name "Petr"}]])
+  (let [db (api/db *api*)]
+    (api/q db
+           '{:find [e]
+             :where [[e :name "Ivan"]]})
+
+    (t/testing "test slowest-queries - post query (min threshold - 1 nanosecond)"
+      (t/is (= :completed (:status (first (api/slowest-queries *api*))))))
+
+    (let [slow-query? @#'n/slow-query?
+          start (Instant/now)
+          query-info {:started-at (Date/from start) :finished-at (Date/from (.plusSeconds start 2))}]
+      (t/is (slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 1)}))
+      (t/is (not (slow-query? query-info {::n/slow-queries-min-threshold (Duration/ofSeconds 10)}))))))
 
 (t/deftest test-active-queries
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]

--- a/docs/reference/modules/ROOT/pages/clojure-api.adoc
+++ b/docs/reference/modules/ROOT/pages/clojure-api.adoc
@@ -193,6 +193,14 @@ with few lifecycle members added.
     "Returns a list of recently completed/failed queries")
 ----
 
+=== slowest-queries
+
+[source,clojure]
+----
+  (slowest-queries [node]
+    "Returns a list of slowest completed/failed queries ran on the node")
+----
+
 [#icruxdatasource]
 == ICruxDatasource
 Represents the database as of a specific valid and transaction time.


### PR DESCRIPTION
Resolves #516

Likely needs some iterating/cleanup but currently:
- List is implemented as a key, `:slowest` within the `!running-queries` atom
- Output is a list of QueryStates, as with `recent-queries` and `active-queries`.
- Adds an arg to `crux.node`, `slow-query-callback-fn` - user can pass a callback function that gets called when a 'slow-query' completes