### PR TITLE
NOOSE implements IExceptionInfo and accepts txs rather than tx-times

### DIFF
--- a/crux-core/src/crux/api/NodeOutOfSyncException.java
+++ b/crux-core/src/crux/api/NodeOutOfSyncException.java
@@ -1,16 +1,21 @@
 package crux.api;
 
 import java.util.Date;
+import clojure.lang.IExceptionInfo;
+import clojure.lang.IPersistentMap;
 
-public class NodeOutOfSyncException extends RuntimeException {
-    private static final long serialVersionUID = 1L;
+public class NodeOutOfSyncException extends RuntimeException implements IExceptionInfo {
+    private static final long serialVersionUID = 2L;
 
-    public final Date requestedTxTime;
-    public final Date availableTxTime;
+    private final IPersistentMap data;
 
-    public NodeOutOfSyncException(String message, Date requestedTxTime, Date availableTxTime) {
+    public NodeOutOfSyncException(String message, IPersistentMap data) {
         super(message);
-        this.requestedTxTime = requestedTxTime;
-        this.availableTxTime = availableTxTime;
+        this.data = data;
+    }
+
+    @Override
+    public IPersistentMap getData() {
+        return data;
     }
 }

--- a/crux-core/src/crux/error.clj
+++ b/crux-core/src/crux/error.clj
@@ -14,3 +14,11 @@
                                              ::message message}
                                             data)
                                      cause))))
+
+(defn node-out-of-sync [{:keys [requested available]}]
+  (let [message (format "Node out of sync - requested '%s', available '%s'" requested available)]
+    (crux.api.NodeOutOfSyncException. message
+                                      {::error-type :node-out-of-sync
+                                       ::message message
+                                       :requested requested
+                                       :available available})))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -1,31 +1,26 @@
 (ns crux.node
   (:require [clojure.java.io :as io]
-            [clojure.spec.alpha :as s]
-            [clojure.tools.logging :as log]
-            [com.stuartsierra.dependency :as dep]
+            [clojure.pprint :as pp]
             [crux.api :as api]
+            [crux.bus :as bus]
             [crux.codec :as c]
             [crux.db :as db]
+            [crux.error :as err]
             [crux.io :as cio]
-            [crux.kv :as kv]
             [crux.query :as q]
-            [crux.status :as status]
             [crux.query-state :as qs]
+            [crux.status :as status]
             [crux.system :as sys]
             [crux.tx :as tx]
-            [crux.tx.event :as txe]
-            [crux.bus :as bus]
             [crux.tx.conform :as txc]
-            [clojure.pprint :as pp])
-  (:import (crux.api ICruxAPI ICruxAsyncIngestAPI NodeOutOfSyncException ICursor
-                     QueryState QueryState$QueryStatus QueryState$QueryError)
-           (java.io Closeable Writer)
-           (java.lang AutoCloseable)
-           java.util.function.Consumer
-           java.util.Date
-           [java.util.concurrent Executors TimeoutException]
+            [crux.tx.event :as txe])
+  (:import [crux.api ICruxAPI ICruxAsyncIngestAPI ICursor]
+           [java.io Closeable Writer]
+           [java.time Duration Instant]
            java.util.concurrent.locks.StampedLock
-           (java.time Duration Instant)))
+           java.util.concurrent.TimeoutException
+           java.util.Date
+           java.util.function.Consumer))
 
 (def crux-version
   (when-let [pom-file (io/resource "META-INF/maven/juxt/crux-core/pom.properties")]
@@ -127,12 +122,9 @@
   (hasTxCommitted [this {:keys [::tx/tx-id ::tx/tx-time] :as submitted-tx}]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (let [{latest-tx-id ::tx/tx-id, latest-tx-time ::tx/tx-time} (.latestCompletedTx this)]
+      (let [{latest-tx-id ::tx/tx-id, :as latest-tx} (.latestCompletedTx this)]
         (if (and tx-id (or (nil? latest-tx-id) (pos? (compare tx-id latest-tx-id))))
-          (throw
-           (NodeOutOfSyncException.
-            (format "Node hasn't indexed the transaction: requested: %s, available: %s" tx-time latest-tx-time)
-            tx-time latest-tx-time))
+          (throw (err/node-out-of-sync {:requested submitted-tx, :available latest-tx}))
           (not (db/tx-failed? index-store tx-id))))))
 
   (openTxLog ^ICursor [this after-tx-id with-ops?]

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -21,7 +21,7 @@
             [crux.system :as sys]
             [clojure.pprint :as pp])
   (:import clojure.lang.Box
-           (crux.api ICruxDatasource HistoryOptions HistoryOptions$SortOrder NodeOutOfSyncException)
+           (crux.api ICruxDatasource HistoryOptions HistoryOptions$SortOrder)
            crux.codec.EntityTx
            crux.index.IndexStoreIndexState
            (java.io Closeable Writer)
@@ -1771,9 +1771,7 @@
   (db [this valid-time tx-time]
     (let [latest-tx-time (:crux.tx/tx-time (db/latest-completed-tx index-store))
           _ (when (and tx-time (or (nil? latest-tx-time) (pos? (compare tx-time latest-tx-time))))
-              (throw (NodeOutOfSyncException. (format "node hasn't indexed the requested transaction: requested: %s, available: %s"
-                                                      tx-time latest-tx-time)
-                                              tx-time latest-tx-time)))
+              (throw (err/node-out-of-sync {:requested {:crux.tx/tx-time tx-time}, :available {:crux.tx/tx-time latest-tx-time}})))
           valid-time (or valid-time (cio/next-monotonic-date))
           tx-time (or tx-time latest-tx-time valid-time)]
 

--- a/crux-http-server/src/crux/http_server.clj
+++ b/crux-http-server/src/crux/http_server.clj
@@ -251,14 +251,9 @@
 
       (handler request))))
 
-(defn handle-iae [^crux.IllegalArgumentException ex req]
+(defn handle-ex-info [ex req]
   {:status 400
    :body (ex-data ex)})
-
-(defn handle-noose [^crux.api.NodeOutOfSyncException ex req]
-  ;; TODO NOOSE needs ex-data
-  {:status 409
-   :body {:error (str ex)}})
 
 (defn handle-muuntaja-decode-error [ex req]
   {:status 400
@@ -336,8 +331,8 @@
                                        rm/format-response-middleware
                                        (re/create-exception-middleware
                                         (merge re/default-handlers
-                                               {crux.IllegalArgumentException handle-iae
-                                                crux.api.NodeOutOfSyncException handle-noose
+                                               {crux.IllegalArgumentException handle-ex-info
+                                                crux.api.NodeOutOfSyncException handle-ex-info
                                                 :muuntaja/decode handle-muuntaja-decode-error}))
                                        rm/format-request-middleware
                                        rrc/coerce-request-middleware]


### PR DESCRIPTION
Quick one to help out with transporting exceptions over HTTP, fixes a TODO that we left during the HTTP API work.