### PR TITLE
Fix Jetty ClassNotFoundException when running crux-sql

### DIFF
--- a/crux-sql/project.clj
+++ b/crux-sql/project.clj
@@ -10,7 +10,9 @@
                  [org.apache.calcite.avatica/avatica-server "1.16.0"]
 
                  ;; dependency conflict resolution:
-                 [commons-logging "1.2"]]
+                 [commons-logging "1.2"]
+                 [org.eclipse.jetty/jetty-util "9.4.30.v20200611"]
+                 [org.eclipse.jetty/jetty-http "9.4.30.v20200611"]]
 
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}
              :test {:dependencies [[juxt/crux-test "crux-git-version"]

--- a/examples/soak/project.clj
+++ b/examples/soak/project.clj
@@ -22,7 +22,7 @@
                  [org.slf4j/slf4j-simple "1.7.26"]
 
                  ;; deps res
-                 [org.eclipse.jetty/jetty-util "9.4.22.v20191022"]
+                 [org.eclipse.jetty/jetty-util "9.4.30.v20200611"]
                  [org.apache.httpcomponents/httpclient "4.5.12"]]
 
   :middleware [leiningen.project-version/middleware]

--- a/project.clj
+++ b/project.clj
@@ -66,8 +66,8 @@
    [org.lz4/lz4-java "1.7.1"]
    [commons-codec "1.12"]
    [joda-time "2.9.9"]
-   [org.eclipse.jetty/jetty-util "9.4.22.v20191022"]
-   [org.eclipse.jetty/jetty-http "9.4.22.v20191022"]
+   [org.eclipse.jetty/jetty-util "9.4.30.v20200611"]
+   [org.eclipse.jetty/jetty-http "9.4.30.v20200611"]
    [org.tukaani/xz "1.8"]
    [com.github.spotbugs/spotbugs-annotations "3.1.9"]
 


### PR DESCRIPTION
Resolves #1170 

At bare minimum to get the ClassNotFoundException, all one had to do is have both `crux-sql` and `crux-http-server` in the same project and attempt to start a node with a `crux-sql` server - `avatica-server` brings in jetty dependencies, as does `http-server`, and the conflict between the two causes the exception. 