### PR TITLE
Add event + lambda that fire when a bench containers is stopped.

### DIFF
--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -72,7 +72,6 @@ Resources:
           }]
           },
 
-
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -402,6 +401,81 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn:
         Fn::GetAtt: ["ScheduleStopInstance", "Arn"]
+
+  BenchMessageLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [lambda.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ["secretsmanager:GetSecretValue"]
+            Resource: '*'
+
+  BenchStoppedSendMessage:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: "Sends a slack message when a bench run fails"
+      Handler: 'index.send_message'
+      Runtime: 'python3.7'
+      Role:
+        Fn::GetAtt: ["BenchMessageLambdaRole", "Arn"]
+      Code:
+        ZipFile: !Sub |
+          import urllib3
+          import json
+          import boto3
+          region = 'eu-west-2'
+          http = urllib3.PoolManager()
+          secrets_manager = boto3.client('secretsmanager', region_name=region)
+          slack_url_secret = secrets_manager.get_secret_value(SecretId='arn:aws:secretsmanager:eu-west-2:955308952094:secret:bench/slack-url-uumMHQ')
+          url = json.loads(slack_url_secret['SecretString'])['slack-url']
+          def send_message(event, context):
+            task_containers = event['detail']['containers']
+            for container in task_containers:
+              if container["name"] == "bench-container":
+                if "reason" in container:
+                  error_message = "*Bench container exited! Reason:* {0}".format(container["reason"])
+                  encoded_data = json.dumps({"text": error_message}).encode('utf-8')
+                  resp = http.request('POST', url, body=encoded_data, headers={'Content-Type': 'application/json'})
+
+  BenchTaskStoppedRule:
+    Type: AWS::Events::Rule
+    DependsOn:
+      - BenchStoppedSendMessage
+    Properties:
+      EventPattern:
+        {
+        "source":["aws.ecs"],
+        "detail-type":["ECS Task State Change"],
+        "detail":
+          {
+             "lastStatus":["STOPPED"],
+             "stoppedReason":["Essential container in task exited"]
+          }
+        }
+      Targets:
+        - Arn:
+            Fn::GetAtt: ["BenchStoppedSendMessage", "Arn"]
+          Id: "benchStopped"
+
+  BenchStoppedMessagePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName:
+        Fn::GetAtt: ["BenchStoppedSendMessage", "Arn"]
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt: ["BenchTaskStoppedRule", "Arn"]
 
 # These are the values output by the CloudFormation template. Be careful
 # about changing any of them, because of them are exported with specific


### PR DESCRIPTION
Resolves #1189 

Lambda is always ran when a bench task exits, and checks the bench-container for an exit reason. If there is one, posts a message
in slack.