### PR TITLE
Migrate HTTP api

### DIFF
--- a/crux-core/src/crux/IllegalArgumentException.java
+++ b/crux-core/src/crux/IllegalArgumentException.java
@@ -8,8 +8,8 @@ public class IllegalArgumentException extends java.lang.IllegalArgumentException
 
     private final IPersistentMap data;
 
-    public IllegalArgumentException(String message, IPersistentMap data) {
-        super(message);
+    public IllegalArgumentException(String message, IPersistentMap data, Throwable cause) {
+        super(message, cause);
         this.data = data;
     }
 

--- a/crux-core/src/crux/error.clj
+++ b/crux-core/src/crux/error.clj
@@ -4,9 +4,13 @@
   ([k] (illegal-arg k {}))
 
   ([k {::keys [^String message] :as data}]
+   (illegal-arg k data nil))
+
+  ([k {::keys [^String message] :as data} cause]
    (let [message (or message (format "Illegal argument: '%s'" k))]
      (crux.IllegalArgumentException. message
                                      (merge {::error-type :illegal-argument
                                              ::error-key k
                                              ::message message}
-                                            data)))))
+                                            data)
+                                     cause))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -235,13 +235,17 @@
                          identity
                          (fn [q]
                            (when-not (s/valid? ::query q)
-                             (throw (ex-info (str "Spec assertion failed\n" (s/explain-str ::query q)) (s/explain-data ::query q))))
+                             (throw (err/illegal-arg :query-spec-failed
+                                                     {::err/message "Query didn't match expected structure"
+                                                      :explain (s/explain-data ::query q)})))
                            (let [q (normalize-query q)]
                              (->ConformedQuery q (s/conform ::query q)))))]
     (if args
       (do
         (when-not (s/valid? ::args args)
-          (throw (ex-info (str "Spec assertion failed\n" (s/explain-str ::args args)) (s/explain-data ::args args))))
+          (throw (err/illegal-arg :args-spec-failed
+                                  {::err/message "Query args didn't match expected structure"
+                                   :explain (s/explain-data ::args args)})))
         (-> conformed-query
             (assoc-in [:q-normalized :args] args)
             (assoc-in [:q-conformed :args] args)))

--- a/crux-core/src/crux/system.clj
+++ b/crux-core/src/crux/system.clj
@@ -104,7 +104,10 @@
           module-var (or (try
                            (requiring-resolve (:sym this))
                            (catch Exception e
-                             (throw (ex-info "Error locating module" {:module sym} e))))
+                             (throw (err/illegal-arg :error-locating-module
+                                                     {::err/message "Error locating module"
+                                                      :module sym}
+                                                     e))))
                          (throw (ex-info "Error locating module" {:module sym})))
           {::keys [deps args before]} (meta module-var)]
       (prepare-dep (->Module (deref module-var) before deps args) k-path opts))))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -83,9 +83,9 @@
        nil
 
        (= 400 status)
-       (let [{:crux.error/keys [error-key] :as error-data} (edn/read-string (cond-> body
-                                                                              (= :stream (:as http-opts)) slurp))]
-         (throw (ce/illegal-arg error-key error-data )))
+       (let [{::ce/keys [error-key] :as error-data} (edn/read-string (cond-> body
+                                                                       (= :stream (:as http-opts)) slurp))]
+         (throw (ce/illegal-arg error-key error-data)))
 
        (and (<= 200 status) (< status 400))
        (if (string? body)

--- a/crux-http-server/src-cljs/crux/ui/common.cljs
+++ b/crux-http-server/src-cljs/crux/ui/common.cljs
@@ -54,31 +54,18 @@
            [k (vector v)]
            [k v])) m))
 
-(defn query-params->formatted-edn-string
-  [query-params-map]
-  (when-let [formatted
-             (not-empty
-              (try
-                (->> (dissoc query-params-map
-                             :valid-time :transaction-time)
-                     (vectorize [:where :args :order-by])
-                     (map (fn [[k v]]
-                            (if (vector? v)
-                              [k (mapv #(reader/read-string %) v)]
-                              [k (reader/read-string v)])))
-                     (into {}))
-                (catch :default _ {})))]
-    (with-out-str
-      (pprint/with-pprint-dispatch
-        pprint/code-dispatch
-        (pprint/pprint formatted)))))
+(defn query->formatted-query-string [query]
+  (with-out-str
+    (pprint/with-pprint-dispatch
+      pprint/code-dispatch
+      (pprint/pprint query))))
 
 (defn edn->query-params
   [edn]
   (->> edn
        (map
         (fn [[k v]]
-          [k (if (or (= :where k) (= :args k) (= :order-by k))
+          [k (if (or (= :where k) (= :args k) (= :order-by k) (= :rules k))
                (mapv str v)
                (str v))]))
        (into {})))

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -20,6 +20,7 @@
                               (str "meta[title=" title "]"))
                              (.getAttribute "content"))
          edn-content (reader/read-string {:readers {'object pr-str
+                                                    'crux/id str
                                                     'crux.http/entity-ref entity-ref/->EntityRef}} result-meta)]
      (if edn-content
        {:db (assoc db handler edn-content)}
@@ -119,13 +120,11 @@
  ::go-to-query-view
  (fn [{:keys [db]} [_ {:keys [values]}]]
    (let [{:strs [q valid-time transaction-time]} values
-         query-params (->>
-                       (merge
-                        (common/edn->query-params (reader/read-string q))
-                        {:valid-time (some-> valid-time js/moment .toDate t/instant)
-                         :transaction-time (some-> transaction-time js/moment .toDate t/instant)})
-                       (remove #(nil? (second %)))
-                       (into {}))
+         query-params (->> {:query (reader/read-string q)
+                            :valid-time (some-> valid-time js/moment .toDate t/instant)
+                            :transaction-time (some-> transaction-time js/moment .toDate t/instant)}
+                           (remove #(nil? (second %)))
+                           (into {}))
          history-elem (dissoc query-params :valid-time :transaction-time)
          current-storage (or (reader/read-string (.getItem js/window.localStorage "query")) [])
          updated-history (conj (into [] (remove #(= history-elem %) current-storage)) history-elem)]

--- a/crux-http-server/src-cljs/crux/ui/routes.cljs
+++ b/crux-http-server/src-cljs/crux/ui/routes.cljs
@@ -4,7 +4,7 @@
 
 (def routes
   [""
-   ["/attribute-stats"
+   ["/_crux/attribute-stats"
     {:name :attribute-stats}]
    ["/_crux/status"
     {:name :status

--- a/crux-http-server/src-cljs/crux/ui/views.cljs
+++ b/crux-http-server/src-cljs/crux/ui/views.cljs
@@ -201,7 +201,7 @@
   (let [{:keys [error data]} @(rf/subscribe [::sub/query-data-table])]
     [:<>
      (cond
-       error [:div.error-box error]
+       error [:div.error-box (str error)]
        (and (empty? (:rows data)) (not (:loading? data))) [:div.no-results "No results found!"]
        :else [:<>
               [:<>
@@ -321,7 +321,7 @@
            [:div.entity-map.entity-map--loading
             [:i.fas.fa-spinner.entity-map__load-icon]]
            (if error
-             [:div.error-box error]
+             [:div.error-box (str error)]
              [:div.entity-map__container
               (if @!raw-edn?
                 [:div.entity-raw-edn
@@ -360,7 +360,7 @@
             [:div.entity-map.entity-map--loading
              [:i.fas.fa-spinner.entity-map__load-icon]]
             (cond
-              entity-error [:div.error-box entity-error]
+              entity-error [:div.error-box (str entity-error)]
               (not diffs?) (let [{:keys [entity-history]} @(rf/subscribe [::sub/entity-result-pane-history])]
                              [:div.entity-histories
                               (for [{:keys [crux.tx/tx-time crux.db/valid-time crux.db/doc]
@@ -439,8 +439,8 @@
         [:tr.table__row.body__row
          [:td.table__cell.body__cell
           [:a
-           {:href (common/route->url :query nil {:find (format "[%s]" (name key))
-                                                 :where (format "[e %s %s]" key (name key))})}
+           {:href (common/route->url :query nil {:query {:find [(symbol (name key))]
+                                                         :where [['e key (symbol (name key))]]}})}
            (common/edn->pretty-string key)]]
          [:td.table__cell.body__cell (common/edn->pretty-string value)]])]]]])
 

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -1,22 +1,44 @@
 (ns crux.http-server.entity
-  (:require [clojure.edn :as edn]
-            [clojure.instant :as instant]
-            [clojure.java.io :as io]
-            [clojure.string :as string]
+  (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [cognitect.transit :as transit]
             [crux.api :as crux]
             [crux.codec :as c]
+            [crux.error :as ce]
             [crux.http-server.entity-ref :as entity-ref]
             [crux.http-server.util :as util]
             [crux.io :as cio]
             [muuntaja.core :as m]
             [muuntaja.format.core :as mfc])
-  (:import crux.http_server.entity_ref.EntityRef
-           (java.io Closeable OutputStream)
-           java.net.URLDecoder
+  (:import crux.codec.Id
+           crux.http_server.entity_ref.EntityRef
+           crux.io.Cursor
+           [java.io Closeable OutputStream]
            [java.time Instant ZonedDateTime ZoneId]
            java.time.format.DateTimeFormatter
            java.util.Date))
+
+(s/def ::sort-order keyword?)
+(s/def ::start-valid-time inst?)
+(s/def ::end-valid-time inst?)
+(s/def ::start-transaction-time inst?)
+(s/def ::end-transaction-time inst?)
+(s/def ::history boolean?)
+(s/def ::with-corrections boolean?)
+(s/def ::with-docs boolean?)
+(s/def ::query-params
+  (s/keys :opt-un [::util/eid
+                   ::history
+                   ::sort-order
+                   ::util/valid-time
+                   ::util/transaction-time
+                   ::start-valid-time
+                   ::start-transaction-time
+                   ::end-valid-time
+                   ::end-transaction-time
+                   ::with-corrections
+                   ::with-docs
+                   ::util/link-entities?]))
 
 (defn- entity-root-html []
   [:div.entity-root
@@ -128,61 +150,63 @@
 
 (defn ->entity-html-encoder [opts]
   (reify mfc/EncodeToBytes
-    (encode-to-bytes [_ {:keys [eid no-entity? not-found? error entity ^Closeable entity-history] :as res} charset]
+    (encode-to-bytes [_ {:keys [eid no-entity? not-found? entity ^Closeable entity-history] :as res} charset]
       (let [^String resp (cond
                            no-entity? (util/raw-html {:body (entity-root-html)
-                                                      :title "/entity"
+                                                      :title "/_crux/entity"
                                                       :options opts})
                            not-found? (let [not-found-message (str eid " entity not found")]
-                                        (util/raw-html {:title "/entity"
+                                        (util/raw-html {:title "/_crux/entity"
                                                         :body [:div.error-box not-found-message]
                                                         :options opts
                                                         :results {:entity-results
                                                                   {"error" not-found-message}}}))
-                           error (let [error-message (.getMessage ^Exception error)]
-                                   (util/raw-html {:title "/entity"
-                                                   :body [:div.error-box error-message]
-                                                   :options opts
-                                                   :results {:entity-results
-                                                             {"error" error-message}}}))
                            entity-history (try
                                             (util/raw-html {:body (entity-history->html res)
-                                                            :title "/entity?history=true"
+                                                            :title "/_crux/entity?history=true"
                                                             :options opts
                                                             :results {:entity-results (iterator-seq entity-history)}})
                                             (finally
                                               (.close entity-history)))
-                           :else (util/raw-html {:body (entity->html res)
-                                                 :title "/entity"
+                           entity (util/raw-html {:body (entity->html res)
+                                                  :title "/_crux/entity"
+                                                  :options opts
+                                                  :results {:entity-results entity}})
+                           :else (util/raw-html {:title "/_crux/entity"
+                                                 :body [:div.error-box (str res)]
                                                  :options opts
-                                                 :results {:entity-results entity}}))]
+                                                 :results {:entity-results
+                                                           {"error" res}}}))]
         (.getBytes resp ^String charset)))))
 
 (defn ->edn-encoder [_]
   (reify
     mfc/EncodeToOutputStream
-    (encode-to-output-stream [_ {:keys [entity entity-history] :as res} _]
+    (encode-to-output-stream [_ {:keys [entity ^Cursor entity-history] :as res} _]
       (fn [^OutputStream output-stream]
         (with-open [w (io/writer output-stream)]
-          (if entity-history
-            (try
-              (print-method (iterator-seq entity-history) w)
-              (finally
-                (cio/try-close entity-history)))
-            (print-method entity w)))))))
+          (cond
+            entity-history (try
+                             (print-method (or (iterator-seq entity-history) '()) w)
+                             (finally
+                               (cio/try-close entity-history)))
+            entity (print-method entity w)
+            :else (.write w ^String (pr-str res))))))))
 
 (defn- ->tj-encoder [_]
   (reify
     mfc/EncodeToOutputStream
-    (encode-to-output-stream [_ {:keys [entity entity-history] :as res} _]
+    (encode-to-output-stream [_ {:keys [entity ^Cursor entity-history] :as res} _]
       (fn [^OutputStream output-stream]
-        (let [w (transit/writer output-stream :json {:handlers {EntityRef entity-ref/ref-write-handler}})]
-          (if entity-history
-            (try
-              (transit/write w (iterator-seq entity-history))
-              (finally
-                (cio/try-close entity-history)))
-            (transit/write w entity)))))))
+        (let [w (transit/writer output-stream :json {:handlers {EntityRef entity-ref/ref-write-handler
+                                                                Id util/crux-id-write-handler}})]
+          (cond
+            entity (transit/write w entity)
+            entity-history (try
+                             (transit/write w (or (iterator-seq entity-history) '()))
+                             (finally
+                               (cio/try-close entity-history)))
+            :else (transit/write w res)))))))
 
 (defn ->entity-muuntaja [opts]
   (m/create (-> m/default-options
@@ -197,85 +221,65 @@
                 (m/install {:name "application/edn"
                             :encoder [->edn-encoder]}))))
 
-(defn search-entity-history [{:keys [crux-node eid valid-time transaction-time sort-order history-opts]}]
+(defn search-entity-history [{:keys [crux-node]} {:keys [eid valid-time transaction-time sort-order with-corrections with-docs
+                                                         start-valid-time start-transaction-time end-valid-time end-transaction-time]}]
   (try
-    (let [eid (edn/read-string {:readers {'crux/id c/id-edn-reader}}
-                               (URLDecoder/decode eid))
-          db (util/db-for-request crux-node {:valid-time valid-time
+    (let [db (util/db-for-request crux-node {:valid-time valid-time
                                              :transact-time transaction-time})
+          history-opts {:with-corrections? with-corrections
+                        :with-docs? with-docs
+                        :start {:crux.db/valid-time start-valid-time
+                                :crux.tx/tx-time start-transaction-time}
+                        :end {:crux.db/valid-time end-valid-time
+                              :crux.tx/tx-time end-transaction-time}}
           entity-history (crux/open-entity-history db eid sort-order history-opts)]
-      (if-not (.hasNext entity-history)
-        {:not-found? true}
-        {:valid-time (crux/valid-time db)
-         :transaction-time (crux/transaction-time db)
-         :entity-history (cio/fmap-cursor (fn [entity-history]
-                                            (map #(update % :crux.db/content-hash str) entity-history))
-                                          entity-history)}))
+      {:entity-history entity-history})
     (catch Exception e
       {:error e})))
 
-(defn search-entity [{:keys [crux-node eid valid-time transaction-time link-entities?] :as params}]
+(defn search-entity [{:keys [crux-node]} {:keys [eid valid-time transaction-time link-entities?]}]
   (try
-    (let [eid (edn/read-string {:readers {'crux/id c/id-edn-reader}}
-                               (URLDecoder/decode eid))
-          db (util/db-for-request crux-node {:valid-time valid-time
+    (let [db (util/db-for-request crux-node {:valid-time valid-time
                                              :transact-time transaction-time})
           entity (crux/entity db eid)]
       (cond
-        (empty? entity) {:not-found? true}
+        (empty? entity) {:eid eid :not-found? true}
         link-entities? {:entity (entity-links db entity)}
         :else {:entity entity}))
     (catch Exception e
       {:error e})))
 
-(defn transform-query-params [{:keys [query-params] :as req}]
-  (if (= "text/html" (get-in req [:muuntaja/response :format]))
-    (assoc query-params "with-docs" "true" "link-entities?" "true")
-    query-params))
+(defn transform-query-params [req]
+  (let [query-params (get-in req [:parameters :query])]
+    (if (= "text/html" (get-in req [:muuntaja/response :format]))
+      (assoc query-params :with-docs true :link-entities? true)
+      query-params)))
 
 (defmulti transform-query-resp
   (fn [resp req]
     (get-in req [:muuntaja/response :format])))
 
 (defmethod transform-query-resp "text/html" [{:keys [error no-entity? not-found? error] :as res} _]
-  {:status (cond
-             no-entity? 400
-             error 500
-             not-found? 404
-             :else 200)
-   :body res})
-
-(defmethod transform-query-resp :default [{:keys [eid error no-entity? not-found? entity entity-history headers] :as res} req]
   (cond
-    no-entity? {:status 400, :body {:error "Missing eid"}}
-    not-found? {:status 404, :body {:error (str eid " entity not found")}}
-    error {:status 500, :body {:error (.getMessage ^Exception error)}}
-    entity-history {:status 200, :body res})
-  :else {:status 200, :body res})
+    error (throw error)
+    :else {:status (cond
+                     no-entity? 400
+                     not-found? 404
+                     :else 200)
+           :body res}))
 
-(defn entity-state [req {:keys [entity-muuntaja] :as options}]
-  (let [req (m/negotiate-and-format-request entity-muuntaja req)
-        {:strs [eid history sort-order
-                valid-time transaction-time
-                start-valid-time start-transaction-time
-                end-valid-time end-transaction-time
-                with-corrections with-docs link-entities?] :as query-params} (transform-query-params req)]
-    (-> (if (nil? eid)
-          (assoc options :no-entity? true)
-          (let [entity-options (assoc options
-                                      :eid eid
-                                      :valid-time (when-not (string/blank? valid-time) (instant/read-instant-date valid-time))
-                                      :transaction-time (when-not (string/blank? transaction-time) (instant/read-instant-date transaction-time)))]
-            (if history
-              (search-entity-history (assoc entity-options
-                                            :sort-order (some-> sort-order keyword)
-                                            :history-opts {:with-corrections? (some-> ^String with-corrections Boolean/valueOf)
-                                                           :with-docs? (some-> ^String with-docs Boolean/valueOf)
-                                                           :start {:crux.db/valid-time (some-> start-valid-time (instant/read-instant-date))
-                                                                   :crux.tx/tx-time (some-> start-transaction-time (instant/read-instant-date))}
-                                                           :end {:crux.db/valid-time (some-> end-valid-time (instant/read-instant-date))
-                                                                 :crux.tx/tx-time (some-> end-transaction-time (instant/read-instant-date))}}))
-              (search-entity (assoc entity-options
-                                    :link-entities? (some-> ^String link-entities? Boolean/valueOf))))))
-        (transform-query-resp req)
-        (->> (m/format-response entity-muuntaja req)))))
+(defmethod transform-query-resp :default [{:keys [error no-entity? eid not-found?] :as res} _]
+  (cond
+    no-entity? (throw (ce/illegal-arg :missing-eid {::ce/message "Missing eid"}))
+    not-found? {:status 404, :body (str eid " entity not found")}
+    error (throw error)
+    :else {:status 200, :body res}))
+
+(defn entity-state [options]
+  (fn [req]
+    (let [{:keys [eid history] :as query-params} (transform-query-params req)]
+      (-> (cond
+            (nil? eid) {:no-entity? true}
+            history (search-entity-history options query-params)
+            :else (search-entity options query-params))
+          (transform-query-resp req)))))

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -206,7 +206,7 @@
                              (transit/write w (or (iterator-seq entity-history) '()))
                              (finally
                                (cio/try-close entity-history)))
-            :else (transit/write w res)))))))
+            :else (throw (IllegalStateException.))))))))
 
 (defn ->entity-muuntaja [opts]
   (m/create (-> m/default-options

--- a/crux-http-server/src/crux/http_server/query.clj
+++ b/crux-http-server/src/crux/http_server/query.clj
@@ -7,17 +7,41 @@
             [clojure.instant :as instant]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [crux.api :as api]
+            [crux.api :as crux]
             [crux.codec :as c]
+            [crux.error :as ce]
             [muuntaja.core :as m]
             [muuntaja.format.core :as mfc]
+            [muuntaja.format.edn :as mfe]
+            [muuntaja.format.transit :as mft]
             [crux.io :as cio]
-            [crux.db :as db])
-  (:import (java.io OutputStream Writer)
+            [crux.db :as db]
+            [crux.query :as q]
+            [clojure.spec.alpha :as s]
+            [spec-tools.core :as st]
+            [crux.error :as err])
+  (:import crux.http_server.entity_ref.EntityRef
+           crux.io.Cursor
+           (java.io OutputStream Writer)
            [java.time Instant ZonedDateTime ZoneId]
            java.time.format.DateTimeFormatter
-           java.util.Date
-           crux.http_server.entity_ref.EntityRef))
+           java.util.Date))
+
+(s/def ::query
+  (st/spec
+   {:spec #(s/valid? ::q/query %)
+    :type :map
+    :decode/string (fn [_ q] (util/try-decode-edn q))}))
+
+;; TODO: Need to ensure all query clasues are present + coerced properly
+(s/def ::query-params
+  (s/keys :opt-un [::util/valid-time ::util/transaction-time ::util/link-entities? ::query]))
+
+(s/def ::args (s/coll-of any? :kind vector?))
+
+(s/def ::body-params
+  (s/keys :req-un [::q/query]
+          :opt-un [::args]))
 
 (def query-root-str
   (string/join "\n"
@@ -32,7 +56,7 @@
                 " :where [[?e :crux.db/id]] ;; select ?e as the entity id for all entities in the database"
                 "}"]))
 
-(defn- query-root-html []
+(defn- query-root-html [{:keys [crux-node]}]
   [:div.query-root
    [:h1.query-root__title
     "Query"]
@@ -46,7 +70,7 @@
      [:form
       {:action "/_crux/query"}
       [:textarea.textarea
-       {:name "q"
+       {:name "query"
         :rows 10
         :cols 40}
        query-root-str]
@@ -63,55 +87,27 @@
         [:input.input.input-time
          {:type "datetime-local"
           :name "transaction-time"
-          :step "0.01"}]]]
+          :step "0.01"
+          :value (some-> (crux/latest-completed-tx crux-node)
+                         :crux.tx/tx-time
+                         ((fn [tx-time] (.toInstant ^Date tx-time)))
+                         (ZonedDateTime/ofInstant (ZoneId/of "Z"))
+                         (->> (.format util/default-date-formatter )))}]]]
       [:button.button
        {:type "submit"}
        "Submit Query"]]]]])
-
-(defn- vectorize-param [param]
-  (if (vector? param) param [param]))
-
-(defn- build-query [{:strs [find where args order-by limit offset full-results link-entities?]}]
-  (let [new-offset (if offset
-                     (Integer/parseInt offset)
-                     0)]
-    (cond-> {:find (c/read-edn-string-with-readers find)
-             :where (->> where vectorize-param (mapv c/read-edn-string-with-readers))
-             :offset new-offset}
-      args (assoc :args (->> args vectorize-param (mapv c/read-edn-string-with-readers)))
-      order-by (assoc :order-by (->> order-by vectorize-param (mapv c/read-edn-string-with-readers)))
-      limit (assoc :limit (Integer/parseInt limit))
-      full-results (assoc :full-results? true)
-      link-entities? (assoc :link-entities? true))))
 
 (defn with-entity-refs
   [results db]
   (let [entity-links (->> (apply concat results)
                           (into #{} (filter c/valid-id?))
-                          (into #{} (filter #(api/entity db %))))]
+                          (into #{} (filter #(crux/entity db %))))]
     (->> results
          (map (fn [tuple]
                 (->> tuple
                      (mapv (fn [el]
                              (cond-> el
                                (get entity-links el) (entity-ref/->EntityRef))))))))))
-
-
-
-(defn resolve-prev-next-offset
-  [query-params prev-offset next-offset]
-  (let [url (str "/_crux/query?"
-                 (subs
-                  (->> (dissoc query-params "offset")
-                       (reduce-kv (fn [coll k v]
-                                    (if (vector? v)
-                                      (apply str coll (mapv #(str "&" k "=" %) v))
-                                      (str coll "&" k "=" v))) ""))
-                  1))
-        prev-url (when prev-offset (str url "&offset=" prev-offset))
-        next-url (when next-offset (str url "&offset=" next-offset))]
-    {:prev-url prev-url
-     :next-url next-url}))
 
 (defn query->html [{:keys [results query] :as res}]
   (let [headers (:find query)]
@@ -138,51 +134,47 @@
                  "Nothing to show"]]])]]
       [:table.table__foot]]]))
 
-(defn run-query [{:keys [link-entities?] :as query} {:keys [crux-node valid-time transaction-time]}]
-  (try
-    (let [db (util/db-for-request crux-node {:valid-time valid-time
-                                             :transact-time transaction-time})]
-      {:query query
-       :valid-time (api/valid-time db)
-       :transaction-time (api/transaction-time db)
-       :results (if link-entities?
-                  (let [results (api/q db query)]
-                    (cio/->cursor (fn []) (with-entity-refs results db)))
-                  (api/open-q db query))})
-    (catch Exception e
-      {:error e})))
+(defn run-query [{:keys [link-entities? query]} {:keys [crux-node valid-time transaction-time]}]
+  (let [db (util/db-for-request crux-node {:valid-time valid-time
+                                           :transact-time transaction-time})]
+    {:query query
+     :valid-time (crux/valid-time db)
+     :transaction-time (crux/transaction-time db)
+     :results (if link-entities?
+                (let [results (crux/q db query)]
+                  (cio/->cursor (fn []) (with-entity-refs results db)))
+                (crux/open-q db query))}))
 
 (defn- ->*sv-encoder [{:keys [sep]}]
   (reify mfc/EncodeToOutputStream
-    (encode-to-output-stream [_ {:keys [results query error]} charset]
+    (encode-to-output-stream [_ {:keys [results query] :as res} charset]
       (fn [^OutputStream output-stream]
         (with-open [w (io/writer output-stream)]
           (try
-            (if error
-              (.write w ^String error)
-              (csv/write-csv w (cons (:find query) (iterator-seq results)) :separator sep))
+            (if results
+              (csv/write-csv w (cons (:find query) (iterator-seq results)) :separator sep)
+              (.write w (pr-str res)))
             (finally
               (cio/try-close results))))))))
 
 (defn ->html-encoder [opts]
   (reify mfc/EncodeToBytes
-    (encode-to-bytes [_ {:keys [no-query? error results] :as res} charset]
+    (encode-to-bytes [_ {:keys [no-query? results] :as res} charset]
       (try
         (let [^String resp (cond
-                             no-query? (util/raw-html {:body (query-root-html)
-                                                       :title "/query"
+                             no-query? (util/raw-html {:body (query-root-html opts)
+                                                       :title "/_crux/query"
                                                        :options opts})
-                             error (let [error-message (.getMessage ^Exception error)]
-                                     (util/raw-html {:title "/query"
-                                                     :body [:div.error-box error-message]
-                                                     :options opts
-                                                     :results {:query-results
-                                                               {"error" error-message}}}))
-                             :else (let [results (iterator-seq results)]
-                                     (util/raw-html {:body (query->html (assoc res :results (drop-last results)))
-                                                     :title "/query"
-                                                     :options opts
-                                                     :results {:query-results results}})))]
+                             results (let [results (iterator-seq results)]
+                                       (util/raw-html {:body (query->html (assoc res :results results))
+                                                       :title "/_crux/query"
+                                                       :options opts
+                                                       :results {:query-results results}}))
+                             :else (util/raw-html {:title "/_crux/query"
+                                                   :body [:div.error-box (str res)]
+                                                   :options opts
+                                                   :results {:query-results
+                                                             {"error" res}}}) )]
           (.getBytes resp ^String charset))
         (finally
           (cio/try-close results))))))
@@ -190,27 +182,30 @@
 (defn ->edn-encoder [_]
   (reify
     mfc/EncodeToOutputStream
-    (encode-to-output-stream [_ {:keys [results error] :as res} _]
+    (encode-to-output-stream [_ {:keys [^Cursor results] :as res} _]
       (fn [^OutputStream output-stream]
         (with-open [w (io/writer output-stream)]
           (try
-            (if error
-              (.write w ^String (pr-str res))
-              (print-method (iterator-seq results) w))
+            (cond
+              (and results (.hasNext results)) (print-method (iterator-seq results) w)
+              results (.write w ^String (pr-str '()))
+              :else (.write w ^String (pr-str res)))
             (finally
               (cio/try-close results))))))))
 
 (defn- ->tj-encoder [_]
   (reify
     mfc/EncodeToOutputStream
-    (encode-to-output-stream [_ {:keys [results error] :as res} _]
+    (encode-to-output-stream [_ {:keys [^Cursor results] :as res} _]
       (fn [^OutputStream output-stream]
-        (try
-          (if error
-            (transit/write (transit/writer output-stream :json) res)
-            (transit/write (transit/writer output-stream :json {:handlers {EntityRef entity-ref/ref-write-handler}}) (iterator-seq results)))
-          (finally
-            (cio/try-close results)))))))
+        (let [w (transit/writer output-stream :json {:handlers {EntityRef entity-ref/ref-write-handler}})]
+          (try
+            (cond
+              (and results (.hasNext results)) (transit/write w (iterator-seq results))
+              results (transit/write w '())
+              :else (transit/write w res))
+            (finally
+              (cio/try-close results))))))))
 
 (defn ->query-muuntaja [opts]
   (m/create (-> m/default-options
@@ -225,31 +220,32 @@
                             :encoder [->html-encoder opts]
                             :return :bytes})
                 (m/install {:name "application/edn"
-                            :encoder [->edn-encoder]})
+                            :encoder [->edn-encoder]
+                            :decoder [mfe/decoder]})
                 (m/install {:name "application/transit+json"
-                            :encoder [->tj-encoder]}))))
+                            :encoder [->tj-encoder]
+                            :decoder [(partial mft/decoder :json)]}))))
 
-(defmulti transform-query-req
+(defmulti transform-req
   (fn [query req]
     (get-in req [:muuntaja/response :format])))
 
-(defmethod transform-query-req "text/html" [query req]
-  (-> query
-      (dissoc :full-results)
-      (update :limit #(if % (inc %) 101))
-      (assoc :link-entities? true)))
+(defmethod transform-req "text/html" [query req]
+  {:query (-> query
+              (dissoc :full-results))
+   :link-entities? true})
 
-(defmethod transform-query-req "text/csv" [query req]
-  (-> query
-      (dissoc :full-results)
-      (dissoc :link-entities?)))
+(defmethod transform-req "text/csv" [query req]
+  {:query (-> query
+              (dissoc :full-results))})
 
-(defmethod transform-query-req "text/tsv" [query req]
-  (-> query
-      (dissoc :full-results)
-      (dissoc :link-entities?)))
+(defmethod transform-req "text/tsv" [query req]
+  {:query (-> query
+              (dissoc :full-results))})
 
-(defmethod transform-query-req :default [query _] query)
+(defmethod transform-req :default [query req]
+  {:query query
+   :link-entities? (get-in req [:parameters :query :link-entities?])})
 
 (defmulti transform-query-resp
   (fn [resp req]
@@ -266,41 +262,35 @@
                         (.format csv-date-formatter ^Instant (.toInstant ^Date transaction-time))
                         ext))))
 
-(defn handle-error [{:keys [no-query? error]}]
+(defmethod transform-query-resp "text/csv" [{:keys [no-query?] :as res} _]
   (cond
-    no-query? {:status 400, :body "No query provided."}
-    error {:status 400, :body {:error (.getMessage ^Exception error)}}))
+    no-query? (throw (ce/illegal-arg :no-query {::ce/message "No query provided"}))
+    :else (-> {:status 200, :body res}
+              (with-download-header res "csv"))))
 
-(defmethod transform-query-resp "text/csv" [{:keys [results query] :as res} req]
-  (or (handle-error res)
-      (-> {:status 200, :body res}
-          (with-download-header res "csv"))))
+(defmethod transform-query-resp "text/tsv" [{:keys [no-query?] :as res} _]
+  (cond
+    no-query? (throw (ce/illegal-arg :no-query {::ce/message "No query provided"}))
+    :else (-> {:status 200, :body res}
+              (with-download-header res "tsv"))))
 
-(defmethod transform-query-resp "text/tsv" [{:keys [results query] :as res} req]
-  (or (handle-error res)
-      ;; TODO what if query is a string?
-      (-> {:status 200, :body res}
-          (with-download-header res "tsv"))))
+(defmethod transform-query-resp "text/html" [res _]
+  {:status 200 :body res})
 
-(defmethod transform-query-resp "text/html" [{:keys [error] :as res} _]
-  {:status (if error 400 200)
-   :body res})
+(defmethod transform-query-resp :default [{:keys [no-query?] :as res} _]
+  (cond
+    no-query? (throw (ce/illegal-arg :no-query {::ce/message "No query provided"}))
+    :else {:status 200, :body res}))
 
-(defmethod transform-query-resp :default [{:keys [results] :as res} _]
-  (or (handle-error res)
-      {:status 200, :body res}))
-
-(defn data-browser-query [req {:keys [query-muuntaja] :as options}]
-  (let [req (cond->> req
-              (not (get-in req [:muuntaja/response :format])) (m/negotiate-and-format-request query-muuntaja))
-        {:strs [valid-time transaction-time q] :as query-params} (:query-params req)]
-    (-> (if (empty? query-params)
-          (assoc options :no-query? true)
-          (run-query (-> (or (some-> q (edn/read-string))
-                             (build-query query-params))
-                         (transform-query-req req))
-                     (assoc options
-                            :valid-time (when-not (string/blank? valid-time) (instant/read-instant-date valid-time))
-                            :transaction-time (when-not (string/blank? transaction-time) (instant/read-instant-date transaction-time)))))
-        (transform-query-resp req)
-        (->> (m/format-response query-muuntaja req)))))
+(defn data-browser-query [options]
+  (fn [req]
+    (let [{query-params :query body-params :body} (get-in req [:parameters])
+          {:keys [valid-time transaction-time query]} query-params
+          query (or query (get body-params :query))]
+      (-> (if (nil? query)
+            (assoc options :no-query? true)
+            (run-query (transform-req query req)
+                       (assoc options
+                              :valid-time valid-time
+                              :transaction-time transaction-time)))
+          (transform-query-resp req)))))

--- a/crux-http-server/src/crux/http_server/status.clj
+++ b/crux-http-server/src/crux/http_server/status.clj
@@ -26,7 +26,8 @@
          [:tr.table__row.body__row
           [:td.table__cell.body__cell
            [:a
-            {:href (format "/_crux/query?find=%s&where=%s" (format "[%s]" (name key)) (format "[e %s %s]" key (name key)))}
+            {:href (format "/_crux/query?query=%s" (pr-str {:find [(symbol (name key))]
+                                                      :where [['e key (symbol (name key))]]}))}
             (with-out-str (pp/pprint key))]]
           [:td.table__cell.body__cell (with-out-str (pp/pprint value))]])))]])
 
@@ -89,8 +90,10 @@
              500)
    :body status-map})
 
-(defn status [req {:keys [status-muuntaja crux-node] :as options}]
-  (let [req (cond->> req
-              (not (get-in req [:muuntaja/response :format])) (m/negotiate-and-format-request status-muuntaja))]
-    (->> (transform-query-resp (assoc options :status-map (api/status crux-node)) req)
-         (m/format-response status-muuntaja req))))
+(defn status [{:keys [crux-node] :as options}]
+  (let [status-muuntaja (->status-muuntaja options)]
+    (fn [req]
+      (let [req (cond->> req
+                  (not (get-in req [:muuntaja/response :format])) (m/negotiate-and-format-request status-muuntaja))]
+        (->> (transform-query-resp (assoc options :status-map (api/status crux-node)) req)
+             (m/format-response status-muuntaja req))))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -100,7 +100,7 @@
 
       (t/testing "malformed query"
         (t/is (thrown-with-msg? Exception
-                                #"(status 400|Spec assertion failed)"
+                                #"Spec assertion failed"
                                 (api/q db '{:in [$ e]}))))
 
       (t/testing "query with streaming result"
@@ -166,7 +166,7 @@
 
   (t/testing "SPARQL query"
     (when (bound? #'fh/*api-url*)
-      (let [repo (SPARQLRepository. (str fh/*api-url* "/sparql"))]
+      (let [repo (SPARQLRepository. (str fh/*api-url* "/_crux/sparql"))]
         (try
           (.initialize repo)
           (with-open [conn (.getConnection repo)]

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -99,8 +99,8 @@
                                         :where [e :name "Ivan"]]))))
 
       (t/testing "malformed query"
-        (t/is (thrown-with-msg? Exception
-                                #"Spec assertion failed"
+        (t/is (thrown-with-msg? IllegalArgumentException
+                                #"Query didn't match expected structure"
                                 (api/q db '{:in [$ e]}))))
 
       (t/testing "query with streaming result"

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1148,11 +1148,10 @@
                                      :where [[#{:ivan :petr} :name name]]}))))
 
   (t/testing "vectors are not supported"
-    (t/is (thrown-with-msg?
-           RuntimeException
-           #"Spec assertion failed"
-           (api/q (api/db *api*) '{:find [e]
-                                   :where [[e :name [:ivan]]]})))))
+    (t/is (thrown-with-msg? IllegalArgumentException
+                            #"Query didn't match expected structure"
+                            (api/q (api/db *api*) '{:find [e]
+                                                    :where [[e :name [:ivan]]]})))))
 
 (t/deftest test-collection-returns
   (t/testing "vectors"
@@ -3359,10 +3358,9 @@
 
 (t/deftest test-nil-query-attribute-453
   (fix/transact! *api* [{:crux.db/id :id :this :that :these :those}])
-  (t/is (thrown-with-msg?
-          RuntimeException
-          #"Spec assertion failed"
-          (= #{[:id]} (api/q (api/db *api*) {:find ['e] :where [['_ nil 'e]]})))))
+  (t/is (thrown-with-msg? IllegalArgumentException
+                          #"Query didn't match expected structure"
+                          (api/q (api/db *api*) {:find ['e] :where [['_ nil 'e]]}))))
 
 ;; TODO: Unsure why this test has started failing, or how much it
 ;; matters?

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -11,7 +11,7 @@ Multiple Crux nodes can placed be behind a HTTP load balancer to spread the writ
 Each Crux node in such a cluster will be independently catching up with the head of the transaction log, and since different queries might go to different nodes, you have to be slightly conscious of read consistency when designing your application to use Crux in this way.
 Fortunately, you can readily achieve read-your-writes consistency with the ability to query consistent point-in-time snapshots using specific temporal coordinates.
 
-The REST API also provides an experimental endpoint for SPARQL 1.1 Protocol queries under `/sparql/`, rewriting the query into the Crux Datalog dialect.
+The REST API also provides an experimental endpoint for SPARQL 1.1 Protocol queries under `/_crux/sparql/`, rewriting the query into the Crux Datalog dialect.
 Only a small subset of SPARQL is supported and no other RDF features are available.
 
 [#start-http-server]
@@ -78,170 +78,226 @@ If the node was started on `localhost:3000`, you can connect to it by doing the 
 include::example$src/docs/examples.clj[tags=start-http-client]
 ----
 
-[#http-api]
-== Using the HTTP API
+[#rest-api]
+== Using the REST API
 
-.API
-[#table-conversion%header,cols="d,d,d"]
-|===
-|uri|method|description
-|<<#entity, `/entity/[:key]`>>|GET|Returns an entity for a given ID and optional valid-time/transaction-time co-ordinates
-|<<#entity-tx, `/entity-tx/[:key]`>>|GET|Returns the transaction that most recently set a key
-|<<#entity, `/entity-history/[:key]`>>|GET|Returns the history of the given entity and optional valid-time/transaction-time co-ordinates
-|<<#query, `/query`>>|POST|Takes a datalog query and returns its results
-|<<#sync, `/sync`>>|GET| Wait until the Kafka consumer's lag is back to 0
-|<<#tx-log, `/tx-log`>>|GET| Returns a list of all transactions
-|<<#tx-log-post, `/tx-log`>>|POST|The "write" endpoint, to post transactions.
-|===
+All of the REST endpoints return both `application/edn` and https://github.com/cognitect/transit-clj[`application/transit+json`].
+Individual endpoints may return additional types - see their docs below.
+
+[#status]
+=== GET `/_crux/status`
+
+Returns the current status information of the node.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/status
+----
 
 [#entity]
-=== GET `/entity/[:key]`
+=== GET `/_crux/entity`
 
-Takes a key and, optionally, a `:valid-time` and/or `:transact-time` (defaulting to now). Returns the value stored under that key at those times.
-
-See xref:bitemporality.adoc[Bitemporality] for more information.
+Returns the document map for a particular entity.
 
 [source,bash]
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $nodeURL/entity/:tommy
+     $CRUX_URL/_crux/entity?eid=:tommy
 ----
 
-[source,clj]
-----
-{:crux.db/id :tommy, :name "Tommy", :last-name "Petrov"}
-----
+==== Query Parameters
+
+.*Required Parameters*
+* `eid` (Crux ID)
+
+.*Optional Parameters*
+* `valid-time` (date, defaulting to now)
+* `transaction-time` (date, defaulting to latest transaction time)
+
+=== GET `/_crux/entity?history=true`
+
+Returns the history of a particular entity.
 
 [source,bash]
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $nodeURL/entity/:tommy?valid-time=1999-01-08T14%3A03%3A27%3A254-00%3A00
+     $CRUX_URL/_crux/entity?eid=:tommy&history=true&sort-order=asc
 ----
 
-[source,clj]
-----
-nil
-----
+==== Query Parameters
+
+.*Required Parameters*
+* `eid` (Crux ID)
+* `sort-order` (either `asc` or `desc`)
+
+.*Optional Parameters*
+* `with-corrections` (boolean, default false): includes bitemporal corrections in the response, inline, orted by valid-time then transaction-time
+* `with-docs` (boolean, default false): includes the documents in the response sequence, under the `:crux.db/doc` key
+* `start-valid-time`, `start-transaction-time` (inclusive, default unbounded): bitemporal co-ordinates to start at
+* `end-valid-time`, `end-transaction-time` (exclusive, default unbounded): bitemporal co-ordinates to stop at
 
 [#entity-tx]
-=== GET `/entity-tx`
+=== GET `/_crux/entity-tx`
 
-Takes a key and, optionally, `:valid-time` and/or `:transact-time` (defaulting to now). Returns the `:put` transaction that most recently set that key at those times.
-
-See xref:bitemporality.adoc[Bitemporality] for more information.
+Returns the transaction details for an entity - returns a map containing the tx-id and tx-time.
 
 [source,bash]
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $nodeURL/entity-tx/:foobar
-----
-[source,clj]
-----
-{:crux.db/id "8843d7f92416211de9ebb963ff4ce28125932878",
- :crux.db/content-hash "7af0444315845ab3efdfbdfa516e68952c1486f2",
- :crux.db/valid-time #inst "2019-01-08T16:34:47.738-00:00",
- :crux.tx/tx-id 0,
- :crux.tx/tx-time #inst "2019-01-08T16:34:47.738-00:00"}
+     $CRUX_URL/_crux/entity-tx?eid=:tommy
 ----
 
-[#entity-history]
-=== GET `/entity-history/[:key]`
+==== Query Parameters
 
-Returns the history for the given entity
+.*Required Parameters*
+* `eid` (Crux ID)
 
-[source,bash]
-----
-curl -X GET $nodeURL/entity-history/:ivan?sort-order=desc
-----
-
-Also accepts the following as optional query parameters:
-* `with-corrections` - includes bitemporal corrections in the response, inline, sorted by valid-time then transaction-time (default false)
-* `with-docs` - includes the documents in the response sequence, under the `:crux.db/doc` key (default false)
-* `start-valid-time`, `start-transaction-time` - bitemporal co-ordinates to start at (inclusive, default unbounded)
-* `end-valid-time`, `end-transaction-time` - bitemporal co-ordinates to stop at (exclusive, default unbounded)
-
-[source,clj]
-----
-[{:crux.db/id "a15f8b81a160b4eebe5c84e9e3b65c87b9b2f18e",
-  :crux.db/content-hash "c28f6d258397651106b7cb24bb0d3be234dc8bd1",
-  :crux.db/valid-time #inst "2019-01-07T14:57:08.462-00:00",
-  :crux.tx/tx-id 14,
-  :crux.tx/tx-time #inst "2019-01-07T16:51:55.185-00:00"
-  :crux.db/doc {...}}
-
- {...}]
-----
+.*Optional Parameters*
+* `valid-time` (date, defaulting to now)
+* `transaction-time` (date, defaulting to latest transaction time)
 
 [#query]
-=== POST `/query`
+=== GET `/_crux/query`
 
-Takes a Datalog query and returns its results.
+Takes a datalog query and returns its results. Results are also available in `text/csv` and `text/tsv` formats (can force negotiation of these by using the `/_crux/query.csv` and `/_crux/query.tsv` endpoints respectively).
 
 [source,bash]
 ----
-curl -X POST \
+curl -g \
+     -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/query?query={%3Afind+[e]+%3Awhere+[[e+%3Acrux.db/id+_]]}
+----
+
+==== Query Parameters
+
+.*Required Parameters*
+* `query` (URL encoded datalog query)
+
+.*Optional Parameters*
+* `valid-time` (date, defaulting to now)
+* `transaction-time` (date, defaulting to latest transaction time)
+
+[#query]
+=== POST `/_crux/query`
+
+Takes a datalog query and returns its results. Results are also available in `text/csv` and `text/tsv` formats (can force negotiation of these by using the `/_crux/query.csv` and `/_crux/query.tsv` endpoints respectively).
+
+[source,bash]
+----
+curl -g \
+     -X POST \
      -H "Content-Type: application/edn" \
      -d '{:query {:find [e] :where [[e :last-name "Petrov"]]}}' \
-     $nodeURL/query
+     $CRUX_URL/_crux/query?valid-time=2019-01-08T16:34:47.738-00:00
 ----
 
-[source,clj]
-----
-#{[:boris][:ivan]}
-----
+==== Parameters
 
-Note that you are able to add `:full-results? true` to the query map to easily retrieve the source documents relating to the entities in the result set. For instance to retrieve _all_ documents in a single query:
+===== Body Parameters
 
-[source,clj]
+.*Required Parameters*
+* `query` (URL encoded datalog query)
+
+===== Query Parameters
+
+.*Optional Parameters*
+* `valid-time` (date, defaulting to now)
+* `transaction-time` (date, defaulting to latest transaction time)
+
+
+[#attribute-stats]
+=== GET `/_crux/attribute-stats`
+
+Returns frequencies of indexed attributes
+
+[source,bash]
 ----
-curl -X POST \
+curl -X GET \
      -H "Content-Type: application/edn" \
-     -d '{:query {:find [e] :where [[e :crux.db/id _]] :full-results? true}}' \
-     $nodeURL/query
+     $CRUX_URL/_crux/attribute-stats
 ----
 
 [#sync]
-=== GET `/sync`
+=== GET `/_crux/sync`
 
-Wait until the Kafka consumer's lag is back to 0 (i.e. when it no longer has pending transactions to write). Timeout is 10 seconds by default, but can be specified as a parameter in milliseconds. Returns the transaction time of the most recent transaction.
+Wait until the Kafka consumer's lag is back to 0 (i.e. when it no longer has pending transactions to write).  Returns the transaction time of the most recent transaction.
 
 [source,bash]
 ----
-curl -X GET $nodeURL/sync?timeout=500
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/sync?timeout=500
 ----
 
-[source,clj]
+==== Query Parameters
+
+.*Optional Parameters*
+* `timeout` (integer): specified in milliseconds (defaulting to 10 seconds)
+
+[#await-tx]
+=== GET `/_crux/await-tx`
+
+Waits until the node has indexed a transaction that is at or past the supplied tx-id. Returns the most recent tx indexed by the node.
+
+[source,bash]
 ----
-#inst "2019-01-08T11:06:41.869-00:00"
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/await-tx?tx-id=1
 ----
+
+==== Query Parameters
+
+.*Required Parameters*
+* `tx-id` (integer): tx-id of transaction to wait for
+
+.*Optional Parameters*
+* `timeout` (integer): specified in milliseconds (defaulting to 10 seconds)
+
+[#await-tx-time]
+=== GET `/_crux/await-tx-time`
+
+Blocks until the node has indexed a transaction that is past the supplied tx-time. The returned date is the latest index time when this node has caught up as of this call.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/await-tx-time?tx-time=2020-09-10T11%3A16%3A10.983Z
+----
+
+==== Query Parameters
+
+.*Required Parameters*
+* `tx-time` (date): tx-time of to wait for
+
+.*Optional Parameters*
+* `timeout` (integer): specified in milliseconds (defaulting to 10 seconds)
 
 [#tx-log]
-=== GET `/tx-log`
+=== GET `/_crux/tx-log`
 
-Returns a list of all transactions, from oldest to newest transaction time.
+Returns a list of all transactions, from oldest to newest transaction time - optionally including documents.
 
 [source,bash]
 ----
-curl -X GET $nodeURL/tx-log
+curl -X GET $CRUX_URL/_crux/tx-log
 ----
 
-[source,clj]
-----
-({:crux.tx/tx-time #inst "2019-01-07T15:11:13.411-00:00",
-  :crux.api/tx-ops [[
-    :crux.tx/put "c28f6d258397651106b7cb24bb0d3be234dc8bd1"
-    #inst "2019-01-07T14:57:08.462-00:00"]],
-  :crux.tx/tx-id 0}
+==== Query Parameters
 
- {:crux.tx/tx-time #inst "2019-01-07T15:11:32.284-00:00",
-  ...})
-----
+.*Optional Parameters*
+* `after-tx-id` (integer, default unbounded): transaction id to start after.
+* `with-ops?` (boolean, defaults to false): should the operations with documents be included?
 
-[#tx-log-post]
-=== POST `/tx-log`
+[#submit-tx]
+=== POST `/_crux/submit-tx`
 
 Takes a vector of transactions (any combination of `:put`, `:delete`, `:match`, and `:evict`) and executes them in order. This is the only "write" endpoint.
 
@@ -252,9 +308,77 @@ curl -X POST \
      -d '[[:crux.tx/put {:crux.db/id :ivan, :name "Ivan" :last-name "Petrov"}],
           [:crux.tx/put {:crux.db/id :boris, :name "Boris" :last-name "Petrov"}],
           [:crux.tx/delete :maria  #inst "2012-05-07T14:57:08.462-00:00"]]' \
-     $nodeURL/tx-log
+     $CRUX_URL/_crux/submit-tx
 ----
-[source,clj]
+
+=== GET `/_crux/tx-committed`
+
+Checks if a submitted tx was successfully committed, returning a map with tx-committed and either `true` or `false` (or a `NodeOutOfSyncException` exception response if the node has not yet indexed the transaction).
+
+[source,bash]
 ----
-{:crux.tx/tx-id 7, :crux.tx/tx-time #inst "2019-01-07T16:14:19.675-00:00"}
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/tx-committed?tx-id=1
+----
+
+==== Query Parameters
+
+.*Required Parameters*
+* `tx-id` (integer): tx-id of transaction to check
+
+
+=== GET `/_crux/latest-completed-tx`
+
+Returns the latest transaction to have been indexed by this node.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/latest-completed-tx
+----
+
+=== GET `/_crux/latest-submitted-tx`
+
+Returns the latest transaction to have been submitted to this cluster.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/latest-submitted-tx
+----
+
+=== GET `/_crux/active-queries`
+
+Returns a list of currently running queries.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/active-queries
+----
+
+=== GET `/_crux/recent-queries`
+
+Returns a list of recently completed/failed queries.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/recent-queries
+----
+
+=== GET `/_crux/slowest-queries`
+
+Returns a list of slowest completed/failed queries ran on the node.
+
+[source,bash]
+----
+curl -X GET \
+     -H "Content-Type: application/edn" \
+     $CRUX_URL/_crux/slowest-queries
 ----


### PR DESCRIPTION
Resolves #1032, #803  - using reitit for routing and proper organized coercion of params against a `spec`.

TODO:
- [x] Clarify the use of crux/ids in the main API - currently need write handlers to pass them over the wire, should this be something we are exposing anyway?
- [x] Merge regular + console endpoints, and under same handler
- [x] Use reitit for routing
- [x] Ensure all routes use muuntaja for negotiation (?)
--> This currently supports EDN and transit+json as outputs, only currently accept EDN inputs
- [x] Ensure all non console routes use clojure API rather than Java API
- [x] Use reitit for handling spec validation + coercion of params
- [x] Migrate remote API to use new routes
- [x] Error messages for spec/coercion fail.
- [x] Cleanup remote API - no string encoding.
- [x] Cleanup the http-server namespace of unused content.
- [x] All endpoints prefixed with `_crux`.
- [x] Should empty `attribute-stats` call return an empty map or a nil?
- [x] Update REST API docs
- [x] Remove HTTP Special case from thrown (API test)
- [x] Remote API use post `query` - ensure ui route test for GET query still works.
- [x] Add transit decoder for body - muuntaja (and test it)
- [ ] Exception handler for muuntaja decode - likely want to think further on exception handlers
- [ ] May want some more specific tests for exceptions in `ui-routes-test`

Among these changes is a refactor and cleanup to the behaviour of `http-server.entity`.

Note: Errors are now (generally) thrown across the board, and error handling is done before muuntaja formatting (such that errors will now be formatted by muuntaja) - this also means that coercion errors within `query`/`entity` will still result in the user getting a page back when requesting HTML.

Likely some updates wanted to the REST API changes (minor tweaks, and perhaps a small explainer on types you're expected to pass?) - can see it here https://www.opencrux.com/http/reference/http.html