### PR TITLE
Index caches

### DIFF
--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -473,7 +473,7 @@
   (lru/compute-if-absent cav-cache
                          [content-hash-buffer attr-buffer]
                          #(mapv mem/copy-to-unpooled-buffer %)
-                         (fn [[content-hash-buffer attr-buffer]]
+                         (fn [_]
                            (let [eid-size (mem/capacity eid-value-buffer)
                                  vs (TreeSet. mem/buffer-comparator)
                                  prefix (encode-ecav-key-to nil

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -805,6 +805,8 @@
                                                                             (take 2)
                                                                             count)
                                                                        1)]
+                                                     ;; TODO: eviction of caches isn't safe as they're shared across snapshots
+                                                     ;; Alternatively, one could leave them and let them expire naturally.
                                                      (when-not (c/can-decode-value-buffer? value-buffer)
                                                        (lru/evict value-cache value-buffer))
                                                      (lru/evict cav-cache (.content-hash quad))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -768,19 +768,19 @@
                                                                                       eid-value))))))
                       not-empty))
           content-idx-kvs (->content-idx-kvs docs)]
-      (some->> (seq content-idx-kvs) (kv/store kv-store))
       (locking ae-cache
-        (doseq [[a ids] (:ae-cache-update (meta content-idx-kvs))
-                :let [^Set es-cache (get ae-cache a)]
-                :when es-cache
-                id ids]
-          (.add es-cache id)))
-      (locking av-cache
-        (doseq [[a vs] (:av-cache-update (meta content-idx-kvs))
-                :let [^Set vs-cache (get av-cache a)]
-                :when vs-cache
-                v vs]
-          (.add vs-cache v)))
+        (locking av-cache
+          (some->> (seq content-idx-kvs) (kv/store kv-store))
+          (doseq [[a ids] (:ae-cache-update (meta content-idx-kvs))
+                  :let [^Set es-cache (get ae-cache a)]
+                  :when es-cache
+                  id ids]
+            (.add es-cache id))
+          (doseq [[a vs] (:av-cache-update (meta content-idx-kvs))
+                  :let [^Set vs-cache (get av-cache a)]
+                  :when vs-cache
+                  v vs]
+            (.add vs-cache v))))
       {:bytes-indexed (->> content-idx-kvs (transduce (comp (mapcat seq) (map mem/capacity)) +))
        :indexed-docs docs}))
 

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -494,11 +494,11 @@
                              a->vs))))
 
 (defn- ae-cache-lookup ^java.util.NavigableSet [{:keys [ae-cache kv-store] :as kv-index-store} ^DirectBuffer attr-buffer]
-  (lru/compute-if-absent ae-cache
-                         attr-buffer
-                         mem/copy-to-unpooled-buffer
-                         (fn [attr-buffer]
-                           (locking ae-cache
+  (locking ae-cache
+    (lru/compute-if-absent ae-cache
+                           attr-buffer
+                           mem/copy-to-unpooled-buffer
+                           (fn [attr-buffer]
                              (with-open [snapshot (kv/new-snapshot kv-store)
                                          cache-i (kv/new-iterator snapshot)
                                          index-snapshot (db/open-index-snapshot kv-index-store)]
@@ -513,11 +513,11 @@
                                  es))))))
 
 (defn- av-cache-lookup ^java.util.NavigableSet [{:keys [av-cache kv-store]} ^DirectBuffer attr-buffer]
-  (lru/compute-if-absent av-cache
-                         attr-buffer
-                         mem/copy-to-unpooled-buffer
-                         (fn [attr-buffer]
-                           (locking av-cache
+  (locking av-cache
+    (lru/compute-if-absent av-cache
+                           attr-buffer
+                           mem/copy-to-unpooled-buffer
+                           (fn [attr-buffer]
                              (with-open [snapshot (kv/new-snapshot kv-store)
                                          cache-i (kv/new-iterator snapshot)]
                                (let [vs (ConcurrentSkipListSet. mem/buffer-comparator)

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -22,7 +22,8 @@
      (binding [*index-store* (kvi/->KvIndexStore kv-store#
                                                  (lru/new-cache kvi/default-cache-size)
                                                  (lru/new-cache kvi/default-cache-size)
-                                                 (lru/new-cache kvi/default-ae-cache-size))]
+                                                 (lru/new-cache kvi/default-index-cache-size)
+                                                 (lru/new-cache kvi/default-index-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -20,8 +20,8 @@
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
      (binding [*index-store* (kvi/->KvIndexStore kv-store#
-                                                 (lru/new-cache kvi/default-cache-size)
-                                                 (lru/new-cache kvi/default-cache-size)
+                                                 (lru/new-cache kvi/default-value-cache-size)
+                                                 (lru/new-cache kvi/default-cav-cache-size)
                                                  (lru/new-cache kvi/default-index-cache-size)
                                                  (lru/new-cache kvi/default-index-cache-size))]
        ~@body)))

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -19,7 +19,10 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-cache-size) (lru/new-cache kvi/default-cache-size))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store#
+                                                 (lru/new-cache kvi/default-cache-size)
+                                                 (lru/new-cache kvi/default-cache-size)
+                                                 (lru/new-cache kvi/default-ae-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
This PR goes further than the CAV cache and caches the top-level of the trees, AV and AE in memory for requested attributes.
This is an experimental PR. Both indexes each make TPC-H faster. Together it's about 2-3 times faster for some queries.

These caches are then kept up to date as more data arrives. An entire attribute column might be evicted from the cache, which is quite small (default size is 128) if it goes cold. The entire column as a whole is cached, and no attempt is made to identify hot ranges. This implies that a column can become very large while still needing to fit in memory. This is less of a problem for AE, as the AV space is usually much larger.

As queries run, the AV/AE data will be cross checked against, actual, temporal and snapshot-based data in AVE and AEV like previously so extra values at the top-level shouldn't affect the result.

Eviction might cause inconsistent reads as data might disappear from a cache during a query. One approach is to simply not remove data from these caches on entity eviction and accept that some data might sit in memory. An alternative approach is to have a global lock and postpone the cache eviction until all current queries are finished (or something similar).

The way the caches are kept up to date depends on usage of locks. When the cache is initiated the entire column is scanned and populated at once, which can cause non-trivial lock contention. As columns can get evicted, new columns might get initialised as the system is running. Other better ways to do this are likely possible.