### PR TITLE
Rocks block cache config

### DIFF
--- a/crux-rocksdb/src/crux/rocksdb.clj
+++ b/crux-rocksdb/src/crux/rocksdb.clj
@@ -14,7 +14,7 @@
            java.nio.ByteBuffer
            (java.nio.file Files Path)
            java.nio.file.attribute.FileAttribute
-           (org.rocksdb Checkpoint CompressionType FlushOptions LRUCache
+           (org.rocksdb BlockBasedTableConfig Checkpoint CompressionType FlushOptions LRUCache
                         Options ReadOptions RocksDB RocksIterator
                         WriteBatch WriteOptions Statistics StatsLevel)))
 
@@ -119,8 +119,15 @@
 
 (def ^:private cp-format {:index-version c/index-version, ::version "6"})
 
+(defn ->lru-block-cache {::sys/args {:cache-size {:doc "Cache size"
+                                                  :default (* 8 1024 1024)
+                                                  :spec ::sys/nat-int}}}
+  [{:keys [cache-size]}]
+  (LRUCache. cache-size))
+
 (defn ->kv-store {::sys/deps {:metrics (fn [_])
-                              :checkpointer (fn [_])}
+                              :checkpointer (fn [_])
+                              :block-cache `->lru-block-cache}
                   ::sys/args {:db-dir {:doc "Directory to store K/V files"
                                        :required? true
                                        :spec ::sys/path}
@@ -132,7 +139,7 @@
                               :disable-wal? {:doc "Disable Write Ahead Log"
                                              :default false
                                              :spec ::sys/boolean}}}
-  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer db-options] :as options}]
+  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer ^Options db-options block-cache] :as options}]
 
   (RocksDB/loadLibrary)
 
@@ -145,6 +152,9 @@
                (.setCompressionType CompressionType/LZ4_COMPRESSION)
                (.setBottommostCompressionType CompressionType/ZSTD_COMPRESSION)
                (.setCreateIfMissing true))
+        opts (cond-> opts
+               (and block-cache (nil? (.tableFormatConfig opts))) (.setTableFormatConfig (doto (BlockBasedTableConfig.)
+                                                                                           (.setBlockCache block-cache))))
 
         db (try
              (RocksDB/open opts (-> (Files/createDirectories db-dir (make-array FileAttribute 0))

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -49,9 +49,17 @@
   (.close node))
 
 (def standalone-config
-  {::crux {:node-opts {:crux/index-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "indexes")}}
-                       :crux/document-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "documents")}}
-                       :crux/tx-log {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file dev-node-dir "tx-log")}}
+  {::crux {:node-opts {:crux/index-store {:kv-store {:crux/module `rocks/->kv-store,
+                                                     :db-dir (io/file dev-node-dir "indexes"),
+                                                     :block-cache :crux.rocksdb/block-cache}}
+                       :crux/document-store {:kv-store {:crux/module `rocks/->kv-store,
+                                                        :db-dir (io/file dev-node-dir "documents")
+                                                        :block-cache :crux.rocksdb/block-cache}}
+                       :crux/tx-log {:kv-store {:crux/module `rocks/->kv-store,
+                                                :db-dir (io/file dev-node-dir "tx-log")
+                                                :block-cache :crux.rocksdb/block-cache}}
+                       :crux.rocksdb/block-cache {:crux/module `rocks/->lru-block-cache
+                                                  :cache-size (* 128 1024 1024)}
                        :crux.metrics.jmx/reporter {}
                        :crux.http-server/server {}
                        :crux.lucene/lucene-store {:db-dir (io/file dev-node-dir "lucene")}}}})

--- a/docs/reference/modules/ROOT/pages/rocksdb.adoc
+++ b/docs/reference/modules/ROOT/pages/rocksdb.adoc
@@ -135,3 +135,55 @@ EDN::
 
 * `instance-name` (string, default `"rocksdb"`): unique name for this instance of RocksDB, used in metrics domains
 * `sample-window` (duration, default 3s): sample window of statistics collector
+
+[#blocks-cache]
+== Configuring the Block Cache
+
+To configure the block cache used by the RocksDB instance, override the `block-cache` dependency:
+
+[tabs]
+====
+JSON::
++
+[source,json]
+----
+{
+  "crux/index-store": {
+    "kv-store": {
+      "crux/module": "crux.rocksdb/->kv-store",
+      "block-cache": {
+	"cache-size":64000000
+      }
+      ...
+    }
+  },
+
+  "crux/document-store": { ... },
+  "crux/tx-log": { ... }
+}
+----
+
+Clojure::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                               :block-cache {:cache-size 64000000}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/index-store {:kv-store {:crux/module crux.rocksdb/->kv-store
+                               :block-cache {:cache-size 64000000}}
+ :crux/document-store {...}
+ :crux/tx-log {...}}
+----
+====
+
+=== Parameters
+
+* `cache-size` (int, default `8*1024*1024`): Size of the cache in bytes.


### PR DESCRIPTION
Making it possible to configure the size and share the block cache as its own dependency between Rocks instances.

See `dev.clj` for an example on how to use it. 

The default mimics the previous behaviour, which is to create a 8Mb block cache per each Rocks instance.
But this is really way to low, the recommended value is 1/3 of the memory budget:
https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size

This hook also allows for creating a static, per JVM cache and do nothing on close, allowing to share it between nodes, but code for this is not included.

Somewhat related to this is that there's a old argument that is an Option instance, allowing users to fine tune their Rocks config. This should really be another dependency itself, but this PR doesn't try to address this, and only aims to fix the common case which is the need to tune the cache size properly.
