### PR TITLE
Handling eventually-consistent doc-stores

### DIFF
--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -164,15 +164,14 @@
 (defmethod <-tx-event :crux.tx/fn [evt]
   (zipmap [:op :fn-eid :args-content-hash] evt))
 
-(defn tx-events->docs [document-store tx-events]
+(defn tx-events->doc-hashes [tx-events]
   (->> tx-events
        (map <-tx-event)
        (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
-       (remove #{c/nil-id-buffer})
-       (db/fetch-docs document-store)))
+       (remove #{c/nil-id-buffer})))
 
 (defn tx-events->tx-ops [document-store tx-events]
-  (let [docs (tx-events->docs document-store tx-events)]
+  (let [docs (db/fetch-docs document-store (tx-events->doc-hashes tx-events))]
     (for [[op id & args] tx-events]
       (into [op]
             (concat (when (contains? #{:crux.tx/delete :crux.tx/evict :crux.tx/fn} op)

--- a/crux-core/test/crux/eventually_consistent_doc_store_test.clj
+++ b/crux-core/test/crux/eventually_consistent_doc_store_test.clj
@@ -1,0 +1,33 @@
+(ns crux.eventually-consistent-doc-store-test
+  (:require [crux.api :as crux]
+            [clojure.test :as t]
+            [crux.fixtures :as fix :refer [*api*]]
+            [crux.db :as db])
+  (:import (java.time Instant Duration)))
+
+(defrecord ECDocStore [!docs]
+  db/DocumentStore
+  (submit-docs [_ new-docs]
+    (swap! !docs (fn [docs]
+                   (-> (merge docs new-docs)
+                       (vary-meta update ::insert-times
+                                  merge (zipmap (keys new-docs) (repeat (Instant/now))))))))
+
+  (fetch-docs [_ ids]
+    (let [docs @!docs
+          insert-times (::insert-times (meta docs))
+          now (Instant/now)]
+      (select-keys docs (->> ids
+                             (filter (fn [id]
+                                       (when-let [^Instant insert-time (get insert-times id)]
+                                         (.isBefore (.plus insert-time (Duration/ofMillis 250)) now)))))))))
+
+(t/use-fixtures :each
+  (fix/with-opts {:crux/document-store {:crux/module (fn [_]
+                                                       (->ECDocStore (atom {})))}})
+  fix/with-node)
+
+(t/deftest test-eventually-consistent-doc-store
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
+  (t/is (= {:crux.db/id :foo}
+           (crux/entity (crux/db *api*) :foo))))

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -245,18 +245,7 @@
     (submit-docs id-and-docs this))
 
   (fetch-docs [this ids]
-    (let [ids (set ids)]
-      (loop [indexed {}]
-        (let [missing-ids (set/difference ids (set (keys indexed)))
-              indexed (merge indexed (when (seq missing-ids)
-                                       (db/fetch-docs local-document-store missing-ids)))]
-          (if (= (count indexed) (count ids))
-            indexed
-            (do
-              (Thread/sleep 100)
-              (when-let [error @!indexing-error]
-                (throw (RuntimeException. "Doc indexing error" error)))
-              (recur indexed))))))))
+    (db/fetch-docs local-document-store ids)))
 
 (defn- read-doc-offsets [index-store]
   (->> (db/read-index-meta index-store :crux.tx-log/consumer-state)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -301,8 +301,8 @@
         ivan1 (assoc ivan :value 1)
         ivan2 (assoc ivan :value 2)
         t #inst "2019-11-29"]
-    (db/index-docs (:index-store *api*) {(c/new-id ivan1) ivan1
-                                     (c/new-id ivan2) ivan2})
+    (db/submit-docs (:document-store *api*) {(c/new-id ivan1) ivan1
+                                             (c/new-id ivan2) ivan2})
 
     (index-tx {:crux.tx/tx-time t, :crux.tx/tx-id 1}
               [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1))]])
@@ -326,8 +326,8 @@
         ivan2 (assoc ivan :value 2)
         t1 #inst "2020-05-01"
         t2 #inst "2020-05-02"]
-    (db/index-docs (:index-store *api*) {(c/new-id ivan1) ivan1
-                                         (c/new-id ivan2) ivan2})
+    (db/submit-docs (:document-store *api*) {(c/new-id ivan1) ivan1
+                                             (c/new-id ivan2) ivan2})
 
     (index-tx {:crux.tx/tx-time t1, :crux.tx/tx-id 1}
               [[:crux.tx/put :ivan (c/->id-buffer (c/new-id ivan1)) t1]])


### PR DESCRIPTION
resolves #1105 
We poll for docs before we index the tx, and have removed the polling from the Kafka doc store.

As usual, tx fns make this more complicated - we have to introduce an extra polling `fetch-docs` call when we put generated docs back to the document store, so that those docs are known to be available from the doc-store before the transaction commits.