### PR TITLE
Value Buffer Thread Local Encoding

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -15,6 +15,7 @@
            java.nio.charset.StandardCharsets
            [java.time LocalDate LocalTime LocalDateTime Instant Duration]
            [java.util Base64 Date Map Set UUID]
+           java.util.function.Supplier
            [org.agrona DirectBuffer ExpandableDirectByteBuffer MutableDirectBuffer]
            org.agrona.concurrent.UnsafeBuffer))
 
@@ -334,8 +335,14 @@
        (.putByte 0 nil-value-type-id))
      value-type-id-size)))
 
+(def ^:private ^ThreadLocal value-buffer-tl
+  (ThreadLocal/withInitial
+   (reify Supplier
+     (get [_]
+       (ExpandableDirectByteBuffer. 32)))))
+
 (defn ->value-buffer ^org.agrona.DirectBuffer [x]
-  (value->buffer x (ExpandableDirectByteBuffer. 32)))
+  (mem/copy-to-unpooled-buffer (value->buffer x (.get value-buffer-tl))))
 
 (defn value-buffer-type-id ^org.agrona.DirectBuffer [^DirectBuffer buffer]
   (mem/limit-buffer buffer value-type-id-size))


### PR DESCRIPTION
Adds a thread local expandable buffer for value encoding and copy it to an unpooled buffer.
This has the same semantics as what's currently there, but up to twice as fast as creating a new expandable buffer all the time.

There's no direct noticeable effect end to end on queries, but still a good tweak.
Might be more noticeable on ingest, as there's more encoding happening then.

In theory most types don't need an expandable buffer, and one could allocate a fixed sized one instead.

Note that `->id-buffer` actually creates pooled buffers. Changing `->value-buffer` to copy to a pooled buffer is almost twice as fast again (on top of this PR's changes) but changes the current behaviour more.