### PR TITLE
Upgrading to Agrona 1.7.2. A bit faster.

### DIFF
--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -12,7 +12,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [org.clojure/data.json "1.0.0"]
                  [org.clojure/tools.cli "1.0.194"]
-                 [org.agrona/agrona "1.0.7"]
+                 [org.agrona/agrona "1.7.2"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
                  [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}


### PR DESCRIPTION
We were on Agrona 1.0.7 which is more than a year old.
No features we use have changed, but there are various tweaks making this release a little bit faster than the old one.