### PR TITLE
Add `--repeat` flag to bench.

### DIFF
--- a/crux-bench/bin/run-bench.sh
+++ b/crux-bench/bin/run-bench.sh
@@ -9,7 +9,7 @@ while [[ "$#" -gt 0 ]]; do
         -r|--rev)
             REV="$2";
             shift 2;;
-        --nodes|--tests|--tpch-query-count|--tpch-field-count)
+        --nodes|--tests|--tpch-query-count|--tpch-field-count|--repeat)
             COMMAND+=", \"$1\", \"$2\""
             shift 2;;
         *) echo "Unknown parameter passed: $1"; exit 1;;

--- a/crux-bench/src/crux/bench/main.clj
+++ b/crux-bench/src/crux/bench/main.clj
@@ -80,7 +80,12 @@
                          [nil "--tpch-scale-factor 0.01" "Scale factor for regular TPCH test"
                           :id :tpch-scale-factor
                           :default 0.01
-                          :parse-fn #(Double/parseDouble %)]])]
+                          :parse-fn #(Double/parseDouble %)]
+
+                         [nil "--repeat 10" "Number of times to repeat the current bench run"
+                          :id :repetitions
+                          :default 1
+                          :parse-fn #(Long/parseLong %)]])]
     (if errors
       (binding [*out* *err*]
         (run! println errors)
@@ -88,10 +93,11 @@
 
       options)))
 
-(defn run-benches [{:keys [selected-nodes selected-tests] :as opts}]
+(defn run-benches [{:keys [selected-nodes selected-tests repetitions] :as opts}]
   (let [nodes (select-keys bench/nodes selected-nodes)]
     (bench/with-embedded-kafka
-      (->> (for [test-fn (vals (select-keys bench-tests selected-tests))]
+      (->> (for [n (range repetitions)
+                 test-fn (vals (select-keys bench-tests selected-tests))]
              (test-fn nodes opts))
            (into [] (mapcat identity))))))
 


### PR DESCRIPTION
Allows you to rerun the entire bench run multiple times - in this instance, I could use it to run a bench on FARGATE of watdiv on standalone-rocksdb ten times by calling the following command: `./bin/run-bench --tests watdiv --nodes standalone-rocksdb --repeat 10`