### PR TITLE
Build api docs on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,12 @@ workflows:
       - test:
           requires:
             - build
+      - create-api-docs:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - deploy-commit:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,13 +170,21 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/
+      - run:
+          command: |
+            if [ -n "${CIRCLE_TAG}" ];
+            then
+              echo 'export DOCS_PREFIX="${CIRCLE_TAG}"' >> $BASH_ENV
+            else
+              echo 'export DOCS_PREFIX="${CIRCLE_BRANCH}"' >> $BASH_ENV
+            fi
       - run: javadoc -Xdoclint:none -d crux-javadoc/ -cp `lein classpath` -sourcepath crux-core/src crux.api
       - aws-s3/sync:
           arguments: |
             --acl public-read
           from: crux-javadoc
           overwrite: true
-          to: 's3://crux-doc/crux-javadoc/${CIRCLE_TAG}'
+          to: 's3://crux-doc/crux-javadoc/${DOCS_PREFIX}'
       - node/install
       - run:
           command: |
@@ -189,7 +197,7 @@ jobs:
             --acl public-read
           from: redoc
           overwrite: true
-          to: 's3://crux-doc/redoc/${CIRCLE_TAG}'
+          to: 's3://crux-doc/redoc/${DOCS_PREFIX}'
 
 
 workflows:

--- a/docs/reference/modules/ROOT/nav.adoc
+++ b/docs/reference/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 * xref:queries.adoc[Queries]
 * Core API
 ** xref:clojure-api.adoc[Clojure]
-** https://crux-doc.s3.eu-west-2.amazonaws.com/crux-javadoc/index.html[Java,window=_blank]
+** https://crux-doc.s3.eu-west-2.amazonaws.com/crux-javadoc/{page-version}/index.html[Java,window=_blank]
 * xref:building.adoc[Building]
 * xref:monitoring.adoc[Monitoring]
 * xref:checkpointing.adoc[Checkpointing]

--- a/docs/reference/modules/ROOT/nav.adoc
+++ b/docs/reference/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 * xref:queries.adoc[Queries]
 * Core API
 ** xref:clojure-api.adoc[Clojure]
-** https://crux-doc.s3.eu-west-2.amazonaws.com/crux-javadoc/20.09-1.12.1/index.html[Java,window=_blank]
+** https://crux-doc.s3.eu-west-2.amazonaws.com/crux-javadoc/index.html[Java,window=_blank]
 * xref:building.adoc[Building]
 * xref:monitoring.adoc[Monitoring]
 * xref:checkpointing.adoc[Checkpointing]

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -92,7 +92,7 @@ include::example$src/docs/examples.clj[tags=start-http-client]
 
 All of the REST endpoints return `application/edn`, `application/json` and https://github.com/cognitect/transit-clj[`application/transit+json`].
 Individual endpoints may return additional types - see their docs below, or see the
-Swagger documentation link:https://crux-doc.s3.eu-west-2.amazonaws.com/redoc/crux-redoc.html[here].
+Swagger documentation link:https://crux-doc.s3.eu-west-2.amazonaws.com/redoc/{page-version}/crux-redoc.html[here].
 
 [NOTE]
 All endpoints with query-parameters accept them in both a kebab-case and camel cased format, (ie: if `valid-time` is taken, `validTime` will also be taken)

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -91,7 +91,8 @@ include::example$src/docs/examples.clj[tags=start-http-client]
 == Using the REST API
 
 All of the REST endpoints return `application/edn`, `application/json` and https://github.com/cognitect/transit-clj[`application/transit+json`].
-Individual endpoints may return additional types - see their docs below.
+Individual endpoints may return additional types - see their docs below, or see the
+Swagger documentation link:https://crux-doc.s3.eu-west-2.amazonaws.com/redoc/crux-redoc.html[here].
 
 [NOTE]
 All endpoints with query-parameters accept them in both a kebab-case and camel cased format, (ie: if `valid-time` is taken, `validTime` will also be taken)


### PR DESCRIPTION
Resolves #1225 - adds links to master versions javadocs/redoc in the docs. 