### PR TITLE
Or join bound vars

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -91,7 +91,7 @@
 (s/def ::or-body (s/+ (s/or :term ::term
                             :and ::and)))
 (s/def ::or (expression-spec 'or ::or-body))
-(s/def ::or-join (expression-spec 'or-join (s/cat :args ::rule-args
+(s/def ::or-join (expression-spec 'or-join (s/cat :args (s/and vector? ::rule-args)
                                                   :body ::or-body)))
 (defmulti pred-args-spec first)
 
@@ -514,9 +514,7 @@
                                                   body-vars)
                                         [free-vars
                                          bound-vars] (if (and or-join? (not (empty? bound-args)))
-                                                       (let [bound-vars (set/intersection known-vars (set bound-args))]
-                                                         [(set/difference (set (concat bound-args free-args)) bound-vars)
-                                                          bound-vars])
+                                                       [free-args bound-args]
                                                        [(set/difference or-vars known-vars)
                                                         (set/intersection or-vars known-vars)])]]
                               (do (when or-join?

--- a/crux-sql/test/crux/calcite_test.clj
+++ b/crux-sql/test/crux/calcite_test.clj
@@ -25,7 +25,7 @@
 (t/use-fixtures :each fix/with-standalone-topology cf/with-calcite-module fix/with-kv-dir fix/with-node with-each-connection-type with-sql-schema)
 
 (defn- inst->iso-str [^java.util.Date t]
-  (.format (ZonedDateTime/ofInstant (.toInstant t) (ZoneId/systemDefault)) DateTimeFormatter/ISO_INSTANT))
+  (.format (ZonedDateTime/ofInstant (.toInstant t) (ZoneId/of "UTC")) DateTimeFormatter/ISO_INSTANT))
 
 (t/deftest test-valid-time
   (let [id (java.util.UUID/randomUUID)

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1895,6 +1895,19 @@
                      [?e :name ?n]))]
       #{1 2 3 4 5 6}
 
+      [(or-join [?e]
+                [?e :name ?n]
+                (and [?e :age ?a]
+                     [?e :name ?n]))]
+      #{1 2 3 4 5 6}
+
+      [[(identity 1) ?e]
+       (or-join [[?e]]
+                [?e :name ?n]
+                (and [?e :age ?a]
+                     [?e :name ?n]))]
+      #{1}
+
       [[?e  :name ?a]
        [?e2 :name ?a]
        (or-join [?e]

--- a/crux-test/test/crux/replay_test.clj
+++ b/crux-test/test/crux/replay_test.clj
@@ -46,7 +46,7 @@
                                            :crux.standalone/event-log-kv-store 'crux.kv.rocksdb/kv})]
           (t/is (= {:crux.tx/tx-id (dec n)}
                    (crux/latest-submitted-tx node)))
-          (t/is (crux/sync node (Duration/ofSeconds 5)))
+          (t/is (crux/sync node (Duration/ofSeconds 10)))
           (t/is (= n
                    (count (crux/q (crux/db node) '{:find [?e]
                                                    :where [[?e :crux.db/id]]})))))))))


### PR DESCRIPTION
Previous behaviour looked like rules:
`(or-join [bound-var-x bound-var-y] free-var-z free-var-w)`

Correct behaviour in EDN Datalog is to add a level of nesting, like this:
`(or-join [[bound-var-x bound-var-y] free-var-z free-var-w])`

Normally an `or-join` looks like this, and only has free vars:
`(or-join [x y])`

This implies that previously `[x y]` were treated as bound vars, though Crux did demote them to free vars if necessary if they couldn't be bound in the parent query. New behaviour will treat `[x y]` free vars, but promote them if possible if they can be bound in the outer query.

Rules rely on bound vars, and compile down to or-join, but they directly generate an AST node, so they didn't run into this parser level issue.