### PR TITLE
Make the index store caches a bit smaller.

### DIFF
--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -785,8 +785,8 @@
      :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
-(def ^:const default-value-cache-size (* 1024 1024))
-(def ^:const default-cav-cache-size (* 1024 1024))
+(def ^:const default-value-cache-size (* 256 1024))
+(def ^:const default-cav-cache-size (* 256 1024))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)


### PR DESCRIPTION
Moving value and cav caches down to 256k elements each as Watdiv doesn't seem to consistently run on bench.