### PR TITLE
Second chance tweaks

### DIFF
--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -14,7 +14,8 @@
                  [org.clojure/tools.cli "1.0.194"]
                  [org.agrona/agrona "1.7.2"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
-                 [edn-query-language/eql "1.0.0"]]
+                 [edn-query-language/eql "1.0.0"]
+                 [org.roaringbitmap/RoaringBitmap "0.9.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}
              :cli-e2e-test {:jvm-opts ["-Dlogback.configurationFile=../resources/logback-test.xml"]
                             :dependencies [[juxt/crux-http-server "crux-git-version-alpha"]]}

--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -14,8 +14,7 @@
                  [org.clojure/tools.cli "1.0.194"]
                  [org.agrona/agrona "1.7.2"]
                  [com.github.jnr/jnr-ffi "2.1.9" :scope "provided"]
-                 [edn-query-language/eql "1.0.0"]
-                 [org.roaringbitmap/RoaringBitmap "0.9.0"]]
+                 [edn-query-language/eql "1.0.0"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}
              :cli-e2e-test {:jvm-opts ["-Dlogback.configurationFile=../resources/logback-test.xml"]
                             :dependencies [[juxt/crux-http-server "crux-git-version-alpha"]]}


### PR DESCRIPTION
Removing the rem usage in random-entry, speeding it up by about 4 times.
Don't set initial cache size on the underlying map, as this will slow down finding entries in the mostly empty array, which was making the resizing of the cache very slow when it was close to empty.