### PR TITLE
Second chance + canonical buffer caches (and other performance tweaks)

### DIFF
--- a/crux-bench/src/crux/bench/tpch_test.clj
+++ b/crux-bench/src/crux/bench/tpch_test.clj
@@ -583,4 +583,11 @@
   ;; SQL:
   (slurp (clojure.java.io/resource "io/airlift/tpch/queries/q1.sql"))
   ;; Results:
-  (slurp (clojure.java.io/resource "io/airlift/tpch/queries/q1.result")))
+  (slurp (clojure.java.io/resource "io/airlift/tpch/queries/q1.result"))
+
+  (let [node (user/crux-node)]
+    (time
+     (doseq [n (range 1 23)]
+       (time
+        (let [actual (crux.bench.tpch-test/run-tpch-query node n)]
+          (prn n (every? true? (crux.bench.tpch-test/validate-tpch-query actual (crux.bench.tpch-test/parse-tpch-result n))))))))))

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -13,5 +13,5 @@
   {::sys/args {:cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
-  [opts]
+  ^crux.cache.ICache [opts]
   (crux.cache.second-chance/->second-chance-cache opts))

--- a/crux-core/src/crux/cache.clj
+++ b/crux-core/src/crux/cache.clj
@@ -1,5 +1,5 @@
 (ns ^:no-doc crux.cache
-  (:require [crux.cache.lru :as lru]
+  (:require [crux.cache.second-chance]
             [crux.system :as sys])
   (:import crux.cache.ICache))
 
@@ -14,4 +14,4 @@
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
   [opts]
-  (lru/->lru-cache opts))
+  (crux.cache.second-chance/->second-chance-cache opts))

--- a/crux-core/src/crux/cache/ICache.java
+++ b/crux-core/src/crux/cache/ICache.java
@@ -9,5 +9,4 @@ import clojure.lang.ILookup;
 public interface ICache<K, V> extends Closeable, Counted, ILookup {
     public V computeIfAbsent(K key, IFn storedKeyFn, IFn f);
     public void evict(K key);
-    public Set<K> keySet();
 }

--- a/crux-core/src/crux/cache/ICache.java
+++ b/crux-core/src/crux/cache/ICache.java
@@ -1,6 +1,7 @@
 package crux.cache;
 
 import java.io.Closeable;
+import java.util.Set;
 import clojure.lang.Counted;
 import clojure.lang.IFn;
 import clojure.lang.ILookup;
@@ -8,4 +9,5 @@ import clojure.lang.ILookup;
 public interface ICache<K, V> extends Closeable, Counted, ILookup {
     public V computeIfAbsent(K key, IFn storedKeyFn, IFn f);
     public void evict(K key);
+    public Set<K> keySet();
 }

--- a/crux-core/src/crux/cache/ICache.java
+++ b/crux-core/src/crux/cache/ICache.java
@@ -1,7 +1,6 @@
 package crux.cache;
 
 import java.io.Closeable;
-import java.util.Set;
 import clojure.lang.Counted;
 import clojure.lang.IFn;
 import clojure.lang.ILookup;

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -49,7 +49,8 @@
   {::sys/args {:cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
-  ^crux.cache.ICache [{:keys [^long cache-size]}]
+  ^crux.cache.ICache [{:keys [^long cache-size]
+                       :or {cache-size (* 128 1024)}}]
   (let [cache (proxy [LinkedHashMap] [cache-size 0.75 true]
                 (removeEldestEntry [_]
                   (> (.size ^Map this) cache-size)))

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -4,7 +4,7 @@
   (:import crux.cache.ICache
            java.util.concurrent.locks.StampedLock
            java.util.function.Function
-           [java.util LinkedHashMap Map]))
+           [java.util Collections LinkedHashMap Map]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -30,6 +30,10 @@
     (cio/with-write-lock lock
       (.remove cache k)))
 
+  (keySet [_]
+    (cio/with-write-lock lock
+      (Collections/unmodifiableSet (.keySet cache))))
+
   (valAt [_ k]
     (cio/with-write-lock lock
       (.get cache k)))
@@ -49,7 +53,7 @@
   {::sys/args {:cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
-  [{:keys [^long cache-size]}]
+  ^crux.cache.ICache [{:keys [^long cache-size]}]
   (let [cache (proxy [LinkedHashMap] [cache-size 0.75 true]
                 (removeEldestEntry [_]
                   (> (.size ^Map this) cache-size)))

--- a/crux-core/src/crux/cache/lru.clj
+++ b/crux-core/src/crux/cache/lru.clj
@@ -4,7 +4,7 @@
   (:import crux.cache.ICache
            java.util.concurrent.locks.StampedLock
            java.util.function.Function
-           [java.util Collections LinkedHashMap Map]))
+           [java.util LinkedHashMap Map]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -29,10 +29,6 @@
   (evict [_ k]
     (cio/with-write-lock lock
       (.remove cache k)))
-
-  (keySet [_]
-    (cio/with-write-lock lock
-      (Collections/unmodifiableSet (.keySet cache))))
 
   (valAt [_ k]
     (cio/with-write-lock lock

--- a/crux-core/src/crux/cache/nop.clj
+++ b/crux-core/src/crux/cache/nop.clj
@@ -1,6 +1,7 @@
 (ns ^:no-doc crux.cache.nop
   (:require [crux.system :as sys])
-  (:import crux.cache.ICache))
+  (:import crux.cache.ICache
+           java.util.Collections))
 
 (defn new-nop-cache
   ([] (new-nop-cache 0))
@@ -11,6 +12,9 @@
        (f k))
 
      (evict [_ k])
+
+     (keySet [_]
+       (Collections/emptySet))
 
      (valAt [_ k])
 
@@ -24,5 +28,5 @@
   {::sys/args {:cache-size {:doc "Cache size"
                             :default 0
                             :spec ::sys/nat-int}}}
-  [{:keys [cache-size]}]
+  ^crux.cache.ICache [{:keys [cache-size]}]
   (new-nop-cache))

--- a/crux-core/src/crux/cache/nop.clj
+++ b/crux-core/src/crux/cache/nop.clj
@@ -14,9 +14,6 @@
 
   (evict [_ k])
 
-  (keySet [_]
-    (Collections/emptySet))
-
   (valAt [_ k])
 
   (valAt [_ k default]

--- a/crux-core/src/crux/cache/nop.clj
+++ b/crux-core/src/crux/cache/nop.clj
@@ -3,30 +3,32 @@
   (:import crux.cache.ICache
            java.util.Collections))
 
-(defn new-nop-cache
-  ([] (new-nop-cache 0))
-  ([size]
-   (reify
-     ICache
-     (computeIfAbsent [this k stored-key-fn f]
-       (f k))
+(deftype NopCache []
+  Object
+  (toString [_]
+    (str (Collections/emptyMap)))
 
-     (evict [_ k])
+  ICache
+  (computeIfAbsent [this k stored-key-fn f]
+    (f k))
 
-     (keySet [_]
-       (Collections/emptySet))
+  (evict [_ k])
 
-     (valAt [_ k])
+  (keySet [_]
+    (Collections/emptySet))
 
-     (valAt [_ k default] default)
+  (valAt [_ k])
 
-     (count [_] 0)
+  (valAt [_ k default]
+    default)
 
-     (close [_]))))
+  (count [_] 0)
+
+  (close [_]))
 
 (defn ->nop-cache
   {::sys/args {:cache-size {:doc "Cache size"
                             :default 0
                             :spec ::sys/nat-int}}}
   ^crux.cache.ICache [{:keys [cache-size]}]
-  (new-nop-cache))
+  (->NopCache))

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -80,8 +80,11 @@
 (defn- free-memory-loop []
   (try
     (while true
-      (.set free-memory-ratio (double (/ (.freeMemory (Runtime/getRuntime))
-                                         (.totalMemory (Runtime/getRuntime)))))
+      (let [max-memory (.maxMemory (Runtime/getRuntime))
+            used-memory (- (.totalMemory (Runtime/getRuntime))
+                           (.freeMemory (Runtime/getRuntime)))
+            free-memory (- max-memory used-memory)]
+        (.set free-memory-ratio (double (/ free-memory max-memory))))
       (Thread/sleep 5000))
     (catch InterruptedException _)))
 

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -1,7 +1,6 @@
 (ns crux.cache.second-chance
   (:import crux.cache.ICache
            crux.cache.second_chance.ValuePointer
-           java.lang.reflect.Field
            java.util.function.Function
            [java.util Map$Entry Queue]
            [java.util.concurrent ArrayBlockingQueue ConcurrentHashMap])
@@ -9,13 +8,9 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(def ^:private ^Field concurrent-map-table-field
-  (doto (.getDeclaredField ConcurrentHashMap "table")
-    (.setAccessible true)))
-
 (defn- random-entry ^java.util.Map$Entry [^ConcurrentHashMap m]
   (when-not (.isEmpty m)
-    (let [table ^objects (.get concurrent-map-table-field m)]
+    (let [table (ValuePointer/getConcurrentHashMapTable m)]
       (loop [i (long (rand-int (alength table)))]
         (if-let [^Map$Entry e (aget table i)]
           e

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -76,6 +76,7 @@
             (.unswizzle vp (.getKey e))))))))
 
 (def ^:private ^AtomicReference free-memory-ratio (AtomicReference. 1.0))
+(def ^:private ^:const free-memory-check-interval-ms 1000)
 
 (defn- free-memory-loop []
   (try
@@ -85,7 +86,7 @@
                            (.freeMemory (Runtime/getRuntime)))
             free-memory (- max-memory used-memory)]
         (.set free-memory-ratio (double (/ free-memory max-memory))))
-      (Thread/sleep 5000))
+      (Thread/sleep free-memory-check-interval-ms))
     (catch InterruptedException _)))
 
 (def ^:private ^Thread free-memory-thread
@@ -126,14 +127,14 @@
                                   :default true
                                   :spec ::sys/boolean}
                :adaptive-break-even-level {:doc "Adaptive break even memory usage level"
-                                           :default 0.95
+                                           :default 0.8
                                            :spec ::sys/pos-double}}}
   ^crux.cache.ICache [{:keys [^long cache-size ^double cooling-factor cold-cache
                               adaptive-sizing? adaptive-break-even-level]
                        :or {cache-size  (* 128 1024)
                             adaptive-sizing? true
                             cooling-factor 0.1
-                            adaptive-break-even-level 0.95}
+                            adaptive-break-even-level 0.8}
                        :as opts}]
   (let [hot (ConcurrentHashMap. cache-size)
         cooling (LinkedBlockingQueue.)

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -34,18 +34,19 @@
                                (let [k (stored-key-fn k)
                                      v (if-some [v (.valAt cold k)]
                                          v
-                                         (f k))
-                                     vp (.computeIfAbsent hot k (reify Function
-                                                                  (apply [_ k]
-                                                                    (ValuePointer. v))))]
-                                 (resize-cache this)
-                                 vp))]
-      (.swizzle vp)))
+                                         (f k))]
+                                 (.computeIfAbsent hot k (reify Function
+                                                           (apply [_ k]
+                                                             (ValuePointer. v))))))
+          v (.swizzle vp)]
+      (resize-cache this)
+      v))
 
-  (evict [_ k]
+  (evict [this k]
     (.evict cold k)
     (when-let [vp ^ValuePointer (.remove hot k)]
-      (.swizzle vp)))
+      (.swizzle vp))
+    (resize-cache this))
 
   (valAt [_ k]
     (when-let [vp ^ValuePointer (.get hot k)]

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -2,7 +2,7 @@
   (:import crux.cache.ICache
            [crux.cache.second_chance ConcurrentHashMapTableAccess ValuePointer]
            java.util.function.Function
-           [java.util Collections Map$Entry Queue]
+           [java.util Map$Entry Queue]
            [java.util.concurrent ArrayBlockingQueue ConcurrentHashMap])
   (:require [crux.system :as sys]
             [crux.cache.nop]))
@@ -44,9 +44,6 @@
     (.evict cold k)
     (when-let [vp ^ValuePointer (.remove hot k)]
       (.swizzle vp)))
-
-  (keySet [_]
-    (Collections/unmodifiableSet (.keySet hot)))
 
   (valAt [_ k]
     (when-let [vp ^ValuePointer (.get hot k)]

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -1,4 +1,4 @@
-(ns crux.cache.second-chance
+(ns ^:no-doc crux.cache.second-chance
   (:import crux.cache.ICache
            [crux.cache.second_chance ConcurrentHashMapTableAccess ValuePointer]
            java.util.function.Function

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -2,7 +2,7 @@
   (:import crux.cache.ICache
            [crux.cache.second_chance ConcurrentHashMapTableAccess ValuePointer]
            java.util.function.Function
-           [java.util Map$Entry Queue]
+           [java.util Collections Map$Entry Queue]
            [java.util.concurrent ArrayBlockingQueue ConcurrentHashMap])
   (:require [crux.system :as sys]))
 
@@ -40,6 +40,9 @@
   (evict [_ k]
     (when-let [vp ^ValuePointer (.remove hot k)]
       (.swizzle vp)))
+
+  (keySet [_]
+    (Collections/unmodifiableSet (.keySet hot)))
 
   (valAt [_ k]
     (when-let [vp ^ValuePointer (.get hot k)]
@@ -85,7 +88,7 @@
                :cooling-factor {:doc "Cooling factor"
                                 :default 0.1
                                 :spec ::sys/pos-double}}}
-  [{:keys [^long cache-size ^double cooling-factor]}]
+  ^crux.cache.ICache [{:keys [^long cache-size ^double cooling-factor]}]
   (let [hot (ConcurrentHashMap. cache-size)
         cooling-factor (or cooling-factor 0.1)
         cooling (ArrayBlockingQueue. (inc (long (Math/ceil (* cooling-factor cache-size)))))]

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -27,11 +27,12 @@
   (computeIfAbsent [this k stored-key-fn f]
     (let [^ValuePointer vp (or (.get hot k)
                                (let [k (stored-key-fn k)
-                                     v (f k)]
-                                 (.computeIfAbsent hot k (reify Function
-                                                           (apply [_ k]
-                                                             (ValuePointer. v))))))]
-      (resize-cache this)
+                                     v (f k)
+                                     vp (.computeIfAbsent hot k (reify Function
+                                                                  (apply [_ k]
+                                                                    (ValuePointer. v))))]
+                                 (resize-cache this)
+                                 vp))]
       (set! (.coldKey vp) nil)
       (.value vp)))
 

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -4,7 +4,8 @@
            java.util.function.Function
            [java.util Collections Map$Entry Queue]
            [java.util.concurrent ArrayBlockingQueue ConcurrentHashMap])
-  (:require [crux.system :as sys]))
+  (:require [crux.system :as sys]
+            [crux.cache.nop]))
 
 ;; Adapted from https://db.in.tum.de/~leis/papers/leanstore.pdf
 
@@ -20,16 +21,18 @@
 
 (declare resize-cache)
 
-(deftype SecondChanceCache [^ConcurrentHashMap hot ^Queue cooling ^double cooling-factor ^long size]
+(deftype SecondChanceCache [^ConcurrentHashMap hot ^Queue cooling ^double cooling-factor ^ICache cold ^long size]
   Object
   (toString [_]
-    (str hot " " cooling))
+    (str hot))
 
   ICache
   (computeIfAbsent [this k stored-key-fn f]
     (let [^ValuePointer vp (or (.get hot k)
                                (let [k (stored-key-fn k)
-                                     v (f k)
+                                     v (if-some [v (.valAt cold k)]
+                                         v
+                                         (f k))
                                      vp (.computeIfAbsent hot k (reify Function
                                                                   (apply [_ k]
                                                                     (ValuePointer. v))))]
@@ -38,6 +41,7 @@
       (.swizzle vp)))
 
   (evict [_ k]
+    (.evict cold k)
     (when-let [vp ^ValuePointer (.remove hot k)]
       (.swizzle vp)))
 
@@ -73,23 +77,27 @@
 
 (defn- resize-cache [^SecondChanceCache cache]
   (let [hot ^ConcurrentHashMap (.hot cache)
-        cooling ^Queue (.cooling cache)]
+        cooling ^Queue (.cooling cache)
+        cold ^ICache (.cold cache)]
     (move-to-cooling-state cache)
     (while (> (.size hot) (.size cache))
       (when-let [vp ^ValuePointer (.poll cooling)]
         (when-some [k (.getKey vp)]
-          (.remove hot k)))
+          (.remove hot k)
+          (.computeIfAbsent cold k identity (constantly (.swizzle vp)))))
       (move-to-cooling-state cache))))
 
 (defn ->second-chance-cache
-  {::sys/args {:cache-size {:doc "Cache size"
+  {::sys/deps {:cold-cache 'crux.cache.nop/->nop-cache}
+   ::sys/args {:cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}
                :cooling-factor {:doc "Cooling factor"
                                 :default 0.1
                                 :spec ::sys/pos-double}}}
-  ^crux.cache.ICache [{:keys [^long cache-size ^double cooling-factor]}]
+  ^crux.cache.ICache [{:keys [^long cache-size ^double cooling-factor cold-cache] :as opts}]
   (let [hot (ConcurrentHashMap. cache-size)
         cooling-factor (or cooling-factor 0.1)
-        cooling (ArrayBlockingQueue. (inc (long (Math/ceil (* cooling-factor cache-size)))))]
-    (->SecondChanceCache hot cooling cooling-factor cache-size)))
+        cooling (ArrayBlockingQueue. (inc (long (Math/ceil (* cooling-factor cache-size)))))
+        cold (or cold-cache (crux.cache.nop/->nop-cache opts))]
+    (->SecondChanceCache hot cooling cooling-factor cold cache-size)))

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -126,12 +126,15 @@
                                            :default 0.95
                                            :spec ::sys/pos-double}}}
   ^crux.cache.ICache [{:keys [^long cache-size ^double cooling-factor cold-cache
-                              adaptive-sizing? adaptive-break-even-level] :as opts}]
+                              adaptive-sizing? adaptive-break-even-level]
+                       :or {cache-size  (* 128 1024)
+                            adaptive-sizing? true
+                            cooling-factor 0.1
+                            adaptive-break-even-level 0.95}
+                       :as opts}]
   (let [hot (ConcurrentHashMap. cache-size)
-        cooling-factor (or cooling-factor 0.1)
         cooling (LinkedBlockingQueue.)
-        cold (or cold-cache (crux.cache.nop/->nop-cache opts))
-        adaptive-break-even-level (or adaptive-break-even-level 0.95)]
+        cold (or cold-cache (crux.cache.nop/->nop-cache opts))]
     (when adaptive-sizing?
       (locking free-memory-thread
         (when-not (.isAlive free-memory-thread)

--- a/crux-core/src/crux/cache/second_chance/ConcurrentHashMapTableAccess.java
+++ b/crux-core/src/crux/cache/second_chance/ConcurrentHashMapTableAccess.java
@@ -1,0 +1,26 @@
+package crux.cache.second_chance;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ConcurrentHashMapTableAccess {
+    private static final MethodHandle TABLE_FIELD_METHOD_HANDLE;
+
+    static {
+        try {
+            Field tableField = ConcurrentHashMap.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            MethodHandle mh = MethodHandles.lookup().unreflectGetter(tableField);
+            TABLE_FIELD_METHOD_HANDLE = mh.asType(mh.type().changeReturnType(Object[].class));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static final <K, V> Object[] getConcurrentHashMapTable(final ConcurrentHashMap<K, V> map) throws Throwable {
+        return (Object[]) TABLE_FIELD_METHOD_HANDLE.invokeExact(map);
+    }
+}

--- a/crux-core/src/crux/cache/second_chance/ValuePointer.java
+++ b/crux-core/src/crux/cache/second_chance/ValuePointer.java
@@ -1,0 +1,10 @@
+package crux.cache.second_chance;
+
+public final class ValuePointer<K, V> {
+    public K coldKey;
+    public final V value;
+
+    public ValuePointer(V value) {
+        this.value = value;
+    }
+}

--- a/crux-core/src/crux/cache/second_chance/ValuePointer.java
+++ b/crux-core/src/crux/cache/second_chance/ValuePointer.java
@@ -12,6 +12,10 @@ public final class ValuePointer<K, V> {
         return this.coolingKey;
     }
 
+    public final V getValue() {
+        return this.value;
+    }
+
     public final V swizzle() {
         this.coolingKey = null;
         return this.value;

--- a/crux-core/src/crux/cache/second_chance/ValuePointer.java
+++ b/crux-core/src/crux/cache/second_chance/ValuePointer.java
@@ -1,10 +1,36 @@
 package crux.cache.second_chance;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+
+import java.util.concurrent.ConcurrentHashMap;
+
 public final class ValuePointer<K, V> {
+    private static final MethodHandle TABLE_FIELD_METHOD_HANDLE;
+
+    static {
+        try {
+            Field tableField = ConcurrentHashMap.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            TABLE_FIELD_METHOD_HANDLE = MethodHandles.lookup().unreflectGetter(tableField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static final <K, V> Object[] getConcurrentHashMapTable(final ConcurrentHashMap<K, V> map) {
+        try {
+            return (Object[]) TABLE_FIELD_METHOD_HANDLE.invoke(map);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
     public K coldKey;
     public final V value;
 
-    public ValuePointer(V value) {
+    public ValuePointer(final V value) {
         this.value = value;
     }
 }

--- a/crux-core/src/crux/cache/second_chance/ValuePointer.java
+++ b/crux-core/src/crux/cache/second_chance/ValuePointer.java
@@ -1,37 +1,27 @@
 package crux.cache.second_chance;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
-
-import java.util.concurrent.ConcurrentHashMap;
-
 public final class ValuePointer<K, V> {
-    private static final MethodHandle TABLE_FIELD_METHOD_HANDLE;
-
-    static {
-        try {
-            Field tableField = ConcurrentHashMap.class.getDeclaredField("table");
-            tableField.setAccessible(true);
-            MethodHandle mh = MethodHandles.lookup().unreflectGetter(tableField);
-            TABLE_FIELD_METHOD_HANDLE = mh.asType(mh.type().changeReturnType(Object[].class));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static final <K, V> Object[] getConcurrentHashMapTable(final ConcurrentHashMap<K, V> map) {
-        try {
-            return (Object[]) TABLE_FIELD_METHOD_HANDLE.invokeExact(map);
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
-        }
-    }
-
-    public K coldKey;
-    public final V value;
+    private K coolingKey;
+    private final V value;
 
     public ValuePointer(final V value) {
         this.value = value;
+    }
+
+    public final K getKey() {
+        return this.coolingKey;
+    }
+
+    public final V swizzle() {
+        this.coolingKey = null;
+        return this.value;
+    }
+
+    public final void unswizzle(K key) {
+        this.coolingKey = key;
+    }
+
+    public final boolean isSwizzled() {
+        return this.coolingKey == null;
     }
 }

--- a/crux-core/src/crux/cache/second_chance/ValuePointer.java
+++ b/crux-core/src/crux/cache/second_chance/ValuePointer.java
@@ -13,7 +13,8 @@ public final class ValuePointer<K, V> {
         try {
             Field tableField = ConcurrentHashMap.class.getDeclaredField("table");
             tableField.setAccessible(true);
-            TABLE_FIELD_METHOD_HANDLE = MethodHandles.lookup().unreflectGetter(tableField);
+            MethodHandle mh = MethodHandles.lookup().unreflectGetter(tableField);
+            TABLE_FIELD_METHOD_HANDLE = mh.asType(mh.type().changeReturnType(Object[].class));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -21,7 +22,7 @@ public final class ValuePointer<K, V> {
 
     public static final <K, V> Object[] getConcurrentHashMapTable(final ConcurrentHashMap<K, V> map) {
         try {
-            return (Object[]) TABLE_FIELD_METHOD_HANDLE.invoke(map);
+            return (Object[]) TABLE_FIELD_METHOD_HANDLE.invokeExact(map);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }

--- a/crux-core/src/crux/cache/soft_values.clj
+++ b/crux-core/src/crux/cache/soft_values.clj
@@ -1,0 +1,66 @@
+(ns ^:no-doc crux.cache.soft-values
+  (:require [crux.system :as sys])
+  (:import crux.cache.ICache
+           crux.cache.soft_values.SoftReferenceWithKey
+           [java.lang.ref Reference ReferenceQueue]
+           java.util.function.Function
+           [java.util Collections Map]
+           java.util.concurrent.ConcurrentHashMap))
+
+(declare cleanup-cache)
+
+(defn- get-or-remove-reference [^Map cache ^SoftReferenceWithKey v-ref]
+  (when v-ref
+    (if-some [v (.get ^Reference v-ref)]
+      v
+      (do (.remove cache (.key v-ref))
+          nil))))
+
+(deftype SoftReferenceCache [^Map cache ^ReferenceQueue reference-queue]
+  Object
+  (toString [_]
+    (str cache))
+
+  ICache
+  (computeIfAbsent [this k stored-key-fn f]
+    (or (get-or-remove-reference cache (.get cache k))
+        (let [k (stored-key-fn k)
+              v (f k)
+              v-ref (.computeIfAbsent cache k (reify Function
+                                                (apply [_ k]
+                                                  (SoftReferenceWithKey. k v reference-queue))))]
+          (cleanup-cache this)
+          v)))
+
+  (evict [_ k]
+    (.remove cache k))
+
+  (keySet [_]
+    (Collections/unmodifiableSet (.keySet cache)))
+
+  (valAt [_ k]
+    (get-or-remove-reference cache (.get cache k)))
+
+  (valAt [_ k default]
+    (let [v-ref (.getOrDefault cache k default)]
+      (if (= default v-ref)
+        v-ref
+        (get-or-remove-reference cache v-ref))))
+
+  (count [_]
+    (.size cache))
+
+  (close [_]
+    (.clear cache)))
+
+(defn- cleanup-cache [^SoftReferenceCache cache]
+  (when-let [v-ref (.poll ^ReferenceQueue (.reference_queue cache))]
+    (.remove ^Map (.cache cache) (.key ^SoftReferenceWithKey v-ref))
+    (recur cache)))
+
+(defn ->soft-values-cache
+  {::sys/args {:cache-size {:doc "Initial cache size"
+                            :default (* 128 1024)
+                            :spec ::sys/nat-int}}}
+  ^crux.cache.ICache [{:keys [^long cache-size cleanup-frequency]}]
+  (->SoftReferenceCache (ConcurrentHashMap. cache-size) (ReferenceQueue.)))

--- a/crux-core/src/crux/cache/soft_values.clj
+++ b/crux-core/src/crux/cache/soft_values.clj
@@ -4,7 +4,7 @@
            crux.cache.soft_values.SoftReferenceWithKey
            [java.lang.ref Reference ReferenceQueue]
            java.util.function.Function
-           [java.util Collections Map]
+           java.util.Map
            java.util.concurrent.ConcurrentHashMap))
 
 (declare cleanup-cache)
@@ -34,9 +34,6 @@
 
   (evict [_ k]
     (.remove cache k))
-
-  (keySet [_]
-    (Collections/unmodifiableSet (.keySet cache)))
 
   (valAt [_ k]
     (get-or-remove-reference cache (.get cache k)))

--- a/crux-core/src/crux/cache/soft_values.clj
+++ b/crux-core/src/crux/cache/soft_values.clj
@@ -16,7 +16,7 @@
       (do (.remove cache (.key v-ref) v-ref)
           nil))))
 
-(deftype SoftReferenceCache [^Map cache ^ReferenceQueue reference-queue]
+(deftype SoftValuesCache [^Map cache ^ReferenceQueue reference-queue]
   Object
   (toString [_]
     (str cache))
@@ -50,7 +50,7 @@
   (close [_]
     (.clear cache)))
 
-(defn- cleanup-cache [^SoftReferenceCache cache]
+(defn- cleanup-cache [^SoftValuesCache cache]
   (when-let [v-ref (.poll ^ReferenceQueue (.reference_queue cache))]
     (.remove ^Map (.cache cache) (.key ^SoftReferenceWithKey v-ref) v-ref)
     (recur cache)))
@@ -60,4 +60,4 @@
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
   ^crux.cache.ICache [{:keys [^long cache-size cleanup-frequency]}]
-  (->SoftReferenceCache (ConcurrentHashMap. cache-size) (ReferenceQueue.)))
+  (->SoftValuesCache (ConcurrentHashMap. cache-size) (ReferenceQueue.)))

--- a/crux-core/src/crux/cache/soft_values.clj
+++ b/crux-core/src/crux/cache/soft_values.clj
@@ -59,5 +59,6 @@
   {::sys/args {:cache-size {:doc "Initial cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
-  ^crux.cache.ICache [{:keys [^long cache-size cleanup-frequency]}]
+  ^crux.cache.ICache [{:keys [^long cache-size]
+                       :or {cache-size (* 128 1024)}}]
   (->SoftValuesCache (ConcurrentHashMap. cache-size) (ReferenceQueue.)))

--- a/crux-core/src/crux/cache/soft_values.clj
+++ b/crux-core/src/crux/cache/soft_values.clj
@@ -13,7 +13,7 @@
   (when v-ref
     (if-some [v (.get ^Reference v-ref)]
       v
-      (do (.remove cache (.key v-ref))
+      (do (.remove cache (.key v-ref) v-ref)
           nil))))
 
 (deftype SoftReferenceCache [^Map cache ^ReferenceQueue reference-queue]
@@ -55,7 +55,7 @@
 
 (defn- cleanup-cache [^SoftReferenceCache cache]
   (when-let [v-ref (.poll ^ReferenceQueue (.reference_queue cache))]
-    (.remove ^Map (.cache cache) (.key ^SoftReferenceWithKey v-ref))
+    (.remove ^Map (.cache cache) (.key ^SoftReferenceWithKey v-ref) v-ref)
     (recur cache)))
 
 (defn ->soft-values-cache

--- a/crux-core/src/crux/cache/soft_values/SoftReferenceWithKey.java
+++ b/crux-core/src/crux/cache/soft_values/SoftReferenceWithKey.java
@@ -1,0 +1,18 @@
+package crux.cache.soft_values;
+
+import java.lang.ref.SoftReference;
+import java.lang.ref.ReferenceQueue;
+
+public final class SoftReferenceWithKey<K, V> extends SoftReference<V> {
+    public final K key;
+
+    public SoftReferenceWithKey(K key, V referent, ReferenceQueue<V> referenceQueue) {
+        super(referent, referenceQueue);
+        this.key = key;
+    }
+
+    public SoftReferenceWithKey(K key, V referent) {
+        super(referent);
+        this.key = key;
+    }
+}

--- a/crux-core/src/crux/hash.clj
+++ b/crux-core/src/crux/hash.clj
@@ -32,12 +32,14 @@
     (catch ClassNotFoundException e
       false)))
 
+(defn byte-utils-id-hash-buffer [to buffer]
+  (ByteUtils/sha1 to buffer))
+
 (defn- init-id-hash []
   (if (and (= "SHA1" id-hash-algorithm)
            byte-utils-sha1-enabled?)
     (do (log/debug "Using ByteUtils/sha1 for ID hashing.")
-        (fn byte-utils-id-hash-buffer [to from]
-          (ByteUtils/sha1 to from)))
+        byte-utils-id-hash-buffer)
     (if-let [openssl-id-hash-buffer (and openssl-enabled?
                                          (jnr-available?)
                                          (some-> 'crux.hash.jnr/openssl-id-hash-buffer requiring-resolve var-get))]
@@ -56,7 +58,17 @@
 (defn- lazy-id-hash [to buffer]
   (locking #'lazy-id-hash
     (when (= id-hash lazy-id-hash)
-      (alter-var-root #'id-hash (fn [_] (init-id-hash))))
+      (alter-var-root #'id-hash (fn [_] (let [f (init-id-hash)
+                                              on-heap-f (if (= "SHA1" id-hash-algorithm)
+                                                          byte-utils-id-hash-buffer
+                                                          message-digest-id-hash-buffer)]
+                                          (if (or (= message-digest-id-hash-buffer f)
+                                                  (= byte-utils-id-hash-buffer f))
+                                            f
+                                            (fn [to buffer]
+                                              (if (mem/off-heap? buffer)
+                                                (f to buffer)
+                                                (on-heap-f to buffer))))))))
     (id-hash to buffer)))
 
 (def id-hash lazy-id-hash)

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -784,10 +784,12 @@
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                                    :value-cache {:crux/module 'crux.cache/->cache
-                                                  :cache-size (* 256 1024)}
-                                    :cav-cache {:crux/module 'crux.cache/->cache
-                                                :cache-size (* 1024 1024)}}
+                                    :value-cache {:crux/module 'crux.cache.second-chance/->second-chance-cache
+                                                  :cache-size (* 128 1024)
+                                                  :cold-cache 'crux.cache.soft-values/->soft-values-cache}
+                                    :cav-cache {:crux/module 'crux.cache.second-chance/->second-chance-cache
+                                                :cache-size (* 128 1024)
+                                                :cold-cache 'crux.cache.soft-values/->soft-values-cache}}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -785,7 +785,7 @@
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
                                     :value-cache {:crux/module 'crux.cache/->cache
-                                                  :cache-size (* 1024 1024)}
+                                                  :cache-size (* 256 1024)}
                                     :cav-cache {:crux/module 'crux.cache/->cache
                                                 :cache-size (* 1024 1024)}}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -796,9 +796,8 @@
      :crux.tx-log/consumer-state (db/read-index-meta this :crux.tx-log/consumer-state)}))
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                                    :value-cache 'crux.cache.second-chance/->second-chance-cache
-                                    :cav-cache {:crux/module 'crux.cache.second-chance/->second-chance-cache
-                                                :cache-size (* 256 1024)}
+                                    :value-cache 'crux.cache/->cache
+                                    :cav-cache 'crux.cache/->cache
                                     :canonical-buffer-cache 'crux.cache.soft-values/->soft-values-cache}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -785,11 +785,9 @@
 
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
                                     :value-cache {:crux/module 'crux.cache.second-chance/->second-chance-cache
-                                                  :cache-size (* 128 1024)
-                                                  :cold-cache 'crux.cache.soft-values/->soft-values-cache}
+                                                  :cache-size (* 128 1024)}
                                     :cav-cache {:crux/module 'crux.cache.second-chance/->second-chance-cache
-                                                :cache-size (* 128 1024)
-                                                :cold-cache 'crux.cache.soft-values/->soft-values-cache}}
+                                                :cache-size (* 256 1024)}}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache] :as opts}]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -798,7 +798,7 @@
 (defn ->kv-index-store {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
                                     :value-cache 'crux.cache/->cache
                                     :cav-cache 'crux.cache/->cache
-                                    :canonical-buffer-cache 'crux.cache.soft-values/->soft-values-cache}
+                                    :canonical-buffer-cache 'crux.cache/->cache}
                         ::sys/args {:skip-index-version-bump {:spec (s/tuple int? int?)
                                                               :doc "Skip an index version bump. For example, to skip from v10 to v11, specify [10 11]"}}}
   [{:keys [kv-store value-cache cav-cache canonical-buffer-cache] :as opts}]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1929,7 +1929,7 @@
                                   :projection-cache {:crux/module 'crux.cache/->cache
                                                      :cache-size 10240}}
                       ::sys/args {:entity-cache-size {:doc "Query Entity Cache Size"
-                                                      :default 10240
+                                                      :default (* 128 1024)
                                                       :spec ::sys/nat-int}
                                   :query-timeout {:doc "Query Timeout ms"
                                                   :default 30000

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1929,7 +1929,7 @@
                                   :projection-cache {:crux/module 'crux.cache/->cache
                                                      :cache-size 10240}}
                       ::sys/args {:entity-cache-size {:doc "Query Entity Cache Size"
-                                                      :default (* 128 1024)
+                                                      :default (* 32 1024)
                                                       :spec ::sys/nat-int}
                                   :query-timeout {:doc "Query Timeout ms"
                                                   :default 30000

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -373,7 +373,8 @@
 
     (let [forked-index-store (fork/->forked-index-store index-store (kvi/->kv-index-store {:kv-store (mem-kv/->kv-store)
                                                                                            :value-cache (nop-cache/->nop-cache {})
-                                                                                           :cav-cache (nop-cache/->nop-cache {})})
+                                                                                           :cav-cache (nop-cache/->nop-cache {})
+                                                                                           :canonical-buffer-cache (nop-cache/->nop-cache {})})
                                                         (::db/valid-time fork-at)
                                                         (::tx-time fork-at))
           forked-document-store (fork/->forked-document-store document-store)]

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -19,7 +19,7 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}))]
+     (binding [*index-store* (kvi/->KvIndexStore kv-store# (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}))]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
* Using second chance cache as default cache, this is somewhat faster than our LRU cache, and less prone to overruns (where a single large scan fills and evicts the cache).
* Smaller index store caches by default, this is slower, but safer + have option to use soft values cold cache or adaptive cache.
* Ability to optionally adapt and grow cache sizes after available memory. The cache will be at its configured size at a configurable break even level, defaulting to 95% memory usage. Above this it will keep shrinking the cache to free up memory. Below the cache can grow beyond the configured limit to make use of available memory.
* The index store CAV and value caches use adaptive caching.
* Canonical buffer cache for the index store, used to de-duplicate buffers stored in caches.
* Larger entity cache during query execution to avoid redoing temporal lookup, related to the above.

(edit: pushed to master separately - @jarohen)
* Postpone temporal resolution on AE level until AEV. This was already the case for AVE. This is faster in the general case, but there might be queries where it turns out to be slower. It's a trade off of avoiding doing temporal lookup vs. having more candidates at this level in the join.
* Create attribute id buffers for the binary indexes once instead of per seek.
* Use `ByteBuffer/allocateDirect` in Rocks instead of converting it back and forth via `crux.memory/allocate-unpooled-buffer` which is slower.
* Also fixes a bug in ByteUtils/sha1 (which is not really used).
