### PR TITLE
Paginated history entry 1006

### DIFF
--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -164,6 +164,7 @@
     mfc/EncodeToOutputStream
     (encode-to-output-stream [_ {:keys [entity entity-history limit]} _]
       (fn [^OutputStream output-stream]
+        (println "Limit: " limit)
         (with-open [w (io/writer output-stream)]
           (if entity-history
             (if limit
@@ -230,7 +231,7 @@
                                 end-valid-time (assoc :end-valid-time end-valid-time)
                                 with-corrections? (assoc :with-corrections with-corrections?)
                                 with-docs? (assoc :with-docs with-docs?))]
-        (assoc {:entity-history (butlast page)} :continuation-opts continuation-opts)))))
+        (assoc {:entity-history (butlast page) :limit limit} :continuation-opts continuation-opts)))))
 
 (defn search-entity-history [{:keys [crux-node eid valid-time transaction-time sort-order history-opts limit resume-after-tx-id] :as params}]
   (try
@@ -294,7 +295,7 @@
     no-entity? {:status 400, :body {:error "Missing eid"}}
     not-found? {:status 404, :body {:error (str eid " entity not found")}}
     error {:status 400, :body {:error (.getMessage ^Exception error)}}
-    entity-history (merge {:status 200, :body {:entity-history entity-history} :headers (merge headers (resume-history-link req continuation-opts))})
+    entity-history (merge {:status 200, :body {:entity-history entity-history :limit limit} :headers (merge headers (resume-history-link req continuation-opts))})
     :else {:status 200, :body {:entity entity}}))
 
 (defn entity-state [req {:keys [entity-muuntaja] :as options}]

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -206,13 +206,13 @@
           db (util/db-for-request crux-node {:valid-time valid-time
                                              :transact-time transaction-time})
           entity-history (api/open-entity-history db eid sort-order history-opts)]
+      (println entity-history)
       (if-not (.hasNext entity-history)
         {:not-found? true}
-        {:entity-history
-         (cio/fmap-cursor (fn [entity-history]
-                            (cond->> (map #(update % :crux.db/content-hash str) entity-history)
-                              limit (take limit)))
-           entity-history)}))
+        {:entity-history (cio/fmap-cursor (fn [entity-history]
+                                            (cond->> (map #(update % :crux.db/content-hash str) entity-history)
+                                              limit (take limit)))
+                           entity-history)}))
     (catch Exception e
       {:error e})))
 

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -205,8 +205,10 @@
         {:eid eid
          :valid-time (api/valid-time db)
          :transaction-time (api/transaction-time db)
-         :entity-history (cond->> (map #(update % :crux.db/content-hash str) entity-history)
-                           limit (take limit))}))
+         :entity-history (cio/fmap-cursor (fn [entity-history]
+                                            (cond->> (map #(update % :crux.db/content-hash str) entity-history)
+                                              limit (take limit)))
+                                          entity-history)}))
     (catch Exception e
       {:error e})))
 

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -228,7 +228,7 @@
       {:entity-history page :limit limit}
       (let [[start-valid-time start-transaction-time end-valid-time end-transaction-time] (map normalize-date (mapcat (juxt :crux.db/valid-time :crux.tx/tx-time) [start end]))
             transaction-time (normalize-date tx-time)
-            start-valid-time (or start-valid-time (normalize-date (:crux.db/valid-time (last page))))
+            start-valid-time (normalize-date (or start-valid-time (:crux.db/valid-time (last page))))
             continuation-opts (cond-> {:resume-from-tx-id (:crux.tx/tx-id (last page))
                                        :transaction-time transaction-time
                                        :start-valid-time start-valid-time

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -121,14 +121,17 @@
     (resolve-entity-map linked-entities (dissoc entity :crux.db/id))]
    (vt-tt-entity-box valid-time transaction-time)])
 
+(def entity-history-limit 100)
+
 (defn- entity-history->html [{:keys [eid entity-history]}]
   [:div.entity-histories__container
    [:div.entity-histories
-    (for [{:keys [crux.tx/tx-time crux.db/valid-time crux.db/doc]} entity-history]
-      [:div.entity-history__container
-       [:div.entity-map
-        (resolve-entity-map {} doc)]
-       (vt-tt-entity-box valid-time tx-time)])]])
+    (take entity-history-limit
+      (for [{:keys [crux.tx/tx-time crux.db/valid-time crux.db/doc]} entity-history]
+        [:div.entity-history__container
+         [:div.entity-map
+          (resolve-entity-map {} doc)]
+         (vt-tt-entity-box valid-time tx-time)]))]])
 
 (defn ->entity-html-encoder [opts]
   (reify mfc/EncodeToBytes

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -228,13 +228,15 @@
       {:entity-history page :limit limit}
       (let [[start-valid-time start-transaction-time end-valid-time end-transaction-time] (map normalize-date (mapcat (juxt :crux.db/valid-time :crux.tx/tx-time) [start end]))
             transaction-time (normalize-date tx-time)
+            start-valid-time (or start-valid-time (normalize-date (:crux.db/valid-time (last page))))
             continuation-opts (cond-> {:resume-from-tx-id (:crux.tx/tx-id (last page))
                                        :transaction-time transaction-time
+                                       :start-valid-time start-valid-time
                                        :history true
                                        :limit limit
                                        :sort-order (name sort-order)
                                        :eid eid}
-                                start-valid-time (assoc :start-valid-time start-valid-time)
+                                ; start-valid-time (assoc :start-valid-time start-valid-time)
                                 start-transaction-time (assoc :start-transaction-time start-transaction-time)
                                 end-valid-time (assoc :end-valid-time end-valid-time)
                                 end-transaction-time (assoc :end-transaction-time end-transaction-time)

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -236,7 +236,6 @@
                                        :limit limit
                                        :sort-order (name sort-order)
                                        :eid eid}
-                                ; start-valid-time (assoc :start-valid-time start-valid-time)
                                 start-transaction-time (assoc :start-transaction-time start-transaction-time)
                                 end-valid-time (assoc :end-valid-time end-valid-time)
                                 end-transaction-time (assoc :end-transaction-time end-transaction-time)

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -303,6 +303,4 @@
               (search-entity (assoc entity-options
                                     :link-entities? (some-> ^String link-entities? Boolean/valueOf))))))
         (transform-query-resp req)
-        ((fn [r] (clojure.pprint/pprint r) r))
-        (->> (m/format-response entity-muuntaja req))
-        ((fn [r] (println r) r)))))
+        (->> (m/format-response entity-muuntaja req)))))

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -135,11 +135,13 @@
 
         ;; First 10 items of history
         (let [hist (get-entity-history "application/edn" 10)]
-          (t/is (= 10 (count (:body hist)))))
+          (t/is (= 10 (count (:body hist))))
+          (t/is (= tx-time (get-in hist [:link-params :end-transaction-time]))))
 
         ;; First 10 items of history
         (let [hist (get-entity-history "application/transit+json" 10)]
-          (t/is (= 10 (count (:body hist)))))
+          (t/is (= 10 (count (:body hist))))
+          (t/is (= tx-time (get-in hist [:link-params :end-transaction-time]))))
 
         ;; Unrestricted history
         (let [hist (get-entity-history "application/edn" 0)]

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -61,9 +61,9 @@
                                 (-> (get-result-from-path "/_crux/entity?eid=:ivan&link-entities?=true" accept-type)
                                     (parse-body accept-type)))]
       (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
-               (get-linked-entities "application/edn"))))
-      ; (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
-      ;          (get-linked-entities "application/transit+json"))))))
+               (get-linked-entities "application/edn")))
+      (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
+               (get-linked-entities "application/transit+json"))))
 
     ;; Testing getting query results
     (let [get-query (fn [accept-type]
@@ -78,8 +78,8 @@
     (let [get-query (fn [accept-type]
                       (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]&link-entities?=true" accept-type)
                                (parse-body accept-type))))]
-      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn"))))
-      ; (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
+      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn")))
+      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
 
     ;; Test file-type based negotiation
     (t/is (= #{[":ivan"] [":peter"] ["e"]}

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -93,15 +93,14 @@
   (letfn [(submit-ivan [valid-time version]
             (-> (http/post (str *api-url* "/tx-log")
                            {:content-type :edn
-                            :body (pr-str [[:crux.tx/put {:crux.db/id :ivan, :crux.db/valid-time valid-time, :name "Ivan" :version version}]])
+                            :body (pr-str [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan" :version version} valid-time]])
                             :as :stream})
               (parse-body "application/edn")))
 
           (create-ivan-history [n]
-            (let [valid-times [#inst "2020-08-19" #inst "2020-08-20" #inst "2020-08-21"]]
-              (doseq [i (range 1 (inc n))]
-                (let [{:keys [crux.tx/tx-id]} (submit-ivan (rand-nth valid-times) i)]
-                  (http/get (str *api-url* "/await-tx?tx-id=" tx-id))))))]
+            (doseq [i (range 1 (inc n))]
+              (submit-ivan (java.util.Date.) i))
+            (http/get (str *api-url* "/await-tx?tx-id=" (dec n))))]
 
       (create-ivan-history 20)
 

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -158,7 +158,6 @@
 
           ;; Next page should be the last, with only 10 items
           (let [nxt (get-entity-history (relative-path (:link hist)) "application/edn" 0)]
-            (println (count (:body nxt)))
             (t/is (= 10 (count (:body nxt))))
             (t/is (= nil (:link nxt)))
             (t/is (= [16 17 6 7 8 18 19 9 10 11] (map :crux.tx/tx-id (:body nxt))))))

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -63,7 +63,7 @@
       (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
                (get-linked-entities "application/edn"))))
       ; (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
-      ;          (get-linked-entities "application/transit+json"))))
+      ;          (get-linked-entities "application/transit+json"))))))
 
     ;; Testing getting query results
     (let [get-query (fn [accept-type]
@@ -78,8 +78,8 @@
     (let [get-query (fn [accept-type]
                       (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]&link-entities?=true" accept-type)
                                (parse-body accept-type))))]
-      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn")))
-      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
+      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn"))))
+      ; (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
 
     ;; Test file-type based negotiation
     (t/is (= #{[":ivan"] [":peter"] ["e"]}

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -38,62 +38,60 @@
   (let [{:keys [crux.tx/tx-id crux.tx/tx-time] :as tx} (-> (http/post (str *api-url* "/tx-log")
                                                                       {:content-type :edn
                                                                        :body (pr-str '[[:crux.tx/put {:crux.db/id :ivan, :linking :peter}]
-                                                                                       [:crux.tx/put {:crux.db/id :peter, :name "Peter"}]
-                                                                                       [:crux.tx/put {:crux.db/id :peter, :name "Pyotr"}]
                                                                                        [:crux.tx/put {:crux.db/id :peter, :name "Peter"}]])
                                                                        :as :stream})
                                                            (parse-body "application/edn"))]
     (http/get (str *api-url* "/await-tx?tx-id=" tx-id))
 
-    ; ;; Test redirect on "/" endpoint.
-    ; (t/is (= "/_crux/index.html" (-> (get-result-from-path "/")
-    ;                                  (get-in [:headers "Content-Location"]))))
-    ;
-    ; ;; Test getting the entity with different types
-    ; (let [get-entity (fn [accept-type] (-> (get-result-from-path "/_crux/entity?eid=:peter" accept-type)
-    ;                                        (parse-body accept-type)))]
-    ;   (t/is (= {:crux.db/id :peter, :name "Peter"}
-    ;            (get-entity "application/edn")))
-    ;   (t/is (= {:crux.db/id :peter, :name "Peter"}
-    ;            (get-entity "application/transit+json"))))
-    ;
-    ; ;; Test getting linked entities
-    ; (let [get-linked-entities (fn [accept-type]
-    ;                             (-> (get-result-from-path "/_crux/entity?eid=:ivan&link-entities?=true" accept-type)
-    ;                                 (parse-body accept-type)))]
-    ;   (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
-    ;            (get-linked-entities "application/edn")))
-    ;   (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
-    ;            (get-linked-entities "application/transit+json"))))
-    ;
-    ; ;; Testing getting query results
-    ; (let [get-query (fn [accept-type]
-    ;                   (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]" accept-type)
-    ;                            (parse-body accept-type))))]
-    ;   (t/is (= #{[:ivan] [:peter]} (get-query "application/edn")))
-    ;   (t/is (= #{[:ivan] [:peter]} (get-query "application/transit+json")))
-    ;   (t/is (= #{[":ivan"] [":peter"] ["e"]} (get-query "text/csv")))
-    ;   (t/is (= #{[":ivan"] [":peter"] ["e"]} (get-query "text/tsv"))))
-    ;
-    ; ;; Testing getting linked entities in query results
-    ; (let [get-query (fn [accept-type]
-    ;                   (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]&link-entities?=true" accept-type)
-    ;                            (parse-body accept-type))))]
-    ;   (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn")))
-    ;   (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
-    ;
-    ; ;; Test file-type based negotiation
-    ; (t/is (= #{[":ivan"] [":peter"] ["e"]}
-    ;          (set (-> (get-result-from-path "/_crux/query.csv?find=[e]&where=[e+%3Acrux.db%2Fid+_]")
-    ;                   (parse-body "text/csv")))))
-    ; (t/is (= #{[":ivan"] [":peter"] ["e"]}
-    ;          (set (-> (get-result-from-path "/_crux/query.tsv?find=[e]&where=[e+%3Acrux.db%2Fid+_]")
-    ;                   (parse-body "text/tsv")))))
+    ;; Test redirect on "/" endpoint.
+    (t/is (= "/_crux/index.html" (-> (get-result-from-path "/")
+                                     (get-in [:headers "Content-Location"]))))
+
+    ;; Test getting the entity with different types
+    (let [get-entity (fn [accept-type] (-> (get-result-from-path "/_crux/entity?eid=:peter" accept-type)
+                                           (parse-body accept-type)))]
+      (t/is (= {:crux.db/id :peter, :name "Peter"}
+               (get-entity "application/edn")))
+      (t/is (= {:crux.db/id :peter, :name "Peter"}
+               (get-entity "application/transit+json"))))
+
+    ;; Test getting linked entities
+    (let [get-linked-entities (fn [accept-type]
+                                (-> (get-result-from-path "/_crux/entity?eid=:ivan&link-entities?=true" accept-type)
+                                    (parse-body accept-type)))]
+      (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
+               (get-linked-entities "application/edn")))
+      (t/is (= {:crux.db/id :ivan, :linking (entity-ref/->EntityRef :peter)}
+               (get-linked-entities "application/transit+json"))))
+
+    ;; Testing getting query results
+    (let [get-query (fn [accept-type]
+                      (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]" accept-type)
+                               (parse-body accept-type))))]
+      (t/is (= #{[:ivan] [:peter]} (get-query "application/edn")))
+      (t/is (= #{[:ivan] [:peter]} (get-query "application/transit+json")))
+      (t/is (= #{[":ivan"] [":peter"] ["e"]} (get-query "text/csv")))
+      (t/is (= #{[":ivan"] [":peter"] ["e"]} (get-query "text/tsv"))))
+
+    ;; Testing getting linked entities in query results
+    (let [get-query (fn [accept-type]
+                      (set (-> (get-result-from-path "/_crux/query?find=[e]&where=[e+%3Acrux.db%2Fid+_]&link-entities?=true" accept-type)
+                               (parse-body accept-type))))]
+      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/edn")))
+      (t/is (= #{[(entity-ref/->EntityRef :ivan)] [(entity-ref/->EntityRef :peter)]} (get-query "application/transit+json"))))
+
+    ;; Test file-type based negotiation
+    (t/is (= #{[":ivan"] [":peter"] ["e"]}
+             (set (-> (get-result-from-path "/_crux/query.csv?find=[e]&where=[e+%3Acrux.db%2Fid+_]")
+                      (parse-body "text/csv")))))
+    (t/is (= #{[":ivan"] [":peter"] ["e"]}
+             (set (-> (get-result-from-path "/_crux/query.tsv?find=[e]&where=[e+%3Acrux.db%2Fid+_]")
+                      (parse-body "text/tsv")))))
 
     ;; Test getting the entity history with different types
     (let [get-entity-history (fn [accept-type] (-> (get-result-from-path "/_crux/entity?eid=:peter&history=true&sort-order=desc" accept-type)
                                                  (parse-body accept-type)))]
-      (t/is (= {:crux.db/id :peter, :name "Peter"}
-               (get-entity-history "application/edn"))))))
-      ; (t/is (= {:crux.db/id :peter, :name "Peter"}
-      ;          (get-entity "application/transit+json"))))))
+      (t/is (= {:crux.tx/tx-id (:crux.tx/tx-id tx), :crux.tx/tx-time (:crux.tx/tx-time tx), :crux.db/valid-time (:crux.tx/tx-time tx), :crux.db/content-hash "28306bae8b2b47e186269b1d8f65674a83f5d763"}
+               (first (get-entity-history "application/edn"))))
+      (t/is (= {:crux.tx/tx-id (:crux.tx/tx-id tx), :crux.tx/tx-time (:crux.tx/tx-time tx), :crux.db/valid-time (:crux.tx/tx-time tx), :crux.db/content-hash "28306bae8b2b47e186269b1d8f65674a83f5d763"}
+               (first (get-entity-history "application/transit+json")))))))

--- a/crux-test/test/crux/ui_routes_test.clj
+++ b/crux-test/test/crux/ui_routes_test.clj
@@ -3,7 +3,6 @@
             [clojure.edn :as edn]
             [clojure.test :as t]
             [crux.api :as crux]
-            [crux.codec :as c]
             [clj-http.client :as http]
             [cognitect.transit :as transit]
             [clojure.data.csv :as csv]


### PR DESCRIPTION
Added options `limit` (number of items per page) and `resume-from-tx-id` (transaction id of the first item in a page of history) to the options for requesting entity histories.

The header of the response to a history request contains a `Link` header with `rel=next` containing the URL of the next page.  Any history options contained in the original request are propagated to the link, as is the latest transaction time upon receipt of the first page request.
