### PR TITLE
Cache interface

### DIFF
--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -50,8 +50,7 @@
                                                       :doc "Azure Storage Account Name"}
                                     :container {:required? true,
                                                 :spec ::sys/string
-                                                :doc "Azure Blob Storage Container"}
-                                    :doc-cache-size ds/doc-cache-size-opt}}
+                                                :doc "Azure Blob Storage Container"}}}
   [{:keys [sas-token storage-account container document-cache] :as opts}]
   (ds/->cached-document-store
    (assoc opts

--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -3,8 +3,7 @@
             [taoensso.nippy :as nippy]
             [crux.db :as db]
             [crux.system :as sys]
-            [crux.document-store :as ds]
-            [crux.lru :as lru]))
+            [crux.document-store :as ds]))
 
 (defn- get-blob [sas-token storage-account container blob-name]
   ;; TODO : ETag

--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -41,7 +41,8 @@
      {}
      docs)))
 
-(defn ->document-store {::sys/args {:sas-token {:required? true
+(defn ->document-store {::sys/deps {:document-cache :crux/document-cache}
+                        ::sys/args {:sas-token {:required? true
                                                 :spec ::sys/string
                                                 :doc "Azure Blob Storage SAS Token"}
                                     :storage-account {:required? true
@@ -51,9 +52,10 @@
                                                 :spec ::sys/string
                                                 :doc "Azure Blob Storage Container"}
                                     :doc-cache-size ds/doc-cache-size-opt}}
-  [{:keys [sas-token storage-account container doc-cache-size] :as opts}]
+  [{:keys [sas-token storage-account container document-cache] :as opts}]
   (ds/->cached-document-store
    (assoc opts
+          :document-cache document-cache
           :document-store
           (->AzureBlobsDocumentStore sas-token
                                      storage-account

--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -41,7 +41,7 @@
      {}
      docs)))
 
-(defn ->document-store {::sys/deps {:document-cache :crux/document-cache}
+(defn ->document-store {::sys/deps {:document-cache 'crux.cache/->cache}
                         ::sys/args {:sas-token {:required? true
                                                 :spec ::sys/string
                                                 :doc "Azure Blob Storage SAS Token"}

--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -52,10 +52,10 @@
                                                 :spec ::sys/string
                                                 :doc "Azure Blob Storage Container"}
                                     :doc-cache-size ds/doc-cache-size-opt}}
-  [{:keys [sas-token storage-account container doc-cache-size]}]
-  (ds/->CachedDocumentStore
-   (lru/new-cache doc-cache-size)
-   (->AzureBlobsDocumentStore sas-token
-                              storage-account
-                              container)))
-
+  [{:keys [sas-token storage-account container doc-cache-size] :as opts}]
+  (ds/->cached-document-store
+   (assoc opts
+          :document-store
+          (->AzureBlobsDocumentStore sas-token
+                                     storage-account
+                                     container))))

--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -150,7 +150,7 @@
                         (sparkline times-taken)
                         (let [time-taken-seconds (/ time-taken-ms 1000)]
                           (pr-str (dissoc bench-map :bench-ns :bench-type :crux-node-type :crux-commit :crux-version :time-taken-ms
-                                          :percentage-difference-since-last-run :minimum-time-taken-this-week :maximum-time-taken-this-week))))]
+                                          :percentage-difference-since-last-run :minimum-time-taken-this-week :maximum-time-taken-this-week :times-taken))))]
                (when (and (= bench-type :ingest) doc-count av-count bytes-indexed)
                  (->> (let [time-taken-seconds (/ time-taken-ms 1000)]
                         {:docs-per-second (int (/ doc-count time-taken-seconds))
@@ -180,7 +180,7 @@
                         (Duration/ofMillis maximum-time-taken-this-week)
                         (sparkline times-taken)
                         (pr-str (dissoc bench-map :bench-ns :bench-type :crux-node-type :crux-commit :crux-version :time-taken-ms
-                                        :percentage-difference-since-last-run :minimum-time-taken-this-week :maximum-time-taken-this-week)))]
+                                        :percentage-difference-since-last-run :minimum-time-taken-this-week :maximum-time-taken-this-week :times-taken)))]
                (when (= bench-type :ingest)
                  (->> (let [time-taken-seconds (/ time-taken-ms 1000)]
                         {:docs-per-second (int (/ doc-count time-taken-seconds))

--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -12,7 +12,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [org.clojure/data.json "1.0.0"]
                  [org.clojure/tools.cli "1.0.194"]
-                 [org.agrona/agrona "1.0.7"]
+                 [org.agrona/agrona "1.7.2"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
                  [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}

--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -12,7 +12,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [org.clojure/data.json "1.0.0"]
                  [org.clojure/tools.cli "1.0.194"]
-                 [org.agrona/agrona "1.7.2"]
+                 [org.agrona/agrona "1.0.7"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
                  [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -394,7 +394,6 @@
                                             :crux/bus 'crux.bus/->bus
                                             :crux/tx-ingester 'crux.tx/->tx-ingester
                                             :crux/document-store 'crux.kv.document-store/->document-store
-                                            :crux/document-cache 'crux.cache.lru/->lru-cache
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
                                             :crux/query-engine 'crux.query/->query-engine}]
                                           (cond-> options (not (vector? options)) vector)))

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -391,8 +391,6 @@
   ^crux.api.ICruxAPI [options]
   (let [system (-> (sys/prep-system (into [{:crux/node 'crux.node/->node
                                             :crux/index-store 'crux.kv.index-store/->kv-index-store
-                                            :crux/value-cache 'crux.cache.lru/->lru-cache
-                                            :crux/cav-cache 'crux.cache.lru/->lru-cache
                                             :crux/bus 'crux.bus/->bus
                                             :crux/tx-ingester 'crux.tx/->tx-ingester
                                             :crux/document-store 'crux.kv.document-store/->document-store

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -391,9 +391,12 @@
   ^crux.api.ICruxAPI [options]
   (let [system (-> (sys/prep-system (into [{:crux/node 'crux.node/->node
                                             :crux/index-store 'crux.kv.index-store/->kv-index-store
+                                            :crux/value-cache 'crux.cache.lru/->lru-cache
+                                            :crux/cav-cache 'crux.cache.lru/->lru-cache
                                             :crux/bus 'crux.bus/->bus
                                             :crux/tx-ingester 'crux.tx/->tx-ingester
                                             :crux/document-store 'crux.kv.document-store/->document-store
+                                            :crux/document-cache 'crux.cache.lru/->lru-cache
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
                                             :crux/query-engine 'crux.query/->query-engine}]
                                           (cond-> options (not (vector? options)) vector)))

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc crux.cache
-  (:require [crux.cache.lru :as lru])
+  (:require [crux.cache.lru :as lru]
+            [crux.system :as sys])
   (:import crux.cache.ICache))
 
 (defn compute-if-absent [^ICache cache k stored-key-fn f]
@@ -8,4 +9,4 @@
 (defn evict [^ICache cache k]
   (.evict cache k))
 
-(def new-cache lru/new-lru-cache)
+(def ->cache lru/->lru-cache)

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -8,4 +8,4 @@
 (defn evict [^ICache cache k]
   (.evict cache k))
 
-(def new-cache lru/new-cache)
+(def new-cache lru/new-lru-cache)

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -9,4 +9,9 @@
 (defn evict [^ICache cache k]
   (.evict cache k))
 
-(def ->cache lru/->lru-cache)
+(defn ->cache
+  {::sys/args {:cache-size {:doc "Cache size"
+                            :default (* 128 1024)
+                            :spec ::sys/nat-int}}}
+  [opts]
+  (lru/->lru-cache opts))

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -1,0 +1,11 @@
+(ns ^:no-doc crux.cache
+  (:require [crux.cache.lru :as lru])
+  (:import crux.cache.ICache))
+
+(defn compute-if-absent [^ICache cache k stored-key-fn f]
+  (.computeIfAbsent cache k stored-key-fn f))
+
+(defn evict [^ICache cache k]
+  (.evict cache k))
+
+(def new-cache lru/new-cache)

--- a/crux-core/src/crux/cache/ICache.java
+++ b/crux-core/src/crux/cache/ICache.java
@@ -1,10 +1,11 @@
 package crux.cache;
 
+import java.io.Closeable;
 import clojure.lang.Counted;
 import clojure.lang.IFn;
 import clojure.lang.ILookup;
 
-public interface ICache<K, V> extends ILookup, Counted {
+public interface ICache<K, V> extends Closeable, Counted, ILookup {
     public V computeIfAbsent(K key, IFn storedKeyFn, IFn f);
     public void evict(K key);
 }

--- a/crux-core/src/crux/cache/ICache.java
+++ b/crux-core/src/crux/cache/ICache.java
@@ -1,0 +1,10 @@
+package crux.cache;
+
+import clojure.lang.Counted;
+import clojure.lang.IFn;
+import clojure.lang.ILookup;
+
+public interface ICache<K, V> extends ILookup, Counted {
+    public V computeIfAbsent(K key, IFn storedKeyFn, IFn f);
+    public void evict(K key);
+}

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -1,7 +1,5 @@
 (ns ^:no-doc crux.cache.lru
-  (:require [crux.db :as db]
-            [crux.io :as cio]
-            [crux.kv :as kv])
+  (:require [crux.io :as cio])
   (:import crux.cache.ICache
            java.util.concurrent.locks.StampedLock
            java.util.function.Function
@@ -16,7 +14,7 @@
         lock (StampedLock.)]
     (reify
       Object
-      (toString [this]
+      (toString [_]
         (.toString cache))
 
       ICache
@@ -36,11 +34,11 @@
         (cio/with-write-lock lock
           (.remove cache k)))
 
-      (valAt [this k]
+      (valAt [_ k]
         (cio/with-write-lock lock
           (.get cache k)))
 
-      (valAt [this k default]
+      (valAt [_ k default]
         (cio/with-write-lock lock
           (.getOrDefault cache k default)))
 

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -8,51 +8,50 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn new-lru-cache [^long size]
-  (let [cache (proxy [LinkedHashMap] [size 0.75 true]
-                (removeEldestEntry [_]
-                  (> (.size ^Map this) size)))
-        lock (StampedLock.)]
-    (reify
-      Object
-      (toString [_]
-        (.toString cache))
+(deftype LRUCache [^LinkedHashMap cache ^StampedLock lock]
+  Object
+  (toString [_]
+    (.toString cache))
 
-      ICache
-      (computeIfAbsent [this k stored-key-fn f]
-        (let [v (.valAt this k ::not-found)] ; use ::not-found as values can be falsy
-          (if (= ::not-found v)
-            (let [k (stored-key-fn k)
-                  v (f k)]
-              (cio/with-write-lock lock
-                ;; lock the cache only after potentially heavy value and key calculations are done
-                (.computeIfAbsent cache k (reify Function
-                                            (apply [_ k]
-                                              v)))))
-            v)))
+  ICache
+  (computeIfAbsent [this k stored-key-fn f]
+    (let [v (.valAt this k ::not-found)] ; use ::not-found as values can be falsy
+      (if (= ::not-found v)
+        (let [k (stored-key-fn k)
+              v (f k)]
+          (cio/with-write-lock lock
+            ;; lock the cache only after potentially heavy value and key calculations are done
+            (.computeIfAbsent cache k (reify Function
+                                        (apply [_ k]
+                                          v)))))
+        v)))
 
-      (evict [_ k]
-        (cio/with-write-lock lock
-          (.remove cache k)))
+  (evict [_ k]
+    (cio/with-write-lock lock
+      (.remove cache k)))
 
-      (valAt [_ k]
-        (cio/with-write-lock lock
-          (.get cache k)))
+  (valAt [_ k]
+    (cio/with-write-lock lock
+      (.get cache k)))
 
-      (valAt [_ k default]
-        (cio/with-write-lock lock
-          (.getOrDefault cache k default)))
+  (valAt [_ k default]
+    (cio/with-write-lock lock
+      (.getOrDefault cache k default)))
 
-      (count [_]
-        (.size cache))
+  (count [_]
+    (.size cache))
 
-      (close [_]
-        (cio/with-write-lock lock
-          (.clear cache))))))
+  (close [_]
+    (cio/with-write-lock lock
+      (.clear cache))))
 
 (defn ->lru-cache
   {::sys/args {:cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
-  [{:keys [cache-size]}]
-  (new-lru-cache cache-size))
+  [{:keys [^long cache-size]}]
+  (let [cache (proxy [LinkedHashMap] [cache-size 0.75 true]
+                (removeEldestEntry [_]
+                  (> (.size ^Map this) cache-size)))
+        lock (StampedLock.)]
+    (->LRUCache cache lock)))

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc crux.cache.lru
-  (:require [crux.io :as cio])
+  (:require [crux.io :as cio]
+            [crux.system :as sys])
   (:import crux.cache.ICache
            java.util.concurrent.locks.StampedLock
            java.util.function.Function
@@ -45,4 +46,13 @@
       (count [_]
         (.size cache))
 
-      (close [_]))))
+      (close [_]
+        (cio/with-write-lock lock
+          (.clear cache))))))
+
+(defn ->lru-cache
+  {::sys/args {:cache-size {:doc "Cache size"
+                            :default (* 128 1024)
+                            :spec ::sys/nat-int}}}
+  [{:keys [cache-size]}]
+  (new-lru-cache cache-size))

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -8,7 +8,7 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype LRUCache [^LinkedHashMap cache ^StampedLock lock]
+(deftype LRUCache [^LinkedHashMap cache ^StampedLock lock ^long size]
   Object
   (toString [_]
     (.toString cache))
@@ -54,4 +54,4 @@
                 (removeEldestEntry [_]
                   (> (.size ^Map this) cache-size)))
         lock (StampedLock.)]
-    (->LRUCache cache lock)))
+    (->LRUCache cache lock cache-size)))

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -2,16 +2,14 @@
   (:require [crux.db :as db]
             [crux.io :as cio]
             [crux.kv :as kv])
-  (:import [clojure.lang Counted ILookup]
-           crux.cache.ICache
-           java.io.Closeable
+  (:import crux.cache.ICache
            java.util.concurrent.locks.StampedLock
            java.util.function.Function
            [java.util LinkedHashMap Map]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn new-cache [^long size]
+(defn new-lru-cache [^long size]
   (let [cache (proxy [LinkedHashMap] [size 0.75 true]
                 (removeEldestEntry [_]
                   (> (.size ^Map this) size)))
@@ -47,4 +45,6 @@
           (.getOrDefault cache k default)))
 
       (count [_]
-        (.size cache)))))
+        (.size cache))
+
+      (close [_]))))

--- a/crux-core/src/crux/cache/nop.clj
+++ b/crux-core/src/crux/cache/nop.clj
@@ -1,0 +1,29 @@
+(ns ^:no-doc crux.cache.nop
+  (:require [crux.io :as cio]
+            [crux.system :as sys])
+  (:import crux.cache.ICache))
+
+(defn new-nop-cache
+  ([] (new-nop-cache 0))
+  ([size]
+   (reify
+     ICache
+     (computeIfAbsent [this k stored-key-fn f]
+       (f k))
+
+     (evict [_ k])
+
+     (valAt [_ k])
+
+     (valAt [_ k default] default)
+
+     (count [_] 0)
+
+     (close [_]))))
+
+(defn ->nop-cache
+  {::sys/args {:cache-size {:doc "Cache size"
+                            :default 0
+                            :spec ::sys/nat-int}}}
+  [{:keys [cache-size]}]
+  (new-nop-cache))

--- a/crux-core/src/crux/cache/nop.clj
+++ b/crux-core/src/crux/cache/nop.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc crux.cache.nop
-  (:require [crux.io :as cio]
-            [crux.system :as sys])
+  (:require [crux.system :as sys])
   (:import crux.cache.ICache))
 
 (defn new-nop-cache

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -1,0 +1,98 @@
+(ns crux.cache.second-chance
+  (:import crux.cache.ICache
+           java.lang.reflect.Field
+           java.util.function.Function
+           [java.util Map$Entry Queue]
+           [java.util.concurrent ArrayBlockingQueue ConcurrentHashMap])
+  (:require [crux.system :as sys]))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(def ^:private ^Field concurrent-map-table-field
+  (doto (.getDeclaredField ConcurrentHashMap "table")
+    (.setAccessible true)))
+
+(defn- random-entry ^java.util.Map$Entry [^ConcurrentHashMap m]
+  (when-not (.isEmpty m)
+    (let [table ^objects (.get concurrent-map-table-field m)]
+      (loop [i (long (rand-int (alength table)))]
+        (if-let [^Map$Entry e (aget table i)]
+          e
+          (recur (rem (inc i) (alength table))))))))
+
+(declare resize-cache)
+
+(deftype SecondChanceCache [^ConcurrentHashMap hot ^Queue cold ^double cold-factor ^long size]
+  Object
+  (toString [_]
+    (str hot " " cold))
+
+  ICache
+  (computeIfAbsent [this k stored-key-fn f]
+    (let [^objects vp (or (.get hot k)
+                          (let [k (stored-key-fn k)
+                                v (f k)]
+                            (.computeIfAbsent hot k (reify Function
+                                                      (apply [_ k]
+                                                        (doto (object-array 2)
+                                                          (aset 0 v)))))))]
+      (resize-cache this)
+      (aset vp 1 nil)
+      (aget vp 0)))
+
+  (evict [_ k]
+    (when-let [vp ^objects (.remove hot k)]
+      (aset vp 1 nil)))
+
+  (valAt [_ k]
+    (when-let [vp ^objects (.get hot k)]
+      (aset vp 1 nil)
+      (aget vp 0)))
+
+  (valAt [_ k default]
+    (let [vp (.getOrDefault hot k default)]
+      (if (= default vp)
+        default
+        (do (aset ^objects vp 1 nil)
+            (aget ^objects vp 0)))))
+
+  (count [_]
+    (.size hot))
+
+  (close [_]
+    (.clear hot)
+    (.clear cold)))
+
+(defn move-to-cold [^SecondChanceCache cache]
+  (let [hot ^ConcurrentHashMap (.hot cache)
+        cold ^Queue (.cold cache)
+        cold-target-size (long (Math/ceil (* (.cold-factor cache) (.size hot))))]
+    (while (< (.size cold) cold-target-size)
+      (let [e (random-entry (.hot cache))]
+        (when-let [vp ^objects (.getValue e)]
+          (when (nil? (aget vp 1))
+            (when (.offer cold vp)
+              (aset vp 1 (.getKey e)))))))))
+
+(defn- resize-cache [^SecondChanceCache cache]
+  (let [hot ^ConcurrentHashMap (.hot cache)
+        cold ^Queue (.cold cache)]
+    (move-to-cold cache)
+    (while (> (.size hot) (.size cache))
+      (when-let [vp ^objects (.poll cold)]
+        (when-let [k (aget vp 1)]
+          (.remove hot k)))
+      (move-to-cold cache))))
+
+(defn ->second-chance-cache
+  {::sys/args {:cache-size {:doc "Cache size"
+                            :default (* 128 1024)
+                            :spec ::sys/nat-int}
+               :cold-factor {:doc "Cold factor"
+                             :default 0.1
+                             :spec ::sys/pos-double}}}
+  [{:keys [^long cache-size ^double cold-factor]}]
+  (let [hot (ConcurrentHashMap. cache-size)
+        cold-factor (or cold-factor 0.1)
+        cold (ArrayBlockingQueue. (inc (long (Math/ceil (* cold-factor cache-size)))))]
+    (->SecondChanceCache hot cold cold-factor cache-size)))

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -75,7 +75,7 @@
 
 (defn ->cached-document-store
   {::sys/deps {:document-store :crux/document-store
-               :document-cache :crux/document-cache}}
+               :document-cache 'crux.cache/->cache}}
   [{:keys [document-cache document-store]}]
   (->CachedDocumentStore document-cache document-store))
 

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -73,24 +73,20 @@
   Closeable
   (close [_]))
 
-(def ^:const default-doc-cache-size (* 128 1024))
-
-(def doc-cache-size-opt
-  {:doc "Cache size to use for document store."
-   :default default-doc-cache-size
-   :spec ::sys/nat-int})
-
 (defn ->cached-document-store
-  {::sys/deps {:document-store :crux/document-store}
-   ::sys/args {:doc-cache-size doc-cache-size-opt}}
-  [{:keys [doc-cache-size document-store]}]
-  (->CachedDocumentStore (cache/new-cache doc-cache-size) document-store))
+  {::sys/deps {:document-store :crux/document-store
+               :document-cache :crux/document-cache}}
+  [{:keys [document-cache document-store]}]
+  (->CachedDocumentStore document-cache document-store))
 
-(defn ->file-document-store {::sys/args {:dir {:doc "Directory to store documents"
-                                                :required? true
-                                                :spec ::sys/path}
-                                         :doc-cache-size doc-cache-size-opt}}
-  [{:keys [^Path dir doc-cache-size] :as opts}]
+(defn ->file-document-store {::sys/deps {:document-cache :crux/document-cache}
+                             ::sys/args {:dir {:doc "Directory to store documents"
+                                               :required? true
+                                               :spec ::sys/path}}}
+  [{:keys [^Path dir document-cache] :as opts}]
   (let [dir (.toFile dir)]
     (.mkdirs dir)
-    (->cached-document-store (assoc opts :document-store (->FileDocumentStore dir)))))
+    (->cached-document-store
+     (assoc opts
+            :document-cache document-cache
+            :document-store (->FileDocumentStore dir)))))

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -81,7 +81,8 @@
    :spec ::sys/nat-int})
 
 (defn ->cached-document-store
-  {::sys/args {:doc-cache-size doc-cache-size-opt}}
+  {::sys/deps {:document-store :crux/document-store}
+   ::sys/args {:doc-cache-size doc-cache-size-opt}}
   [{:keys [doc-cache-size document-store]}]
   (->CachedDocumentStore (cache/new-cache doc-cache-size) document-store))
 

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -79,7 +79,7 @@
   [{:keys [document-cache document-store]}]
   (->CachedDocumentStore document-cache document-store))
 
-(defn ->file-document-store {::sys/deps {:document-cache :crux/document-cache}
+(defn ->file-document-store {::sys/deps {:document-cache 'crux.cache/->cache}
                              ::sys/args {:dir {:doc "Directory to store documents"
                                                :required? true
                                                :spec ::sys/path}}}

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -267,9 +267,6 @@
 (defn new-n-ary-constraining-layered-virtual-index [idx constrain-result-fn]
   (->NAryConstrainingLayeredVirtualIndex idx constrain-result-fn (NAryWalkState. [] nil)))
 
-
-
-
 (defn layered-idx->seq [idx]
   (when idx
     (let [max-depth (long (db/max-depth idx))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -267,27 +267,35 @@
 (defn new-n-ary-constraining-layered-virtual-index [idx constrain-result-fn]
   (->NAryConstrainingLayeredVirtualIndex idx constrain-result-fn (NAryWalkState. [] nil)))
 
+
+
+
 (defn layered-idx->seq [idx]
   (when idx
     (let [max-depth (long (db/max-depth idx))
           step (fn step [max-ks ^long depth needs-seek?]
                  (when (Thread/interrupted)
                    (throw (InterruptedException.)))
-                 (if (= depth (dec max-depth))
-                   (concat (for [v (idx->seq idx)]
-                             (conj max-ks v))
-                           (when (pos? depth)
-                             (lazy-seq
-                              (db/close-level idx)
-                              (step (pop max-ks) (dec depth) false))))
-                   (if-let [v (if needs-seek?
-                                (db/seek-values idx nil)
-                                (db/next-values idx))]
-                     (do (db/open-level idx)
-                         (recur (conj max-ks v) (inc depth) true))
-                     (when (pos? depth)
-                       (db/close-level idx)
-                       (recur (pop max-ks) (dec depth) false)))))]
+                 (let [close-level (fn []
+                                     (when (pos? depth)
+                                       (lazy-seq
+                                        (db/close-level idx)
+                                        (step (pop max-ks) (dec depth) false))))
+                       open-level (fn [v]
+                                    (db/open-level idx)
+                                    (let [max-ks (conj max-ks v)]
+                                      (step max-ks (inc depth) true)
+                                      (do (db/close-level idx)
+                                          (step max-ks depth false))))]
+                   (if (= depth (dec max-depth))
+                     (concat (for [v (idx->seq idx)]
+                               (conj max-ks v))
+                             (close-level))
+                     (if-let [v (if needs-seek?
+                                  (db/seek-values idx nil)
+                                  (db/next-values idx))]
+                       (open-level v)
+                       (close-level)))))]
       (when (pos? max-depth)
         (step [] 0 true)))))
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -24,7 +24,7 @@
     (when-let [[v & vs] (.-seq state)]
       (set! (.-seq state) vs)
       (set! (.-key state) v)
-      v))))
+      v)))
 
 (defn new-index-store-index ^crux.index.IndexStoreIndex [seek-fn]
   (->IndexStoreIndex seek-fn (IndexStoreIndexState. nil nil)))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -280,10 +280,7 @@
                                         (step (pop max-ks) (dec depth) false))))
                        open-level (fn [v]
                                     (db/open-level idx)
-                                    (let [max-ks (conj max-ks v)]
-                                      (step max-ks (inc depth) true)
-                                      (do (db/close-level idx)
-                                          (step max-ks depth false))))]
+                                    (step (conj max-ks v) (inc depth) true))]
                    (if (= depth (dec max-depth))
                      (concat (for [v (idx->seq idx)]
                                (conj max-ks v))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -274,23 +274,21 @@
           step (fn step [max-ks ^long depth needs-seek?]
                  (when (Thread/interrupted)
                    (throw (InterruptedException.)))
-                 (let [close-level (fn []
-                                     (when (pos? depth)
-                                       (lazy-seq
-                                        (db/close-level idx)
-                                        (step (pop max-ks) (dec depth) false))))
-                       open-level (fn [v]
-                                    (db/open-level idx)
-                                    (step (conj max-ks v) (inc depth) true))]
-                   (if (= depth (dec max-depth))
-                     (concat (for [v (idx->seq idx)]
-                               (conj max-ks v))
-                             (close-level))
-                     (if-let [v (if needs-seek?
-                                  (db/seek-values idx nil)
-                                  (db/next-values idx))]
-                       (open-level v)
-                       (close-level)))))]
+                 (if (= depth (dec max-depth))
+                   (concat (for [v (idx->seq idx)]
+                             (conj max-ks v))
+                           (when (pos? depth)
+                             (lazy-seq
+                              (db/close-level idx)
+                              (step (pop max-ks) (dec depth) false))))
+                   (if-let [v (if needs-seek?
+                                (db/seek-values idx nil)
+                                (db/next-values idx))]
+                     (do (db/open-level idx)
+                         (recur (conj max-ks v) (inc depth) true))
+                     (when (pos? depth)
+                       (db/close-level idx)
+                       (recur (pop max-ks) (dec depth) false)))))]
       (when (pos? max-depth)
         (step [] 0 true)))))
 

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -15,15 +15,16 @@
 (defrecord IndexStoreIndex [seek-fn ^IndexStoreIndexState state]
   db/Index
   (seek-values [this k]
-    (set! (.-iterator state) (some-> ^Collection (seek-fn k) (.iterator)))
-    (db/next-values this))
+    (let [[v & vs] (seq (seek-fn k))]
+      (set! (.-seq state) vs)
+      (set! (.-key state) v)
+      v))
 
   (next-values [this]
-    (when-let [^Iterator i (.-iterator state)]
-      (let [v (when (.hasNext i)
-                (.next i))]
-        (set! (.-key state) v)
-        v))))
+    (when-let [[v & vs] (.-seq state)]
+      (set! (.-seq state) vs)
+      (set! (.-key state) v)
+      v))))
 
 (defn new-index-store-index ^crux.index.IndexStoreIndex [seek-fn]
   (->IndexStoreIndex seek-fn (IndexStoreIndexState. nil nil)))

--- a/crux-core/src/crux/index/IndexStoreIndexState.java
+++ b/crux-core/src/crux/index/IndexStoreIndexState.java
@@ -1,11 +1,11 @@
 package crux.index;
 
 public class IndexStoreIndexState {
-    public Object iterator;
+    public Object seq;
     public Object key;
 
-    public IndexStoreIndexState(Object iterator, Object key) {
-        this.iterator = iterator;
+    public IndexStoreIndexState(Object seq, Object key) {
+        this.seq = seq;
         this.key = key;
     }
 }

--- a/crux-core/src/crux/ingest_client.clj
+++ b/crux-core/src/crux/ingest_client.clj
@@ -40,6 +40,7 @@
   (let [system (-> (sys/prep-system (into [{:crux/ingest-client `->ingest-client
                                             :crux/bus 'crux.bus/->bus
                                             :crux/document-store 'crux.kv.document-store/->document-store
+                                            :crux/document-cache 'crux.cache.lru/->lru-cache
                                             :crux/tx-log 'crux.kv.tx-log/->ingest-only-tx-log}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]

--- a/crux-core/src/crux/ingest_client.clj
+++ b/crux-core/src/crux/ingest_client.clj
@@ -40,7 +40,6 @@
   (let [system (-> (sys/prep-system (into [{:crux/ingest-client `->ingest-client
                                             :crux/bus 'crux.bus/->bus
                                             :crux/document-store 'crux.kv.document-store/->document-store
-                                            :crux/document-cache 'crux.cache.lru/->lru-cache
                                             :crux/tx-log 'crux.kv.tx-log/->ingest-only-tx-log}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]

--- a/crux-core/src/crux/kv/document_store.clj
+++ b/crux-core/src/crux/kv/document_store.clj
@@ -56,7 +56,7 @@
   (close [_]))
 
 (defn ->document-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                                    :document-cache :crux/document-cache}}
+                                    :document-cache 'crux.cache/->cache}}
   [{:keys [kv-store document-cache] :as opts}]
   (ds/->cached-document-store
    (assoc opts

--- a/crux-core/src/crux/kv/document_store.clj
+++ b/crux-core/src/crux/kv/document_store.clj
@@ -4,7 +4,7 @@
             [crux.document-store :as ds]
             [crux.memory :as mem]
             [crux.kv :as kv]
-            [crux.lru :as lru]
+            [crux.cache :as cache]
             [crux.system :as sys])
   (:import java.util.function.Supplier
            org.agrona.ExpandableDirectByteBuffer
@@ -57,5 +57,5 @@
 
 (defn ->document-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
                         ::sys/args {:doc-cache-size ds/doc-cache-size-opt}}
-  [{:keys [kv-store doc-cache-size]}]
-  (ds/->CachedDocumentStore (lru/new-cache doc-cache-size) (->KvDocumentStore kv-store)))
+  [{:keys [kv-store doc-cache-size] :as opts}]
+  (ds/->cached-document-store (assoc opts :document-store (->KvDocumentStore kv-store))))

--- a/crux-core/src/crux/kv/document_store.clj
+++ b/crux-core/src/crux/kv/document_store.clj
@@ -55,7 +55,10 @@
   Closeable
   (close [_]))
 
-(defn ->document-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
-                        ::sys/args {:doc-cache-size ds/doc-cache-size-opt}}
-  [{:keys [kv-store doc-cache-size] :as opts}]
-  (ds/->cached-document-store (assoc opts :document-store (->KvDocumentStore kv-store))))
+(defn ->document-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
+                                    :document-cache :crux/document-cache}}
+  [{:keys [kv-store document-cache] :as opts}]
+  (ds/->cached-document-store
+   (assoc opts
+          :document-cache document-cache
+          :document-store (->KvDocumentStore kv-store))))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -785,8 +785,8 @@
      :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
-(def ^:const default-value-cache-size (* 256 1024))
-(def ^:const default-cav-cache-size (* 256 1024))
+(def ^:const default-value-cache-size (* 64 1024))
+(def ^:const default-cav-cache-size (* 64 1024))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -787,9 +787,9 @@
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
                                     :value-cache {:crux/module 'crux.cache/->cache
-                                                  :cache-size (* 256 1024)}
+                                                  :cache-size (* 1024 1024)}
                                     :cav-cache {:crux/module 'crux.cache/->cache
-                                                :cache-size (* 256 1024)}}
+                                                :cache-size (* 1024 1024)}}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -787,9 +787,9 @@
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
                                     :value-cache {:crux/module 'crux.cache/->cache
-                                                  :cache-size (* 32 1024)}
+                                                  :cache-size (* 256 1024)}
                                     :cav-cache {:crux/module 'crux.cache/->cache
-                                                :cache-size (* 32 1024)}}
+                                                :cache-size (* 256 1024)}}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -785,20 +785,11 @@
      :crux.doc-log/consumer-state (db/read-index-meta this :crux.doc-log/consumer-state)
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
-(def ^:const default-value-cache-size (* 16 1024))
-(def ^:const default-cav-cache-size (* 16 1024))
-
-(defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}
+(defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
+                                    :value-cache :crux/value-cache
+                                    :cav-cache :crux/cav-cache}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
-                                                              :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}
-                                    :value-cache-size {:doc "Value Cache Size"
-                                                       :default default-value-cache-size
-                                                       :spec ::sys/nat-int}
-                                    :cav-cache-size {:doc "CAV Cache Size"
-                                                     :default default-cav-cache-size
-                                                     :spec ::sys/nat-int}}}
-  [{:keys [kv-store value-cache-size cav-cache-size] :as opts}]
+                                                              :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
+  [{:keys [kv-store value-cache cav-cache] :as opts}]
   (check-and-store-index-version opts)
-  (->KvIndexStore kv-store
-                  (cache/new-cache (or value-cache-size default-value-cache-size))
-                  (cache/new-cache (or cav-cache-size default-cav-cache-size))))
+  (->KvIndexStore kv-store value-cache cav-cache))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -786,8 +786,8 @@
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                                    :value-cache 'crux.cache.lru/->lru-cache
-                                    :cav-cache 'crux.cache.lru/->lru-cache}
+                                    :value-cache 'crux.cache/->cache
+                                    :cav-cache 'crux.cache/->cache}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -786,8 +786,8 @@
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                                    :value-cache :crux/value-cache
-                                    :cav-cache :crux/cav-cache}
+                                    :value-cache 'crux.cache.lru/->lru-cache
+                                    :cav-cache 'crux.cache.lru/->lru-cache}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -8,7 +8,6 @@
             [crux.db :as db]
             [crux.io :as cio]
             [crux.kv :as kv]
-            [crux.lru :as lru]
             [crux.query :as q]
             [crux.status :as status]
             [crux.query-state :as qs]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1433,7 +1433,7 @@
     (db/open-index-snapshot index-store)))
 
 (defn- with-entity-resolver-cache [entity-resolver-fn {:keys [entity-cache-size]}]
-  (let [entity-cache (cache/new-cache entity-cache-size)]
+  (let [entity-cache (cache/->cache {:cache-size entity-cache-size})]
     (fn [k]
       (cache/compute-if-absent entity-cache k mem/copy-to-unpooled-buffer entity-resolver-fn))))
 
@@ -1935,7 +1935,7 @@
                                                   :default true
                                                   :spec ::sys/boolean}
                                   :entity-cache-size {:doc "Query Entity Cache Size"
-                                                      :default 10000
+                                                      :default 10240
                                                       :spec ::sys/nat-int}
                                   :query-timeout {:doc "Query Timeout ms"
                                                   :default 30000
@@ -1945,7 +1945,7 @@
                                                :required? true
                                                :spec ::sys/pos-int}}}
   [{:keys [query-cache-size conform-cache-size projection-cache-size] :as opts}]
-  (map->QueryEngine (merge opts {:conform-cache (cache/new-cache conform-cache-size)
-                                 :query-cache (cache/new-cache query-cache-size)
-                                 :projection-cache (cache/new-cache projection-cache-size)
+  (map->QueryEngine (merge opts {:conform-cache (cache/->cache {:cache-size conform-cache-size})
+                                 :query-cache (cache/->cache {:cache-size query-cache-size})
+                                 :projection-cache (cache/->cache {:cache-size projection-cache-size})
                                  :interrupt-executor (Executors/newSingleThreadScheduledExecutor (cio/thread-factory "crux-query-interrupter"))})))

--- a/crux-core/src/crux/system.clj
+++ b/crux-core/src/crux/system.clj
@@ -253,6 +253,12 @@
 (s/def ::nat-int (s/and ::int nat-int?))
 (s/def ::pos-int (s/and ::int pos-int?))
 
+(s/def ::double
+  (s/and (s/conformer (fn [x] (cond (float? x) x, (string? x) (Double/parseDouble x), :else x)))
+         float?))
+
+(s/def ::pos-double (s/and ::double pos?))
+
 (s/def ::string-map (s/map-of string? string?))
 (s/def ::string-list (s/coll-of string?))
 

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -4,7 +4,7 @@
             [clojure.tools.logging :as log]
             [crux.error :as err]
             [crux.bus :as bus]
-            [crux.cache :as cache]
+            [crux.cache.nop :as nop-cache]
             [crux.codec :as c]
             [crux.db :as db]
             [crux.io :as cio]
@@ -365,19 +365,15 @@
                    :committed? false
                    ::txe/tx-events @!tx-events})))
 
-(def ^:private forked-cache-size 1024)
-
 (defrecord TxIngester [!error index-store document-store bus query-engine ^ExecutorService stats-executor]
   db/TxIngester
   (begin-tx [_ {:keys [fork-at], ::keys [tx-time] :as tx}]
     (log/debug "Indexing tx-id:" (::tx-id tx))
     (bus/send bus {:crux/event-type ::indexing-tx, ::submitted-tx tx})
 
-    (let [value-cache (or (:value-cache index-store) (cache/new-cache forked-cache-size))
-          cav-cache (or (:cav-cache index-store) (cache/new-cache forked-cache-size))
-          forked-index-store (fork/->forked-index-store index-store (kvi/->kv-index-store {:kv-store (mem-kv/->kv-store)
-                                                                                           :value-cache value-cache
-                                                                                           :cav-cache cav-cache})
+    (let [forked-index-store (fork/->forked-index-store index-store (kvi/->kv-index-store {:kv-store (mem-kv/->kv-store)
+                                                                                           :value-cache (nop-cache/->nop-cache {})
+                                                                                           :cav-cache (nop-cache/->nop-cache {})})
                                                         (::db/valid-time fork-at)
                                                         (::tx-time fork-at))
           forked-document-store (fork/->forked-document-store document-store)]

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -110,10 +110,13 @@
          (map (juxt (comp c/new-id c/hex->id-buffer :event_key) #(-> (:v %) (<-blob dialect))))
          (into {}))))
 
-(defn ->document-store {::sys/deps {:connection-pool `->connection-pool}
-                        ::sys/args {:doc-cache-size ds/doc-cache-size-opt}}
-  [{{:keys [pool dialect]} :connection-pool, :keys [doc-cache-size] :as opts}]
-  (ds/->cached-document-store (assoc opts :document-store (->JdbcDocumentStore pool dialect))))
+(defn ->document-store {::sys/deps {:connection-pool `->connection-pool
+                                    :document-cache :crux/document-cache}}
+  [{{:keys [pool dialect]} :connection-pool, :keys [document-cache] :as opts}]
+  (ds/->cached-document-store
+   (assoc opts
+          :document-cache document-cache
+          :document-store (->JdbcDocumentStore pool dialect))))
 
 (defrecord JdbcTxLog [pool dialect ^Closeable tx-consumer]
   db/TxLog

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -113,9 +113,8 @@
 
 (defn ->document-store {::sys/deps {:connection-pool `->connection-pool}
                         ::sys/args {:doc-cache-size ds/doc-cache-size-opt}}
-  [{{:keys [pool dialect]} :connection-pool, :keys [doc-cache-size]}]
-  (->> (->JdbcDocumentStore pool dialect)
-       (ds/->CachedDocumentStore (lru/new-cache doc-cache-size))))
+  [{{:keys [pool dialect]} :connection-pool, :keys [doc-cache-size] :as opts}]
+  (ds/->cached-document-store (assoc opts :document-store (->JdbcDocumentStore pool dialect))))
 
 (defrecord JdbcTxLog [pool dialect ^Closeable tx-consumer]
   db/TxLog

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -111,7 +111,7 @@
          (into {}))))
 
 (defn ->document-store {::sys/deps {:connection-pool `->connection-pool
-                                    :document-cache :crux/document-cache}}
+                                    :document-cache 'crux.cache/->cache}}
   [{{:keys [pool dialect]} :connection-pool, :keys [document-cache] :as opts}]
   (ds/->cached-document-store
    (assoc opts

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -5,7 +5,6 @@
             [crux.db :as db]
             [crux.document-store :as ds]
             [crux.io :as cio]
-            [crux.lru :as lru]
             [crux.system :as sys]
             [crux.tx :as tx]
             [next.jdbc :as jdbc]

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -118,13 +118,14 @@
                                              :doc "S3 bucket"}
                                     :prefix {:required? false,
                                              :spec ::prefix
-                                             :doc "S3 prefix"}
-                                    :doc-cache-size ds/doc-cache-size-opt}
-                        ::sys/deps {:configurator `->configurator}}
+                                             :doc "S3 prefix"}}
+                        ::sys/deps {:configurator `->configurator
+                                    :document-cache :crux/document-cache}}
 
-  [{:keys [bucket prefix ^S3Configurator configurator doc-cache-size] :as opts}]
+  [{:keys [bucket prefix ^S3Configurator configurator document-cache] :as opts}]
   (ds/->cached-document-store
    (assoc opts
+          :document-cache document-cache
           :document-store
           (->S3DocumentStore configurator
                              (.makeClient configurator)

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -1,7 +1,6 @@
 (ns crux.s3
   (:require [crux.db :as db]
             [crux.document-store :as ds]
-            [crux.lru :as lru]
             [crux.node :as n]
             [clojure.spec.alpha :as s]
             [taoensso.nippy :as nippy]

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -120,7 +120,7 @@
                                              :spec ::prefix
                                              :doc "S3 prefix"}}
                         ::sys/deps {:configurator `->configurator
-                                    :document-cache :crux/document-cache}}
+                                    :document-cache 'crux.cache/->cache}}
 
   [{:keys [bucket prefix ^S3Configurator configurator document-cache] :as opts}]
   (ds/->cached-document-store

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -123,9 +123,11 @@
                                     :doc-cache-size ds/doc-cache-size-opt}
                         ::sys/deps {:configurator `->configurator}}
 
-  [{:keys [bucket prefix ^S3Configurator configurator doc-cache-size]}]
-  (ds/->CachedDocumentStore (lru/new-cache doc-cache-size)
-                            (->S3DocumentStore configurator
-                                               (.makeClient configurator)
-                                               bucket
-                                               prefix)))
+  [{:keys [bucket prefix ^S3Configurator configurator doc-cache-size] :as opts}]
+  (ds/->cached-document-store
+   (assoc opts
+          :document-store
+          (->S3DocumentStore configurator
+                             (.makeClient configurator)
+                             bucket
+                             prefix))))

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (cache/new-cache kvi/default-value-cache-size) (cache/new-cache kvi/default-cav-cache-size))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (cache/new-cache 1024) (cache/new-cache 1024))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -3,9 +3,9 @@
             [clojure.test.check.clojure-test :as tcct]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
+            [crux.cache :as cache]
             [crux.codec :as c]
             [crux.db :as db]
-            [crux.lru :as lru]
             [crux.fixtures :as f]
             [crux.fixtures.kv :as fkv]
             [crux.kv.index-store :as kvi]
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (lru/new-cache kvi/default-value-cache-size) (lru/new-cache kvi/default-cav-cache-size))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (cache/new-cache kvi/default-value-cache-size) (cache/new-cache kvi/default-cav-cache-size))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -3,7 +3,7 @@
             [clojure.test.check.clojure-test :as tcct]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [crux.cache :as cache]
+            [crux.cache.nop :as nop-cache]
             [crux.codec :as c]
             [crux.db :as db]
             [crux.fixtures :as f]
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (cache/new-cache 1024) (cache/new-cache 1024))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
Moves crux.lru down to crux.cache.lru and adds crux.cache.ICache interface.
Turned most caches into nested components, which are possible to override one by one.

The query engine's smaller caches (for compiled queries etc.) now work like this and the configuration is nested.
These caches are highly unlikely that someone would tune.

The index store's caches are nested onto the index store. The document store cache is added as a nested component to each cached" document store. A further branch, `cached-doc-store-as-config` turns this around, and make the cached document store explicit in the config and removes it from the code. This is cleaner, but requires users to upgrade their config to not lose caching behaviour.

Will close #1153.