### PR TITLE
Tuple return vars

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -250,6 +250,11 @@
                                       >= <=
                                       = =})
 
+(defn- maybe-unquote [x]
+  (if (and (list? x) (= 'quote (first x)) (= 2 (count x)))
+    (recur (second x))
+    x))
+
 (defn- rewrite-self-join-triple-clause [{:keys [e v] :as triple}]
   (let [v-var (gensym (str "self-join_" v "_"))]
     {:triple [(with-meta
@@ -786,11 +791,6 @@
                                arg-binding))
           pred-result (apply pred-fn args)]
       (bind-pred-result clause pred-ctx idx-id->idx pred-result))))
-
-(defn- maybe-unquote [x]
-  (if (and (list? x) (= 'quote (first x)) (= 2 (count x)))
-    (recur (second x))
-    x))
 
 (defn- build-pred-constraints [rule-name->rules encode-value-fn pred-clause+idx-ids var->bindings vars-in-join-order]
   (for [[{:keys [pred return] :as clause} idx-id] pred-clause+idx-ids

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -720,7 +720,7 @@
       false)
     pred-result))
 
-(defmethod pred-constraint 'q [{:keys [return] {:keys [pred-fn]} :pred :as clause} encode-value-fn idx-id arg-bindings return-vars-tuple-idxs-in-join-order rule-name->rules]
+(defmethod pred-constraint 'q [{:keys [return] :as clause} encode-value-fn idx-id arg-bindings return-vars-tuple-idxs-in-join-order rule-name->rules]
   (let [query (normalize-query (second arg-bindings))
         parent-rules (:rules (meta rule-name->rules))]
     (fn pred-constraint [index-store db idx-id->idx join-keys]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -102,11 +102,12 @@
 (defmulti pred-args-spec first)
 
 (defmethod pred-args-spec 'q [_]
-  (s/cat :pred-fn #{'q} :args (s/spec (s/cat :query (s/or :quoted-query (s/cat :quote #{'quote} :query ::query)
-                                                          :query ::query)
-                                             :args (s/* (s/cat :key (s/or :quoted-symbol (s/cat :quote #{'quote} :sym symbol?)
-                                                                          :keyword keyword?)
-                                                               :val some?))))
+  (s/cat :pred-fn #{'q}
+         :args (s/spec (s/cat :query (s/or :quoted-query (s/cat :quote #{'quote} :query ::query)
+                                           :query ::query)
+                              :args (s/* (s/cat :key (s/or :quoted-symbol (s/cat :quote #{'quote} :sym symbol?)
+                                                           :keyword keyword?)
+                                                :val any?))))
          :return (s/? ::pred-return)))
 
 (defmethod pred-args-spec 'get-attr [_]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -710,7 +710,7 @@
                                  (c/vectorize-value pred-result)
                                  pred-result))]
       (do (if (logic-var? return)
-            (idx/update-relation-virtual-index! idx values encode-value-fn true)
+            (idx/update-relation-virtual-index! idx (mapv vector values))
             (->> (for [tuple values
                        :when (<= (count return-vars-tuple-idxs-in-join-order)
                                  (count tuple))]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1130,24 +1130,20 @@
              (api/q (api/db *api*) '{:find [x y z]
                                      :where [[(q {:find [x y z]
                                                   :where [[(identity 2) y]
-                                                          [(+ x y) z]]}
-                                                 :x 1) [x y z]]]})))
+                                                          [(+ x y) z]]} :x 1) [x y z]]]})))
 
     (t/is (= #{[1 3 4]}
              (api/q (api/db *api*) '{:find [x y z]
                                      :where [[(identity 1) x]
                                              [(q {:find [z]
-                                                  :where [[(+ x 2) z]]}
-                                                 :x x)
-                                              [y]]
+                                                  :where [[(+ x 2) z]]} :x x) [y]]
                                              [(+ x y) z]]})))
 
     (t/testing "can use quoted symbols as names"
       (t/is (= #{[1]}
                (api/q (api/db *api*) '{:find [x]
                                        :where [[(q {:find [y]
-                                                    :where [[(identity x) y]]}
-                                                   'x 1) [x]]]}))))
+                                                    :where [[(identity x) y]]} 'x 1) [x]]]}))))
 
     (t/testing "can handle quoted sub query"
       (t/is (= #{[2]}
@@ -1182,21 +1178,18 @@
              (api/q (api/db *api*) '{:find [x]
                                      :where [[(identity 2) x]
                                              [(q {:find [x]
-                                                  :where [[(even? x)]]}
-                                                 :x x)]]})))
+                                                  :where [[(even? x)]]} :x x)]]})))
 
     (t/is (empty? (api/q (api/db *api*) '{:find [x]
                                           :where [[(identity 2) x]
                                                   [(q {:find [y]
-                                                       :where [[(odd? y)]]}
-                                                      :y x)]]})))
+                                                       :where [[(odd? y)]]} :y x)]]})))
 
     (t/is (= #{[2]}
              (api/q (api/db *api*) '{:find [x]
                                      :where [[(identity 2) x]
                                              (not [(q {:find [y]
-                                                       :where [[(odd? y)]]}
-                                                      :y x)])]})))))
+                                                       :where [[(odd? y)]]} :y x)])]})))))
 
 (t/deftest test-simple-numeric-range-search
   (t/is (= '[[:triple {:e i, :a :age, :v age}]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1147,7 +1147,13 @@
                (api/q (api/db *api*) '{:find [x]
                                        :where [[(q {:find [y]
                                                     :where [[(identity x) y]]}
-                                                   'x 1) [x]]]})))))
+                                                   'x 1) [x]]]}))))
+
+    (t/testing "can handled quoted sub query"
+      (t/is (= #{[2]}
+               (api/q (api/db *api*) '{:find [x]
+                                       :where [[(q '{:find [y]
+                                                     :where [[(identity 2) y]]}) [x]]]})))))
 
   (t/testing "can inherit rules from parent query"
     (t/is (empty?

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1159,7 +1159,7 @@
                                      :where [[(identity #{[1 2] [3 4]}) [[_ x]]]
                                              [(identity #{[4 2]}) [[x _]]]]}))))
 
-  (t/testing "can bind full tuple"
+  (t/testing "can bind full tuple using collection binding"
     (t/is (= #{[[1 2]]
                [[3 4]]}
              (api/q (api/db *api*) '{:find [x]
@@ -2448,11 +2448,11 @@
                            :where [(identity ?in) _]])
                #{[:a]}))
 
-      ;; TODO: Crux doesn't support tuple collections
-      #_(t/is (= (api/q db '[:find ?x ?z
-                             :args {?in [:a :b :c]} {?in [:d :e :f]}
-                             :where [(identity ?in) [[?x _ ?z] ...]]])
-                 #{[:a :c] [:d :f]}))
+      (t/is (= (api/q db '[:find ?x ?z
+                           :args {?in [[:a :b :c]
+                                       [:d :e :f]]}
+                           :where [(identity ?in) [[?x _ ?z]]]])
+               #{[:a :c] [:d :f]}))
 
       (t/is (= (api/q db '[:find ?in
                            :args {?in []}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1149,11 +1149,23 @@
                                                     :where [[(identity x) y]]}
                                                    'x 1) [x]]]}))))
 
-    (t/testing "can handled quoted sub query"
+    (t/testing "can handle quoted sub query"
       (t/is (= #{[2]}
                (api/q (api/db *api*) '{:find [x]
                                        :where [[(q '{:find [y]
-                                                     :where [[(identity 2) y]]}) [x]]]})))))
+                                                     :where [[(identity 2) y]]}) [x]]]}))))
+
+    (t/testing "can handle vector sub queries"
+      (t/is (= #{[2]}
+               (api/q (api/db *api*) '{:find [x]
+                                       :where [[(q [:find y
+                                                    :where [(identity 2) y]]) [x]]]}))))
+
+    (t/testing "can handle string sub queries"
+      (t/is (= #{[2]}
+               (api/q (api/db *api*) '{:find [x]
+                                       :where [[(q "[:find y
+                                                     :where [(identity 2) y]]") [x]]]})))))
 
   (t/testing "can inherit rules from parent query"
     (t/is (empty?

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -2332,13 +2332,11 @@
                #{["a" 1] ["abc" 3]})))
 
     (t/testing "Built-in vector, hashmap"
-      ;; Crux differs here by treating vectors and sets as multiple
-      ;; results.
-      #_(t/is (= (api/q db
-                        '{:find [?tx-data]
-                          :where [[(identity :db/add) ?op]
-                                  [(vector ?op -1 :attr 12) ?tx-data]]})
-                 #{[[:db/add -1 :attr 12]]}))
+      (t/is (= (api/q db
+                      '{:find [?tx-data]
+                        :where [[(identity :db/add) ?op]
+                                [(vector ?op -1 :attr 12) ?tx-data]]})
+               #{[[:db/add -1 :attr 12]]}))
 
       (t/is (= (api/q db
                       '{:find [?tx-data]
@@ -2372,13 +2370,12 @@
                                 [(identity 2) ?n]]})
                #{})))
 
-    ;; NOTE: Crux does not currently support destructuring.
-    #_(t/testing "Destructured conflicting function values for two bindings."
-        (t/is (= (d/q '[:find  ?n ?x
+    (t/testing "Destructured conflicting function values for two bindings."
+      (t/is (= (api/q db
+                      '[:find  ?n ?x
                         :where [(identity [3 4]) [?n ?x]]
-                        [(identity [1 2]) [?n ?x]]]
-                      db)
-                 #{})))
+                        [(identity [1 2]) [?n ?x]]])
+               #{})))
 
     (t/testing "Rule bindings interacting with function binding. (fn, rule)"
       (t/is (= (api/q db
@@ -2440,31 +2437,27 @@
                                 {:?in 4}]})
                  #{[2] [4]})))
 
-    ;; NOTE: Crux does not currently support destructuring.
-    #_(t/testing "Result bindings"
-        (t/is (= (d/q '[:find ?a ?c
-                        :in ?in
-                        :where [(ground ?in) [?a _ ?c]]]
-                      [:a :b :c])
-                 #{[:a :c]}))
+    (t/testing "Result bindings"
+      (t/is (= (api/q db '[:find ?a ?c
+                           :args {?in [:a :b :c]}
+                           :where [(identity ?in) [?a _ ?c]]])
+               #{[:a :c]}))
 
-        (t/is (= (d/q '[:find ?in
-                        :in ?in
-                        :where [(ground ?in) _]]
-                      :a)
-                 #{[:a]}))
+      (t/is (= (api/q db '[:find ?in
+                           :args {?in :a}
+                           :where [(identity ?in) _]])
+               #{[:a]}))
 
-        (t/is (= (d/q '[:find ?x ?z
-                        :in ?in
-                        :where [(ground ?in) [[?x _ ?z]...]]]
-                      [[:a :b :c] [:d :e :f]])
+      ;; TODO: Crux doesn't support tuple collections
+      #_(t/is (= (api/q db '[:find ?x ?z
+                             :args {?in [:a :b :c]} {?in [:d :e :f]}
+                             :where [(identity ?in) [[?x _ ?z] ...]]])
                  #{[:a :c] [:d :f]}))
 
-        (t/is (= (d/q '[:find ?in
-                        :in [?in ...]
-                        :where [(ground ?in) _]]
-                      [])
-                 #{})))))
+      (t/is (= (api/q db '[:find ?in
+                           :args {?in []}
+                           :where [(identity ?in) [_ ...]]])
+               #{})))))
 
 
 (t/deftest datascript-test-predicates

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1171,7 +1171,14 @@
                                           :where [[(identity 2) x]
                                                   [(q {:find [y]
                                                        :where [[(odd? y)]]}
-                                                      :y x)]]})))))
+                                                      :y x)]]})))
+
+    (t/is (= #{[2]}
+             (api/q (api/db *api*) '{:find [x]
+                                     :where [[(identity 2) x]
+                                             (not [(q {:find [y]
+                                                       :where [[(odd? y)]]}
+                                                      :y x)])]})))))
 
 (t/deftest test-simple-numeric-range-search
   (t/is (= '[[:triple {:e i, :a :age, :v age}]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1103,7 +1103,13 @@
     (t/is (= #{[4]}
              (api/q (api/db *api*) '{:find [x]
                                      :where [[(identity #{[1 2] [3 4]}) [_ x]]
-                                             [(identity #{[4 2]}) [x _]]]})))))
+                                             [(identity #{[4 2]}) [x _]]]}))))
+
+  (t/testing "can bind full tuple"
+    (t/is (= #{[[1 2]]
+               [[3 4]]}
+             (api/q (api/db *api*) '{:find [x]
+                                     :where [[(identity #{[1 2] [3 4]}) x]]})))))
 
 (t/deftest test-simple-numeric-range-search
   (t/is (= '[[:triple {:e i, :a :age, :v age}]


### PR DESCRIPTION
Allows to bind the elements of each returned tuple from a predicate, like this:

`[(identity #{[1 2] [3 4]}) [x y]]` 

In Crux, query returns are always assumed to be sets.
In normal EDN Datalog the above requires another level of nesting:

`[(identity #{[1 2] [3 4]}) [[x y]]]`

In Crux (currently), a set or vector always gets un-nested to one level, so `[(identity [1 2]) x]` binds x twice, and not to the vector itself. One reason for this behaviour is to be symmetric to how vector and set attributes are indexed. This PR doesn't change that behaviour, and only applies to the binding of each value.
