### PR TITLE
Making get-attr produce a collection, respecting return bindings.

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -163,7 +163,7 @@
          :return (s/? ::pred-return)))
 
 (defmethod pred-args-spec 'get-attr [_]
-  (s/cat :pred-fn  #{'get-attr} :args (s/spec (s/cat :e-var logic-var? :attr literal? :not-found (s/? literal?))) :return (s/? ::pred-return)))
+  (s/cat :pred-fn  #{'get-attr} :args (s/spec (s/cat :e-var logic-var? :attr literal? :not-found (s/? any?))) :return (s/? ::pred-return)))
 
 (defmethod pred-args-spec '== [_]
   (s/cat :pred-fn #{'==} :args (s/tuple some? some?)))
@@ -902,7 +902,7 @@
       (let [e (.get join-keys e-result-index)
             vs (db/aev index-store attr e nil entity-resolver-fn)
             values (if (and (empty? vs) not-found?)
-                     (c/vectorize-value not-found)
+                     [not-found]
                      (not-empty (mapv #(db/decode-value index-store %) vs)))]
         (bind-pred-result pred-ctx (get idx-id->idx idx-id) values)))))
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -900,22 +900,28 @@
         e-result-index (.result-index ^VarBinding e-var)]
     (fn pred-get-attr-constraint [index-store {:keys [entity-resolver-fn] :as db} idx-id->idx ^List join-keys]
       (let [e (.get join-keys e-result-index)
-            vs (db/aev index-store attr e nil entity-resolver-fn)]
-        (case return-type
-          :collection
-          (let [values (if (and (empty? vs) not-found?)
-                         [(encode-value-fn not-found)]
-                         (not-empty vs))]
-            (idx/update-relation-virtual-index! (get idx-id->idx idx-id) values identity true)
-            values)
+            vs (db/aev index-store attr e nil entity-resolver-fn)
+            return-not-found? (and (empty? vs) not-found?)]
+        (if (and (empty? vs) (not not-found?))
+          false
+          (case return-type
+            :collection
+            (let [values (if return-not-found?
+                           [(encode-value-fn not-found)]
+                           vs)]
+              (idx/update-relation-virtual-index! (get idx-id->idx idx-id) values identity true)
+              true)
 
-          (:scalar :tuple :relation)
-          (let [values (if (and (empty? vs) not-found?)
-                         [not-found]
-                         (not-empty (mapv #(db/decode-value index-store %) vs)))]
-            (bind-pred-result pred-ctx (get idx-id->idx idx-id) values))
+            (:scalar :tuple :relation)
+            (let [values (if return-not-found?
+                           [not-found]
+                           (mapv #(db/decode-value index-store %) vs))]
+              (bind-pred-result pred-ctx (get idx-id->idx idx-id) values)
+              true)
 
-          (not-empty vs))))))
+            (if return-not-found?
+              not-found
+              true)))))))
 
 (defmethod pred-constraint 'q [{:keys [return] :as clause} {:keys [encode-value-fn idx-id arg-bindings rule-name->rules]
                                                             :as pred-ctx}]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -967,19 +967,24 @@
 (t/deftest test-get-attr
   (fix/transact! *api* (fix/people [{:crux.db/id :ivan :name "Ivan" :age 21 :friends #{:petr :oleg}}]))
   (t/testing "existing attribute"
-    (t/is (= #{[:ivan 21]}
+    (t/is (= #{[:ivan [21]]}
              (api/q (api/db *api*) '{:find [e age]
                                      :where [[e :name "Ivan"]
                                              [(get-attr e :age) age]]})))
 
+    (t/is (= #{[:ivan 21]}
+             (api/q (api/db *api*) '{:find [e age]
+                                     :where [[e :name "Ivan"]
+                                             [(get-attr e :age) [age ...]]]})))
+
     (t/is (empty? (api/q (api/db *api*) '{:find [e age]
                                           :where [[e :name "Oleg"]
-                                                  [(get-attr e :age) age]]})))
+                                                  [(get-attr e :age) [age ...]]]})))
 
     (t/is (= #{}
              (api/q (api/db *api*) '{:find [e age]
                                      :where [[e :name "Ivan"]
-                                             [(get-attr e :age) age]
+                                             [(get-attr e :age) [age ...]]
                                              [(> age 30)]]}))))
 
   (t/testing "many valued attribute"
@@ -987,35 +992,40 @@
                [:ivan :oleg]}
              (api/q (api/db *api*) '{:find [e friend]
                                      :where [[e :name "Ivan"]
-                                             [(get-attr e :friends) friend]]}))))
+                                             [(get-attr e :friends) [friend ...]]]}))))
 
   (t/testing "unknown attribute"
     (t/is (empty? (api/q (api/db *api*) '{:find [e email]
                                           :where [[e :name "Ivan"]
-                                                  [(get-attr e :email) email]]}))))
+                                                  [(get-attr e :email) [email ...]]]}))))
 
   (t/testing "optional found attribute"
     (t/is (= #{[:ivan 21]}
              (api/q (api/db *api*) '{:find [e age]
                                      :where [[e :name "Ivan"]
-                                             [(get-attr e :age 0) age]]}))))
+                                             [(get-attr e :age 0) [age ...]]]}))))
 
   (t/testing "optional not found attribute"
-    (t/is (= #{[:ivan "N/A"]}
+    (t/is (= #{[:ivan ["N/A"]]}
              (api/q (api/db *api*) '{:find [e email]
                                      :where [[e :name "Ivan"]
                                              [(get-attr e :email "N/A") email]]})))
+
+    (t/is (= #{[:ivan "N/A"]}
+             (api/q (api/db *api*) '{:find [e email]
+                                     :where [[e :name "Ivan"]
+                                             [(get-attr e :email "N/A") [email ...]]]})))
 
     (t/is (= #{[:ivan "ivan@example.com"]
                [:ivan "ivanov@example.com"]}
              (api/q (api/db *api*) '{:find [e email]
                                      :where [[e :name "Ivan"]
                                              [(get-attr e :email #{"ivan@example.com"
-                                                                   "ivanov@example.com"}) email]]})))
+                                                                   "ivanov@example.com"}) [email ...]]]})))
 
     (t/is (empty? (api/q (api/db *api*) '{:find [e email]
                                           :where [[e :name "Ivan"]
-                                                  [(get-attr e :email #{}) email]]})))))
+                                                  [(get-attr e :email #{}) [email ...]]]})))))
 
 (t/deftest test-multiple-values-literals
   (fix/transact! *api* (fix/people [{:crux.db/id :ivan :name "Ivan" :age 21 :friends #{:petr :oleg}}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1005,6 +1005,17 @@
                                      :where [[e :name "Ivan"]
                                              [(get-attr e :age 0) [age ...]]]}))))
 
+  (t/testing "use as predicate"
+    (t/is (= #{[:ivan]}
+             (api/q (api/db *api*) '{:find [e]
+                                     :where [[e :name "Ivan"]
+                                             [(get-attr e :name)]]})))
+
+    (t/is (empty?
+           (api/q (api/db *api*) '{:find [e]
+                                   :where [[e :name "Ivan"]
+                                           [(get-attr e :email)]]}))))
+
   (t/testing "optional not found attribute"
     (t/is (= #{[:ivan ["N/A"]]}
              (api/q (api/db *api*) '{:find [e email]
@@ -1016,16 +1027,10 @@
                                      :where [[e :name "Ivan"]
                                              [(get-attr e :email "N/A") [email ...]]]})))
 
-    (t/is (= #{[:ivan "ivan@example.com"]
-               [:ivan "ivanov@example.com"]}
+    (t/is (= #{[:ivan nil]}
              (api/q (api/db *api*) '{:find [e email]
                                      :where [[e :name "Ivan"]
-                                             [(get-attr e :email #{"ivan@example.com"
-                                                                   "ivanov@example.com"}) [email ...]]]})))
-
-    (t/is (empty? (api/q (api/db *api*) '{:find [e email]
-                                          :where [[e :name "Ivan"]
-                                                  [(get-attr e :email #{}) [email ...]]]})))))
+                                             [(get-attr e :email nil) [email ...]]]})))))
 
 (t/deftest test-multiple-values-literals
   (fix/transact! *api* (fix/people [{:crux.db/id :ivan :name "Ivan" :age 21 :friends #{:petr :oleg}}


### PR DESCRIPTION
Incremental tweak to get-attr so it respects bindings properly. When get-attr is produced by rewriting leaf vars, it expands to a collection binding, `[x ...]`. Binding to `x` will bind the entire collection. Normal usage would hence to be use the `[x ...]` binding.

Also changes to remove support for sets as the optional argument being treated as multiple values. That is, the optional argument will always just be a single value.