### PR TITLE
Const tweaks

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -62,7 +62,7 @@
 (def ^:const ^:private max-value-index-length 224)
 
 (def ^:const ^:private string-terminate-mark-size Byte/BYTES)
-(def ^:const ^:private string-terminate-mark (byte 1))
+(def ^:const ^:private string-terminate-mark 1)
 
 (defprotocol IdOrBuffer
   (new-id ^crux.codec.Id [id])

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -151,7 +151,7 @@
 
 ;; Utils
 
-(def ^:private chunk-size 8)
+(def ^:const ^:private chunk-size 8)
 
 (defn idx->seq
   [idx]


### PR DESCRIPTION
Two small tweaks to `^:const` usage, which is not too intuitive in Clojure. Found via YourKit.

Both changes are order of magnitude faster for the code that accessed the var, but this isn't visible at all end to end.
But still a good change.

These issues weren't caught by unboxed warnings due to the combination of `=` and consts if I understand it correctly. 