### PR TITLE
Cache boundaries

### DIFF
--- a/crux-bench/src/crux/bench/tpch_test.clj
+++ b/crux-bench/src/crux/bench/tpch_test.clj
@@ -61,7 +61,7 @@
 (def q2 '{:find [s_acctbal
                  s_name
                  n_name
-                 p_partkey
+                 p
                  p_mfgr
                  s_address
                  s_phone
@@ -70,7 +70,7 @@
                   [p :p_size 15]
                   [p :p_type p_type]
                   [(re-find #"^.*BRASS$" p_type)]
-                  [ps :ps_partkey p_partkey]
+                  [ps :ps_partkey p]
                   [ps :ps_supplycost ps_supplycost]
                   [(q {:find [(min ps_supplycost)]
                        :in [$ p]
@@ -93,7 +93,7 @@
           :order-by [[s_acctbal :desc]
                      [n_name :asc]
                      [s_name :asc]
-                     [p_partkey :asc]]
+                     [p :asc]]
           :limit 100})
 
 ;; "Elapsed time: 5786.047011 msecs"

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -3,6 +3,7 @@
             [crux.db :as db]
             [crux.io :as cio]
             [crux.kv :as kv]
+            [crux.lru :as lru]
             [crux.memory :as mem]
             [crux.status :as status]
             [crux.morton :as morton]
@@ -461,6 +462,7 @@
                             decode-value-iterator-delay
                             nested-index-snapshot-state
                             ^Map temp-hash-cache
+                            value-cache
                             ^AtomicBoolean closed?]
   Closeable
   (close [_]
@@ -603,10 +605,15 @@
     (assert (some? value-buffer))
     (if (c/can-decode-value-buffer? value-buffer)
       (c/decode-value-buffer value-buffer)
-      (or (.get temp-hash-cache value-buffer)
-          (let [i @decode-value-iterator-delay]
-            (when (advance-iterator-to-hash-cache-value i value-buffer)
-              (some-> (kv/value i) (mem/<-nippy-buffer)))))))
+      (lru/compute-if-absent
+       value-cache
+       value-buffer
+       mem/copy-to-unpooled-buffer
+       (fn [value-buffer]
+         (or (.get temp-hash-cache value-buffer)
+             (let [i @decode-value-iterator-delay]
+               (when (advance-iterator-to-hash-cache-value i value-buffer)
+                 (some-> (kv/value i) (mem/<-nippy-buffer)))))))))
 
   (encode-value [this value]
     (let [value-buffer (c/->value-buffer value)]
@@ -616,7 +623,7 @@
       value-buffer))
 
   (open-nested-index-snapshot [this]
-    (let [nested-index-snapshot (new-kv-index-snapshot snapshot temp-hash-cache false)]
+    (let [nested-index-snapshot (new-kv-index-snapshot snapshot temp-hash-cache value-cache false)]
       (swap! nested-index-snapshot-state conj nested-index-snapshot)
       nested-index-snapshot)))
 
@@ -642,7 +649,7 @@
              (conj (MapEntry/create (encode-hash-cache-key-to nil value-buffer eid-value-buffer) (mem/->nippy-buffer v)))))
          (apply concat))))
 
-(defn- new-kv-index-snapshot [snapshot temp-hash-cache close-snapshot?]
+(defn- new-kv-index-snapshot [snapshot temp-hash-cache value-cache close-snapshot?]
   (->KvIndexSnapshot snapshot
                      close-snapshot?
                      (delay (kv/new-iterator snapshot))
@@ -651,9 +658,10 @@
                      (delay (kv/new-iterator snapshot))
                      (atom [])
                      temp-hash-cache
+                     value-cache
                      (AtomicBoolean.)))
 
-(defrecord KvIndexStore [kv-store]
+(defrecord KvIndexStore [kv-store value-cache]
   db/IndexStore
   (index-docs [this docs]
     (let [crux-db-id (c/->id-buffer :crux.db/id)
@@ -694,6 +702,8 @@
                                                                             (take 2)
                                                                             count)
                                                                        1)]
+                                                     (when-not (c/can-decode-value-buffer? value-buffer)
+                                                       (lru/evict value-cache value-buffer))
                                                      (cond-> acc
                                                        true (update :tombstones assoc (.content-hash quad) {:crux.db/id (c/new-id eid)
                                                                                                             :crux.db/evicted? true})
@@ -749,7 +759,7 @@
       (some? (kv/get-value snapshot (encode-failed-tx-id-key-to nil tx-id)))))
 
   (open-index-snapshot [this]
-    (new-kv-index-snapshot (kv/new-snapshot kv-store) (HashMap.) true))
+    (new-kv-index-snapshot (kv/new-snapshot kv-store) (HashMap.) value-cache true))
 
   status/Status
   (status-map [this]
@@ -757,9 +767,13 @@
      :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
+
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
-                                                              :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
-  [{:keys [kv-store] :as opts}]
+                                                              :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}
+                                    :value-cache-size {:doc "Value Cache Size"
+                                                       :default 100000
+                                                       :spec ::sys/nat-int}}}
+  [{:keys [kv-store value-cache-size] :as opts}]
   (check-and-store-index-version opts)
-  (->KvIndexStore kv-store))
+  (->KvIndexStore kv-store (lru/new-cache (or value-cache-size 100000))))

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -5,6 +5,7 @@
             [clojure.test.check.properties :as prop]
             [crux.codec :as c]
             [crux.db :as db]
+            [crux.lru :as lru]
             [crux.fixtures :as f]
             [crux.fixtures.kv :as fkv]
             [crux.kv.index-store :as kvi]
@@ -18,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store#)]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-value-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
This PR does cache decoding of hashed values which aren't stored in the content indexes directly. This cache sits on the index store and is shared between snapshots. Close to 50% improvement on TPC-H.