### PR TITLE
Ensure embedded kafka starts before crux node in user.clj

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -23,40 +23,45 @@
 (def dev-node-dir
   (io/file "dev/dev-node"))
 
-(defmethod i/init-key :crux [_ node-opts]
+(defmethod i/init-key ::crux [_ {:keys [node-opts]}]
   (crux/start-node node-opts))
 
-(defmethod i/halt-key! :crux [_ ^ICruxAPI node]
+(defmethod i/halt-key! ::crux [_ ^ICruxAPI node]
   (.close node))
 
 (def standalone-config
-  {:crux {:crux/index-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "indexes")}}
-          :crux/document-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "documents")}}
-          :crux/tx-log {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "tx-log")}}
-          :crux.metrics.jmx/reporter {}
-          :crux.http-server/server {}}})
+  {::crux {:node-opts {:crux/index-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "indexes")}}
+                       :crux/document-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "documents")}}
+                       :crux/tx-log {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "tx-log")}}
+                       :crux.metrics.jmx/reporter {}
+                       :crux.http-server/server {}}}})
 
-(defmethod i/init-key :embedded-kafka [_ {:keys [kafka-port kafka-dir]}]
+(defmethod i/init-key ::embedded-kafka [_ {:keys [kafka-port kafka-dir]}]
   (ek/start-embedded-kafka #::ek{:zookeeper-data-dir (io/file kafka-dir "zk-data")
                                  :zookeeper-port (cio/free-port)
                                  :kafka-log-dir (io/file kafka-dir "kafka-log")
                                  :kafka-port kafka-port}))
 
-(defmethod i/halt-key! :embedded-kafka [_ ^Closeable embedded-kafka]
+(defmethod i/halt-key! ::embedded-kafka [_ ^Closeable embedded-kafka]
   (.close embedded-kafka))
 
 (def embedded-kafka-config
   (let [kafka-port (cio/free-port)]
-    {:embedded-kafka {:kafka-port kafka-port
-                      :kafka-dir (io/file dev-node-dir "kafka")}
-     :crux {::k/kafka-config {:bootstrap-servers (str "localhost:" kafka-port)}
-            :crux/index-store {:kv-store {:crux/module `rocks/->kv-store
-                                          :db-dir (io/file dev-node-dir "ek-indexes")}}
-            :crux/document-store {:crux/module `k/->document-store,
-                                  :kafka-config ::k/kafka-config
-                                  :local-document-store {:kv-store {:crux/module `rocks/->kv-store,
-                                                                    :db-dir (io/file dev-node-dir "ek-documents")}}}
-            :crux/tx-log {:crux/module `k/->tx-log, :kafka-config ::k/kafka-config}}}))
+    {::embedded-kafka {:kafka-port kafka-port
+                       :kafka-dir (io/file dev-node-dir "kafka")}
+     ::crux {:ek (i/ref ::embedded-kafka)
+             :node-opts {::k/kafka-config {:bootstrap-servers (str "http://localhost:" kafka-port)
+                                           :properties-map {"key.serializer" "crux.kafka.json.JsonSerializer"
+                                                            "key.deserializer" "crux.kafka.json.JsonDeserializer"
+                                                            "value.serializer" "crux.kafka.json.JsonSerializer"
+                                                            "value.deserializer" "crux.kafka.json.JsonDeserializer"}}
+                         :crux/index-store {:kv-store {:crux/module `rocks/->kv-store
+                                                       :db-dir (io/file dev-node-dir "ek-indexes")}}
+                         :crux/document-store {:crux/module `k/->document-store,
+                                               :kafka-config ::k/kafka-config
+                                               :local-document-store {:kv-store {:crux/module `rocks/->kv-store,
+                                                                                 :db-dir (io/file dev-node-dir "ek-documents")}}}
+                         :crux/tx-log {:crux/module `k/->tx-log, :kafka-config ::k/kafka-config}}}}))
 
 ;; swap for `embedded-kafka-config` to use embedded-kafka
 (ir/set-prep! (fn [] standalone-config))


### PR DESCRIPTION
Added some bits to the integrant within `user.clj` to handle this.