### PR TITLE
Preparing for versioning docs.

### DIFF
--- a/docs/about/antora.yml
+++ b/docs/about/antora.yml
@@ -1,5 +1,6 @@
 name: about
 title: Crux
 version: master
+start_page: ROOT:what-is-crux.adoc
 nav:
   - nav.adoc

--- a/docs/about/modules/ROOT/pages/what-is-crux.adoc
+++ b/docs/about/modules/ROOT/pages/what-is-crux.adoc
@@ -1,5 +1,4 @@
 = What is Crux?
-:page-aliases: index.adoc
 
 Crux—to use Martin Kleppmann’s phrase—is an _unbundled_ database.
 

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -12,20 +12,15 @@ content:
     - url: ../
       start_path: docs/tutorials
       branches: HEAD
+#   - url: https://github.com/juxt/crux
+#      start_path: docs/reference
+#      branches:
+#        - example-version-branch
+#      tag:
+#        - release-version
     - url: ../
       start_path: docs/reference
       branches: HEAD
-  #  - url: ../
-  #    start_path: docs/concepts
-  #    branches: HEAD
-  #  - url: ../
-  #    start_path: docs/reference
-  #    branches: HEAD
-  # - url: https://github.com/juxt/crux
-  #   start_path: docs/reference
-  #   branches:
-  #     - test-release-branch-1.5
-  #     - test-release-branch-1.4
 ui:
   bundle:
     url: ./crux-site/ui-bundle.zip

--- a/docs/reference/antora.yml
+++ b/docs/reference/antora.yml
@@ -1,5 +1,7 @@
 name: reference
 title: Reference
 version: master
+display_version: Latest
+start_page: ROOT:get-started.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/reference/modules/ROOT/pages/get-started.adoc
+++ b/docs/reference/modules/ROOT/pages/get-started.adoc
@@ -1,5 +1,5 @@
 = Get Started
-:page-aliases: index.adoc, docs::index.adoc
+:page-aliases: docs::index.adoc
 :toc: macro
 
 toc::[]

--- a/docs/tutorials/antora.yml
+++ b/docs/tutorials/antora.yml
@@ -1,5 +1,6 @@
 name: tutorials
 title: Tutorials
 version: master
+start_page: ROOT:space-adventure.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/tutorials/modules/ROOT/pages/space-adventure.adoc
+++ b/docs/tutorials/modules/ROOT/pages/space-adventure.adoc
@@ -1,5 +1,4 @@
 = Space Adventure
-:page-aliases: index.adoc
 
 The "choose your own adventure" style tutorial series is an interactive story
 that you can follow along with and complete assignments.


### PR DESCRIPTION
(See also: juxt/crux-site#4 - want to merge that first, then update this to point to crux-site's master)

Resolves #1039 - adds the plumbing for versioning `reference`.

The current state of this - when releasing, we need to edit `antora.yml` within `reference`, remove the "Latest" `display_version` change the `version`. Post release, on master, we change it back to how it was. The `antora-playbook.yml` will point to a list of tags/release branches (currently commented out, prior to the next release), as well as using the local repository's HEAD to release "Latest".