### PR TITLE
Add lucene test, check query results not limited to 1000

### DIFF
--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -324,6 +324,12 @@
                             (c/q db {:find '[?e]
                                      :where '[[(lucene-text-search "firstname: Fred") [[?e]]]]})))))
 
+(t/deftest results-not-limited-to-1000
+  (submit+await-tx (for [n (range 1001)] [:crux.tx/put {:crux.db/id n, :description (str "Entity " n)}]))
+  (with-open [db (c/open-db *api*)]
+    (t/is (= 1001 (count (c/q db {:find '[?e]
+                                  :where '[[(text-search :description "Entity*") [[?e]]]]}))))))
+
 (comment
   (do
     (import '[ch.qos.logback.classic Level Logger]


### PR DESCRIPTION
(edit, @jarohen)
Added fix. While the Lucene search lazily pages through, we later eagerly evaluate the results - we'll need to implement the standard query engine `Index` protocol to ensure this results are lazy end-to-end.
