### PR TITLE
Resurrecting docs, #1127

### DIFF
--- a/crux-test/test/crux/index_test.clj
+++ b/crux-test/test/crux/index_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :as t]
             [crux.codec :as c]
             [crux.db :as db]
-            [crux.fixtures :as f]
             [crux.index :as idx])
   (:import clojure.lang.Box))
 
@@ -206,6 +205,11 @@
                  (set (for [join-keys (-> (idx/new-n-ary-join-layered-virtual-index [unary-and-idx])
                                           (idx/layered-idx->seq))]
                         (mapv c/decode-value-buffer join-keys)))))))))
+
+(t/deftest test-empty-unary-join
+  (let [p-idx (idx/new-relation-virtual-index [] 1 c/->value-buffer)
+        q-idx (idx/new-relation-virtual-index [] 1 c/->value-buffer)]
+    (t/is (empty? (idx/idx->seq (idx/new-unary-join-virtual-index [p-idx q-idx]))))))
 
 (t/deftest test-n-ary-join-based-on-relational-tuples-with-n-ary-conjunction-and-disjunction
   (let [p-idx (idx/new-relation-virtual-index [[1 3]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3624,3 +3624,16 @@
                    :type :person}]}
                (api/q db '{:find [(eql/project ?dc [*])]
                            :where [[?dc :person/name "Daniel Craig"]]}))))))
+
+(t/deftest resurrecting-doc-1127
+  (let [query {:find '[n]
+               :where '[[n :name "hello"]
+                        [n :age 17]]}]
+
+    (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :my-id, :name "hello", :age 17}]])
+
+    (t/is (= #{[:my-id]} (api/q (api/db *api*) query)))
+
+    (fix/submit+await-tx [[:crux.tx/delete :my-id]])
+
+    (t/is (= #{} (api/q (api/db *api*) query)))))


### PR DESCRIPTION
Fixes #1127 

Issue caused by UnaryJoinVirtualIndex errantly returning an empty buffer instead of `nil` (causing a result to be yielded) when _all_ of its sub-indices were empty. Fixed by adding specific handling of this case.