### PR TITLE
Remove JS-less versions of HTML pages.

### DIFF
--- a/crux-http-server/resources/public/scss/all.scss
+++ b/crux-http-server/resources/public/scss/all.scss
@@ -25,6 +25,11 @@ html, body {
     box-sizing: border-box;
 }
 
+.noscript-content {
+    background-color: white;
+    padding: 1rem;
+}
+
 .header {
     background: #1e1e1e;
     width: 100%;

--- a/crux-http-server/src/crux/http_server/util.clj
+++ b/crux-http-server/src/crux/http_server/util.clj
@@ -1,5 +1,6 @@
 (ns crux.http-server.util
   (:require [clojure.edn :as edn]
+            [clojure.pprint :as pp]
             [clojure.spec.alpha :as s]
             [cognitect.transit :as transit]
             [crux.api :as api]
@@ -85,7 +86,7 @@
     :else
     (.db crux-node)))
 
-(defn raw-html [{:keys [body title options results]}]
+(defn raw-html [{:keys [title options results]}]
   (let [latest-completed-tx (api/latest-completed-tx (:crux-node options))]
     (str (hiccup2/html
           [:html
@@ -127,7 +128,8 @@
                 [:a "Placeholder"]]]]]
             [:div.console
              [:div#app
-              [:div.container.page-pane body]]]
+              [:noscript
+               [:pre.noscript-content (with-out-str (pp/pprint results))]]]]
             [:script {:src "/cljs-out/dev-main.js" :type "text/javascript"}]]]))))
 
 (defn entity-link [eid {:keys [valid-time transaction-time]}]


### PR DESCRIPTION
Resolves #1076

Currently, if JS is disabled, returns the raw-html template, with a `<noscript>` containing containing a `<pre>` with pretty printed results.