### PR TITLE
In bindings

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -309,10 +309,29 @@
   The tx-ops will only be visible in the value returned from this function - they're not submitted to the cluster, nor are they visible to any other database value in your application.
   If the transaction doesn't commit (eg because of a failed 'match'), this function returns nil."))
 
-(defn q [db q & args]
+(defn q
+  "q[uery] a Crux db.
+  query param is a datalog query in map, vector or string form.
+  This function will return a set of result tuples if you do not specify `:order-by`, `:limit` or `:offset`;
+  otherwise, it will return a vector of result tuples."
+  [db q & args]
   (q* db q args))
 
-(defn open-q ^crux.api.ICursor [db q & args]
+(defn open-q
+  "lazily q[uery] a Crux db.
+  query param is a datalog query in map, vector or string form.
+
+  This function returns a Cursor of result tuples - once you've consumed
+  as much of the sequence as you need to, you'll need to `.close` the sequence.
+  A common way to do this is using `with-open`:
+
+  (with-open [res (crux/open-q db '{:find [...]
+                                    :where [...]})]
+    (doseq [row (iterator-seq res)]
+      ...))
+
+  Once the sequence is closed, attempting to iterate it is undefined."
+  ^crux.api.ICursor [db q & args]
   (open-q* db q args))
 
 (let [arglists '(^crux.api.ICursor

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -244,13 +244,13 @@
   include tx-id and tx-time.
   eid is an object that can be coerced into an entity id.")
 
-  (q [db query]
+  (q* [db query args]
     "q[uery] a Crux db.
   query param is a datalog query in map, vector or string form.
   This function will return a set of result tuples if you do not specify `:order-by`, `:limit` or `:offset`;
   otherwise, it will return a vector of result tuples.")
 
-  (open-q ^crux.api.ICursor [db query]
+  (open-q* ^crux.api.ICursor [db query args]
     "lazily q[uery] a Crux db.
   query param is a datalog query in map, vector or string form.
 
@@ -309,6 +309,12 @@
   The tx-ops will only be visible in the value returned from this function - they're not submitted to the cluster, nor are they visible to any other database value in your application.
   If the transaction doesn't commit (eg because of a failed 'match'), this function returns nil."))
 
+(defn q [db q & args]
+  (q* db q args))
+
+(defn open-q ^crux.api.ICursor [db q & args]
+  (open-q* db q args))
+
 (let [arglists '(^crux.api.ICursor
                  [db eid sort-order]
                  ^crux.api.ICursor
@@ -323,8 +329,8 @@
   (entity [this eid] (.entity this eid))
   (entity-tx [this eid] (.entityTx this eid))
 
-  (q [this query] (.query this query))
-  (open-q [this query] (.openQuery this query))
+  (q* [this query args] (.query this query (object-array args)))
+  (open-q* [this query args] (.openQuery this query (object-array args)))
 
   (entity-history
     ([this eid sort-order] (entity-history this eid sort-order {}))

--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -37,17 +37,19 @@ public interface ICruxDatasource extends Closeable {
      * otherwise, it will return a vector of result tuples.
      *
      * @param query the query in map, vector or string form.
+     * @param args  bindings for in.
      * @return      a set or vector of result tuples.
      */
-    public Collection<List<?>> query(Object query);
+    public Collection<List<?>> query(Object query, Object... args);
 
     /**
      * Queries the db lazily.
      *
      * @param query the query in map, vector or string form.
+     * @param args  bindings for in.
      * @return      a cursor of result tuples.
      */
-    public ICursor<List<?>> openQuery(Object query);
+    public ICursor<List<?>> openQuery(Object query, Object... args);
 
     /**
      * Eagerly retrieves entity history for the given entity.

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -966,8 +966,14 @@
                                       :as pred-ctx}]
   (fn pred-constraint [index-snapshot db idx-id->idx join-keys]
     (let [[pred-fn & args] (for [arg-binding arg-bindings]
-                             (if (instance? VarBinding arg-binding)
+                             (cond
+                               (instance? VarBinding arg-binding)
                                (bound-result-for-var index-snapshot arg-binding join-keys)
+
+                               (= '$ arg-binding)
+                               db
+
+                               :else
                                arg-binding))
           pred-result (apply pred-fn args)]
       (bind-binding return-type tuple-idxs-in-join-order (get idx-id->idx idx-id) pred-result))))

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -130,16 +130,17 @@
                        :http-opts {:method :get}
                        :->jwt-token ->jwt-token}))
 
-  (query [this q]
-    (with-open [res (.openQuery this q)]
+  (query [this q args]
+    (with-open [res (.openQuery this q args)]
       (if (:order-by q)
         (vec (iterator-seq res))
         (set (iterator-seq res)))))
 
-  (openQuery [this q]
+  (openQuery [this q args]
     (let [in (api-request-sync (str url "/query")
                                {:body (assoc (as-of-map this)
-                                             :query (q/normalize-query q))
+                                             :query (q/normalize-query q)
+                                             :args (vec args))
                                 :->jwt-token ->jwt-token
                                 :http-opts {:as :stream}})]
       (cio/->cursor #(.close ^Closeable in)

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -111,7 +111,7 @@
 (s/def ::transact-time date?)
 (s/def ::args (s/coll-of any? :kind vector?))
 
-(s/def ::query-map (s/and #(set/superset? #{:query :valid-time :transact-time} (keys %))
+(s/def ::query-map (s/and #(set/superset? #{:query :args :valid-time :transact-time} (keys %))
                           (s/keys :req-un [:crux.query/query]
                                   :opt-un [::args
                                            ::valid-time

--- a/crux-rdf/src/crux/sparql/protocol.clj
+++ b/crux-rdf/src/crux/sparql/protocol.clj
@@ -90,7 +90,7 @@
                    accept)
           {:keys [find] :as query-map} (sparql/sparql->datalog query)
           db (.db crux-node)
-          results (.query db query-map)]
+          results (.query db query-map (object-array 0))]
       (log/debug :sparql query)
       (log/debug :sparql->datalog query-map)
       (cond

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -94,11 +94,13 @@
         (t/is (= submitted-tx (.awaitTx n submitted-tx nil)))
         (t/is (= #{[:ivan]} (.query (.db n)
                                     '{:find [e]
-                                      :where [[e :name "Ivan"]]}))))
+                                      :where [[e :name "Ivan"]]}
+                                    (object-array 0)))))
 
       (t/is (= #{[:ivan]} (.query (.db n)
                                   '{:find [e]
-                                    :where [[e :name "Ivan"]]})))
+                                    :where [[e :name "Ivan"]]}
+                                  (object-array 0))))
 
       (with-open [n2 (api/start-node {:crux/tx-log {:crux/module `j/->tx-log, :connection-pool ::j/connection-pool}
                                       :crux/document-store {:crux/module `j/->document-store, :connection-pool ::j/connection-pool}
@@ -108,20 +110,23 @@
 
         (t/is (= #{} (.query (.db n2)
                              '{:find [e]
-                               :where [[e :name "Ivan"]]})))
+                               :where [[e :name "Ivan"]]}
+                             (object-array 0))))
 
         (let [valid-time (Date.)
               submitted-tx (.submitTx n2 [[:crux.tx/put {:crux.db/id :ivan :name "Iva"} valid-time]])]
           (t/is (= submitted-tx (.awaitTx n2 submitted-tx nil)))
           (t/is (= #{[:ivan]} (.query (.db n2)
                                       '{:find [e]
-                                        :where [[e :name "Iva"]]}))))
+                                        :where [[e :name "Iva"]]}
+                                      (object-array 0)))))
 
         (t/is n2))
 
       (t/is (= #{[:ivan]} (.query (.db n)
                                   '{:find [e]
-                                    :where [[e :name "Ivan"]]}))))))
+                                    :where [[e :name "Ivan"]]}
+                                  (object-array 0)))))))
 
 (defmacro with-latest-tx [latest-tx & body]
   `(with-redefs [api/latest-completed-tx (fn [node#]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -120,6 +120,31 @@
                                                                :where [[e :name name]]
                                                                :args [{:name "Petr"}]}))))
 
+    (t/testing "Can query entity by single field"
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ name]
+                                                               :where [[e :name name]]} "Ivan")))
+
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ name last-name]
+                                                               :where [[e :name name]
+                                                                       [e :last-name last-name]]} "Ivan" "Ivanov")))
+
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [name]]
+                                                               :where [[e :name name]]} ["Ivan"])))
+
+      (t/is (= #{[(:crux.db/id ivan)]
+                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [[name]]]
+                                                               :where [[e :name name]]} [["Ivan"]
+                                                                                         ["Petr"]])))
+
+      (t/is (= #{[(:crux.db/id ivan)]
+                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [name ...]]
+                                                               :where [[e :name name]]} ["Ivan" "Petr"]))))
+
     (t/testing "Can query entity by entity position"
       (t/is (= #{["Ivan"]
                  ["Petr"]} (api/q (api/db *api*) {:find '[name]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1259,16 +1259,16 @@
     (t/is (= #{[1 2 3]}
              (api/q (api/db *api*) '{:find [x y z]
                                      :where [[(q {:find [x y z]
-                                                  :args [{:x 1}]
+                                                  :in [$ x]
                                                   :where [[(identity 2) y]
-                                                          [(+ x y) z]]}) [[x y z]]]]})))
+                                                          [(+ x y) z]]} 1) [[x y z]]]]})))
 
     (t/is (= #{[1 3 4]}
              (api/q (api/db *api*) '{:find [x y z]
                                      :where [[(identity 1) x]
                                              [(q {:find [z]
-                                                  :args [{:x x}]
-                                                  :where [[(+ x 2) z]]}) [[y]]]
+                                                  :in [$ x]
+                                                  :where [[(+ x 2) z]]} x) [[y]]]
                                              [(+ x y) z]]})))
 
     (t/testing "can use varargs instead of inline arguments"
@@ -1276,38 +1276,30 @@
                (api/q (api/db *api*) '{:find [x y z]
                                        :where [[(identity 1) x]
                                                [(q {:find [z]
-                                                    :where [[(+ x 2) z]]} :x x) [[y]]]
+                                                    :in [$ x]
+                                                    :where [[(+ x 2) z]]} x) [[y]]]
                                                [(+ x y) z]]})))
 
       (t/testing "can use quoted symbols"
         (t/is (= #{[1]}
                  (api/q (api/db *api*) '{:find [x]
                                          :where [[(q {:find [y]
-                                                      :where [[(identity x) y]]} 'x 1) [[x]]]]})))))
-
-    (t/is (thrown-with-msg?
-           IllegalArgumentException
-           #"Sub-queries don't support more than one argument tuple"
-           (api/q (api/db *api*) '{:find [x y z]
-                                     :where [[(identity 1) x]
-                                             [(q {:find [z]
-                                                  :args [{:x x} {:x 1}]
-                                                  :where [[(+ x 2) z]]}) [[y]]]
-                                             [(+ x y) z]]})))
+                                                      :in [$ x]
+                                                      :where [[(identity x) y]]} 1) [[x]]]]})))))
 
     (t/testing "can use symbols as argument names"
       (t/is (= #{[1]}
                (api/q (api/db *api*) '{:find [x]
                                        :where [[(q {:find [y]
-                                                    :args [{x 1}]
-                                                    :where [[(identity x) y]]}) [[x]]]]})))
+                                                    :in [$ x]
+                                                    :where [[(identity x) y]]} 1) [[x]]]]})))
 
       (t/testing "can use quoted symbols"
         (t/is (= #{[1]}
                  (api/q (api/db *api*) '{:find [x]
                                          :where [[(q {:find [y]
-                                                      :args [{'x 1}]
-                                                      :where [[(identity x) y]]}) [[x]]]]})))))
+                                                      :in [$ x]
+                                                      :where [[(identity x) y]]} 1) [[x]]]]})))))
 
     (t/testing "can handle quoted sub query"
       (t/is (= #{[2]}
@@ -1342,21 +1334,21 @@
              (api/q (api/db *api*) '{:find [x]
                                      :where [[(identity 2) x]
                                              [(q {:find [x]
-                                                  :args [{:x x}]
-                                                  :where [[(even? x)]]})]]})))
+                                                  :in [$ x]
+                                                  :where [[(even? x)]]} x)]]})))
 
     (t/is (empty? (api/q (api/db *api*) '{:find [x]
                                           :where [[(identity 2) x]
                                                   [(q {:find [y]
-                                                       :args [{:y x}]
-                                                       :where [[(odd? y)]]})]]})))
+                                                       :in [$ y]
+                                                       :where [[(odd? y)]]} x)]]})))
 
     (t/is (= #{[2]}
              (api/q (api/db *api*) '{:find [x]
                                      :where [[(identity 2) x]
                                              (not [(q {:find [y]
-                                                       :args [{:y x}]
-                                                       :where [[(odd? y)]]})])]})))))
+                                                       :in [$ y]
+                                                       :where [[(odd? y)]]} x)])]})))))
 
 (t/deftest test-simple-numeric-range-search
   (t/is (= '[[:triple {:e i, :a :age, :v age}]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -238,30 +238,34 @@
   (let [[ivan petr] (fix/transact! *api* (fix/people [{:name "Ivan" :last-name "Ivanov"}
                                                       {:name "Petr" :last-name "Petrov"}]))]
 
-    (t/testing "Can query entity by single field"
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ name]
-                                                               :where [[e :name name]]} "Ivan")))
+    (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                             :in [$ name]
+                                                             :where [[e :name name]]} "Ivan")))
 
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ name last-name]
-                                                               :where [[e :name name]
-                                                                       [e :last-name last-name]]} "Ivan" "Ivanov")))
+    (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                             :in [$ name last-name]
+                                                             :where [[e :name name]
+                                                                     [e :last-name last-name]]} "Ivan" "Ivanov")))
 
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [name]]
-                                                               :where [[e :name name]]} ["Ivan"])))
+    (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                             :in [$ [name]]
+                                                             :where [[e :name name]]} ["Ivan"])))
 
-      (t/is (= #{[(:crux.db/id ivan)]
-                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [[name]]]
-                                                               :where [[e :name name]]} [["Ivan"]
-                                                                                         ["Petr"]])))
+    (t/is (= #{[(:crux.db/id ivan)]
+               [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                             :in [$ [[name]]]
+                                                             :where [[e :name name]]} [["Ivan"]
+                                                                                       ["Petr"]])))
 
-      (t/is (= #{[(:crux.db/id ivan)]
-                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [name ...]]
-                                                               :where [[e :name name]]} ["Ivan" "Petr"]))))))
+    (t/is (= #{[(:crux.db/id ivan)]
+               [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                             :in [$ [name ...]]
+                                                             :where [[e :name name]]} ["Ivan" "Petr"])))
+
+    (t/testing "can access the db"
+      (t/is (= #{[crux.query.QueryDatasource]} (api/q (api/db *api*) '{:find [t]
+                                                                       :in [$]
+                                                                       :where [[(type $) t]]}))))))
 
 (t/deftest test-multiple-results
   (fix/transact! *api* (fix/people [{:name "Ivan" :last-name "1"}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -242,6 +242,11 @@
                                                              :in [$ name]
                                                              :where [[e :name name]]} "Ivan")))
 
+    (t/testing "the db var is optional"
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [name]
+                                                               :where [[e :name name]]} "Ivan"))))
+
     (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
                                                              :in [$ name last-name]
                                                              :where [[e :name name]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -120,31 +120,6 @@
                                                                :where [[e :name name]]
                                                                :args [{:name "Petr"}]}))))
 
-    (t/testing "Can query entity by single field"
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ name]
-                                                               :where [[e :name name]]} "Ivan")))
-
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ name last-name]
-                                                               :where [[e :name name]
-                                                                       [e :last-name last-name]]} "Ivan" "Ivanov")))
-
-      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [name]]
-                                                               :where [[e :name name]]} ["Ivan"])))
-
-      (t/is (= #{[(:crux.db/id ivan)]
-                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [[name]]]
-                                                               :where [[e :name name]]} [["Ivan"]
-                                                                                         ["Petr"]])))
-
-      (t/is (= #{[(:crux.db/id ivan)]
-                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
-                                                               :in [$ [name ...]]
-                                                               :where [[e :name name]]} ["Ivan" "Petr"]))))
-
     (t/testing "Can query entity by entity position"
       (t/is (= #{["Ivan"]
                  ["Petr"]} (api/q (api/db *api*) {:find '[name]
@@ -258,6 +233,35 @@
         (t/is (= #{[22]} (api/q (api/db *api*) '{:find [age]
                                                  :where [[(>= age 21)]]
                                                  :args [{:age 22}]})))))))
+
+(t/deftest test-query-with-in-bindings
+  (let [[ivan petr] (fix/transact! *api* (fix/people [{:name "Ivan" :last-name "Ivanov"}
+                                                      {:name "Petr" :last-name "Petrov"}]))]
+
+    (t/testing "Can query entity by single field"
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ name]
+                                                               :where [[e :name name]]} "Ivan")))
+
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ name last-name]
+                                                               :where [[e :name name]
+                                                                       [e :last-name last-name]]} "Ivan" "Ivanov")))
+
+      (t/is (= #{[(:crux.db/id ivan)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [name]]
+                                                               :where [[e :name name]]} ["Ivan"])))
+
+      (t/is (= #{[(:crux.db/id ivan)]
+                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [[name]]]
+                                                               :where [[e :name name]]} [["Ivan"]
+                                                                                         ["Petr"]])))
+
+      (t/is (= #{[(:crux.db/id ivan)]
+                 [(:crux.db/id petr)]} (api/q (api/db *api*) '{:find [e]
+                                                               :in [$ [name ...]]
+                                                               :where [[e :name name]]} ["Ivan" "Petr"]))))))
 
 (t/deftest test-multiple-results
   (fix/transact! *api* (fix/people [{:name "Ivan" :last-name "1"}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1271,35 +1271,19 @@
                                                   :where [[(+ x 2) z]]} x) [[y]]]
                                              [(+ x y) z]]})))
 
-    (t/testing "can use varargs instead of inline arguments"
-      (t/is (= #{[1 3 4]}
-               (api/q (api/db *api*) '{:find [x y z]
-                                       :where [[(identity 1) x]
-                                               [(q {:find [z]
-                                                    :in [$ x]
-                                                    :where [[(+ x 2) z]]} x) [[y]]]
-                                               [(+ x y) z]]})))
+    (t/is (= #{[1]}
+             (api/q (api/db *api*) '{:find [x]
+                                     :where [[(q {:find [y]
+                                                  :in [$ x]
+                                                  :where [[(identity x) y]]} 1) [[x]]]]})))
 
-      (t/testing "can use quoted symbols"
-        (t/is (= #{[1]}
-                 (api/q (api/db *api*) '{:find [x]
-                                         :where [[(q {:find [y]
-                                                      :in [$ x]
-                                                      :where [[(identity x) y]]} 1) [[x]]]]})))))
-
-    (t/testing "can use symbols as argument names"
-      (t/is (= #{[1]}
-               (api/q (api/db *api*) '{:find [x]
-                                       :where [[(q {:find [y]
-                                                    :in [$ x]
-                                                    :where [[(identity x) y]]} 1) [[x]]]]})))
-
-      (t/testing "can use quoted symbols"
-        (t/is (= #{[1]}
-                 (api/q (api/db *api*) '{:find [x]
-                                         :where [[(q {:find [y]
-                                                      :in [$ x]
-                                                      :where [[(identity x) y]]} 1) [[x]]]]})))))
+    (t/is (= #{[1 3 4]}
+             (api/q (api/db *api*) '{:find [x y z]
+                                     :where [[(identity 1) x]
+                                             [(q {:find [z]
+                                                  :in [$ x]
+                                                  :where [[(+ x 2) z]]} x) [[y]]]
+                                             [(+ x y) z]]})))
 
     (t/testing "can handle quoted sub query"
       (t/is (= #{[2]}


### PR DESCRIPTION
This is a tentative PR to support `:in` bindings in Crux:
```
(api/q (api/db *api*) '{:find [e]
                        :in [$ name]
                        :where [[e :name name]]} "Ivan")
```

The bindings build upon the recently added return bindings, so the expected scalar, collection, tuple and relation bindings are supported.

Changes sub-queries to only use this form when binding logic vars to sub-queries instead of rewriting the args-map.
Supports an (currently) ignored optional source var `$` at the front of the bindings.
Does not remove support for our current `:args` map.

Adds wrappers to the PCruxDatasource protocol to support varargs to provide the actual bindings for `q` and `open-q`.
The Java API uses varargs here. The HTTP API provides the varargs in the same map as the query, valid and tx-time.

This PR is a discussion point, I'm not sure we should add this or not?