### PR TITLE
Inlining calls to ByteUtils that have Clojure wrappers.

### DIFF
--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -199,6 +199,11 @@
    (some-> b (ByteUtils/hexToBuffer to))))
 
 (defn compare-buffers
+  {:inline (fn [a b & [max-length]]
+             (if max-length
+               `(ByteUtils/compareBuffers ~a ~b ~max-length)
+               `(ByteUtils/compareBuffers ~a ~b)))
+   :inline-arities #{2 3}}
   (^long [^DirectBuffer a ^DirectBuffer b]
    (ByteUtils/compareBuffers a b))
   (^long [^DirectBuffer a ^DirectBuffer b ^long max-length]
@@ -208,6 +213,11 @@
   ByteUtils/UNSIGNED_BUFFER_COMPARATOR)
 
 (defn buffers=?
+  {:inline (fn [a b & [max-length]]
+             (if max-length
+               `(ByteUtils/equalBuffers ~a ~b ~max-length)
+               `(ByteUtils/equalBuffers ~a ~b)))
+   :inline-arities #{2 3}}
   ([^DirectBuffer a ^DirectBuffer b]
    (ByteUtils/equalBuffers a b))
   ([^DirectBuffer a ^DirectBuffer b ^long max-length]


### PR DESCRIPTION
For stylistic reasons we have Clojure wrappers for some calls in `crux.ByteUtils`, like `compareBuffers` and `equalBuffers`
Adding Clojure inline metadata cuts down the call overhead with 10-15%.

Note that this isn't directly visible in end to end benchmarks, as there's a lot of other things going on, and many calls to `compareBuffers` go via `crux.memory/buffer-comparator`. The places where they will be inlined will mainly be in `crux.kv.index-store`.

There are potentially other places where utility functions (Java wrappers or small Clojure snippets) could benefit from simple inline metadata in a similar fashion.