### PR TITLE
Fix for await-tx - fail if ingester has already failed before await

### DIFF
--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -135,8 +135,9 @@
 
 (t/deftest test-await-tx
   (let [bus (bus/->bus {})
+        tx-ingester (tx/map->TxIngester {:!error (atom nil)})
         await-tx (fn [tx timeout]
-                   (#'n/await-tx {:bus bus} ::tx/tx-id tx timeout))
+                   (#'n/await-tx {:bus bus :tx-ingester tx-ingester} ::tx/tx-id tx timeout))
         tx1 {::tx/tx-id 1
              ::tx/tx-time (Date.)}
         tx-evt {:crux/event-type ::tx/indexed-tx


### PR DESCRIPTION
Fix for #1260 

The test was intermittently failing because the `crux.tx/ingester-error` event was being sent on the bus before `await-tx` had created a listener for it - `await-tx` wasn't checking for tx-ingester errors before creating the listeners, so any fails on the `tx-ingester` before the `await-tx` call were being ignored. 

This fix also includes an edit to the test to better trigger this to happen and check both behaviours.