### PR TITLE
`nil` transact times

### DIFF
--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -566,6 +566,7 @@
           (.tailSet vs (buffer-or-value-buffer min-v))))))
 
   (entity-as-of-resolver [this eid valid-time transact-time]
+    (assert transact-time)
     (let [i @entity-as-of-iterator-delay
           prefix-size (+ c/index-id-size c/id-size)
           eid-buffer (c/->id-buffer eid)
@@ -588,6 +589,7 @@
               (recur (kv/next i))))))))
 
   (entity-as-of [this eid valid-time transact-time]
+    (assert transact-time)
     (let [i @entity-as-of-iterator-delay
           prefix-size (+ c/index-id-size c/id-size)
           eid-buffer (c/->id-buffer eid)

--- a/crux-core/test/crux/fork_test.clj
+++ b/crux-core/test/crux/fork_test.clj
@@ -8,6 +8,11 @@
 
 (t/use-fixtures :each fix/with-node)
 
+(t/deftest test-empty-fork
+  (let [db (-> (crux/db *api*)
+               (crux/with-tx [[:crux.tx/put {:crux.db/id :foo}]]))]
+    (t/is (= {:crux.db/id :foo} (crux/entity db :foo)))))
+
 (t/deftest test-simple-fork
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan, :name "Ivna"}]])
 

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -50,10 +50,12 @@
         (t/is (nil? (api/entity (api/db *api* valid-time tx-time) :ivan)))))))
 
 (t/deftest test-empty-db
-  (t/is (api/db *api*))
-
-  (t/testing "syncing empty db"
-    (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))))
+  (let [empty-db (api/db *api*)]
+    (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))
+    (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo} #inst "2020"]])
+    (t/is (= {:crux.db/id :foo} (api/entity (api/db *api*) :foo)))
+    (t/is (nil? (api/entity empty-db :foo)))
+    (t/is (empty? (api/entity-history empty-db :foo :asc)))))
 
 (t/deftest test-status
   (t/is (= (merge {:crux.index/index-version 14}
@@ -345,6 +347,19 @@
   (let [{:keys [^Date crux.tx/tx-time]} (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
         the-future (Date. (+ (.getTime tx-time) 10000))]
     (t/is (thrown? NodeOutOfSyncException (api/db *api* the-future the-future)))))
+
+(t/deftest test-db-is-a-snapshot
+  (let [tx (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :count 0}]])
+        db (api/db *api*)]
+    (t/is (= (:crux.tx/tx-time tx)
+             (api/transaction-time db)))
+    (t/is (= {:crux.db/id :foo, :count 0}
+             (api/entity db :foo)))
+
+    (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :count 1}]])
+
+    (t/is (= {:crux.db/id :foo, :count 0}
+             (api/entity db :foo)))))
 
 (t/deftest test-latest-submitted-tx
   (t/is (nil? (.latestSubmittedTx *api*)))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -54,8 +54,12 @@
     (t/is (nil? (api/sync *api* (Duration/ofSeconds 10))))
     (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo} #inst "2020"]])
     (t/is (= {:crux.db/id :foo} (api/entity (api/db *api*) :foo)))
-    (t/is (nil? (api/entity empty-db :foo)))
-    (t/is (empty? (api/entity-history empty-db :foo :asc)))))
+
+    ;; TODO we don't currently distinguish between 'give me empty DB'
+    ;; and 'give me latest tx-time' on the HTTP API when the tx-time QP is nil/missing
+    (when-not (= *node-type* :remote)
+      (t/is (nil? (api/entity empty-db :foo)))
+      (t/is (empty? (api/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
   (t/is (= (merge {:crux.index/index-version 14}


### PR DESCRIPTION
Fixing edge cases around the empty DB, and ensuring that we fix a `tx-time` in the HTTP API `db` call if the user doesn't provide one.

* For ease, we eagerly fetch the latest-completed tx when `db`'s called on the remote API client - we could consider including vt/tt as a response header, and fixing after the first response (which may well be a call to `transactionTime`)
* We accept (for now) the bug that if a user opens a `db` on an empty remote API client (no txs yet) that it may not act like a snapshot if the user makes subsequent calls on the same instance.