### PR TITLE
CAV cache per CA

### DIFF
--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -481,7 +481,7 @@
                                (when k
                                  (let [k (mem/copy-to-unpooled-buffer k)
                                        v (decode-ecav-key-as-v-from k eid-size)]
-                                   (.add ^Set vs v)
+                                   (.add vs v)
                                    (recur (kv/next i)))))
                              vs))))
 

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-cache-size) (lru/new-cache kvi/default-cache-size))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-value-cache-size) (lru/new-cache kvi/default-cav-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
Move CAV cache to cache per CA pair instead of full documents. Remove chunked seqs for now.

The current CAV cache is too eager which helps TPC-H, but not Watdiv, where it ended up running out of memory due to too large caches of unused data. Chunked seqs are a bit similar, they can help if you will scan, but not when jumping around. So removing them as well.

Caching per CA pair loses some of the benefit of not scanning out the data while in the area, and is somewhat slower even though less data is read. The caches are more manageable though, as with full CAV cache any single attribute access would stop the entire document from being evicted.