### PR TITLE
Value types for BigInteger and BigInt

### DIFF
--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -48,6 +48,8 @@
    (->> gen/double
         (gen/such-that #(Double/isFinite %))
         (gen/fmap #(BigDecimal/valueOf ^double %)))
+   (->> gen/large-integer (gen/fmap biginteger))
+   (->> gen/large-integer (gen/fmap bigint))
    (->> gen-zdt (gen/fmap #(.toLocalDate ^ZonedDateTime %)))
    (->> gen-zdt (gen/fmap #(.toLocalTime ^ZonedDateTime %)))
    (->> gen-zdt (gen/fmap #(.toLocalDateTime ^ZonedDateTime %)))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -62,7 +62,7 @@
       (t/is (empty? (api/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 15}
+  (t/is (= (merge {:crux.index/index-version 16}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))


### PR DESCRIPTION
N.B. these are different value types - if some documents have BigInts and some BigIntegers, they won't compare properly.
this is consistent with the note in #1281 - we'll need a wider change to make these comparable.