### PR TITLE
ECAV Cache

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -368,7 +368,7 @@
                       (new-sorted-virtual-index (if (instance? NavigableSet tuples)
                                                   tuples
                                                   (doto (TreeSet. mem/buffer-comparator)
-                                                    (.addAll tuples))))
+                                                    (.addAll (mapv encode-value-fn tuples)))))
                       (new-sorted-virtual-index (.navigableKeySet ^NavigableMap tree)))
          state ^RelationVirtualIndexState (.state relation)]
      (set! (.tree state) tree)

--- a/crux-core/src/crux/index/IndexStoreIndexState.java
+++ b/crux-core/src/crux/index/IndexStoreIndexState.java
@@ -1,11 +1,11 @@
 package crux.index;
 
 public class IndexStoreIndexState {
-    public Object seq;
+    public Object iterator;
     public Object key;
 
-    public IndexStoreIndexState(Object seq, Object key) {
-        this.seq = seq;
+    public IndexStoreIndexState(Object iterator, Object key) {
+        this.iterator = iterator;
         this.key = key;
     }
 }

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -570,8 +570,7 @@
           eid-value-buffer (buffer-or-value-buffer e)
           eid-buffer (value-buffer->id-buffer this eid-value-buffer)]
       (when-let [content-hash-buffer (entity-resolver-fn eid-buffer)]
-        (let [prefix (encode-ecav-key-to nil eid-value-buffer content-hash-buffer attr-buffer)
-              a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)
+        (let [a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)
               vs ^NavigableSet (.get a->vs attr-buffer)]
           (seq (.tailSet vs (buffer-or-value-buffer min-v)))))))
 

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -492,7 +492,7 @@
      (when k
        (if-let [k (k-fn k)]
          (cons k (lazy-seq (step (kv/next i))))
-         (lazy-seq (step (kv/next i))))))
+         (recur (kv/next i)))))
    (kv/seek i seek-k)))
 
 (defn- chunk-stepper [i k-fn seek-k]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -730,6 +730,7 @@
                                                                        1)]
                                                      (when-not (c/can-decode-value-buffer? value-buffer)
                                                        (lru/evict value-cache value-buffer))
+                                                     (lru/evict ecav-cache (.content-hash quad))
                                                      (cond-> acc
                                                        true (update :tombstones assoc (.content-hash quad) {:crux.db/id (c/new-id eid)
                                                                                                             :crux.db/evicted? true})

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -13,8 +13,8 @@
            crux.api.IndexVersionOutOfSyncException
            java.io.Closeable
            java.nio.ByteOrder
-           [java.util Date HashMap Map]
-           java.util.function.Supplier
+           [java.util Date HashMap List Map NavigableSet Set TreeSet]
+           [java.util.function Function Supplier]
            java.util.concurrent.atomic.AtomicBoolean
            (clojure.lang MapEntry)
            (org.agrona DirectBuffer MutableDirectBuffer ExpandableDirectByteBuffer)))
@@ -146,6 +146,8 @@
 (defn- encode-ecav-key-to
   (^org.agrona.MutableDirectBuffer [b entity]
    (encode-ecav-key-to b entity mem/empty-buffer mem/empty-buffer mem/empty-buffer))
+  (^org.agrona.MutableDirectBuffer [b entity content-hash]
+   (encode-ecav-key-to b entity content-hash mem/empty-buffer mem/empty-buffer))
   (^org.agrona.MutableDirectBuffer [b entity content-hash attr]
    (encode-ecav-key-to b entity content-hash attr mem/empty-buffer))
   (^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b ^DirectBuffer entity ^DirectBuffer content-hash ^DirectBuffer attr ^DirectBuffer v]
@@ -172,6 +174,20 @@
             attr (Id. (mem/slice-buffer k (+ c/index-id-size eid-size c/id-size) c/id-size) 0)
             value (key-suffix k (+ c/index-id-size eid-size c/id-size c/id-size))]
         (->Quad attr entity content-hash value)))))
+
+(defn- decode-ecav-key-as-v-from [^DirectBuffer k ^long eid-size]
+  (let [length (long (.capacity k))]
+    (assert (<= (+ c/index-id-size eid-size c/id-size c/id-size) length) (mem/buffer->hex k))
+    (let [index-id (.getByte k 0)]
+      (assert (= c/ecav-index-id index-id))
+      (key-suffix k (+ c/index-id-size eid-size c/id-size c/id-size)))))
+
+(defn- decode-ecav-key-as-a-from [^DirectBuffer k ^long eid-size]
+  (let [length (long (.capacity k))]
+    (assert (<= (+ c/index-id-size eid-size c/id-size c/id-size) length) (mem/buffer->hex k))
+    (let [index-id (.getByte k 0)]
+      (assert (= c/ecav-index-id index-id))
+      (mem/slice-buffer k (+ c/index-id-size eid-size c/id-size) c/id-size))))
 
 (defn- encode-hash-cache-key-to
   (^org.agrona.MutableDirectBuffer [b value]
@@ -452,22 +468,45 @@
 (defn- value-buffer->id-buffer [index-snapshot ^DirectBuffer value-buffer]
   (c/->id-buffer (db/decode-value index-snapshot value-buffer)))
 
+(defn- ecav-cache-lookup ^java.util.Map [ecav-cache ecav-i ^DirectBuffer eid-value-buffer ^DirectBuffer content-hash-buffer]
+  (lru/compute-if-absent ecav-cache
+                         content-hash-buffer
+                         mem/copy-to-unpooled-buffer
+                         (fn [content-hash-buffer]
+                           (let [eid-size (mem/capacity eid-value-buffer)
+                                 a->vs (HashMap.)]
+                             (doseq [k (all-keys-in-prefix ecav-i
+                                                           (encode-ecav-key-to (.get seek-buffer-tl)
+                                                                               eid-value-buffer
+                                                                               content-hash-buffer))]
+                               (let [a (decode-ecav-key-as-a-from k eid-size)
+                                     v (decode-ecav-key-as-v-from k eid-size)
+                                     vs (.computeIfAbsent a->vs
+                                                          a
+                                                          (reify Function
+                                                            (apply [_ k]
+                                                              (TreeSet. mem/buffer-comparator))))]
+                                 (.add ^Set vs v)))
+                             a->vs))))
+
 (defrecord KvIndexSnapshot [snapshot
                             close-snapshot?
                             level-1-iterator-delay
                             level-2-iterator-delay
                             entity-as-of-iterator-delay
                             decode-value-iterator-delay
+                            ecav-iterator-delay
                             nested-index-snapshot-state
                             ^Map temp-hash-cache
                             value-cache
+                            ecav-cache
                             ^AtomicBoolean closed?]
   Closeable
   (close [_]
     (when (.compareAndSet closed? false true)
       (doseq [nested-index-snapshot @nested-index-snapshot-state]
         (cio/try-close nested-index-snapshot))
-      (doseq [i [level-1-iterator-delay level-2-iterator-delay entity-as-of-iterator-delay decode-value-iterator-delay]
+      (doseq [i [level-1-iterator-delay level-2-iterator-delay entity-as-of-iterator-delay decode-value-iterator-delay ecav-iterator-delay]
               :when (realized? i)]
         (cio/try-close @i))
       (when close-snapshot?
@@ -502,17 +541,13 @@
                     (let [eid-value-buffer (key-suffix k (.capacity prefix))
                           eid-buffer (value-buffer->id-buffer this eid-value-buffer)
                           head (when-let [content-hash-buffer (entity-resolver-fn eid-buffer)]
-                                 (let [version-k (encode-ecav-key-to (.get seek-buffer-tl)
-                                                                     eid-value-buffer
-                                                                     content-hash-buffer
-                                                                     attr-buffer
-                                                                     value-buffer)]
-                                   (when (kv/get-value snapshot version-k)
+                                 (let [a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)]
+                                   (when (.contains ^Set (.get a->vs attr-buffer) value-buffer)
                                      eid-value-buffer)))]
 
                       (if head
                         (cons head (lazy-seq (step (kv/next i))))
-                        (lazy-seq (step (kv/next i)))))))))))
+                        (recur (kv/next i))))))))))
 
   (ae [this a min-e entity-resolver-fn]
     (let [attr-buffer (c/->id-buffer a)
@@ -528,7 +563,7 @@
                           eid-buffer (value-buffer->id-buffer this eid-value-buffer)]
                       (if (entity-resolver-fn eid-buffer)
                         (cons eid-value-buffer (lazy-seq (step (kv/next i))))
-                        (lazy-seq (step (kv/next i)))))))))))
+                        (recur (kv/next i))))))))))
 
   (aev [this a e min-v entity-resolver-fn]
     (let [attr-buffer (c/->id-buffer a)
@@ -536,18 +571,9 @@
           eid-buffer (value-buffer->id-buffer this eid-value-buffer)]
       (when-let [content-hash-buffer (entity-resolver-fn eid-buffer)]
         (let [prefix (encode-ecav-key-to nil eid-value-buffer content-hash-buffer attr-buffer)
-              i (new-prefix-kv-iterator @level-2-iterator-delay prefix)]
-          (some->> (encode-ecav-key-to
-                    (.get seek-buffer-tl)
-                    eid-value-buffer
-                    content-hash-buffer
-                    attr-buffer
-                    (buffer-or-value-buffer min-v))
-                   (kv/seek i)
-                   ((fn step [^DirectBuffer k]
-                      (when k
-                        (cons (key-suffix k (.capacity prefix))
-                              (lazy-seq (step (kv/next i))))))))))))
+              a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)
+              vs ^NavigableSet (.get a->vs attr-buffer)]
+          (seq (.tailSet ^NavigableSet (.get a->vs attr-buffer) (buffer-or-value-buffer min-v)))))))
 
   (entity-as-of-resolver [this eid valid-time transact-time]
     (let [i @entity-as-of-iterator-delay
@@ -622,7 +648,7 @@
       value-buffer))
 
   (open-nested-index-snapshot [this]
-    (let [nested-index-snapshot (new-kv-index-snapshot snapshot temp-hash-cache value-cache false)]
+    (let [nested-index-snapshot (new-kv-index-snapshot snapshot temp-hash-cache value-cache ecav-cache false)]
       (swap! nested-index-snapshot-state conj nested-index-snapshot)
       nested-index-snapshot)))
 
@@ -648,9 +674,10 @@
              (conj (MapEntry/create (encode-hash-cache-key-to nil value-buffer eid-value-buffer) (mem/->nippy-buffer v)))))
          (apply concat))))
 
-(defn- new-kv-index-snapshot [snapshot temp-hash-cache value-cache close-snapshot?]
+(defn- new-kv-index-snapshot [snapshot temp-hash-cache value-cache ecav-cache close-snapshot?]
   (->KvIndexSnapshot snapshot
                      close-snapshot?
+                     (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
@@ -658,9 +685,10 @@
                      (atom [])
                      temp-hash-cache
                      value-cache
+                     ecav-cache
                      (AtomicBoolean.)))
 
-(defrecord KvIndexStore [kv-store value-cache]
+(defrecord KvIndexStore [kv-store value-cache ecav-cache]
   db/IndexStore
   (index-docs [this docs]
     (let [crux-db-id (c/->id-buffer :crux.db/id)
@@ -758,7 +786,7 @@
       (some? (kv/get-value snapshot (encode-failed-tx-id-key-to nil tx-id)))))
 
   (open-index-snapshot [this]
-    (new-kv-index-snapshot (kv/new-snapshot kv-store) (HashMap.) value-cache true))
+    (new-kv-index-snapshot (kv/new-snapshot kv-store) (HashMap.) value-cache ecav-cache true))
 
   status/Status
   (status-map [this]
@@ -766,14 +794,17 @@
      :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
-(def ^:const default-value-cache-size (* 128 1024))
+(def ^:const default-cache-size (* 128 1024))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}
                                     :value-cache-size {:doc "Value Cache Size"
-                                                       :default default-value-cache-size
-                                                       :spec ::sys/nat-int}}}
-  [{:keys [kv-store value-cache-size] :as opts}]
+                                                       :default default-cache-size
+                                                       :spec ::sys/nat-int}
+                                    :ecav-cache-size {:doc "EAV Cache Size"
+                                                      :default default-cache-size
+                                                      :spec ::sys/nat-int}}}
+  [{:keys [kv-store value-cache-size ecav-cache-size] :as opts}]
   (check-and-store-index-version opts)
-  (->KvIndexStore kv-store (lru/new-cache (or value-cache-size default-value-cache-size))))
+  (->KvIndexStore kv-store (lru/new-cache (or value-cache-size default-cache-size)) (lru/new-cache (or ecav-cache-size default-cache-size))))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -573,7 +573,7 @@
         (let [prefix (encode-ecav-key-to nil eid-value-buffer content-hash-buffer attr-buffer)
               a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)
               vs ^NavigableSet (.get a->vs attr-buffer)]
-          (seq (.tailSet ^NavigableSet (.get a->vs attr-buffer) (buffer-or-value-buffer min-v)))))))
+          (seq (.tailSet vs (buffer-or-value-buffer min-v)))))))
 
   (entity-as-of-resolver [this eid valid-time transact-time]
     (let [i @entity-as-of-iterator-delay

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -582,7 +582,7 @@
       (when-let [content-hash-buffer (entity-resolver-fn eid-buffer)]
         (let [a->vs (cav-cache-lookup cav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)]
           (when-let [vs ^NavigableSet (.get a->vs attr-buffer)]
-            (seq (.tailSet vs (buffer-or-value-buffer min-v))))))))
+            (.tailSet vs (buffer-or-value-buffer min-v)))))))
 
   (entity-as-of-resolver [this eid valid-time transact-time]
     (let [i @entity-as-of-iterator-delay

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -13,7 +13,7 @@
            crux.api.IndexVersionOutOfSyncException
            java.io.Closeable
            java.nio.ByteOrder
-           [java.util Date HashMap List Map NavigableSet Set TreeSet]
+           [java.util Date HashMap Map NavigableSet Set TreeSet]
            [java.util.function Function Supplier]
            java.util.concurrent.atomic.AtomicBoolean
            (clojure.lang MapEntry)
@@ -559,7 +559,7 @@
                                        eid-buffer (value-buffer->id-buffer this eid-value-buffer)]
                                    (when-let [content-hash-buffer (entity-resolver-fn eid-buffer)]
                                      (let [a->vs (ecav-cache-lookup ecav-cache @ecav-iterator-delay eid-value-buffer content-hash-buffer)]
-                                       (when-let [vs ^NavigableSet (.get a->vs attr-buffer)]
+                                       (when-let [vs ^Set (.get a->vs attr-buffer)]
                                          (when (.contains vs value-buffer)
                                            eid-value-buffer)))))))))
 

--- a/crux-core/src/crux/lru.clj
+++ b/crux-core/src/crux/lru.clj
@@ -5,9 +5,8 @@
   (:import [clojure.lang Counted ILookup]
            java.io.Closeable
            java.util.concurrent.locks.StampedLock
-           java.util.concurrent.atomic.AtomicBoolean
            java.util.function.Function
-           java.util.LinkedHashMap))
+           [java.util LinkedHashMap Map]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -19,7 +18,7 @@
 (defn new-cache [^long size]
   (let [cache (proxy [LinkedHashMap] [size 0.75 true]
                 (removeEldestEntry [_]
-                  (> (count this) size)))
+                  (> (.size ^Map this) size)))
         lock (StampedLock.)]
     (reify
       Object

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -905,16 +905,17 @@
                            (mapv #(db/decode-value index-snapshot %) vs))]
             (bind-binding return-type tuple-idxs-in-join-order (get idx-id->idx idx-id) (not-empty values))))))))
 
-(defmethod pred-constraint 'q [{:keys [return] :as clause} {:keys [encode-value-fn idx-id arg-bindings rule-name->rules
-                                                                   return-type tuple-idxs-in-join-order]
-                                                            :as pred-ctx}]
-  (let [query (normalize-query (second arg-bindings))
+(defmethod pred-constraint 'q [_ {:keys [encode-value-fn idx-id arg-bindings rule-name->rules
+                                         return-type tuple-idxs-in-join-order]
+                                  :as pred-ctx}]
+  (let [query (cond-> (normalize-query (second arg-bindings))
+                (nil? return-type) (assoc :limit 1))
         parent-rules (:rules (meta rule-name->rules))]
     (fn pred-constraint [index-snapshot db idx-id->idx join-keys]
       (let [[_ _ & args] (for [arg-binding arg-bindings]
-                              (if (instance? VarBinding arg-binding)
-                                (bound-result-for-var index-snapshot arg-binding join-keys)
-                                arg-binding))
+                           (if (instance? VarBinding arg-binding)
+                             (bound-result-for-var index-snapshot arg-binding join-keys)
+                             arg-binding))
             query (cond-> query
                     (seq parent-rules) (update :rules (comp vec concat) parent-rules))]
         (with-open [pred-result (.openQuery ^ICruxDatasource db query (object-array args))]

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-value-cache-size))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-cache-size) (lru/new-cache kvi/default-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
Eagerly builds caches of ECAV, keyed by content hash. This incurs an extra cost at first access to a content hash (less than 10%), but TPC-H queries are about 50% faster once the caches are warm. As the cache is based on content hashes they live on the IndexStore itself and is shared across queries and time. Also adds chunked seqs to the index store.