### PR TITLE
Rename encoded q params

### DIFF
--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -118,14 +118,14 @@
     (api-request-sync (str url "/_crux/entity")
                       {:->jwt-token ->jwt-token
                        :http-opts {:method :get
-                                   :query-params {:eid (pr-str eid)
+                                   :query-params {:eid-edn (pr-str eid)
                                                   :valid-time (some-> valid-time (cio/format-rfc3339-date))
                                                   :transact-time (some->  transact-time (cio/format-rfc3339-date))}}}))
 
   (entityTx [this eid]
     (api-request-sync (str url "/_crux/entity-tx")
                       {:http-opts {:method :get
-                                   :query-params {:eid (pr-str eid)
+                                   :query-params {:eid-edn (pr-str eid)
                                                   :valid-time (some-> valid-time (cio/format-rfc3339-date))
                                                   :transact-time (some->  transact-time (cio/format-rfc3339-date))}}
                        :->jwt-token ->jwt-token}))
@@ -152,7 +152,7 @@
       (vec (iterator-seq history))))
 
   (openEntityHistory [this eid opts]
-    (let [qps {:eid (pr-str eid)
+    (let [qps {:eid-edn (pr-str eid)
                :history true
                :sort-order (condp = (.sortOrder opts)
                              HistoryOptions$SortOrder/ASC (name :asc)

--- a/crux-http-server/src-cljs/crux/ui/common.cljs
+++ b/crux-http-server/src-cljs/crux/ui/common.cljs
@@ -90,8 +90,3 @@
        (walk/postwalk
         (fn [map] (cond->> map
                     (map? map) (into (sorted-map)))))))
-
-(defn entity-link [eid valid-time transaction-time]
-  (route->url :entity {} {:eid-edn (pr-str eid)
-                          :valid-time valid-time
-                          :transaction-time transaction-time}))

--- a/crux-http-server/src-cljs/crux/ui/common.cljs
+++ b/crux-http-server/src-cljs/crux/ui/common.cljs
@@ -25,7 +25,7 @@
    (rfe/href k params query)))
 
 (defn url->route
-  "url: abosolute string path i.e. '/_entity?eid=...'"
+  "url: abosolute string path i.e. '/_crux/entity?eid-edn=...'"
   [url]
   (reitit/match-by-path (navigation/router) url))
 
@@ -92,6 +92,6 @@
                     (map? map) (into (sorted-map)))))))
 
 (defn entity-link [eid valid-time transaction-time]
-  (route->url :entity {} {:eid (pr-str eid)
+  (route->url :entity {} {:eid-edn (pr-str eid)
                           :valid-time valid-time
                           :transaction-time transaction-time}))

--- a/crux-http-server/src-cljs/crux/ui/events.cljs
+++ b/crux-http-server/src-cljs/crux/ui/events.cljs
@@ -185,7 +185,7 @@
    (let [query-params (->>
                        {:valid-time (some-> valid-time js/moment .toDate t/instant)
                         :transaction-time (some-> transaction-time js/moment .toDate t/instant)
-                        :eid eid}
+                        :eid-edn eid}
                        (remove #(nil? (second %)))
                        (into {}))]
      {:db db

--- a/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
+++ b/crux-http-server/src-cljs/crux/ui/subscriptions.cljs
@@ -73,7 +73,7 @@
                                 (:crux.tx/tx-time)
                                 (t/instant))
          transaction-time (str (:transaction-time query-params latest-tx-time))]
-     {"eid" (:eid query-params)
+     {"eid" (:eid-edn query-params)
       "valid-time" (js/moment valid-time)
       "transaction-time" (js/moment transaction-time)})))
 
@@ -141,7 +141,7 @@
 (rf/reg-sub
  ::eid-submitted?
  (fn [db _]
-   (some? (get-in db [:current-route :query-params :eid]))))
+   (some? (get-in db [:current-route :query-params :eid-edn]))))
 
 (rf/reg-sub
  ::entity-pane-tab
@@ -183,7 +183,7 @@
    (if-let [error (get-in db [:entity :error])]
      {:error error}
      (let [query-params (get-in db [:current-route :query-params])]
-       {:eid (:eid query-params)
+       {:eid (:eid-edn query-params)
         :vt (common/iso-format-datetime (or (:valid-time query-params) (t/now)))
         :tt (or (common/iso-format-datetime (:transaction-time query-params)) "Using Latest")
         :document (get-in db [:entity :http :document])}))))
@@ -205,7 +205,7 @@
 (rf/reg-sub
  ::entity-result-pane-history
  (fn [db _]
-   (let [eid (get-in db [:current-route :query-params :eid])
+   (let [eid (get-in db [:current-route :query-params :eid-edn])
          history (-> (get-in db [:entity :http :history])
                      format-history-times)]
      {:eid eid
@@ -225,7 +225,7 @@
 (rf/reg-sub
  ::entity-result-pane-history-diffs
  (fn [db _]
-   (let [eid (get-in db [:current-route :query-params :eid])
+   (let [eid (get-in db [:current-route :query-params :eid-edn])
          history (-> (get-in db [:entity :http :history])
                      format-history-times)
          entity-history (history-docs->diffs history)]

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -31,11 +31,13 @@
   (cond-> response
     date (assoc-in [:headers "Last-Modified"] (rt/format-date date))))
 
-(s/def ::entity-tx-spec (s/keys :req-un [::util/eid] :opt-un [::util/valid-time ::util/transaction-time]))
+(s/def ::entity-tx-spec (s/keys :req-un [(or ::util/eid-edn ::util/eid)]
+                                :opt-un [::util/valid-time ::util/transaction-time]))
 
 (defn- entity-tx [^ICruxAPI crux-node]
   (fn [req]
-    (let [{:keys [eid valid-time transaction-time]} (get-in req [:parameters :query])
+    (let [{:keys [eid eid-edn valid-time transaction-time]} (get-in req [:parameters :query])
+          eid (or eid-edn eid)
           db (util/db-for-request crux-node {:valid-time valid-time
                                              :transact-time transaction-time})
           {::tx/keys [tx-time] :as entity-tx} (crux/entity-tx db eid)]

--- a/crux-http-server/src/crux/http_server/entity.clj
+++ b/crux-http-server/src/crux/http_server/entity.clj
@@ -28,6 +28,7 @@
 (s/def ::with-docs boolean?)
 (s/def ::query-params
   (s/keys :opt-un [::util/eid
+                   ::util/eid-edn
                    ::history
                    ::sort-order
                    ::util/valid-time
@@ -138,10 +139,12 @@
       {:error e})))
 
 (defn transform-query-params [req]
-  (let [query-params (get-in req [:parameters :query])]
-    (if (= "text/html" (get-in req [:muuntaja/response :format]))
-      (assoc query-params :with-docs true :link-entities? true)
-      query-params)))
+  (let [{:keys [eid eid-edn] :as query-params} (get-in req [:parameters :query])]
+    (->
+     (if (= "text/html" (get-in req [:muuntaja/response :format]))
+       (assoc query-params :with-docs true :link-entities? true)
+       query-params)
+     (assoc :eid (or eid-edn eid)))))
 
 (defmulti transform-query-resp
   (fn [resp req]

--- a/crux-http-server/src/crux/http_server/entity_ref.cljc
+++ b/crux-http-server/src/crux/http_server/entity_ref.cljc
@@ -16,7 +16,7 @@
               :cljs (some-> valid-time tick/instant))
         tt #?(:clj (some-> ^Date transaction-time .toInstant)
               :cljs (some-> transaction-time tick/instant))
-        query-params (cond-> (str "?eid=" encoded-eid)
+        query-params (cond-> (str "?eid-edn=" encoded-eid)
                        vt (str "&valid-time=" vt)
                        tt (str "&transaction-time=" tt))]
     (str "/_crux/entity" query-params)))

--- a/crux-http-server/src/crux/http_server/util.clj
+++ b/crux-http-server/src/crux/http_server/util.clj
@@ -133,11 +133,3 @@
               [:noscript
                [:pre.noscript-content (with-out-str (pp/pprint results))]]]]
             [:script {:src "/cljs-out/dev-main.js" :type "text/javascript"}]]]))))
-
-(defn entity-link [eid {:keys [valid-time transaction-time]}]
-  (let [encoded-eid (URLEncoder/encode (pr-str eid) "UTF-8")
-        query-params (format "?eid=%s&valid-time=%s&transaction-time=%s"
-                             encoded-eid
-                             (.toInstant ^Date valid-time)
-                             (.toInstant ^Date transaction-time))]
-    (str "/entity" query-params)))

--- a/crux-http-server/src/crux/http_server/util.clj
+++ b/crux-http-server/src/crux/http_server/util.clj
@@ -24,7 +24,9 @@
     (catch Exception e
       ::s/invalid)))
 
-(s/def ::eid
+(s/def ::eid (and string? c/valid-id?))
+
+(s/def ::eid-edn
   (st/spec
    {:spec c/valid-id?
     :decode/string (fn [_ eid] (try-decode-edn eid))}))

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -105,13 +105,15 @@ Returns the document map for a particular entity.
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $CRUX_URL/_crux/entity?eid=:tommy
+     $CRUX_URL/_crux/entity?eid-edn=:tommy
 ----
 
 ==== Query Parameters
 
 .*Required Parameters*
-* `eid` (Crux ID)
+* One of the following:
+** `eid-edn` (EDN formatted Crux ID)
+** `eid` (String IDs)
 
 .*Optional Parameters*
 * `valid-time` (date, defaulting to now)
@@ -125,13 +127,15 @@ Returns the history of a particular entity.
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $CRUX_URL/_crux/entity?eid=:tommy&history=true&sort-order=asc
+     $CRUX_URL/_crux/entity?eid-edn=:tommy&history=true&sort-order=asc
 ----
 
 ==== Query Parameters
 
 .*Required Parameters*
-* `eid` (Crux ID)
+* One of the following:
+** `eid-edn` (EDN formatted Crux ID)
+** `eid` (String IDs)
 * `sort-order` (either `asc` or `desc`)
 
 .*Optional Parameters*
@@ -149,13 +153,15 @@ Returns the transaction details for an entity - returns a map containing the tx-
 ----
 curl -X GET \
      -H "Content-Type: application/edn" \
-     $CRUX_URL/_crux/entity-tx?eid=:tommy
+     $CRUX_URL/_crux/entity-tx?eid-edn=:tommy
 ----
 
 ==== Query Parameters
 
 .*Required Parameters*
-* `eid` (Crux ID)
+* One of the following:
+** `eid-edn` (EDN formatted Crux ID)
+** `eid` (String IDs)
 
 .*Optional Parameters*
 * `valid-time` (date, defaulting to now)


### PR DESCRIPTION
Resolves #1141 

`entity` and `entity-tx` were the only endpoints which particularly fell under this change - assuming that `query` is out of scope (as mentioned within #284 )