### PR TITLE
Update/fix current examples for entity-history/history-range

### DIFF
--- a/docs/reference/modules/ROOT/examples/src/docs/examples.clj
+++ b/docs/reference/modules/ROOT/examples/src/docs/examples.clj
@@ -360,56 +360,75 @@
      :person/wealth 1000}
     #inst "2015-05-18T09:20:27.966"]])
 
-;yields
+; yields
 {:crux.tx/tx-id 1555314836178,
  :crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00"}
 
-
-(api/history system :ids.persons/Jeff)
+; Returning the history in descending order
+; To return in ascending order, use :asc in place of :desc
+(api/entity-history (api/db system) :ids.persons/Jeff :desc)
 
 ; yields
-[{:crux.db/id ; sha1 hash of document id
-  "c7e66f757f198e08a07a8ea6dfc84bc3ab1c6613",
-  :crux.db/content-hash ; sha1 hash of document contents
-  "6ca48d3bf05a16cd8d30e6b466f76d5cc281b561",
+[{:crux.tx/tx-time #inst "2019-04-15T07:53:55.817-00:00",
+  :crux.tx/tx-id 1555314835817,
   :crux.db/valid-time #inst "2018-05-18T09:20:27.966-00:00",
-  :crux.tx/tx-time #inst "2019-04-15T07:53:55.817-00:00",
-  :crux.tx/tx-id 1555314835817}
- {:crux.db/id "c7e66f757f198e08a07a8ea6dfc84bc3ab1c6613",
-  :crux.db/content-hash "a95f149636e0a10a78452298e2135791c0203529",
+  :crux.db/content-hash ; sha1 hash of document contents
+  "6ca48d3bf05a16cd8d30e6b466f76d5cc281b561"}
+ {:crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00",
+  :crux.tx/tx-id 1555314836178,
   :crux.db/valid-time #inst "2015-05-18T09:20:27.966-00:00",
-  :crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00",
-  :crux.tx/tx-id 1555314836178}]
+  :crux.db/content-hash "a95f149636e0a10a78452298e2135791c0203529"}]
 ;; end::history-full[]
 
-;; tag::history-range[]
-(api/history-range system :ids.persons/Jeff
-  #inst "2015-05-18T09:20:27.966"  ; valid-time start or nil
-  #inst "2015-05-18T09:20:27.966"  ; transaction-time start or nil
-  #inst "2020-05-18T09:20:27.966"  ; valid-time end or nil, inclusive
-  #inst "2020-05-18T09:20:27.966") ; transaction-time end or nil, inclusive.
+;; tag::history-with-docs[]
+(api/entity-history (api/db system) :ids.persons/Jeff :desc {:with-docs? true})
 
 ; yields
-({:crux.db/id ; sha1 hash of document id
-  "c7e66f757f198e08a07a8ea6dfc84bc3ab1c6613",
-  :crux.db/content-hash  ; sha1 hash of document contents
-  "a95f149636e0a10a78452298e2135791c0203529",
+[{:crux.tx/tx-time #inst "2019-04-15T07:53:55.817-00:00",
+  :crux.tx/tx-id 1555314835817,
+  :crux.db/valid-time #inst "2018-05-18T09:20:27.966-00:00",
+  :crux.db/content-hash
+  "6ca48d3bf05a16cd8d30e6b466f76d5cc281b561"
+  :crux.db/doc
+  {:crux.db/id :ids.persons/Jeff
+   :person/name "Jeff"
+   :person/wealth 100}}
+ {:crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00",
+  :crux.tx/tx-id 1555314836178,
   :crux.db/valid-time #inst "2015-05-18T09:20:27.966-00:00",
-  :crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00",
-  :crux.tx/tx-id 1555314836178}
-  {:crux.db/id "c7e66f757f198e08a07a8ea6dfc84bc3ab1c6613",
-   :crux.db/content-hash "6ca48d3bf05a16cd8d30e6b466f76d5cc281b561",
-   :crux.db/valid-time #inst "2018-05-18T09:20:27.966-00:00",
-   :crux.tx/tx-time #inst "2019-04-15T07:53:55.817-00:00",
-   :crux.tx/tx-id 1555314835817})
+  :crux.db/content-hash "a95f149636e0a10a78452298e2135791c0203529"
+  :crux.db/doc
+  {:crux.db/id :ids.persons/Jeff
+   :person/name "Jeff"
+   :person/wealth 1000}}]
+;; end::history-with-docs[]
 
+;; tag::history-range[]
 
-(api/entity (api/db system) "c7e66f757f198e08a07a8ea6dfc84bc3ab1c6613")
+; Passing the aditional 'opts' map with the start/end bounds.
+; As we are returning results in :asc order, the :start map contains the earlier co-ordinates -
+; If returning history range in descending order, we pass the later co-ordinates to the :start map
+(api/entity-history
+ (api/db system)
+ :ids.persons/Jeff
+ :asc
+ {:start {:crux.db/valid-time #inst "2015-05-18T09:20:27.966" ; valid-time-start
+          :crux.tx/tx-time #inst "2015-05-18T09:20:27.966"} ; tx-time-start
+  :end {:crux.db/valid-time #inst "2020-05-18T09:20:27.966" ; valid-time-end
+        :crux.tx/tx-time #inst "2020-05-18T09:20:27.966"} ; tx-time-end
+  })
 
 ; yields
-{:crux.db/id :ids.persons/Jeff,
- :d.person/name "Jeff",
- :d.person/wealth 100}
+[{:crux.tx/tx-time #inst "2019-04-15T07:53:56.178-00:00",
+  :crux.tx/tx-id 1555314836178,
+  :crux.db/valid-time #inst "2015-05-18T09:20:27.966-00:00",
+  :crux.db/content-hash
+  "a95f149636e0a10a78452298e2135791c0203529"}
+ {:crux.tx/tx-time #inst "2019-04-15T07:53:55.817-00:00",
+  :crux.tx/tx-id 1555314835817
+  :crux.db/valid-time #inst "2018-05-18T09:20:27.966-00:00",
+  :crux.db/content-hash "6ca48d3bf05a16cd8d30e6b466f76d5cc281b561"}]
+
 ;; end::history-range[]
 )
 
@@ -425,8 +444,8 @@
         ;; end::join-d[]
         ]
     (crux/submit-tx node
-                   (vec (for [m maps]
-                          [:crux.tx/put m])))))
+                    (vec (for [m maps]
+                           [:crux.tx/put m])))))
 
 (defn query-example-join-q1 [node]
  (crux/q

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -481,16 +481,23 @@ include::example$src/docs/examples.clj[tags=streaming-query]
 == History API
 
 [#history-full-document-history]
-=== Full Document History
-Crux allows you to retrieve all versions of a document:
+=== Full Entity History
+Crux allows you to retrieve all versions of a given entity:
 [source,clj]
 ----
 include::example$src/docs/examples.clj[tags=history-full]
 ----
 
+=== Retrieving previous documents
+When retrieving the previous versions of an entity, you have the option to additionally return the documents associated with those versions (by using `:with-docs?` in the additional options map)
+[source,clj]
+----
+include::example$src/docs/examples.clj[tags=history-with-docs]
+----
+
 [#history-document-history-range]
 === Document History Range
-Retrievable document versions can be bounded by four time coordinates:
+Retrievable entity versions can be bounded by four time coordinates:
 
 * valid-time-start
 * tx-time-start


### PR DESCRIPTION
Bringing this section of the docs up to date - and adding a small example about using `with-docs?`.