### PR TITLE
crux-jdbc: update next.jdbc dep to 1.1.582

### DIFF
--- a/crux-jdbc/project.clj
+++ b/crux-jdbc/project.clj
@@ -4,11 +4,10 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.logging "1.0.0"]
+                 [org.clojure/tools.logging "1.1.0"]
                  [juxt/crux-core "crux-git-version-beta"]
-                 [seancorfield/next.jdbc "1.0.9"]
-                 [org.clojure/java.data "0.1.4"]
-                 [com.zaxxer/HikariCP "3.3.1"]
+                 [seancorfield/next.jdbc "1.1.582"]
+                 [com.zaxxer/HikariCP "3.4.5"]
                  [com.taoensso/nippy "2.14.0"]
                  [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]]
   :middleware [leiningen.project-version/middleware]


### PR DESCRIPTION
* remove old `org.clojure/java.data` dep => `next.jdbc` brings in a new one
* update `com.zaxxer/HikariCP` to `3.4.5`
* update `org.clojure/tools.logging` to `1.1.0`

the current `crux-jdbc` deps:

```clojure
  :dependencies [[org.clojure/clojure "1.10.1"]
                 [org.clojure/tools.logging "1.0.0"]
                 [juxt/crux-core "crux-git-version-beta"]
                 [seancorfield/next.jdbc "1.0.9"]
                 [org.clojure/java.data "0.1.4"]
                 [com.zaxxer/HikariCP "3.3.1"]
                 [com.taoensso/nippy "2.14.0"]
                 [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]]
```

prevent `crux-jdbc` to be used with the latest `next.jdbc` due to the outdated `java.data` dep