### PR TITLE
add crux.error to throw IAEs with data, s.t. they can be easily passed over the wire

### DIFF
--- a/crux-core/src/crux/IllegalArgumentException.java
+++ b/crux-core/src/crux/IllegalArgumentException.java
@@ -1,0 +1,20 @@
+package crux;
+
+import clojure.lang.IExceptionInfo;
+import clojure.lang.IPersistentMap;
+
+public class IllegalArgumentException extends java.lang.IllegalArgumentException implements IExceptionInfo {
+    private static final long serialVersionUID = 8569715935234823692L;
+
+    private final IPersistentMap data;
+
+    public IllegalArgumentException(String message, IPersistentMap data) {
+        super(message);
+        this.data = data;
+    }
+
+    @Override
+    public IPersistentMap getData() {
+        return data;
+    }
+}

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -1,6 +1,7 @@
 (ns ^:no-doc crux.codec
   #:clojure.tools.namespace.repl{:load false, :unload false} ; because of the deftypes in here
   (:require [clojure.edn :as edn]
+            [crux.error :as err]
             [crux.hash :as hash]
             [crux.memory :as mem]
             [crux.morton :as morton]
@@ -289,7 +290,8 @@
       7 (Date. (decode-long buffer)) ;; date-value-type-id
       8 (decode-string buffer) ;; string-value-type-id
       9 (decode-char buffer) ;; char-value-type-id
-      (throw (IllegalArgumentException. (str "Unknown type id: " type-id))))))
+      (throw (err/illegal-arg :unknown-type-id
+                              {::err/message (str "Unknown type id: " type-id)})))))
 
 (def ^:private hex-id-pattern
   (re-pattern (format "\\p{XDigit}{%d}" (* 2 (dec id-size)))))
@@ -325,8 +327,8 @@
        (doto to
          (.putBytes 0 this))
        id-size)
-      (throw (IllegalArgumentException.
-              (str "Not an id byte array: " (mem/buffer->hex (mem/as-buffer this)))))))
+      (throw (err/illegal-arg :not-an-id-byte-array
+                              {::err/message (str "Not an id byte array: " (mem/buffer->hex (mem/as-buffer this)))}))))
 
   ByteBuffer
   (id->buffer [this ^MutableDirectBuffer to]
@@ -510,7 +512,8 @@
                                 (maybe-keyword-str id)
                                 (maybe-url-str id)
                                 (maybe-map-str id)
-                                (throw (IllegalArgumentException. "EDN reader doesn't support string IDs"))))))
+                                (throw (err/illegal-arg :unsupported-string-ids
+                                                        {::err/message "EDN reader doesn't support string IDs"}))))))
              (new-id id))
            id))
 

--- a/crux-core/src/crux/error.clj
+++ b/crux-core/src/crux/error.clj
@@ -1,0 +1,12 @@
+(ns crux.error)
+
+(defn illegal-arg
+  ([k] (illegal-arg k {}))
+
+  ([k {::keys [^String message] :as data}]
+   (let [message (or message (format "Illegal argument: '%s'" k))]
+     (crux.IllegalArgumentException. message
+                                     (merge {::error-type :illegal-argument
+                                             ::error-key k
+                                             ::message message}
+                                            data)))))

--- a/crux-core/src/crux/ingest_client.clj
+++ b/crux-core/src/crux/ingest_client.clj
@@ -1,5 +1,6 @@
 (ns crux.ingest-client
   (:require [crux.db :as db]
+            [crux.error :as err]
             [crux.system :as sys]
             [crux.tx.conform :as txc])
   (:import crux.api.ICruxAsyncIngestAPI
@@ -18,7 +19,8 @@
 
   (openTxLog ^crux.api.ICursor [_ after-tx-id with-ops?]
     (when with-ops?
-      (throw (IllegalArgumentException. "with-ops? not supported")))
+      (throw (err/illegal-arg :with-opts-not-supported
+                              {::err/message "with-ops? not supported"})))
     (db/open-tx-log tx-log after-tx-id))
 
   Closeable

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc crux.tx.conform
   (:require [crux.codec :as c]
+            [crux.error :as err]
             [crux.db :as db])
   (:import (java.util UUID)))
 
@@ -103,7 +104,8 @@
 
     (conform-tx-op-type op)
     (catch Exception e
-      (throw (IllegalArgumentException. (str "invalid tx-op: " (.getMessage e)) e)))))
+      (throw (err/illegal-arg :invalid-tx-op
+                              {::err/message (str "invalid tx-op: " (.getMessage e))})))))
 
 (defmulti ->tx-event :op :default ::default)
 
@@ -133,7 +135,8 @@
     arg-doc-id (conj arg-doc-id)))
 
 (defmethod ->tx-event ::default [tx-op]
-  (throw (IllegalArgumentException. (str "invalid op: " (pr-str tx-op)))))
+  (throw (err/illegal-arg :invalid-op
+                          {::err/message (str "invalid op: " (pr-str tx-op))})))
 
 (defmulti <-tx-event first
   :default ::default)

--- a/crux-kafka-connect/src/crux/kafka/connect.clj
+++ b/crux-kafka-connect/src/crux/kafka/connect.clj
@@ -4,6 +4,7 @@
             [clojure.tools.logging :as log]
             [crux.codec :as c]
             [crux.io :as cio]
+            [crux.error :as err]
             [cognitect.transit :as transit])
   (:import [org.apache.kafka.connect.data Schema Schema$Type Struct Field]
            org.apache.kafka.connect.sink.SinkRecord
@@ -65,7 +66,8 @@
           (map->edn payload)
 
           :else
-          (throw (IllegalArgumentException. (str "Unknown JSON payload type: " record)))))
+          (throw (err/illegal-arg :unknown-json-payload-type
+                                  {::err/message (str "Unknown JSON payload type: " record)}))))
 
       (instance? Map value)
       (map->edn value)
@@ -78,7 +80,8 @@
           (c/read-edn-string-with-readers value)))
 
       :else
-      (throw (IllegalArgumentException. (str "Unknown message type: " record))))))
+      (throw (err/illegal-arg :unknown-message-type
+                              {::err/message (str "Unknown message type: " record)})))))
 
 (defn- coerce-eid [id]
   (cond

--- a/crux-lmdb/src/crux/lmdb.clj
+++ b/crux-lmdb/src/crux/lmdb.clj
@@ -6,7 +6,8 @@
             [crux.io :as cio]
             [crux.kv :as kv]
             [crux.memory :as mem]
-            [crux.system :as sys])
+            [crux.system :as sys]
+            [crux.error :as err])
   (:import clojure.lang.ExceptionInfo
            java.io.Closeable
            java.util.concurrent.locks.StampedLock
@@ -95,7 +96,8 @@
 (defn- env-copy [^long env path]
   (let [file (io/file path)]
     (when (.exists file)
-      (throw (IllegalArgumentException. (str "Directory exists: " (.getAbsolutePath file)))))
+      (throw (err/illegal-arg :directory-exists
+                              {::err/message (str "Directory exists: " (.getAbsolutePath file))})))
     (.mkdirs file)
     (success? (LMDB/mdb_env_copy env (.getAbsolutePath file)))))
 


### PR DESCRIPTION
Added a sub-class of Java's IAE so that Java consumers can continue to catch IAE, but also implemented IExceptionInfo so that these errors can be handled with `ex-data` in Clojure, used as an HTTP response nigh-on verbatim, and reconstructed on the client side (for #1082)

TODO:
* [x] I've migrated a few of the exceptions thrown in `crux.tx` but we'll need a wider migration to make this work for HTTP
* [x] Do we throw exceptions that aren't IAE, exceptions that should also be passed over the wire without just throwing our hands up and declaring 500?