### PR TITLE
Ingest performance

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -21,11 +21,17 @@
   (index-entity-txs [this tx entity-txs])
   (mark-tx-as-failed [this tx])
   (store-index-meta [this k v])
-  (read-index-meta [this k] [this k not-found])
   (latest-completed-tx [this])
   (tx-failed? [this tx-id])
   (open-index-snapshot ^java.io.Closeable [this]))
 ;; end::IndexStore[]
+
+(defprotocol IndexMeta
+  (-read-index-meta [this k not-found]))
+
+(defn read-index-meta
+  ([index-meta k] (-read-index-meta index-meta k nil))
+  ([index-meta k not-found] (-read-index-meta index-meta k not-found)))
 
 ;; tag::IndexSnapshot[]
 (defprotocol IndexSnapshot

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -138,8 +138,7 @@
     (swap! !evicted-eids set/union (set eids))
     (db/unindex-eids transient-index-store eids)
 
-    (with-open [persistent-index-snapshot (db/open-index-snapshot persistent-index-store)
-                transient-index-snapshot (db/open-index-snapshot transient-index-store)]
+    (with-open [transient-index-snapshot (db/open-index-snapshot transient-index-store)]
       (let [tombstones (->> (for [eid eids
                                   etx (concat (db/entity-history persistent-index-snapshot eid :asc
                                                                  {:with-corrections? true})

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -131,7 +131,7 @@
                              capped-valid-time capped-tx-id]
   db/IndexStore
   (index-docs [this docs]
-    (swap! !indexed-docs merge docs)
+    (swap! !indexed-docs into docs)
     (db/index-docs transient-index-store docs))
 
   (unindex-eids [this eids]
@@ -152,10 +152,10 @@
         {:tombstones tombstones})))
 
   (index-entity-txs [this tx entity-txs]
-    (swap! !etxs merge (->> entity-txs
-                            (into {} (map (juxt (fn [^EntityTx etx]
-                                                  [(.eid etx) (.vt etx) (.tt etx) (.tx-id etx)])
-                                                identity)))))
+    (swap! !etxs into (->> entity-txs
+                           (into {} (map (juxt (fn [^EntityTx etx]
+                                                 [(.eid etx) (.vt etx) (.tt etx) (.tx-id etx)])
+                                               identity)))))
     (db/index-entity-txs transient-index-store tx entity-txs))
 
   (store-index-meta [this k v]
@@ -207,7 +207,7 @@
 (defrecord ForkedDocumentStore [doc-store !docs]
   db/DocumentStore
   (submit-docs [_ docs]
-    (swap! !docs merge docs))
+    (swap! !docs into docs))
 
   (fetch-docs [_ ids]
     (let [overridden-docs (select-keys @!docs ids)]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -290,10 +290,10 @@
 (defn- etx->kvs [^EntityTx etx]
   (let [eid (c/->id-buffer (.eid etx))
         z (encode-entity-tx-z-number (.vt etx) (.tx-id etx))]
-    [[(encode-bitemp-key-to nil eid (.vt etx) (.tx-id etx) (.tt etx))
-      (c/->id-buffer (.content-hash etx))]
-     [(encode-bitemp-z-key-to nil eid z (.tt etx))
-      (c/->id-buffer (.content-hash etx))]]))
+    [(MapEntry/create (encode-bitemp-key-to nil eid (.vt etx) (.tx-id etx) (.tt etx))
+                      (c/->id-buffer (.content-hash etx)))
+     (MapEntry/create (encode-bitemp-z-key-to nil eid z (.tt etx))
+                      (c/->id-buffer (.content-hash etx)))]))
 
 ;; Index Version
 
@@ -848,7 +848,7 @@
     (kv/store kv-store
               (->> (conj (mapcat etx->kvs entity-txs)
                          (MapEntry/create (encode-tx-time-mapping-key-to nil tx-time tx-id) mem/empty-buffer))
-                   (into (sorted-map-by mem/buffer-comparator)))))
+                   (sort-by key mem/buffer-comparator))))
 
   (store-index-meta [_ k v]
     (store-meta kv-store k v))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -710,7 +710,11 @@
   (open-nested-index-snapshot [this]
     (let [nested-index-snapshot (new-kv-index-snapshot snapshot temp-hash-cache cav-cache canonical-buffer-cache false)]
       (swap! nested-index-snapshot-state conj nested-index-snapshot)
-      nested-index-snapshot)))
+      nested-index-snapshot))
+
+  db/IndexMeta
+  (-read-index-meta [_ k not-found]
+    (read-meta-snapshot snapshot k not-found)))
 
 ;;;; IndexStore
 
@@ -853,18 +857,16 @@
   (store-index-meta [_ k v]
     (store-meta kv-store k v))
 
-  (read-index-meta [this k]
-    (db/read-index-meta this k nil))
-
-  (read-index-meta [this k not-found]
-    (read-meta kv-store k not-found))
-
   (latest-completed-tx [this]
     (latest-completed-tx kv-store))
 
   (tx-failed? [this tx-id]
     (with-open [snapshot (kv/new-snapshot kv-store)]
       (some? (kv/get-value snapshot (encode-failed-tx-id-key-to nil tx-id)))))
+
+  db/IndexMeta
+  (-read-index-meta [this k not-found]
+    (read-meta kv-store k not-found))
 
   (open-index-snapshot [this]
     (new-kv-index-snapshot (kv/new-snapshot kv-store) (HashMap.) cav-cache canonical-buffer-cache true))

--- a/crux-core/src/crux/kv/mutable_kv.clj
+++ b/crux-core/src/crux/kv/mutable_kv.clj
@@ -1,0 +1,61 @@
+(ns crux.kv.mutable-kv
+  (:require [crux.kv :as kv]
+            [crux.memory :as mem])
+  (:import clojure.lang.ISeq
+           java.io.Closeable
+           [java.util NavigableMap TreeMap]))
+
+(deftype MutableKvIterator [^NavigableMap db, !tail-seq]
+  kv/KvIterator
+  (seek [this k]
+    (some-> (reset! !tail-seq (seq (.tailMap db (mem/as-buffer k) true))) first key))
+
+  (next [this]
+    (some-> (swap! !tail-seq rest) first key))
+
+  (prev [this]
+    (when-let [[[k] :as tail-seq] (seq @!tail-seq)]
+      (some-> (reset! !tail-seq (when-let [le (.lowerEntry db k)]
+                                  (cons le tail-seq)))
+              first
+              key)))
+
+  (value [this]
+    (some-> (first @!tail-seq) val))
+
+  Closeable
+  (close [_]))
+
+(deftype MutableKvSnapshot [^NavigableMap db]
+  kv/KvSnapshot
+  (new-iterator [this] (->MutableKvIterator db (atom nil)))
+  (get-value [this k] (get db (mem/as-buffer k)))
+
+  ISeq
+  (seq [_] (seq db))
+
+  Closeable
+  (close [_]))
+
+(deftype MutableKvStore [^NavigableMap db]
+  kv/KvStore
+  (new-snapshot ^java.io.Closeable [this]
+    (->MutableKvSnapshot db))
+
+  (store [this kvs]
+    (doseq [[k v] kvs]
+      (.put db (mem/as-buffer k) (mem/as-buffer v))))
+
+  (delete [this ks]
+    (doseq [k ks]
+      (.remove db (mem/as-buffer k))))
+
+  (fsync [this])
+  (compact [this])
+  (count-keys [this] (count db))
+  (db-dir [this])
+  (kv-name [this] (str (class this))))
+
+(defn ->mutable-kv-store
+  ([] (->mutable-kv-store {}))
+  ([_] (->MutableKvStore (TreeMap. mem/buffer-comparator))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1662,11 +1662,11 @@
         [in in-args] (add-legacy-args q [])]
     (compile-sub-query encode-value-fn nil where in (rule-name->rules rules) stats)))
 
-(defn query [{:keys [index-store index-snapshot] :as db} ^ConformedQuery conformed-q in-args]
+(defn query [{:keys [index-snapshot] :as db} ^ConformedQuery conformed-q in-args]
   (let [q (.q-normalized conformed-q)
         q-conformed (.q-conformed conformed-q)
         {:keys [find where in rules offset limit order-by full-results?]} q-conformed
-        stats (or (db/read-index-meta index-store :crux/attribute-stats) {})
+        stats (or (db/read-index-meta index-snapshot :crux/attribute-stats) {})
         [in in-args] (add-legacy-args q-conformed in-args)]
     (when full-results?
       (defonce -full-results-deprecation-log

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -52,8 +52,9 @@
   (let [ids (set ids)]
     (loop [indexed {}]
       (let [missing-ids (set/difference ids (set (keys indexed)))
-            indexed (merge indexed (when (seq missing-ids)
-                                     (db/fetch-docs document-store missing-ids)))]
+            indexed (into indexed
+                          (when (seq missing-ids)
+                            (db/fetch-docs document-store missing-ids)))]
         (if (= (count indexed) (count ids))
           indexed
           (do
@@ -212,12 +213,12 @@
                       (let [conformed-tx-ops (mapv txc/conform-tx-op res)
                             tx-events (mapv txc/->tx-event conformed-tx-ops)]
                         {:tx-events tx-events
-                         :docs (merge (when args-doc-id
-                                        {args-content-hash {:crux.db/id args-doc-id
-                                                            :crux.db.fn/tx-events tx-events}})
-                                      (into {}
-                                            (mapcat :docs)
-                                            conformed-tx-ops))})))
+                         :docs (into (if args-doc-id
+                                       {args-content-hash {:crux.db/id args-doc-id
+                                                           :crux.db.fn/tx-events tx-events}}
+                                       {})
+                                     (mapcat :docs)
+                                     conformed-tx-ops)})))
 
                   (catch Throwable t
                     (reset! !last-tx-fn-error t)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -325,13 +325,14 @@
                                        {:abort? true
                                         :docs docs}
                                        res)))]
-                             (db/submit-docs forked-document-store docs)
+                             (when (seq docs)
+                               (db/submit-docs forked-document-store docs))
 
                              (when-not abort?
                                (doto forked-index-store
-                                 (db/index-docs docs)
-                                 (db/unindex-eids evict-eids)
-                                 (db/index-entity-txs tx etxs)))
+                                 (cond-> (seq docs) (db/index-docs docs))
+                                 (cond-> (seq evict-eids) (db/unindex-eids evict-eids))
+                                 (cond-> (seq etxs) (db/index-entity-txs tx etxs))))
 
                              (or abort?
                                  (recur (concat new-tx-events more-tx-events))))))]

--- a/crux-test/src/crux/fixtures/kv.clj
+++ b/crux-test/src/crux/fixtures/kv.clj
@@ -17,12 +17,14 @@
 (defmacro with-kv-store [bindings & body]
   `(with-kv-store* (fn [~@bindings] ~@body)))
 
-(def rocks-dep {:crux/module `crux.rocksdb/->kv-store, :db-dir-suffix "rocksdb"})
-(def lmdb-dep {:crux/module `crux.lmdb/->kv-store, :db-dir-suffix "lmdb", :env-mapsize 4096})
-(def memkv-dep {:crux/module `crux.mem-kv/->kv-store})
+(def rocks-dep {:crux/module 'crux.rocksdb/->kv-store, :db-dir-suffix "rocksdb"})
+(def lmdb-dep {:crux/module 'crux.lmdb/->kv-store, :db-dir-suffix "lmdb", :env-mapsize 4096})
+(def memkv-dep {:crux/module 'crux.mem-kv/->kv-store})
+(def mutablekv-dep {:crux/module 'crux.kv.mutable-kv/->mutable-kv-store})
 
 (defn with-each-kv-store* [f]
   (doseq [kv-opts [memkv-dep
+                   mutablekv-dep
                    rocks-dep
                    {:crux/module `crux.rocksdb.jnr/->kv-store
                     :db-dir-suffix "rocksdb-jnr"}

--- a/crux-test/test/crux/kv_test.clj
+++ b/crux-test/test/crux/kv_test.clj
@@ -147,19 +147,20 @@
 
 (t/deftest test-checkpoint-and-restore-db
   (fkv/with-kv-store [kv-store]
-    (fix/with-tmp-dir "kv-store-backup" [backup-dir]
-      (kv/store kv-store [[(long->bytes 1) (.getBytes "Crux")]])
-      (cio/delete-dir backup-dir)
-      (cp/save-checkpoint kv-store backup-dir)
-      (binding [fkv/*kv-opts* (merge fkv/*kv-opts* {:db-dir backup-dir})]
-        (fkv/with-kv-store [restored-kv]
-          (t/is (= "Crux" (String. ^bytes (value restored-kv (long->bytes 1)))))
+    (when (satisfies? cp/CheckpointSource kv-store)
+      (fix/with-tmp-dir "kv-store-backup" [backup-dir]
+        (kv/store kv-store [[(long->bytes 1) (.getBytes "Crux")]])
+        (cio/delete-dir backup-dir)
+        (cp/save-checkpoint kv-store backup-dir)
+        (binding [fkv/*kv-opts* (merge fkv/*kv-opts* {:db-dir backup-dir})]
+          (fkv/with-kv-store [restored-kv]
+            (t/is (= "Crux" (String. ^bytes (value restored-kv (long->bytes 1)))))
 
-          (t/testing "backup and original are different"
-            (kv/store kv-store [[(long->bytes 1) (.getBytes "Original")]])
-            (kv/store restored-kv [[(long->bytes 1) (.getBytes "Backup")]])
-            (t/is (= "Original" (String. ^bytes (value kv-store (long->bytes 1)))))
-            (t/is (= "Backup" (String. ^bytes (value restored-kv (long->bytes 1)))))))))))
+            (t/testing "backup and original are different"
+              (kv/store kv-store [[(long->bytes 1) (.getBytes "Original")]])
+              (kv/store restored-kv [[(long->bytes 1) (.getBytes "Backup")]])
+              (t/is (= "Original" (String. ^bytes (value kv-store (long->bytes 1)))))
+              (t/is (= "Backup" (String. ^bytes (value restored-kv (long->bytes 1))))))))))))
 
 (t/deftest test-compact []
   (fkv/with-kv-store [kv-store]


### PR DESCRIPTION
N.B. out of scope: moving the 'fork' functionality from the tx ingester to the index store - couple of gnarly evict bugs still to iron out, and haven't yet gotten to the bottom of the query (!) performance regression. Will bank this one, and then come back with a subsequent moving-the-fork PR.

Main changes:
* In-memory index-store uses a `j.u.TreeMap`, rather than `c.l.PersistentTreeMap`. The 'snapshots' yielded from this, strictly speaking, aren't snapshots - they're mutable, but they're only ever read from one thread, and that thread is _either_ reading or writing, never both at once - i.e. it's immutable through the sections that matter.
* We were calling `unindex-eids` even when there weren't any eids to unindex - this didn't have any `seq` checks, and opened/closed snapshots regardless. `(when (seq eids) ...)` cut about 10% of my microbench.
* I've replaced a few usages of `merge` with `into` - the former does `(reduce conj ...)`, which doesn't use transient data structures.
* I've not removed the check where we read the KV store to decide whether to index the doc, one for another PR.
* (not performance, but) have included more of the tx-ingestion in the try-catches that then report the error back to anyone awaiting - we should see fewer errors slipping through the net, and fewer awaits hanging indefinitely

TODO/RFC:
* [x] I've split out `IndexSnapshotFactory` as a separate protocol just containing `open-index-snapshot`, so that `IndexStoreTx` can also implement it. Should we migrate usages of `open-nested-index-snapshot` to this as well, or is the distinction helpful? I suspect the distinction's helpful, as the nested one doesn't open up a snapshot on the underlying KV store?

Microbench:
* Attach profiler
* Submit 25 transactions with 1k simple docs, `crux/sync`
* Restart node, time `crux/sync`

Timings (YourKit, 'tracing' - about 10-15x slower than just running at the REPL, but more interested in the relative speedup): before 25s, after 17s.

Bench (in progress, will update):
* TODO