### PR TITLE
Add note distinguishing between using symbols in EDN / Clojure

### DIFF
--- a/docs/reference/modules/ROOT/pages/azure-blobs.adoc
+++ b/docs/reference/modules/ROOT/pages/azure-blobs.adoc
@@ -33,6 +33,24 @@ pom.xml::
 
 Replace the implementation of the document store with `+crux.azure.blobs/->document-store+`
 
+[tabs]
+====
+JSON::
++
+[source,json]
+----
+{
+  "crux/document-store": {
+    "crux/module": "crux.azure.blobs/->document-store",
+    "sas-token": "your-sas-token",
+    "storage-account": "your-storage-account",
+    "container": "your-container-name"
+  },
+}
+----
+
+Clojure::
++
 [source,clojure]
 ----
 {:crux/document-store {:crux/module 'crux.azure.blobs/->document-store
@@ -40,6 +58,17 @@ Replace the implementation of the document store with `+crux.azure.blobs/->docum
                        :storage-account "your-storage-account"
                        :container "your-container-name"}}
 ----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module crux.azure.blobs/->document-store
+                       :sas-token "your-sas-token"
+                       :storage-account "your-storage-account"
+                       :container "your-container-name"}}
+----
+====
 
 You'll need to create a `Storage Account`, then a `Container` for storing the documents.
 

--- a/docs/reference/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/reference/modules/ROOT/pages/checkpointing.adoc
@@ -17,18 +17,6 @@ You can enable checkpoints on your index-store by adding a `:checkpointer` depen
 
 [tabs]
 ====
-Clojure/EDN::
-+
-[source,clojure]
-----
-{:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
-                               ...
-                               :checkpointer {:crux/module 'crux.checkpoint/->checkpointer
-                                              :store {:crux/module 'crux.s3.checkpoint/->cp-store
-                                                      :bucket "<bucket>"}
-                                              :approx-frequency "PT6H"}}}
- ...}
-----
 JSON::
 +
 [source,json]
@@ -50,6 +38,32 @@ JSON::
   },
   ...
 }
+----
+
+Clojure::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                               ...
+                               :checkpointer {:crux/module 'crux.checkpoint/->checkpointer
+                                              :store {:crux/module 'crux.s3.checkpoint/->cp-store
+                                                      :bucket "<bucket>"}
+                                              :approx-frequency (Duration/ofHours 6)}}}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module crux.rocksdb/->kv-store
+                               ...
+                               :checkpointer {:crux/module crux.checkpoint/->checkpointer
+                                              :store {:crux/module crux.s3.checkpoint/->cp-store
+                                                      :bucket "<bucket>"}
+                                              :approx-frequency "PT6H"}}}
+ ...}
 ----
 ====
 

--- a/docs/reference/modules/ROOT/pages/configuration.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration.adoc
@@ -100,7 +100,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.http-server/server {:port 3000}}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -141,11 +148,20 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/document-store {:crux/module 'crux.s3/->document-store
+                       :bucket "my-bucket"
+                       :prefix "my-prefix"}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module crux.s3/->document-store
                        :bucket "my-bucket"
                        :prefix "my-prefix"}}
 ----
@@ -193,12 +209,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/tx-log {:kv-store {:crux/module 'crux.rocksdb/->kv-store
                           :db-dir (io/file "/tmp/txs")}}
+ :crux/document-store {...}
+ :crux/index-store {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/tx-log {:kv-store {:crux/module crux.rocksdb/->kv-store
+                          :db-dir "/tmp/txs"}}
  :crux/document-store {...}
  :crux/index-store {...}}
 ----
@@ -283,12 +309,23 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:my-rocksdb {:crux/module 'crux.rocksdb/->kv-store
               :db-dir (io/file "/tmp/rocksdb")}
+ :crux/tx-log {:kv-store :my-rocksdb}
+ :crux/document-store {:kv-store :my-rocksdb}}
+----
+
+
+EDN::
++
+[source,clojure]
+----
+{:my-rocksdb {:crux/module crux.rocksdb/->kv-store
+              :db-dir "/tmp/rocksdb"}
  :crux/tx-log {:kv-store :my-rocksdb}
  :crux/document-store {:kv-store :my-rocksdb}}
 ----

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -40,7 +40,15 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.http-server/server {:port 3000
+                           ...}
+----
+
+EDN::
 +
 [source,clojure]
 ----

--- a/docs/reference/modules/ROOT/pages/jdbc.adoc
+++ b/docs/reference/modules/ROOT/pages/jdbc.adoc
@@ -77,12 +77,24 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/tx-log {:crux/module 'crux.jdbc/->tx-log
                :connection-pool {:dialect {:crux/module 'crux.jdbc.psql/->dialect}
+                                 :pool-opts { ... }
+                                 :db-spec { ... }}
+               :poll-sleep-duration (Duration/ofSeconds 1)}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/tx-log {:crux/module crux.jdbc/->tx-log
+               :connection-pool {:dialect {:crux/module crux.jdbc.psql/->dialect}
                                  :pool-opts { ... }
                                  :db-spec { ... }}
                :poll-sleep-duration "PT1S"}
@@ -116,12 +128,23 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/document-store {:crux/module 'crux.jdbc/->document-store
                        :connection-pool {:dialect {:crux/module 'crux.jdbc.psql/->dialect}
+                                         :pool-opts { ... }
+                                         :db-spec { ... }}}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module crux.jdbc/->document-store
+                       :connection-pool {:dialect {:crux/module crux.jdbc.psql/->dialect}
                                          :pool-opts { ... }
                                          :db-spec { ... }}}
  ...}
@@ -162,7 +185,7 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
@@ -172,6 +195,20 @@ Clojure/EDN::
  :crux/tx-log {:crux/module 'crux.jdbc/->tx-log
                :connection-pool :crux.jdbc/connection-pool}
  :crux/document-store {:crux/module 'crux.jdbc/->document-store
+                       :connection-pool :crux.jdbc/connection-pool}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux.jdbc/connection-pool {:dialect {:crux/module crux.jdbc.psql/->dialect}
+                             :pool-opts { ... }
+                             :db-spec { ... }}
+ :crux/tx-log {:crux/module crux.jdbc/->tx-log
+               :connection-pool :crux.jdbc/connection-pool}
+ :crux/document-store {:crux/module crux.jdbc/->document-store
                        :connection-pool :crux.jdbc/connection-pool}
  ...}
 ----

--- a/docs/reference/modules/ROOT/pages/kafka.adoc
+++ b/docs/reference/modules/ROOT/pages/kafka.adoc
@@ -67,11 +67,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/tx-log {:crux/module 'crux.kafka/->tx-log
+               :kafka-config {:bootstrap-servers "localhost:9092"}
+               :tx-topic-opts {:topic-name "crux-transaction-log"}
+               :poll-wait-duration (Duration/ofSeconds 1)}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/tx-log {:crux/module crux.kafka/->tx-log
                :kafka-config {:bootstrap-servers "localhost:9092"}
                :tx-topic-opts {:topic-name "crux-transaction-log"}
                :poll-wait-duration "PT1S"}
@@ -113,7 +124,7 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
@@ -123,6 +134,21 @@ Clojure/EDN::
                        :doc-topic-opts {:topic-name "crux-docs"
                                         ...}
                        :local-document-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                                                         :db-dir (io/file "/tmp/rocksdb")}}
+                       :poll-wait-duration (Duration/ofSeconds 1)}
+ ...}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module crux.kafka/->document-store
+                       :kafka-config {:bootstrap-servers "localhost:9092"
+                                      ...}
+                       :doc-topic-opts {:topic-name "crux-docs"
+                                        ...}
+                       :local-document-store {:kv-store {:crux/module crux.rocksdb/->kv-store
                                                          :db-dir "/tmp/rocksdb"}}
                        :poll-wait-duration "PT1S"}
  ...}
@@ -162,12 +188,24 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {...
  :local-rocksdb {:crux/module 'crux.rocksdb/->kv-store
+                 :db-dir (io/file "/tmp/rocksdb")}
+ :crux/document-store {...
+                       :local-document-store {:kv-store :local-rocksdb}}
+ :crux/index-store {:kv-store :local-rocksdb}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{...
+ :local-rocksdb {:crux/module crux.rocksdb/->kv-store
                  :db-dir "/tmp/rocksdb"}
  :crux/document-store {...
                        :local-document-store {:kv-store :local-rocksdb}}
@@ -206,7 +244,7 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
@@ -217,6 +255,21 @@ Clojure/EDN::
                :kafka-config :kafka-config
                ...}
  :crux/document-store {:crux/module 'crux.kafka/->document-store
+                       :kafka-config :kafka-config
+                       ...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:kafka-config {:crux/module crux.kafka/->kafka-config
+                :bootstrap-servers "localhost:9092"
+                ...}
+ :crux/tx-log {:crux/module crux.kafka/->tx-log
+               :kafka-config :kafka-config
+               ...}
+ :crux/document-store {:crux/module crux.kafka/->document-store
                        :kafka-config :kafka-config
                        ...}}
 ----

--- a/docs/reference/modules/ROOT/pages/lmdb.adoc
+++ b/docs/reference/modules/ROOT/pages/lmdb.adoc
@@ -52,12 +52,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/index-store {:kv-store {:crux/module 'crux.lmdb/->kv-store
                                :db-dir (io/file "/tmp/lmdb")}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module crux.lmdb/->kv-store
+                               :db-dir "/tmp/lmdb"}}
  :crux/document-store {...}
  :crux/tx-log {...}}
 ----

--- a/docs/reference/modules/ROOT/pages/lucene.adoc
+++ b/docs/reference/modules/ROOT/pages/lucene.adoc
@@ -47,7 +47,15 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{...
+ :crux.lucene/lucene-store {:db-dir "lucene-dir"}}
+----
+
+EDN::
 +
 [source,clojure]
 ----

--- a/docs/reference/modules/ROOT/pages/monitoring.adoc
+++ b/docs/reference/modules/ROOT/pages/monitoring.adoc
@@ -47,6 +47,21 @@ JSON::
   "crux.metrics/metrics": { ... },
 }
 ----
+
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics/metrics { ... }}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux.metrics/metrics { ... }}
+----
+
 ====
 
 You can omit this if you're happy with its default parameters.
@@ -92,7 +107,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.prometheus/reporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -142,7 +164,14 @@ JSON::
 ----
 
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.prometheus/http-exporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -187,7 +216,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.cloudwatch/reporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -234,7 +270,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.jmx/reporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -269,7 +312,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.console/reporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----
@@ -304,7 +354,14 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{:crux.metrics.csv/reporter { ... }}
+----
+
+EDN::
 +
 [source,clojure]
 ----

--- a/docs/reference/modules/ROOT/pages/rocksdb.adoc
+++ b/docs/reference/modules/ROOT/pages/rocksdb.adoc
@@ -50,12 +50,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
                                :db-dir (io/file "/tmp/rocksdb")}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module crux.rocksdb/->kv-store
+                               :db-dir "/tmp/rocksdb"}}
  :crux/document-store {...}
  :crux/tx-log {...}}
 ----
@@ -100,12 +110,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
                                :metrics {:crux/module 'crux.rocksdb.metrics/->metrics}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module crux.rocksdb/->kv-store
+                               :metrics {:crux/module crux.rocksdb.metrics/->metrics}}
  :crux/document-store {...}
  :crux/tx-log {...}}
 ----

--- a/docs/reference/modules/ROOT/pages/s3.adoc
+++ b/docs/reference/modules/ROOT/pages/s3.adoc
@@ -46,11 +46,20 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux.document-store {:crux/module 'crux.s3/->document-store
+                       :bucket "your-bucket"
+                       ...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux.document-store {:crux/module crux.s3/->document-store
                        :bucket "your-bucket"
                        ...}}
 ----
@@ -89,7 +98,7 @@ By default, we get credentials through the usual AWS credentials provider, and s
 
 [tabs]
 ====
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----

--- a/docs/reference/modules/ROOT/pages/sql.adoc
+++ b/docs/reference/modules/ROOT/pages/sql.adoc
@@ -64,7 +64,15 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
++
+[source,clojure]
+----
+{...
+ :crux.calcite/server {:port 1501}}
+----
+
+EDN::
 +
 [source,clojure]
 ----

--- a/docs/reference/modules/ROOT/pages/xodus.adoc
+++ b/docs/reference/modules/ROOT/pages/xodus.adoc
@@ -39,12 +39,22 @@ JSON::
 }
 ----
 
-Clojure/EDN::
+Clojure::
 +
 [source,clojure]
 ----
 {:crux/index-store {:kv-store {:crux/module 'avisi.crux.xodus/->kv-store
                                :db-dir (io/file "/tmp/xodus")}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module avisi.crux.xodus/->kv-store
+                               :db-dir "/tmp/xodus"}}
  :crux/document-store {...}
  :crux/tx-log {...}}
 ----


### PR DESCRIPTION
Resolves #1243 

Decided to add a little note about the usage of leading characters directly underneath where we state about being able to use configuration files to start nodes - can see it here: https://opencrux.com/doc-note/reference/configuration.html