### PR TITLE
Lucene mismatched tx

### DIFF
--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -116,15 +116,18 @@
         (let [index-searcher (IndexSearcher. directory-reader)
               q (TermQuery. (Term. "meta" "latest-completed-tx"))
               d ^ScoreDoc (first (.-scoreDocs (.search index-searcher q 1)))]
-          (when d (some-> (.doc index-searcher (.-doc d))
-                          (.get "latest-completed-tx")
-                          (Long/parseLong))))))))
+          (when d
+            (some-> (.doc index-searcher (.-doc d))
+                    (.get "latest-completed-tx")
+                    (Long/parseLong))))))))
 
 (defn validate-lucene-store-up-to-date [index-store lucene-store]
-  (when-let [{:crux.tx/keys [tx-id] :as latest-tx} (db/latest-completed-tx index-store)]
-    (let [latest-lucene-tx-id (latest-submitted-tx lucene-store)]
-      (when-not (= tx-id latest-lucene-tx-id)
-        (throw (IllegalStateException. "Lucene store latest tx mismatch"))))))
+  (let [{:crux.tx/keys [tx-id] :as latest-tx} (db/latest-completed-tx index-store)
+        latest-lucene-tx-id (latest-submitted-tx lucene-store)]
+    (when (and tx-id
+               (or (nil? latest-lucene-tx-id)
+                   (> tx-id latest-lucene-tx-id)))
+      (throw (IllegalStateException. "Lucene store latest tx mismatch")))))
 
 (defn search [lucene-store, k, v]
   (assert lucene-store)


### PR DESCRIPTION
Fix #1301 

Changes to lucene startup behaviour, allowing any `tx-id` equal to or less to the `lucene-tx-id`, alongside a general fix to the check.