### PR TITLE
Returned `indexed-docs` on bus - use directly in lucene

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -34,9 +34,10 @@
 (s/def ::bytes-indexed nat-int?)
 (s/def ::doc-ids (s/coll-of #(instance? crux.codec.Id %) :kind set?))
 (s/def ::eids (s/coll-of c/valid-id? :kind set?))
+(s/def ::docs (s/nilable (s/coll-of map?)))
 
 (defmethod bus/event-spec ::indexing-docs [_] (s/keys :req-un [::doc-ids]))
-(defmethod bus/event-spec ::indexed-docs [_] (s/keys :req-un [::doc-ids ::av-count ::bytes-indexed]))
+(defmethod bus/event-spec ::indexed-docs [_] (s/keys :req-un [::doc-ids ::av-count ::bytes-indexed ::docs]))
 (defmethod bus/event-spec ::indexing-tx [_] (s/keys :req [::submitted-tx]))
 (defmethod bus/event-spec ::indexing-tx-pre-commit [_] (s/keys :req [::submitted-tx]))
 (defmethod bus/event-spec ::indexed-tx [_] (s/keys :req [::submitted-tx ::txe/tx-events], :req-un [::committed?]))
@@ -267,7 +268,7 @@
 
         (bus/send bus {:crux/event-type ::indexed-docs,
                        :doc-ids doc-ids
-                       :indexed-docs indexed-docs
+                       :docs (vals indexed-docs)
                        :av-count (->> (vals indexed-docs) (apply concat) (count))
                        :bytes-indexed bytes-indexed})))))
 

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -267,6 +267,7 @@
 
         (bus/send bus {:crux/event-type ::indexed-docs,
                        :doc-ids doc-ids
+                       :indexed-docs indexed-docs
                        :av-count (->> (vals indexed-docs) (apply concat) (count))
                        :bytes-indexed bytes-indexed})))))
 

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -182,12 +182,12 @@
                      :crux.bus/executor (reify java.util.concurrent.Executor
                                           (execute [_ f]
                                             (.run f)))}
-                (fn [{:keys [crux/event-type crux.tx/submitted-tx indexed-docs eids] :as event}]
+                (fn [{:keys [crux/event-type crux.tx/submitted-tx docs eids] :as event}]
                   (case event-type
                     :crux.tx/indexing-tx-pre-commit
                     (index-tx! lucene-store submitted-tx)
                     :crux.tx/indexed-docs
-                    (index-docs! document-store lucene-store (vals indexed-docs))
+                    (index-docs! document-store lucene-store docs)
                     :crux.tx/unindexing-eids
                     (evict! index-store lucene-store eids))))
     lucene-store))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -902,8 +902,7 @@
                 {:crux/event-type ::tx/indexing-docs, :doc-ids #{(c/new-id doc-1) (c/new-id doc-2)}}
                 {:crux/event-type ::tx/indexed-docs
                  :doc-ids #{(c/new-id doc-1) (c/new-id doc-2)}
-                 :indexed-docs {(c/new-id doc-1) doc-1
-                                (c/new-id doc-2) doc-2}
+                 :docs #{doc-1 doc-2}
                  :av-count 4}
                 {:crux/event-type ::tx/indexed-tx,
                  ::tx/submitted-tx submitted-tx,
@@ -915,7 +914,8 @@
                                    #crux/id "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
                                    #crux/id "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
                (-> (vec @!events)
-                   (update 2 dissoc :bytes-indexed)))))))
+                   (update 2 dissoc :bytes-indexed)
+                   (update 2 update :docs set)))))))
 
 
 (t/deftest await-fails-quickly-738

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -902,6 +902,8 @@
                 {:crux/event-type ::tx/indexing-docs, :doc-ids #{(c/new-id doc-1) (c/new-id doc-2)}}
                 {:crux/event-type ::tx/indexed-docs
                  :doc-ids #{(c/new-id doc-1) (c/new-id doc-2)}
+                 :indexed-docs {(c/new-id doc-1) doc-1
+                                (c/new-id doc-2) doc-2}
                  :av-count 4}
                 {:crux/event-type ::tx/indexed-tx,
                  ::tx/submitted-tx submitted-tx,


### PR DESCRIPTION
Saves roundtrip to get docs back from the document-store - open question on if there's any security concerns doing this on the bus?