### PR TITLE
migrate kv/delete into kv/store

### DIFF
--- a/crux-core/src/crux/kv.clj
+++ b/crux-core/src/crux/kv.clj
@@ -1,10 +1,9 @@
 (ns ^:no-doc crux.kv
   "Protocols for KV backend implementations."
+  (:refer-clojure :exclude [next])
   (:require [crux.io :as cio]
             [crux.status :as status]
-            [crux.system :as sys])
-  (:refer-clojure :exclude [next])
-  (:import java.io.Closeable))
+            [crux.system :as sys]))
 
 (defprotocol KvIterator
   (seek [this k])
@@ -20,7 +19,6 @@
 (defprotocol KvStore
   (new-snapshot ^java.io.Closeable [this])
   (store [this kvs])
-  (delete [this ks])
   (fsync [this])
   (compact [this])
   (count-keys [this])

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -840,7 +840,10 @@
                                                                               (set (all-keys-in-prefix bitemp-i (encode-bitemp-z-key-to nil eid-id-buffer)))))))
                                                             eids)})))]
 
-      (kv/delete kv-store ks)
+      ;; TODO this is naively replacing kv/delete with kv/store after #1310
+      ;; later, we'll want to combine this with the kv/store when we index the docs
+      (kv/store kv-store (for [k ks]
+                           [k nil]))
       {:tombstones tombstones}))
 
   (mark-tx-as-failed [this {:crux.tx/keys [tx-id tx-time] :as tx}]

--- a/crux-core/src/crux/kv/mutable_kv.clj
+++ b/crux-core/src/crux/kv/mutable_kv.clj
@@ -44,11 +44,9 @@
 
   (store [this kvs]
     (doseq [[k v] kvs]
-      (.put db (mem/as-buffer k) (mem/as-buffer v))))
-
-  (delete [this ks]
-    (doseq [k ks]
-      (.remove db (mem/as-buffer k))))
+      (if v
+        (.put db (mem/as-buffer k) (mem/as-buffer v))
+        (.remove db (mem/as-buffer k)))))
 
   (fsync [this])
   (compact [this])

--- a/crux-rocksdb/src/crux/rocksdb.clj
+++ b/crux-rocksdb/src/crux/rocksdb.clj
@@ -74,13 +74,9 @@
   (store [_ kvs]
     (with-open [wb (WriteBatch.)]
       (doseq [[k v] kvs]
-        (.put wb (mem/direct-byte-buffer k) (mem/direct-byte-buffer v)))
-      (.write db write-options wb)))
-
-  (delete [_ ks]
-    (with-open [wb (WriteBatch.)]
-      (doseq [k ks]
-        (.remove wb (mem/direct-byte-buffer k)))
+        (if v
+          (.put wb (mem/direct-byte-buffer k) (mem/direct-byte-buffer v))
+          (.remove wb (mem/direct-byte-buffer k))))
       (.write db write-options wb)))
 
   (compact [_]

--- a/crux-rocksdb/src/crux/rocksdb/jnr.clj
+++ b/crux-rocksdb/src/crux/rocksdb/jnr.clj
@@ -209,21 +209,10 @@
       (try
         (doseq [[k v] kvs
                 :let [k (mem/ensure-off-heap k kb)
-                      v (mem/ensure-off-heap v vb)]]
-          (.rocksdb_writebatch_put rocksdb wb (buffer->pointer k) (.capacity k) (buffer->pointer v) (.capacity v)))
-        (.rocksdb_write rocksdb db write-options wb errptr-out)
-        (finally
-          (.rocksdb_writeoptions_destroy rocksdb wb)
-          (check-error errptr-out)))))
-
-  (delete [_ ks]
-    (let [wb (.rocksdb_writebatch_create rocksdb)
-          errptr-out (make-array String 1)
-          kb (ExpandableDirectByteBuffer.)]
-      (try
-        (doseq [k ks
-                :let [k (mem/ensure-off-heap k kb)]]
-          (.rocksdb_writebatch_delete rocksdb wb (buffer->pointer k) (.capacity k)))
+                      v (some-> v (mem/ensure-off-heap vb))]]
+          (if v
+            (.rocksdb_writebatch_put rocksdb wb (buffer->pointer k) (.capacity k) (buffer->pointer v) (.capacity v))
+            (.rocksdb_writebatch_delete rocksdb wb (buffer->pointer k) (.capacity k))))
         (.rocksdb_write rocksdb db write-options wb errptr-out)
         (finally
           (.rocksdb_writeoptions_destroy rocksdb wb)

--- a/crux-test/src/crux/fixtures/kv.clj
+++ b/crux-test/src/crux/fixtures/kv.clj
@@ -6,7 +6,7 @@
 (def ^:dynamic *kv-opts* {})
 
 (defn with-kv-store* [f]
-  (fix/with-tmp-dir "kv" [db-dir]
+  (fix/with-tmp-dirs #{db-dir}
     (with-open [sys (-> (sys/prep-system
                          {:kv-store (merge (when-let [db-dir-suffix (:db-dir-suffix *kv-opts*)]
                                              {:db-dir (io/file db-dir db-dir-suffix)})
@@ -39,7 +39,7 @@
   `(with-each-kv-store* (fn [] ~@body)))
 
 (defn with-kv-store-opts* [kv-opts f]
-  (fix/with-tmp-dir "db-dir" [db-dir]
+  (fix/with-tmp-dirs #{db-dir}
     (letfn [(->kv-opts [module]
               (merge (when-let [db-dir-suffix (:db-dir-suffix kv-opts)]
                        {:db-dir (io/file db-dir db-dir-suffix module)})


### PR DESCRIPTION
Rather than two separate calls, `kv/store` and `kv/delete`, this PR combines them s.t. previous calls to `kv/delete` can be replaced with calls to `kv/store` with nil values. This means that we can combine together additions and removals of KVs into one transaction on the underlying KV store - previously, we'd have one call to `store` and one to `delete`, which would open two transactions on the store.

Looks like we might need a wider refactor to get the value from this change - the `kv/delete` call in `crux.kv.index-store` is a fair way away from the `kv/store` call, will take the refactoring in my `move-the-fork` branch to actually get KV puts/deletes in the same write transaction.

#1310 