### PR TITLE
Add nippy and byte-array value types

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -250,7 +250,8 @@
                                (binding [*sort-unordered-colls* true]
                                  (nippy/fast-freeze this))
                                (nippy/fast-freeze this))]
-      (if (< max-value-index-length (alength nippy-bytes))
+      (if (or (< max-value-index-length (alength nippy-bytes))
+              (not (nippy/freezable? this)))
         (doto (id-function to nippy-bytes)
           (.putByte 0 object-value-type-id))
         (mem/limit-buffer

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -301,7 +301,7 @@
 (defn- decode-nippy [^DirectBuffer buffer]
   (mem/<-nippy-buffer (mem/slice-buffer buffer value-type-id-size (- (.capacity buffer) value-type-id-size))))
 
-(defn- decode-bytes [^DirectBuffer buffer]
+(defn- decode-bytes ^bytes [^DirectBuffer buffer]
   (doto (byte-array (- (.capacity buffer) value-type-id-size))
     (->> (.getBytes buffer value-type-id-size))))
 

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -246,7 +246,9 @@
 
   Object
   (value->buffer [this ^MutableDirectBuffer to]
-    (let [^bytes nippy-bytes (binding [*sort-unordered-colls* true]
+    (let [^bytes nippy-bytes (if (coll? this)
+                               (binding [*sort-unordered-colls* true]
+                                 (nippy/fast-freeze this))
                                (nippy/fast-freeze this))]
       (if (< max-value-index-length (alength nippy-bytes))
         (doto (id-function to nippy-bytes)

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -22,7 +22,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def index-version 13)
+(def index-version 14)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -177,9 +177,6 @@
             value (key-suffix k (+ c/index-id-size eid-size c/id-size c/id-size))]
         (->Quad attr entity content-hash value)))))
 
-(defn- decode-ecav-key-as-v-from [^DirectBuffer k ^long eid-size]
-  (key-suffix k (+ c/index-id-size eid-size c/id-size c/id-size)))
-
 (defn- encode-hash-cache-key-to
   (^org.agrona.MutableDirectBuffer [b value]
    (encode-hash-cache-key-to b value mem/empty-buffer))
@@ -478,8 +475,7 @@
                              (MapEntry/create (canonical-buffer-lookup canonical-buffer-cache content-hash-buffer)
                                               (canonical-buffer-lookup canonical-buffer-cache attr-buffer)))
                            (fn [_]
-                             (let [eid-size (mem/capacity eid-value-buffer)
-                                   vs (TreeSet. mem/buffer-comparator)
+                             (let [vs (TreeSet. mem/buffer-comparator)
                                    prefix (encode-ecav-key-to nil
                                                               eid-value-buffer
                                                               content-hash-buffer
@@ -487,7 +483,7 @@
                                    i (new-prefix-kv-iterator cache-i prefix)]
                                (loop [k (kv/seek i prefix)]
                                  (when k
-                                   (let [v (decode-ecav-key-as-v-from k eid-size)
+                                   (let [v (key-suffix k (.capacity prefix))
                                          v (canonical-buffer-lookup canonical-buffer-cache v)]
                                      (.add vs v)
                                      (recur (kv/next i)))))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -473,10 +473,10 @@
 (defn- cav-cache-lookup ^java.util.NavigableSet [cav-cache canonical-buffer-cache cache-i ^DirectBuffer eid-value-buffer
                                                  ^DirectBuffer content-hash-buffer ^DirectBuffer attr-buffer]
   (cache/compute-if-absent cav-cache
-                           [content-hash-buffer attr-buffer]
+                           (MapEntry/create content-hash-buffer attr-buffer)
                            (fn [_]
-                             [(canonical-buffer-lookup canonical-buffer-cache content-hash-buffer)
-                              (canonical-buffer-lookup canonical-buffer-cache attr-buffer)])
+                             (MapEntry/create (canonical-buffer-lookup canonical-buffer-cache content-hash-buffer)
+                                              (canonical-buffer-lookup canonical-buffer-cache attr-buffer)))
                            (fn [_]
                              (let [eid-size (mem/capacity eid-value-buffer)
                                    vs (TreeSet. mem/buffer-comparator)

--- a/crux-core/src/data_readers.clj
+++ b/crux-core/src/data_readers.clj
@@ -1,1 +1,2 @@
-{crux/id crux.codec/id-edn-reader}
+{crux/id crux.codec/id-edn-reader
+ crux/base64 crux.codec/base64-reader}

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -73,6 +73,10 @@
     (t/is (not= (c/new-id "http://xmlns.com/foaf/0.1/firstName")
                 #crux/id ":http://xmlns.com/foaf/0.1/firstName"))))
 
+(t/deftest test-base64-reader
+  (t/is (Arrays/equals (byte-array [1 2 3])
+                       ^bytes (c/read-edn-string-with-readers "#crux/base64 \"AQID\""))))
+
 (tcct/defspec test-generative-primitive-value-decoder 1000
   (prop/for-all [v (gen/one-of [(gen/return nil)
                                 gen/large-integer

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -101,7 +101,7 @@
                       (= v (c/decode-value-buffer buffer)))
                     (cond
                       (and (string? v)
-                           (< @#'c/max-value-index-length (count v)))
+                           (< @#'c/max-value-index-length (alength (.getBytes ^String v "UTF-8"))))
                       (= @#'c/clob-value-type-id
                          (.getByte (c/value-buffer-type-id buffer) 0))
 

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -95,14 +95,20 @@
 
                       :else
                       (= v (c/decode-value-buffer buffer)))
-                    (if (and (or (string? v) (bytes? v))
-                             (>= (+ @#'c/value-type-id-size (count v))
-                                 @#'c/max-value-index-length))
-                      (if (string? v)
-                        (= @#'c/clob-value-type-id
-                           (.getByte (c/value-buffer-type-id buffer) 0))
-                        (= @#'c/object-value-type-id
-                           (.getByte (c/value-buffer-type-id buffer) 0)))
+                    (cond
+                      (and (string? v)
+                           (> (+ c/value-type-id-size (alength (.getBytes ^String v "UTF-8")))
+                              @#'c/max-value-index-length))
+                      (= @#'c/clob-value-type-id
+                         (.getByte (c/value-buffer-type-id buffer) 0))
+
+                      (and (bytes? v)
+                           (> (+ @#'c/value-type-id-size (alength ^bytes v))
+                              @#'c/max-value-index-length))
+                      (= @#'c/blob-value-type-id
+                         (.getByte (c/value-buffer-type-id buffer) 0))
+
+                      :else
                       false)))))
 
 (t/deftest test-unordered-coll-hashing-1001

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -97,14 +97,12 @@
                       (= v (c/decode-value-buffer buffer)))
                     (cond
                       (and (string? v)
-                           (> (+ c/value-type-id-size (alength (.getBytes ^String v "UTF-8")))
-                              @#'c/max-value-index-length))
+                           (< @#'c/max-value-index-length (count v)))
                       (= @#'c/clob-value-type-id
                          (.getByte (c/value-buffer-type-id buffer) 0))
 
                       (and (bytes? v)
-                           (> (+ @#'c/value-type-id-size (alength ^bytes v))
-                              @#'c/max-value-index-length))
+                           (< @#'c/max-value-index-length (alength ^bytes v)))
                       (= @#'c/blob-value-type-id
                          (.getByte (c/value-buffer-type-id buffer) 0))
 

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -56,7 +56,7 @@
     (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 13}
+  (t/is (= (merge {:crux.index/index-version 14}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -1130,35 +1130,7 @@
                     '{:find [e]
                       :where [[:ivan :photo photo]
                               [e :name "Oleg"]
-                              [e :photo photo]]}))))
-
-  (t/testing "range queries"
-    (t/is (= #{[:ivan]
-               [:petr]
-               [:oleg]}
-             (api/q (api/db *api*)
-                    '{:find [e]
-                      :in [$ photo]
-                      :where [[e :photo p]
-                              [(>= p photo)]]}
-                    (byte-array [0 1]))))
-
-    (t/is (= #{[:petr]}
-             (api/q (api/db *api*)
-                    '{:find [e]
-                      :in [$ photo]
-                      :where [[e :photo p]
-                              [(> p photo)]]}
-                    (byte-array [2]))))
-
-    (t/is (= #{[:ivan]}
-             (api/q (api/db *api*)
-                    '{:find [e]
-                      :in [$ photo]
-                      :where [[e :photo p]
-                              [e :name "Ivan"]
-                              [(< p photo)]]}
-                    (byte-array [3]))))))
+                              [e :photo photo]]})))))
 
 (t/deftest test-multiple-values-literals
   (fix/transact! *api* (fix/people [{:crux.db/id :ivan :name "Ivan" :age 21 :friends #{:petr :oleg}}

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3608,10 +3608,10 @@
       (let [!lookup-counts (atom [])]
         (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
           (t/is (= #{[{:person/name "Daniel Craig",
-                       :film/_bond [{:film/name "Quantum of Solace", :film/year "2008"}
-                                    {:film/name "Spectre", :film/year "2015"}
-                                    {:film/name "Skyfall", :film/year "2012"}
-                                    {:film/name "Casino Royale", :film/year "2006"}]}]}
+                       :film/_bond [#:film{:name "Skyfall", :year "2012"}
+                                    #:film{:name "Spectre", :year "2015"}
+                                    #:film{:name "Casino Royale", :year "2006"}
+                                    #:film{:name "Quantum of Solace", :year "2008"}]}]}
                    (api/q db '{:find [(eql/project ?dc [:person/name
                                                         {:film/_bond [:film/name :film/year]}])]
                                :where [[?dc :person/name "Daniel Craig"]]})))


### PR DESCRIPTION
Adds Nippy and byte array value types. Similar to strings, allows values less than 128 bytes to be encoded inline
Covers things like keywords and uuids indirectly via Nippy, both which are common to use as eids.
Large values are hashed like before, but have their own value types. `object-value-type-id` for Nippy (as before), and `blob-value-type-id` for large byte arrays.

Adding byte arrays as values might have some unforeseen implication, as this was explicitly avoided before.

This PR further improves performance, as it removes most hashed values that need to be looked up indirectly.

[edit: pushed to master separately]
Removes the need for the value cache in `crux.kv.index-store`, as these values are usually either already cached in the temp hash cache (for value created during the query) or are uncommonly accessed larger values.

Requires an index bump.