### PR TITLE
CloudWatch bench graphs, #1155

### DIFF
--- a/crux-bench/cloudformation.yaml
+++ b/crux-bench/cloudformation.yaml
@@ -199,6 +199,9 @@ Resources:
             - Name: "SLACK_URL"
               ValueFrom:
                 "arn:aws:secretsmanager:eu-west-2:955308952094:secret:bench/slack-url-uumMHQ"
+          Environment:
+            - Name: 'CRUX_BENCH_CW_METRICS'
+              Value: 'true'
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/crux-bench/src/crux/bench/cloudwatch.clj
+++ b/crux-bench/src/crux/bench/cloudwatch.clj
@@ -1,0 +1,46 @@
+(ns crux.bench.cloudwatch
+  (:import java.util.List
+           software.amazon.awssdk.regions.Region
+           software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+           [software.amazon.awssdk.services.cloudwatch.model Dimension MetricDatum PutMetricDataRequest StandardUnit]))
+
+(def ^CloudWatchClient ^:private cloudwatch-client
+  (delay
+    (.. (CloudWatchClient/builder)
+        (region (Region/EU_WEST_2))
+        (build))))
+
+(defn- ->cw-dimension ^Dimension [k v]
+  (.. (Dimension/builder)
+      (name (name k))
+      (value (name v))
+      (build)))
+
+(def ^:private cw-namespace
+  ;; uncomment this to test CW metrics locally, but don't commit it!
+  (or #_"crux.bench.dev"
+      (when (Boolean/parseBoolean (System/getenv "CRUX_BENCH_CW_METRICS"))
+        "crux.bench")))
+
+(defn put-cw-metrics! [results]
+  (when cw-namespace
+    (when-let [^List
+               metric-data (seq (for [{:keys [time-taken-ms bench-type] :as result} results
+                                      :when (and (:crux-node-type result)
+                                                 (:success? result))
+                                      :when (contains? #{:ingest :queries :queries-warm} bench-type)]
+                                  (let [^List
+                                        dimensions (for [k #{:crux-node-type :bench-ns :bench-type}]
+                                                     (->cw-dimension k (get result k)))]
+                                    (.. (MetricDatum/builder)
+                                        (metricName "time-taken")
+                                        (dimensions dimensions)
+                                        (unit StandardUnit/MILLISECONDS)
+                                        (value (double time-taken-ms))
+                                        (build)))))]
+      (let [^PutMetricDataRequest
+            req (.. (PutMetricDataRequest/builder)
+                    (namespace cw-namespace)
+                    (metricData metric-data)
+                    (build))]
+        (.putMetricData ^CloudWatchClient @cloudwatch-client req)))))

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -3,12 +3,11 @@
             [clojure.tools.cli :as cli]
             [crux.bench :as bench]
             [crux.bench.sorted-maps-microbench :as sorted-maps]
-            [crux.bench.ts-devices :as devices]
-            [crux.bench.ts-weather :as weather]
-            [crux.bench.watdiv-crux :as watdiv-crux]
             [crux.bench.tpch-stress-test :as tpch-stress]
             [crux.bench.tpch-test :as tpch]
-            [clojure.set :as set]))
+            [crux.bench.ts-devices :as devices]
+            [crux.bench.ts-weather :as weather]
+            [crux.bench.watdiv-crux :as watdiv-crux]))
 
 (defn post-to-slack [results]
   (doto results
@@ -41,12 +40,14 @@
                              (watdiv-crux/summarise-query-results query-results))
                      (bench/with-comparison-times)
                      (doto post-to-slack)))))
+
    :tpch-stress (fn [nodes {:keys [tpch-query-count tpch-field-count] :as opts}]
                   (bench/with-nodes [node nodes]
                     (-> (bench/with-comparison-times
                           (tpch-stress/run-tpch-stress-test node {:query-count tpch-query-count
                                                                   :field-count tpch-field-count}))
                         (doto post-to-slack))))
+
    :tpch (fn [nodes {:keys [tpch-scale-factor] :as opts}]
            (bench/with-nodes [node nodes]
              (-> (bench/with-comparison-times

--- a/crux-bench/src/crux/bench/tpch_stress_test.clj
+++ b/crux-bench/src/crux/bench/tpch_stress_test.clj
@@ -6,8 +6,9 @@
 
 (defn- load-tpch-docs [node]
   (bench/run-bench :ingest
-   (bench/with-additional-index-metrics node
-     (tpch/load-docs! node))))
+    (bench/with-additional-index-metrics node
+      (tpch/load-docs! node))
+    {:success? true}))
 
 (def fields '{:l_orderkey l_orderkey
               :l_partkey l_partkey

--- a/crux-bench/src/crux/bench/tpch_test.clj
+++ b/crux-bench/src/crux/bench/tpch_test.clj
@@ -26,8 +26,9 @@
     (bench/with-bench-ns :tpch-test
       (bench/with-crux-dimensions
         (bench/run-bench :ingest
-                         (bench/with-additional-index-metrics node
-                           (tpch/load-docs! node scale-factor tpch/tpch-entity->pkey-doc)))
+          (bench/with-additional-index-metrics node
+            (tpch/load-docs! node scale-factor tpch/tpch-entity->pkey-doc))
+          {:success true})
 
         ;; TODO we may want to split this up, à la WatDiv, so that we can see if
         ;; specific queries are slower than our comparison databases

--- a/crux-bench/src/crux/bench/ts_devices.clj
+++ b/crux-bench/src/crux/bench/ts_devices.clj
@@ -75,7 +75,7 @@
                                                                    [:crux.tx/put reading-doc time]))))
                                      nil))))]
         (crux/await-tx node last-tx (Duration/ofMinutes 20))
-        {}))))
+        {:success? true}))))
 
 (defn test-battery-readings [node]
   ;; 10 most recent battery temperature readings for charging devices
@@ -105,18 +105,18 @@
                           [r :reading/battery-temperature battery-temperature]]
                   :order-by [[time :desc] [device-id :desc]]
                   :limit 10}
-          successful? (= (crux/q (crux/db node) query)
-                         [[#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000999 88.7]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000998 93.1]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000997 90.7]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000996 92.8]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000995 91.9]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000994 92.0]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000993 92.8]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000992 87.6]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000991 93.1]
-                          [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000990 89.9]])]
-      {:successful? successful?})))
+          success? (= (crux/q (crux/db node) query)
+                      [[#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000999 88.7]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000998 93.1]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000997 90.7]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000996 92.8]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000995 91.9]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000994 92.0]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000993 92.8]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000992 87.6]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000991 93.1]
+                       [#inst "2016-11-15T20:19:30.000-00:00" :device-info/demo000990 89.9]])]
+      {:success? success?})))
 
 (defn test-busiest-devices [node]
   ;; Busiest devices (1 min avg) whose battery level is below 33% and is not charging
@@ -153,38 +153,38 @@
                   :order-by [[cpu-avg-1min :desc] [time :desc]]
                   :limit 5}
 
-          successful? (= (crux/q (crux/db node) query)
-                         [[#inst "2016-11-15T20:19:30.000-00:00"
-                           :device-info/demo000818
-                           33.45
-                           26.0
-                           :discharging
-                           "focus"]
-                          [#inst "2016-11-15T20:19:30.000-00:00"
-                           :device-info/demo000278
-                           32.59
-                           14.0
-                           :discharging
-                           "focus"]
-                          [#inst "2016-11-15T20:19:30.000-00:00"
-                           :device-info/demo000418
-                           32.11
-                           18.0
-                           :discharging
-                           "mustang"]
-                          [#inst "2016-11-15T20:19:30.000-00:00"
-                           :device-info/demo000942
-                           31.72
-                           26.0
-                           :discharging
-                           "pinto"]
-                          [#inst "2016-11-15T20:19:30.000-00:00"
-                           :device-info/demo000800
-                           31.34
-                           25.0
-                           :discharging
-                           "focus"]])]
-      {:successful? successful?})))
+          success? (= (crux/q (crux/db node) query)
+                      [[#inst "2016-11-15T20:19:30.000-00:00"
+                        :device-info/demo000818
+                        33.45
+                        26.0
+                        :discharging
+                        "focus"]
+                       [#inst "2016-11-15T20:19:30.000-00:00"
+                        :device-info/demo000278
+                        32.59
+                        14.0
+                        :discharging
+                        "focus"]
+                       [#inst "2016-11-15T20:19:30.000-00:00"
+                        :device-info/demo000418
+                        32.11
+                        18.0
+                        :discharging
+                        "mustang"]
+                       [#inst "2016-11-15T20:19:30.000-00:00"
+                        :device-info/demo000942
+                        31.72
+                        26.0
+                        :discharging
+                        "pinto"]
+                       [#inst "2016-11-15T20:19:30.000-00:00"
+                        :device-info/demo000800
+                        31.34
+                        25.0
+                        :discharging
+                        "focus"]])]
+      {:success? success?})))
 
 
 (defn test-min-max-battery-level-per-hour [node]
@@ -242,18 +242,18 @@
                        (finally
                          (run! cio/try-close histories))))
 
-            successful? (= [[#inst "2016-11-15T12:00:00.000-00:00" 20.0 99.0]
-                            [#inst "2016-11-15T13:00:00.000-00:00" 13.0 100.0]
-                            [#inst "2016-11-15T14:00:00.000-00:00" 9.0 100.0]
-                            [#inst "2016-11-15T15:00:00.000-00:00" 6.0 100.0]
-                            [#inst "2016-11-15T16:00:00.000-00:00" 6.0 100.0]
-                            [#inst "2016-11-15T17:00:00.000-00:00" 6.0 100.0]
-                            [#inst "2016-11-15T18:00:00.000-00:00" 6.0 100.0]
-                            [#inst "2016-11-15T19:00:00.000-00:00" 6.0 100.0]
-                            [#inst "2016-11-15T20:00:00.000-00:00" 6.0 100.0]]
-                           result)]
+            success? (= [[#inst "2016-11-15T12:00:00.000-00:00" 20.0 99.0]
+                         [#inst "2016-11-15T13:00:00.000-00:00" 13.0 100.0]
+                         [#inst "2016-11-15T14:00:00.000-00:00" 9.0 100.0]
+                         [#inst "2016-11-15T15:00:00.000-00:00" 6.0 100.0]
+                         [#inst "2016-11-15T16:00:00.000-00:00" 6.0 100.0]
+                         [#inst "2016-11-15T17:00:00.000-00:00" 6.0 100.0]
+                         [#inst "2016-11-15T18:00:00.000-00:00" 6.0 100.0]
+                         [#inst "2016-11-15T19:00:00.000-00:00" 6.0 100.0]
+                         [#inst "2016-11-15T20:00:00.000-00:00" 6.0 100.0]]
+                        result)]
 
-        {:successful? successful?}))))
+        {:success? success?}))))
 
 (defn run-devices-bench [node]
   (bench/with-bench-ns :ts-devices

--- a/crux-bench/src/crux/bench/ts_weather.clj
+++ b/crux-bench/src/crux/bench/ts_weather.clj
@@ -62,7 +62,7 @@
                                                              [:crux.tx/put condition-doc time]))))
                                      nil))))]
         (api/await-tx node last-tx (Duration/ofMinutes 20))
-        {}))))
+        {:success? true}))))
 
 (defn test-last-10-readings [node]
   ;; NOTE: Does not work with range, takes latest values.
@@ -91,55 +91,55 @@
   ;; (10 rows)
 
   (bench/run-bench :last-10-readings
-    (let [successful? (= (api/q (api/db node)
-                                '{:find [time device-id temperature humidity]
-                                  :where [[c :condition/time time]
-                                          [c :condition/device-id device-id]
-                                          [c :condition/temperature temperature]
-                                          [c :condition/humidity humidity]]
-                                  :order-by [[time :desc] [device-id :asc]]
-                                  :limit 10})
-                         [[#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000000
-                           42.0
-                           54.600000000000094]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000001
-                           42.0
-                           54.49999999999998]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000002
-                           42.0
-                           55.200000000000074]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000003
-                           42.0
-                           52.70000000000004]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000004
-                           70.00000000000004
-                           49.000000000000014]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000005
-                           70.30000000000014
-                           48.60000000000001]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000006
-                           42.0
-                           50.00000000000003]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000007
-                           69.89999999999998
-                           49.50000000000002]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000008
-                           42.0
-                           53.70000000000008]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000009
-                           91.0
-                           92.40000000000006]])]
-      {:successful? successful?})))
+    (let [success? (= (api/q (api/db node)
+                             '{:find [time device-id temperature humidity]
+                               :where [[c :condition/time time]
+                                       [c :condition/device-id device-id]
+                                       [c :condition/temperature temperature]
+                                       [c :condition/humidity humidity]]
+                               :order-by [[time :desc] [device-id :asc]]
+                               :limit 10})
+                      [[#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000000
+                        42.0
+                        54.600000000000094]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000001
+                        42.0
+                        54.49999999999998]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000002
+                        42.0
+                        55.200000000000074]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000003
+                        42.0
+                        52.70000000000004]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000004
+                        70.00000000000004
+                        49.000000000000014]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000005
+                        70.30000000000014
+                        48.60000000000001]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000006
+                        42.0
+                        50.00000000000003]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000007
+                        69.89999999999998
+                        49.50000000000002]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000008
+                        42.0
+                        53.70000000000008]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000009
+                        91.0
+                        92.40000000000006]])]
+      {:success? success?})))
 
 (defn trunc ^double [d ^long scale]
   (.doubleValue (.setScale (bigdec d) scale RoundingMode/HALF_UP)))
@@ -182,62 +182,62 @@
                   :limit 10
                   :timeout 120000}
 
-          successful? (= (for [[time device-id location temperature humidity]
-                               (api/q (api/db node) query)]
-                           [time device-id location (trunc temperature 2) (trunc humidity 2)])
+          success? (= (for [[time device-id location temperature humidity]
+                            (api/q (api/db node) query)]
+                        [time device-id location (trunc temperature 2) (trunc humidity 2)])
 
-                         [[#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000000
-                           :arctic-000000
-                           42.0
-                           54.6]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000001
-                           :arctic-000001
-                           42.0
-                           54.5]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000002
-                           :arctic-000002
-                           42.0
-                           55.2]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000003
-                           :arctic-000003
-                           42.0
-                           52.7]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000006
-                           :arctic-000004
-                           42.0
-                           50.0]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000008
-                           :arctic-000005
-                           42.0
-                           53.7]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000009
-                           :swamp-000000
-                           91.0
-                           92.4]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000012
-                           :swamp-000001
-                           91.0
-                           94.3]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000017
-                           :swamp-000002
-                           91.0
-                           90.5]
-                          [#inst "2016-11-16T21:18:00.000-00:00"
-                           :location/weather-pro-000018
-                           :swamp-000003
-                           91.0
-                           96.9]])]
+                      [[#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000000
+                        :arctic-000000
+                        42.0
+                        54.6]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000001
+                        :arctic-000001
+                        42.0
+                        54.5]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000002
+                        :arctic-000002
+                        42.0
+                        55.2]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000003
+                        :arctic-000003
+                        42.0
+                        52.7]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000006
+                        :arctic-000004
+                        42.0
+                        50.0]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000008
+                        :arctic-000005
+                        42.0
+                        53.7]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000009
+                        :swamp-000000
+                        91.0
+                        92.4]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000012
+                        :swamp-000001
+                        91.0
+                        94.3]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000017
+                        :swamp-000002
+                        91.0
+                        90.5]
+                       [#inst "2016-11-16T21:18:00.000-00:00"
+                        :location/weather-pro-000018
+                        :swamp-000003
+                        91.0
+                        96.9]])]
 
-      {:successful? successful?})))
+      {:success? success?})))
 
 (defn kw-starts-with? [kw prefix]
   (str/starts-with? (name kw) prefix))
@@ -318,33 +318,33 @@
                        (finally
                          (run! cio/try-close histories))))
 
-            successful? (= result
-                           [[#inst "2016-11-15T12:00:00.000-00:00" 73.45 68.0 79.2]
-                            [#inst "2016-11-15T13:00:00.000-00:00" 74.43 68.7 80.4]
-                            [#inst "2016-11-15T14:00:00.000-00:00" 75.44 69.5 81.4]
-                            [#inst "2016-11-15T15:00:00.000-00:00" 76.47 70.5 82.7]
-                            [#inst "2016-11-15T16:00:00.000-00:00" 77.48 71.5 83.4]
-                            [#inst "2016-11-15T17:00:00.000-00:00" 78.46 72.5 84.6]
-                            [#inst "2016-11-15T18:00:00.000-00:00" 79.45 73.5 85.5]
-                            [#inst "2016-11-15T19:00:00.000-00:00" 80.42 74.8 86.5]
-                            [#inst "2016-11-15T20:00:00.000-00:00" 81.41 75.6 87.4]
-                            [#inst "2016-11-15T21:00:00.000-00:00" 82.42 76.1 88.4]
-                            [#inst "2016-11-15T22:00:00.000-00:00" 83.4 77.0 89.5]
-                            [#inst "2016-11-15T23:00:00.000-00:00" 84.38 78.3 90.0]
-                            [#inst "2016-11-16T00:00:00.000-00:00" 85.35 79.3 90.0]
-                            [#inst "2016-11-16T01:00:00.000-00:00" 85.27 78.8 90.0]
-                            [#inst "2016-11-16T02:00:00.000-00:00" 84.26 77.7 89.4]
-                            [#inst "2016-11-16T03:00:00.000-00:00" 83.25 76.5 88.5]
-                            [#inst "2016-11-16T04:00:00.000-00:00" 82.24 75.3 87.9]
-                            [#inst "2016-11-16T05:00:00.000-00:00" 81.23 74.1 87.2]
-                            [#inst "2016-11-16T06:00:00.000-00:00" 80.21 72.6 86.3]
-                            [#inst "2016-11-16T07:00:00.000-00:00" 79.19 71.5 84.9]
-                            [#inst "2016-11-16T08:00:00.000-00:00" 78.17 71.1 84.2]
-                            [#inst "2016-11-16T09:00:00.000-00:00" 77.17 70.1 83.2]
-                            [#inst "2016-11-16T10:00:00.000-00:00" 77.18 70.1 83.6]
-                            [#inst "2016-11-16T11:00:00.000-00:00" 78.17 71.0 84.8]])]
+            success? (= result
+                        [[#inst "2016-11-15T12:00:00.000-00:00" 73.45 68.0 79.2]
+                         [#inst "2016-11-15T13:00:00.000-00:00" 74.43 68.7 80.4]
+                         [#inst "2016-11-15T14:00:00.000-00:00" 75.44 69.5 81.4]
+                         [#inst "2016-11-15T15:00:00.000-00:00" 76.47 70.5 82.7]
+                         [#inst "2016-11-15T16:00:00.000-00:00" 77.48 71.5 83.4]
+                         [#inst "2016-11-15T17:00:00.000-00:00" 78.46 72.5 84.6]
+                         [#inst "2016-11-15T18:00:00.000-00:00" 79.45 73.5 85.5]
+                         [#inst "2016-11-15T19:00:00.000-00:00" 80.42 74.8 86.5]
+                         [#inst "2016-11-15T20:00:00.000-00:00" 81.41 75.6 87.4]
+                         [#inst "2016-11-15T21:00:00.000-00:00" 82.42 76.1 88.4]
+                         [#inst "2016-11-15T22:00:00.000-00:00" 83.4 77.0 89.5]
+                         [#inst "2016-11-15T23:00:00.000-00:00" 84.38 78.3 90.0]
+                         [#inst "2016-11-16T00:00:00.000-00:00" 85.35 79.3 90.0]
+                         [#inst "2016-11-16T01:00:00.000-00:00" 85.27 78.8 90.0]
+                         [#inst "2016-11-16T02:00:00.000-00:00" 84.26 77.7 89.4]
+                         [#inst "2016-11-16T03:00:00.000-00:00" 83.25 76.5 88.5]
+                         [#inst "2016-11-16T04:00:00.000-00:00" 82.24 75.3 87.9]
+                         [#inst "2016-11-16T05:00:00.000-00:00" 81.23 74.1 87.2]
+                         [#inst "2016-11-16T06:00:00.000-00:00" 80.21 72.6 86.3]
+                         [#inst "2016-11-16T07:00:00.000-00:00" 79.19 71.5 84.9]
+                         [#inst "2016-11-16T08:00:00.000-00:00" 78.17 71.1 84.2]
+                         [#inst "2016-11-16T09:00:00.000-00:00" 77.17 70.1 83.2]
+                         [#inst "2016-11-16T10:00:00.000-00:00" 77.18 70.1 83.6]
+                         [#inst "2016-11-16T11:00:00.000-00:00" 78.17 71.0 84.8]])]
 
-        {:successful? successful?}))))
+        {:success? success?}))))
 
 (defn run-weather-bench [node]
   (bench/with-bench-ns :ts-weather

--- a/crux-bench/src/crux/bench/watdiv_crux.clj
+++ b/crux-bench/src/crux/bench/watdiv_crux.clj
@@ -33,7 +33,8 @@
       (let [{:keys [last-tx entity-count]} (with-open [in (io/input-stream watdiv/watdiv-input-file)]
                                              (rdf/submit-ntriples node in 1000))]
         (crux/await-tx node last-tx)
-        {:entity-count entity-count
+        {:success? true
+         :entity-count entity-count
          :neo4j-time-taken-ms (get-in @parsed-db-results [:neo4j :ingest])
          :rdf4j-time-taken-ms (get-in @parsed-db-results [:rdf4j :ingest])
          :datomic-time-taken-ms (get-in @parsed-db-results [:datomic :ingest])}))))
@@ -84,7 +85,8 @@
 (defn summarise-query-results [watdiv-query-results]
   (let [base-map (select-keys (first watdiv-query-results) [:bench-ns :crux-node-type])
         query-summary (merge base-map
-                             {:bench-type "queries"
+                             {:success? true
+                              :bench-type :queries
                               :time-taken-ms (->> watdiv-query-results (map :time-taken-ms) (reduce +))})
         summarised-results (concat
                             [query-summary]

--- a/crux-bench/src/crux/bench/watdiv_datomic.clj
+++ b/crux-bench/src/crux/bench/watdiv_datomic.clj
@@ -331,7 +331,8 @@
                                                   (vec)))
                            (reset! done? true)))
                        (+ n (count entities))))
-                   0)))))
+                   0))
+      {:success? true})))
 
 (defn run-watdiv-bench [{:keys [test-count] :as opts}]
   (with-datomic

--- a/crux-bench/src/crux/bench/watdiv_rdf4j.clj
+++ b/crux-bench/src/crux/bench/watdiv_rdf4j.clj
@@ -26,7 +26,8 @@
 (defn load-rdf-into-sail [^RepositoryConnection conn]
   (bench/run-bench :ingest-rdf
     (with-open [in (io/input-stream watdiv/watdiv-input-file)]
-      {:entity-count
+      {:success? true
+       :entity-count
        (->> (partition-all rdf/*ntriples-log-size* (line-seq (io/reader in)))
             (reduce (fn [n chunk]
                       (.add conn (StringReader. (string/join "\n" chunk)) "" RDFFormat/NTRIPLES rdf/empty-resource-array)


### PR DESCRIPTION
Pushing bench timings to CloudWatch metrics so that we can generate graphs and dashboards.

There's one large commit here standardising on `:success? true`, so that we can look out for it in result parsing - maybe best to filter to the middle commit.

TODO:
* [x] Add env var to docker image (but only overnight runs?)
* [ ] Pick graphs to be included on CloudWatch dashboard, and share link