### PR TITLE
Bump Kafka to 2.6.0 

### DIFF
--- a/crux-bench/project.clj
+++ b/crux-bench/project.clj
@@ -44,8 +44,9 @@
                  [org.ow2.asm/asm-tree "7.2"]
                  [org.ow2.asm/asm "7.2"]
                  [org.ow2.asm/asm-analysis "7.2"]
-                 [com.github.luben/zstd-jni "1.4.3-1"]
+                 [com.github.luben/zstd-jni "1.4.4-7"]
                  [com.google.guava/guava "28.2-jre"]
+                 [org.slf4j/slf4j-api "1.7.30"]
                  [org.apache.httpcomponents/httpclient "4.5.12"]
                  [org.apache.httpcomponents/httpcore "4.4.13"]
                  [com.fasterxml.jackson.core/jackson-core "2.10.2"]
@@ -53,7 +54,9 @@
                  [com.fasterxml.jackson.core/jackson-databind "2.10.2"]
                  [com.github.spotbugs/spotbugs-annotations "3.1.9"]
                  [org.reactivestreams/reactive-streams "1.0.3"]
-                 [org.codehaus.janino/commons-compiler "3.0.11"]]
+                 [org.codehaus.janino/commons-compiler "3.0.11"]
+                 [org.eclipse.jetty/jetty-server "9.4.30.v20200611"]
+                 [javax.servlet/javax.servlet-api "4.0.1"]]
 
   :middleware [leiningen.project-version/middleware]
 

--- a/crux-core/project.clj
+++ b/crux-core/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.logging "1.1.0"]
-                 [org.slf4j/slf4j-api "1.7.29"]
+                 [org.slf4j/slf4j-api "1.7.30"]
                  [org.clojure/spec.alpha "0.2.176"]
                  [com.stuartsierra/dependency "0.2.0"]
                  [com.taoensso/nippy "2.15.1"]

--- a/crux-kafka-connect/project.clj
+++ b/crux-kafka-connect/project.clj
@@ -9,8 +9,9 @@
                  [org.clojure/tools.logging "1.1.0"]
                  [cheshire "5.9.0"]
                  [com.taoensso/nippy "2.15.1"]
-                 [com.cognitect/transit-clj "1.0.324"]]
-  :profiles {:provided {:dependencies [[org.apache.kafka/connect-api "2.3.0"]]}}
+                 [com.cognitect/transit-clj "1.0.324"]
+                 [org.slf4j/slf4j-api "1.7.30"]]
+  :profiles {:provided {:dependencies [[org.apache.kafka/connect-api "2.6.0"]]}}
   :middleware [leiningen.project-version/middleware]
   :aliases {"package" ["do" ["inline-deps"] ["with-profile" "+plugin.mranderson/config" "uberjar"] ["archive"]]}
   :confluent-hub-manifest {:component_types ["sink" "source"]

--- a/crux-kafka-embedded/project.clj
+++ b/crux-kafka-embedded/project.clj
@@ -5,13 +5,13 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [juxt/crux-core "crux-git-version-beta"]
-                 [org.apache.kafka/kafka_2.12 "2.3.0"]
+                 [org.apache.kafka/kafka_2.12 "2.6.0"]
                  [org.apache.zookeeper/zookeeper "3.6.1"
                   ;; naughty of ZK to depend on a specific SLF4J impl, we don't want to.
                   :exclusions [org.slf4j/slf4j-log4j12]]
 
                  ;; dependency conflict resolution
-                 [org.slf4j/slf4j-api "1.7.29"]
+                 [org.slf4j/slf4j-api "1.7.30"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.10.2"]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}}
   :middleware [leiningen.project-version/middleware]

--- a/crux-kafka/project.clj
+++ b/crux-kafka/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.logging "1.1.0"]
                  [juxt/crux-core "crux-git-version-beta"]
-                 [org.apache.kafka/kafka-clients "2.3.0" :exclusions [org.lz4/lz4-java]]
+                 [org.apache.kafka/kafka-clients "2.6.0" :exclusions [org.lz4/lz4-java]]
                  [cheshire "5.10.0"]
                  [com.cognitect/transit-clj "1.0.324" :exclusions [org.msgpack/msgpack]]]
   :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}}

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -82,7 +82,7 @@
   (AdminClient/create ^Map kafka-config))
 
 (defn- create-topic [^AdminClient admin-client {:keys [topic-name num-partitions replication-factor topic-config]}]
-  (let [new-topic (doto (NewTopic. topic-name num-partitions replication-factor)
+  (let [new-topic (doto (NewTopic. topic-name num-partitions (short replication-factor))
                     (.configs topic-config))]
     (try
       @(.all (.createTopics admin-client [new-topic]))

--- a/crux-test/project.clj
+++ b/crux-test/project.clj
@@ -64,7 +64,7 @@
                                    [net.minidev/json-smart "2.3"]
 
                                    ;; Kafka connect tests
-                                   [org.apache.kafka/connect-api "2.3.0"]
+                                   [org.apache.kafka/connect-api "2.6.0"]
 
                                    ;; dependency conflict resolution
                                    [com.fasterxml.jackson.core/jackson-core "2.10.2"]

--- a/examples/soak/Dockerfile
+++ b/examples/soak/Dockerfile
@@ -1,7 +1,8 @@
 FROM clojure:openjdk-11-lein-2.9.3
 
 WORKDIR /usr/local/lib/crux
-ENTRYPOINT ["java","-cp","crux-soak.jar","-Xms3g","-Xmx3g","-Dclojure.main.report=stderr","clojure.main"]
+ENTRYPOINT ["java","-cp","crux-soak.jar","-Xms512m","-Xmx512m","-Dclojure.main.report=stderr","clojure.main"]
+ENV MALLOC_ARENA_MAX=2
 
 EXPOSE 8080
 ADD target/crux-soak.jar .

--- a/examples/soak/cloudformation/ecs-service.yml
+++ b/examples/soak/cloudformation/ecs-service.yml
@@ -153,7 +153,7 @@ Resources:
       ServiceName: 'crux-soak'
       Cluster: 'crux-soak'
       LaunchType: FARGATE
-      HealthCheckGracePeriodSeconds: 600
+      HealthCheckGracePeriodSeconds: 10800
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 75

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
    [juxt/crux-test "crux-git-version"]
    [juxt/crux-bench "crux-git-version"]
 
-   [org.apache.kafka/connect-api "2.3.0" :scope "provided"]
+   [org.apache.kafka/connect-api "2.6.0" :scope "provided"]
 
    [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]
    [com.h2database/h2 "1.4.200"]


### PR DESCRIPTION
Resolves #1231 - ensuring tests pass, it's still readable, and Soak still works. 

May want a last browse through the Kafka upgrade log to sanity check: https://kafka.apache.org/26/documentation.html#upgrade, though seems most changes don't particularly affect the API as we 
 use it (asides from the one fix I had to make to the call to `NewTopic`) - mostly seems to impact Kstreams, and various changes related to partition APIs.