### PR TITLE
Transaction function race condition #1049

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -163,14 +163,15 @@
 
 (defmethod index-tx-event :crux.tx/fn [[op k args-doc :as tx-op]
                                        {:crux.tx/keys [tx-time tx-id] :as tx}
-                                       {:keys [query-engine index-store], :as tx-ingester}]
+                                       {:keys [query-engine document-store index-store], :as tx-ingester}]
   (let [fn-id (c/new-id k)
         {args-doc-id :crux.db/id, :crux.db.fn/keys [args tx-events failed?]} args-doc
         args-content-hash (c/new-id args-doc)
 
         {:keys [tx-events docs failed?]}
         (cond
-          tx-events {:tx-events tx-events}
+          tx-events {:tx-events tx-events
+                     :docs (txc/tx-events->docs document-store tx-events)}
 
           failed? (do
                     (log/warn "Transaction function failed when originally evaluated:"

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -162,14 +162,11 @@
   (zipmap [:op :fn-eid :args-content-hash] evt))
 
 (defn tx-events->docs [document-store tx-events]
-  (let [docs (->> tx-events
-                  (map <-tx-event)
-                  (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
-                  (db/fetch-docs document-store))]
-    (merge docs
-           (when-let [more-events (seq (->> (vals docs)
-                                            (mapcat :crux.db.fn/tx-events)))]
-             (tx-events->docs document-store more-events)))))
+  (->> tx-events
+       (map <-tx-event)
+       (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
+       (remove #{c/nil-id-buffer})
+       (db/fetch-docs document-store)))
 
 (defn tx-events->tx-ops [document-store tx-events]
   (let [docs (tx-events->docs document-store tx-events)]


### PR DESCRIPTION
resolves #1049, see #1045 for the original report.

When a transaction function runs successfully, it replaces the argument doc with the yielded tx-events. This is to ensure that, should one of the documents read by the transaction function later get evicted, the result of the transaction remains unaltered in subsequent replays of the tx-log - we wouldn't want a transaction to commit first time through and abort in a later run-through.

So, when a transaction function is evaluated, we either have two states - whether or not the arg doc has yet been replaced. If it hasn't, we eval the function and replace the document; if it has, we simply yield the tx-events calculated by an earlier node. It's not an issue for two nodes to both eval the function and both replace the document, because the transaction function is pure and deterministic (we can replace a call to such a function with its result) and the update idempotent.

This race condition was caused by two reads of the argument doc - the first picking up the un-replaced doc, the second the replaced doc. This was a problem because we only indexed documents referenced in the arg-doc on the first read, not on the second - so any documents yielded by the transaction function were not indexed in this case. We've fixed the issue by doing all of the document indexing based on the second read.

Separately (not in this PR, now) is handling document stores being eventually consistent, ensuring that all document stores behave the same way as Kafka currently does - i.e. waiting until all the documents are present before returning. We did see another issue whereby if the arg doc was replaced before the yielded docs were written, the same symptoms occurred. 