### PR TITLE
OpenTxLog off-by-one error

### DIFF
--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -95,10 +95,8 @@
                                           (cons (assoc (decode-tx-event-key-from k)
                                                        :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
                                                 (tx-log (kv/next iterator))))))]
-                               (let [first-key (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
-                                 (->> (tx-log (if (and after-tx-id (tx-event-key? first-key))
-                                                (kv/next iterator)
-                                                first-key))
+                               (let [after-tx-id (or (some-> after-tx-id (+ 1)) 0)]
+                                 (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id after-tx-id})))
                                       (take batch-size)
                                       vec))))]
                    (concat txs

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -95,9 +95,12 @@
                                           (cons (assoc (decode-tx-event-key-from k)
                                                        :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
                                                 (tx-log (kv/next iterator))))))]
-                               (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)})))
-                                    (take batch-size)
-                                    vec)))]
+                               (let [first-key (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id (or after-tx-id 0)}))]
+                                 (->> (tx-log (if (and after-tx-id (tx-event-key? first-key))
+                                                (kv/next iterator)
+                                                first-key))
+                                      (take batch-size)
+                                      vec))))]
                    (concat txs
                            (when (= batch-size (count txs))
                              (tx-log (::tx/tx-id (last txs))))))))]


### PR DESCRIPTION
While writing tests for the kafka connector, I came across (and replicated) this behaviour:

The general problem lies with the use of `after-tx-id` in the `crux.kv.tx-log` implementation of `open-tx-log`. After an initial transaction, `(iterator-seq (.openTxLog *api* 0 true))` should and indeed does return an empty sequence - so it appears that transactions with the id equal to that of `after-tx-id` are excluded. However, after subsequent transactions, you see that it gets included within the list:

```clojure
({:crux.tx/tx-id 0, :crux.tx/tx-time #inst "2020-09-25T11:02:05.906-00:00", :crux.api/tx-ops ([:crux.tx/put #:crux.db{:id :hello}])} 
 {:crux.tx/tx-id 1, :crux.tx/tx-time #inst "2020-09-25T11:02:05.930-00:00", :crux.api/tx-ops ([:crux.tx/match #:crux.db{:id :hello}])})
```

Currently added a [failing test ](https://app.circleci.com/pipelines/github/danmason/crux/1300/workflows/5f36390c-1e6f-4f6c-84b8-91971d26e21c/jobs/2926)for this `after-tx-id` within `api-test` - and as mentioned, it currently fails for `local-standalone`/`remote`.