### PR TITLE
Data browser - Keep tab state

### DIFF
--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -43,8 +43,12 @@
 
 (rf/reg-event-fx
  ::console-tab-selected
- (fn [_ [_ tab]]
-   {:dispatch [:navigate tab {} {}]}))
+ (fn [{:keys [db]} [_ tab]]
+   (let [current-tab (get-in db [:current-route :data :name] :query)
+         current-params (get-in db [:current-route :query-params])]
+     (when (not= tab current-tab)
+       {:db (assoc-in db [:previous-params current-tab] current-params)
+        :dispatch [:navigate tab {} (get-in db [:previous-params tab])]}))))
 
 (rf/reg-event-db
  ::toggle-form-pane

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -47,7 +47,8 @@
    (let [current-tab (get-in db [:current-route :data :name] :query)
          current-params (get-in db [:current-route :query-params])]
      (when (not= tab current-tab)
-       {:db (assoc-in db [:previous-params current-tab] current-params)
+       {:db (-> (assoc-in db [:previous-params current-tab] current-params)
+                (assoc :load-from-state? true))
         :dispatch [:navigate tab {} (get-in db [:previous-params tab])]}))))
 
 (rf/reg-event-db

--- a/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
+++ b/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
@@ -232,14 +232,11 @@
  ::query-form-history
  (fn [db _]
    ;; Get newest first
-   (reverse
-    (mapv
-     (fn [x]
-       {"q" (common/query-params->formatted-edn-string
-             (dissoc x :valid-time :transaction-time))
-        "valid-time" (:valid-time x)
-        "transaction-time" (:transaction-time x)})
-     (:query-history db)))))
+   (mapv
+    (fn [x]
+      {"q" (common/query-params->formatted-edn-string
+            (dissoc x :valid-time :transaction-time))})
+    (:query-history db))))
 
 (rf/reg-sub
  ::show-vt?

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -198,9 +198,7 @@
     [:<>
      (cond
        error [:div.error-box error]
-       (and
-        (:rows data)
-        (empty? (:rows data))) [:div.no-results "No results found!"]
+       (empty? (:rows data)) [:div.no-results "No results found!"]
        :else [:<>
               [:<>
                [:div.query-table-topbar

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -127,25 +127,26 @@
       "Query history is stored within temporary storage in your browser"]
      (if (not-empty query-history-list)
        [:div.form-pane__history-scrollable
-        (map-indexed
-         (fn [idx {:strs [q] :as history-q}]
-           ^{:key (gensym)}
-           [:div.form-pane__history-scrollable-el
-            [:div.form-pane__history-delete
-             {:on-click #(rf/dispatch [::events/remove-query-from-local-storage idx])}
-             [:i.fas.fa-trash-alt]]
-            [:div.form-pane__history-scrollable-el-left
-             [:div.form-pane__history-buttons
-              [:div.form-pane__history-button
-               {:on-click #(do (set-values {"q" q})
-                               (rf/dispatch [::events/query-form-tab-selected :edit-query]))}
-               "Edit"]
-              [:div.form-pane__history-button
-               {:on-click #(rf/dispatch [::events/go-to-historical-query history-q])}
-               "Run"]]
-             [:div
-              [cm/code-mirror-static q {:class "cm-textarea__query"}]]]])
-         query-history-list)]
+        (reverse
+         (map-indexed
+          (fn [idx {:strs [q] :as history-q}]
+            ^{:key (gensym)}
+            [:div.form-pane__history-scrollable-el
+             [:div.form-pane__history-delete
+              {:on-click #(rf/dispatch [::events/remove-query-from-local-storage idx])}
+              [:i.fas.fa-trash-alt]]
+             [:div.form-pane__history-scrollable-el-left
+              [:div.form-pane__history-buttons
+               [:div.form-pane__history-button
+                {:on-click #(do (set-values {"q" q})
+                                (rf/dispatch [::events/query-form-tab-selected :edit-query]))}
+                "Edit"]
+               [:div.form-pane__history-button
+                {:on-click #(rf/dispatch [::events/go-to-historical-query history-q])}
+                "Run"]]
+              [:div
+               [cm/code-mirror-static q {:class "cm-textarea__query"}]]]])
+          query-history-list))]
        [:div.form-pane__history-empty
         [:b "No recent queries found."]])]))
 

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -232,8 +232,8 @@
 
 (defmethod transform-query-resp :default [{:keys [eid error no-entity? not-found? entity entity-history] :as res} _]
   (cond
-    no-entity? {:status 400, :body "Missing eid"}
-    not-found? {:status 404, :body (str eid " entity not found")}
+    no-entity? {:status 400, :body {:error "Missing eid"}}
+    not-found? {:status 404, :body {:error (str eid " entity not found")}}
     error {:status 400, :body {:error (.getMessage ^Exception error)}}
     entity-history {:status 200, :body entity-history}
     :else {:status 200, :body entity}))


### PR DESCRIPTION
(Currently based on top of #1017)

Resolves #1004 - stores previous query params of console-tab and loads them when tab is clicked, also preventing unnecessary re-fetching of data.

Some additional points/bug fixes:
- Small bug I noticed while testing this (unrelated to the PR itself): Attempting to delete elements of query history actually deletes elements at other positions - likely because the list is being reversed. Will push a fix on this branch (though could well bring in seperately)
- In entity, `not-found` and `missing eid` messages were not showing as errors - returning them from EDN within an error map serves as a fix. 
- Empty set of results from query was no longer showing 'no results found' - instead showing an empty table.
