### PR TITLE
Removing meta from Nippy encodings when creating value-buffers, #1197

### DIFF
--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -227,7 +227,13 @@
              (.putByte idx (unchecked-byte (inc b))))))))))
 
 (defn <-nippy-buffer [buf]
-  (nippy/thaw-from-in! (DataInputStream. (DirectBufferInputStream. buf))))
+  (nippy/thaw-from-in! (-> (DirectBufferInputStream. buf)
+                           (DataInputStream.))))
 
 (defn ->nippy-buffer [v]
-  (->off-heap (nippy/fast-freeze v)))
+  (let [to (ExpandableDirectByteBuffer. 64)
+        dos (-> (ExpandableDirectBufferOutputStream. to)
+                (DataOutputStream.))]
+    (nippy/-freeze-without-meta! v dos)
+    (-> to
+        (limit-buffer (.size dos)))))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -128,7 +128,7 @@
                          (.getByte (c/value-buffer-type-id buffer) 0))
 
                       (and (bytes? v)
-                           (< @#'c/max-value-index-length (alength ^bytes (nippy/fast-freeze v))))
+                           (< @#'c/max-value-index-length (alength ^bytes (mem/->on-heap (mem/->nippy-buffer v)))))
                       (= @#'c/object-value-type-id
                          (.getByte (c/value-buffer-type-id buffer) 0))
 

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3599,3 +3599,11 @@
     (fix/submit+await-tx [[:crux.tx/delete :my-id]])
 
     (t/is (= #{} (api/q (api/db *api*) query)))))
+
+(t/deftest hashing-quoted-lists-1197
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :a-list '(1 2 3)}]])
+
+  (t/is (= #{[:foo]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :a-list (1 2 3)]]}))))


### PR DESCRIPTION
Not removing it when creating id buffers to preserve backwards compatibility of id hashing.