### PR TITLE
Add `when-let` to metrics index-store listener

### DIFF
--- a/crux-metrics/src/crux/metrics/index_store.clj
+++ b/crux-metrics/src/crux/metrics/index_store.clj
@@ -61,8 +61,8 @@
                     (swap! !timer-store assoc submitted-tx (dropwizard/start timer))
 
                     :crux.tx/indexed-tx
-                    (do
-                      (dropwizard/stop (get @!timer-store submitted-tx))
+                    (when-let [timer-context (get @!timer-store submitted-tx)]
+                      (dropwizard/stop timer-context)
                       (swap! !timer-store dissoc submitted-tx)))))
     timer))
 


### PR DESCRIPTION
In the case of `indexed-tx` event getting called without an associated `indexed-tx`. This is possible, though unlikely, if the listeners are still in the process of being created. Similar problem to that fixed in #1286 (where listeners depended on other listeners having occurred)

May go some way in resolving #1320.