### PR TITLE
EQL unions, recursive queries and attribute renaming #1184

### DIFF
--- a/crux-core/src/crux/eql_project.clj
+++ b/crux-core/src/crux/eql_project.clj
@@ -1,0 +1,154 @@
+(ns ^:no-doc crux.eql-project
+  (:require [crux.codec :as c]
+            [crux.db :as db]
+            [edn-query-language.core :as eql]
+            [clojure.string :as string])
+  (:import clojure.lang.MapEntry))
+
+(defn- recognise-union [child]
+  (when (and (= :join (:type child))
+             (= :union (get-in child [:children 0 :type])))
+    :union))
+
+(defn- replace-docs [v docs]
+  (if (not-empty (::hashes (meta v)))
+    (v docs)
+    v))
+
+(defn- lookup-docs [v {:keys [document-store]}]
+  (when-let [hashes (not-empty (::hashes (meta v)))]
+    (db/fetch-docs document-store hashes)))
+
+(defmacro let-docs [[binding hashes] & body]
+  `(-> (fn ~'let-docs [~binding]
+         ~@body)
+       (with-meta {::hashes ~hashes})))
+
+(defn- after-doc-lookup [f lookup]
+  (if-let [hashes (::hashes (meta lookup))]
+    (let-docs [docs hashes]
+      (let [res (replace-docs lookup docs)]
+        (if (::hashes (meta res))
+          (after-doc-lookup f res)
+          (f res))))
+    (f lookup)))
+
+(defn- raise-doc-lookup-out-of-coll
+  "turns a vector/set where each of the values could be doc lookups into a single doc lookup returning a vector/set"
+  [coll]
+  (if-let [hashes (not-empty (into #{} (mapcat (comp ::hashes meta)) coll))]
+    (let-docs [docs hashes]
+      (->> coll
+           (into (empty coll) (map #(replace-docs % docs)))
+           raise-doc-lookup-out-of-coll))
+    coll))
+
+(defn- project-child [v db child-fns]
+  (->> (mapv (fn [f]
+               (f v db))
+             child-fns)
+       (raise-doc-lookup-out-of-coll)
+       (after-doc-lookup (fn [res]
+                           (into {} (mapcat identity) res)))))
+
+(declare project-child-fns)
+
+(defn- forward-joins-child-fn [{:keys [props special forward-joins unions]}]
+  (when-not (every? empty? [props special forward-joins unions])
+    (let [forward-join-child-fns (for [{:keys [dispatch-key] :as join} forward-joins]
+                                   (let [child-fns (project-child-fns join)]
+                                     (fn [doc db]
+                                       (let [v (get doc dispatch-key)]
+                                         (->> (if (c/multiple-values? v)
+                                                (->> (into [] (map #(project-child % db child-fns)) v)
+                                                     (raise-doc-lookup-out-of-coll))
+                                                (project-child v db child-fns))
+                                              (after-doc-lookup (fn [res]
+                                                                  (MapEntry/create dispatch-key res))))))))
+          union-child-fns (for [{:keys [dispatch-key children]} unions
+                                {:keys [union-key] :as child} (get-in children [0 :children])]
+                            (let [child-fns (project-child-fns child)]
+                              (fn [value doc db]
+                                (->> (c/vectorize-value (get doc dispatch-key))
+                                     (keep (fn [v]
+                                             (when (= v union-key)
+                                               (project-child value db child-fns))))))))
+          prop-dispatch-keys (into #{} (map :dispatch-key) props)
+          project-star? (contains? (into #{} (map :dispatch-key) special) '*)]
+
+      (fn [value {:keys [entity-resolver-fn] :as db}]
+        (let [content-hash (entity-resolver-fn (c/->id-buffer value))]
+          (let-docs [docs #{content-hash}]
+            (let [doc (get docs (c/new-id content-hash))]
+              (->> (concat (->> forward-join-child-fns (map (fn [f] (f doc db))))
+                           (->> union-child-fns (mapcat (fn [f] (f value doc db)))))
+                   (raise-doc-lookup-out-of-coll)
+                   (after-doc-lookup (fn [res]
+                                       ;; TODO do we need a deeper merge here?
+                                       (into (if project-star?
+                                               doc
+                                               (select-keys doc prop-dispatch-keys))
+                                             res)))))))))))
+
+(defn- reverse-joins-child-fn [reverse-joins]
+  (when-not (empty? reverse-joins)
+    (let [reverse-join-child-fns (for [{:keys [dispatch-key] :as join} reverse-joins]
+                                   (let [child-fns (project-child-fns join)
+                                         forward-key (keyword (namespace dispatch-key)
+                                                              (subs (name dispatch-key) 1))
+                                         one? (= :one (get-in join [:params :crux/cardinality]))]
+                                     (fn [value-buffer {:keys [index-snapshot entity-resolver-fn] :as db}]
+                                       (->> (vec (for [v (cond->> (db/ave index-snapshot (c/->id-buffer forward-key) value-buffer nil entity-resolver-fn)
+                                                           one? (take 1)
+                                                           :always vec)]
+                                                   (project-child (db/decode-value index-snapshot v) db child-fns)))
+                                            (raise-doc-lookup-out-of-coll)
+                                            (after-doc-lookup (fn [res]
+                                                                (MapEntry/create dispatch-key
+                                                                                 (cond->> res
+                                                                                   one? first))))))))]
+      (fn [value db]
+        (let [value-buffer (c/->value-buffer value)]
+          (->> (for [f reverse-join-child-fns]
+                 (f value-buffer db))
+               (raise-doc-lookup-out-of-coll)))))))
+
+(defn- project-child-fns [project-spec]
+  (let [{special :special,
+         props :prop,
+         joins :join,
+         unions :union} (->> (:children project-spec)
+                             (group-by (some-fn recognise-union
+                                                :type
+                                                (constantly :special))))
+
+        {forward-joins false, reverse-joins true}
+        (group-by (comp #(string/starts-with? % "_") name :dispatch-key) joins)]
+
+    (->> [(forward-joins-child-fn {:special special, :props props, :forward-joins forward-joins, :unions unions})
+          (reverse-joins-child-fn reverse-joins)]
+         (remove nil?))))
+
+(defn compile-project-spec [project-spec]
+  (let [root-fns (project-child-fns (eql/query->ast project-spec))]
+    (fn [value db]
+      (project-child value db root-fns))))
+
+(defn ->project-result [db compiled-find q-conformed res]
+  (->> res
+       (map (fn [row]
+              (mapv (fn [value ->result]
+                      (->result value db))
+                    row
+                    (mapv :->result compiled-find))))
+       (partition-all (or (:batch-size q-conformed)
+                          (:batch-size db)
+                          100))
+       (map (fn [results]
+              (->> results
+                   (mapv raise-doc-lookup-out-of-coll)
+                   raise-doc-lookup-out-of-coll)))
+       (mapcat (fn [lookup]
+                 (if (::hashes (meta lookup))
+                   (recur (replace-docs lookup (lookup-docs lookup db)))
+                   lookup)))))

--- a/crux-core/test/crux/eql_project_test.clj
+++ b/crux-core/test/crux/eql_project_test.clj
@@ -1,8 +1,9 @@
-(ns crux.project-test
+(ns crux.eql-project-test
   (:require [clojure.test :as t]
             [crux.api :as crux]
             [crux.fixtures :as fix :refer [*api*]]
             [crux.query :as q]
+            [crux.eql-project :as project]
             [clojure.java.io :as io]))
 
 (t/use-fixtures :each fix/with-node)
@@ -14,7 +15,7 @@
   (let [->lookup-docs (let [f @#'q/lookup-docs]
                         (fn [!lookup-counts]
                           (fn [v db]
-                            (swap! !lookup-counts conj (count (::q/hashes (meta v))))
+                            (swap! !lookup-counts conj (count (::project/hashes (meta v))))
                             (f v db))))
         db (crux/db *api*)]
 
@@ -30,14 +31,14 @@
                        [{:vehicle/brand "Aston Martin", :vehicle/model "V8 Vantage Volante"}]
                        [{:vehicle/brand "Aston Martin", :vehicle/model "V12 Vanquish"}]}]
         (let [!lookup-counts (atom [])]
-          (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+          (with-redefs [project/lookup-docs (->lookup-docs !lookup-counts)]
             (t/is (= expected
                      (crux/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
                                   :where [[?v :vehicle/brand "Aston Martin"]]})))
             (t/is (= [6] @!lookup-counts) "batching lookups")))
 
         (let [!lookup-counts (atom [])]
-          (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+          (with-redefs [project/lookup-docs (->lookup-docs !lookup-counts)]
             (t/is (= expected
                      (crux/q db '{:find [(eql/project ?v [:vehicle/brand :vehicle/model])]
                                   :where [[?v :vehicle/brand "Aston Martin"]]
@@ -46,7 +47,7 @@
 
     (t/testing "forward joins"
       (let [!lookup-counts (atom [])]
-        (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+        (with-redefs [project/lookup-docs (->lookup-docs !lookup-counts)]
           (t/is (= #{[{:film/year "2002",
                        :film/name "Die Another Day"
                        :film/bond {:person/name "Pierce Brosnan"},
@@ -64,7 +65,7 @@
 
     (t/testing "reverse joins"
       (let [!lookup-counts (atom [])]
-        (with-redefs [q/lookup-docs (->lookup-docs !lookup-counts)]
+        (with-redefs [project/lookup-docs (->lookup-docs !lookup-counts)]
           (t/is (= #{[{:person/name "Daniel Craig",
                        :film/_bond [#:film{:name "Skyfall", :year "2012"}
                                     #:film{:name "Spectre", :year "2015"}

--- a/crux-core/test/crux/project_test.clj
+++ b/crux-core/test/crux/project_test.clj
@@ -18,6 +18,10 @@
                             (f v db))))
         db (crux/db *api*)]
 
+    (t/is (= #{[{}]}
+             (crux/q db '{:find [(eql/project ?v [])]
+                          :where [[?v :vehicle/brand "Aston Martin"]]})))
+
     (t/testing "simple props"
       (let [expected #{[{:vehicle/brand "Aston Martin", :vehicle/model "DB5"}]
                        [{:vehicle/brand "Aston Martin", :vehicle/model "DB10"}]

--- a/crux-core/test/crux/project_test.clj
+++ b/crux-core/test/crux/project_test.clj
@@ -77,3 +77,21 @@
                    :type :person}]}
                (crux/q db '{:find [(eql/project ?dc [*])]
                             :where [[?dc :person/name "Daniel Craig"]]}))))))
+
+(t/deftest test-union
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo
+                                       :type :a
+                                       :x 2
+                                       :y "this"
+                                       :z :not-this}]
+                        [:crux.tx/put {:crux.db/id :bar
+                                       :type :b
+                                       :y "not this"
+                                       :z 5}]])
+
+  (t/is (= #{[{:crux.db/id :foo, :x 2, :y "this"}]
+             [{:crux.db/id :bar, :z 5}]}
+           (crux/q (crux/db *api*)
+                   '{:find [(eql/project ?it [{:type {:a [:x :y], :b [:z]}}
+                                              :crux.db/id])]
+                     :where [[?it :crux.db/id]]}))))

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -410,7 +410,6 @@ You can quickly grab the whole document by specifying `*` in the projection spec
 
 [source,clojure]
 ----
-;; with just 'query':
 {:find [(eql/project ?user [*])]
  :where [[?user :user/id 1]]}
 
@@ -418,7 +417,7 @@ You can quickly grab the whole document by specifying `*` in the projection spec
 ----
 
 For full details on what's supported in the projection-spec, see the https://edn-query-language.org/eql/1.0.0/specification.html[EQL specification^]
-Crux does not (yet) support union queries or recursive queries.
+
 [#ordering-and-pagination]
 == Ordering and Pagination
 

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -406,6 +406,20 @@ We can also navigate in the reverse direction, looking for entities that refer t
 ;;      :user/_profession [{:user/id 2, :user/name "Sergei"}]}]
 ----
 
+To rename attributes in the result, wrap the attribute in `(:source-attribute {:as :output-name})`:
+
+[source,clojure]
+----
+{:find [(eql/project ?profession [:profession/name {(:user/_profession {:as :users}) [:user/id :user/name]}])]
+ :where [[?profession :profession/name]]}
+
+;; => [{:profession/name "Doctor",
+;;      :users [{:user/id 1, :user/name "Ivan"},
+;;              {:user/id 3, :user/name "Petr"}]},
+;;     {:profession/name "Lawyer",
+;;      :users [{:user/id 2, :user/name "Sergei"}]}]
+----
+
 You can quickly grab the whole document by specifying `*` in the projection spec:
 
 [source,clojure]


### PR DESCRIPTION
Adding unions, recursive queries and attribute renaming to our EQL support.

Notes:
* I've extracted the projection code out to its own namespace, `crux.project`, and simplified it significantly - would recommend reading the final state rather than the diff.
* Unions look like joins once EQL's parsed them, except that queries specified in a union are to apply to the _same_ document, at the same level - nested queries specified within a join apply to the child document.
* We add a `RecurseState`, a pair of the current recursion depth and the projection functions for the current level. When we recurse, we increment the recurse-depth (checking it against the limit if it's bounded) and use the same projection functions at the next level; for 'normal' nested queries, we reset the recurse-depth to 0 and use the next level's projection functions.
* Have also taken the liberty of adding an `:as` parameter to rename attributes in the result - see https://clojurians.slack.com/archives/CG3AM2F7V/p1603271755193300