### PR TITLE
crux.index tweaks

### DIFF
--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -1,7 +1,7 @@
 (ns ^:no-doc crux.index
   (:require [crux.db :as db]
             [crux.memory :as mem])
-  (:import [clojure.lang Box IDeref IPersistentVector PersistentVector]
+  (:import [clojure.lang Box IDeref IPersistentVector]
            java.util.function.Function
            [java.util ArrayList Arrays Collection Comparator Iterator List NavigableSet NavigableMap TreeMap TreeSet]
            org.agrona.DirectBuffer))
@@ -317,7 +317,7 @@
                        (db/close-level idx)
                        (recur max-ks (dec depth) false)))))]
       (when (pos? max-depth)
-        (step (PersistentVector/adopt (object-array max-depth)) 0 true)))))
+        (step (vec (repeat max-depth nil)) 0 true)))))
 
 (deftype SortedVirtualIndex [^NavigableSet s ^:unsynchronized-mutable ^Iterator iterator]
   db/Index


### PR DESCRIPTION
Changes `layered-idx->seq` to take a template tuple and using `assocN` into it instead of `pop` and conj`.
This is about 1/3 faster in micro benchmarks, but again not (currently) visible end to end.

Also tweaks the `RelationalVirtualIndex` to use per-index allocated object arrays instead persistent stacks while walking the tree. About twice as fast in micro benchmarks when calling `layered-idx->seq` that walks the tree.

But a part of this performance boost comes from removing the call to `last` that was previously used to find the active index. `clojure.core/last` is linear and doesn't take the type into account, which meant that the deeper the tree was, the slower it became. This was called at every `seek/next-values` call.