### PR TITLE
Create and keep around folder directly in `load-rocksdb-native-lib`

### DIFF
--- a/crux-rocksdb/src/crux/rocksdb/loader.clj
+++ b/crux-rocksdb/src/crux/rocksdb/loader.clj
@@ -6,11 +6,9 @@
            org.rocksdb.NativeLibraryLoader))
 
 (defn- load-rocksdb-native-lib []
-  (let [tmp (cio/create-tmpdir "crux_rocksdb")
+  (let [tmp (doto (io/file (System/getProperty "java.io.tmpdir") "crux_rocksdb-6.12.7") .mkdirs)
         library (io/file tmp (Environment/getJniLibraryFileName "rocksdb"))]
-    (io/make-parents library)
     (.loadLibrary (NativeLibraryLoader/getInstance) (str tmp))
-    (assert (or (cio/native-image?) *compile-files* (.exists library)))
     (str library)))
 
 (defonce rocksdb-library-path (load-rocksdb-native-lib))


### PR DESCRIPTION
Fixes #1023 

As per the notes on the card: the issue was caused by the shutdown hook of `create-tmp-dir` attempting to delete the rocksdb `dll` - we've added a change to remove that call, opting instead to create the folder directly within the temp directory and keeping it around, preventing the exception being thrown and stopping unnecessary creation of temporary folders.

(James)
We accept that the DLL might stick around on Windows after a Crux run, if `deleteOnExit` isn't able to delete the file - but because we know that it's put in the same file each time, and it's a temporary file, we won't see a large number of files created - the same file will be used in subsequent Crux JVM runs