### PR TITLE
Fix bench-emails NPE

### DIFF
--- a/crux-bench/src/crux/bench/tpch_test.clj
+++ b/crux-bench/src/crux/bench/tpch_test.clj
@@ -27,8 +27,8 @@
       (bench/with-crux-dimensions
         (bench/run-bench :ingest
           (bench/with-additional-index-metrics node
-            (tpch/load-docs! node scale-factor tpch/tpch-entity->pkey-doc))
-          {:success true})
+            (tpch/load-docs! node scale-factor tpch/tpch-entity->pkey-doc)
+            {:success true}))
 
         ;; TODO we may want to split this up, à la WatDiv, so that we can see if
         ;; specific queries are slower than our comparison databases


### PR DESCRIPTION
Wasn't returning index metrics within the ingest of tpch_test, results->html attempted a divide by nil as a result and created an NPE.