### PR TITLE
Ensure we always submit an arg doc for tx-fns (even 0-arg)

### DIFF
--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -80,14 +80,13 @@
    :eid (check-eid eid)})
 
 (defmethod conform-tx-op-type :crux.tx/fn [[_ fn-eid & args :as _op] _decoders]
-  (merge {:op :crux.tx/fn
-          :fn-eid (check-eid fn-eid)}
-         (when (seq args)
-           (let [arg-doc {:crux.db/id (UUID/randomUUID)
-                          :crux.db.fn/args args}
-                 arg-doc-id (c/new-id arg-doc)]
-             {:arg-doc-id arg-doc-id
-              :docs {arg-doc-id arg-doc}}))))
+  (let [arg-doc {:crux.db/id (UUID/randomUUID)
+                 :crux.db.fn/args args}
+        arg-doc-id (c/new-id arg-doc)]
+    {:op :crux.tx/fn
+     :fn-eid (check-eid fn-eid)
+     :arg-doc-id arg-doc-id
+     :docs {arg-doc-id arg-doc}}))
 
 (defn conform-tx-op
   ([op] (conform-tx-op op {}))


### PR DESCRIPTION
Previously, we weren't submitting an arg doc for 0-arg tx-fns, which causes a relatively silent issue when coming to replace a non-existing doc. Found it as part of fixing #1240, but it's a separate bug.

This fix submits an arg doc for 0-arg tx-fn calls too, and also adds a test to show that the tx ingester still copes with tx-fns without arg-docs - there may will still be transaction functions on users' tx-logs without one.