### PR TITLE
Cache GLibC JNR instance

### DIFF
--- a/crux-core/src/crux/cli.clj
+++ b/crux-core/src/crux/cli.clj
@@ -68,7 +68,6 @@
     shutdown?))
 
 (defn start-node-from-command-line [args]
-  (cio/try-set-malloc-arena-max 2)
   (cio/install-uncaught-exception-handler!)
 
   (let [{::keys [errors help node-opts]} (parse-args args)]


### PR DESCRIPTION
Don't create a new JNR stub for every call to glibc. Remove malloc arena max default, making it fully explicit.