### PR TITLE
BigDecimal and java.time classes as value types

### DIFF
--- a/crux-core/src/crux/codec/MathCodec.java
+++ b/crux-core/src/crux/codec/MathCodec.java
@@ -1,0 +1,63 @@
+package crux.codec;
+
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.ExpandableDirectByteBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@SuppressWarnings("unused")
+public class MathCodec {
+
+    public static int encodeExponent(BigDecimal x) {
+        return Integer.MIN_VALUE ^ (x.signum() * (x.precision() - x.scale()));
+    }
+
+    private static int binaryCodedChar(String s, int idx) {
+        return idx < s.length() ? Character.digit(s.charAt(idx), 10) + 1 : 0;
+    }
+
+    public static int putBinaryCodedDecimal(int signum, String s, MutableDirectBuffer buf, int offset) {
+        int chars = s.length();
+        int mask = signum < 0 ? 0xff : 0;
+        int bytes = (chars / 2) + 1;
+
+        for (int i = 0; i < bytes; i++) {
+            int c1 = binaryCodedChar(s, i * 2);
+            int c2 = binaryCodedChar(s, i * 2 + 1);
+            buf.putByte(i + offset, (byte) (mask ^ (c1 << 4 | c2)));
+        }
+
+        return bytes;
+    }
+
+    public static String getBinaryCodedDecimal(DirectBuffer buf, int signum) {
+        int mask = signum < 0 ? 0xff : 0;
+
+        boolean lastDigitZero = 0 == ((mask ^ buf.getByte(buf.capacity() - 1)) & 0xf);
+        int precision = (buf.capacity() * 2) - (lastDigitZero ? 1 : 0);
+
+        StringBuilder sb = new StringBuilder(precision);
+        for (int i = 0; i < buf.capacity(); i++) {
+            byte b = (byte) (mask ^ buf.getByte(i));
+            int nibble = (0xf & (b >> 4)) - 1;
+            if (nibble >= 0) sb.append(nibble);
+            nibble = (0xf & b) - 1;
+            if (nibble >= 0) sb.append(nibble);
+        }
+
+        return sb.toString();
+    }
+
+    public static BigDecimal decodeBigDecimal(int signum, int encodedExponent, String decodedBCD) {
+        BigInteger bigInt = new BigInteger(decodedBCD);
+        if (signum < 0) bigInt = bigInt.negate();
+
+        int scale = decodedBCD.length() - signum * (Integer.MIN_VALUE ^ encodedExponent);
+
+        return new BigDecimal(bigInt, scale);
+    }
+}


### PR DESCRIPTION
Adding support for `BigDecimal`, `LocalDate`, `LocalTime`, `LocalDateTime`, `Instant` and `Duration` as value types, allowing them to be used in range filters.

`BigDecimal` implementation adapted from [Orderly](https://github.com/ndimiduk/orderly/blob/master/orderly-core/src/main/java/orderly/BigDecimalRowKey.java)

RFC: I haven't included `BigInteger` here, because in Clojure there's also `clojure.lang.BigInt` to consider (a separate type to `java.math.BigInteger`, neither being a sub-class/super-class of the other) - this is therefore more susceptible than the others to the known issue of Crux values not being comparable between types, but with (I'd wager) significantly less awareness, even within the Clojure community. Could also be argued that supporting `BigDecimal` but not `BigInteger` is a big gotcha, particularly for JVM devs who _really_ don't care about this Clojure nuance. Eurgh.

Overnight RFC: (definitely a separate PR, if at all) - for the time being, could/should we make range filters refuse to compare values from different types? i.e. `10` is neither `<`, `>` nor `=` to `10.0`? May be less counter-intuitive than having (say) `12.0 < 10` because the binary representation of doubles happen to be 'less' than longs.