### PR TITLE
Ensure that ints, shorts, bytes and floats as keys are translated to longs and doubles respectively

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -362,6 +362,22 @@
   (id->buffer [this to]
     (id-function to (nippy/fast-freeze this)))
 
+  Byte
+  (id->buffer [this to]
+    (id->buffer (long this) to))
+
+  Short
+  (id->buffer [this to]
+    (id->buffer (long this) to))
+
+  Integer
+  (id->buffer [this to]
+    (id->buffer (long this) to))
+
+  Float
+  (id->buffer [this to]
+    (id->buffer (double this) to))
+
   Number
   (id->buffer [this to]
     (id-function to (nippy/fast-freeze this)))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -21,7 +21,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def ^:const index-version 12)
+(def index-version 12)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/crux-test/test/crux/index_version_override_test.clj
+++ b/crux-test/test/crux/index_version_override_test.clj
@@ -1,0 +1,39 @@
+(ns crux.index-version-override-test
+  (:require [clojure.test :as t]
+            [crux.api :as crux]
+            [crux.codec :as c]
+            [crux.fixtures :as fix])
+  (:import crux.api.IndexVersionOutOfSyncException))
+
+(t/deftest test-index-version-override
+  (fix/with-tmp-dir "db-dir" [db-dir]
+    (let [index-version c/index-version
+          inc-index-version (inc index-version)
+          topo {:crux.node/topology '[crux.standalone/topology crux.kv.rocksdb/kv-store]
+                :crux.kv/db-dir db-dir}]
+
+      (doto (crux/start-node topo) .close)
+
+      (with-redefs [c/index-version inc-index-version]
+        (t/testing "standard IVOOSE"
+          (t/is (thrown? IndexVersionOutOfSyncException
+                         (doto (crux/start-node topo)
+                           (.close)))))
+
+        (t/testing "version numbers have to match exactly"
+          (t/is (thrown? IndexVersionOutOfSyncException
+                         (doto (crux/start-node (assoc topo :crux.kv-indexer/skip-index-version-bump [(dec index-version) inc-index-version]))
+                           (.close))))
+
+
+          (t/is (thrown? IndexVersionOutOfSyncException
+                         (doto (crux/start-node (assoc topo :crux.kv-indexer/skip-index-version-bump [index-version (inc inc-index-version)]))
+                           (.close)))))
+
+        (t/testing "supplying skip flag"
+          (with-open [node (crux/start-node (assoc topo :crux.kv-indexer/skip-index-version-bump [index-version inc-index-version]))]
+            (t/is node)))
+
+        (t/testing "only need to supply skip-index-version-bump once"
+          (with-open [node (crux/start-node topo)]
+            (t/is node)))))))


### PR DESCRIPTION
fixes #1043

If we were to be pedantic, this would require an index version bump given that documents with the aforementioned key types will have a different representation in the indices after this change. Discussion required!

Options:
* No bump - make it clear in the changelog
* Bump - make everyone re-index
* Some kind of flag that says 'trust me, I don't need one this time'?