### PR TITLE
Increase LMDB max readers

### DIFF
--- a/crux-lmdb/src/crux/lmdb/jnr.clj
+++ b/crux-lmdb/src/crux/lmdb/jnr.clj
@@ -148,11 +148,15 @@
                                     {:env-flags {:doc "LMDB Flags"
                                                  :spec ::sys/nat-int}
                                      :env-mapsize {:doc "LMDB Map size"
-                                                   :spec ::sys/nat-int}})}
-  [{:keys [^Path db-dir checkpointer sync? env-flags env-mapsize]}]
+                                                   :spec ::sys/nat-int}
+                                     :env-maxreaders {:doc "LMDB Max readers"
+                                                      :default 1024
+                                                      :spec ::sys/nat-int}})}
+  [{:keys [^Path db-dir checkpointer sync? env-flags env-mapsize env-maxreaders]}]
   (let [db-dir (.toFile db-dir)
         _ (some-> checkpointer (cp/try-restore db-dir cp-format))
-        env (.open (Env/create DirectBufferProxy/PROXY_DB)
+        env (.open (cond-> (Env/create DirectBufferProxy/PROXY_DB)
+                     env-maxreaders (.setMaxReaders env-maxreaders))
                    (doto db-dir (.mkdirs))
                    (into-array EnvFlags (cond-> default-env-flags
                                           (not sync?) (concat no-sync-env-flags))))


### PR DESCRIPTION
Increase LMDB max readers to 1024 from default 126, and add a config for it.

This seems innocent, here's the comment around it from `mdb.c`:
```
        /**     Number of slots in the reader table.
         *      This value was chosen somewhat arbitrarily. 126 readers plus a
         *      couple mutexes fit exactly into 8KB on my development machine.
         *      Applications should set the table size using #mdb_env_set_maxreaders().
         */
#define DEFAULT_READERS 126
```

Related to #664 