### PR TITLE
fetch-docs waits for documents to be present before returning

### DIFF
--- a/crux-azure-blobs/src/crux/azure/blobs.clj
+++ b/crux-azure-blobs/src/crux/azure/blobs.clj
@@ -24,7 +24,6 @@
 
 (defrecord AzureBlobsDocumentStore [sas-token storage-account container]
   db/DocumentStore
-
   (submit-docs [_ docs]
     (->> (for [[id doc] docs]
            (future
@@ -34,7 +33,7 @@
          vec
          (run! deref)))
 
-  (fetch-docs [_ docs]
+  (-fetch-docs [_ docs]
     (cio/with-nippy-thaw-all
       (reduce
        #(if-let [doc (get-blob sas-token storage-account container (str %2))]

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -14,7 +14,7 @@
 
 (defrecord FileDocumentStore [dir]
   db/DocumentStore
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (cio/with-nippy-thaw-all
       (persistent!
        (reduce
@@ -41,7 +41,7 @@
 
 (defrecord CachedDocumentStore [cache document-store]
   db/DocumentStore
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (let [ids (set ids)
           cached-id->docs (persistent!
                            (reduce
@@ -51,7 +51,7 @@
                                 acc))
                             (transient {}) ids))
           missing-ids (set/difference ids (keys cached-id->docs))
-          missing-id->docs (db/fetch-docs document-store missing-ids)]
+          missing-id->docs (db/-fetch-docs document-store missing-ids)]
       (persistent!
        (reduce-kv
         (fn [acc id doc]

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -213,9 +213,9 @@
   (submit-docs [_ docs]
     (swap! !docs into docs))
 
-  (fetch-docs [_ ids]
+  (-fetch-docs [_ ids]
     (let [overridden-docs (select-keys @!docs ids)]
-      (into overridden-docs (db/fetch-docs doc-store (set/difference (set ids) (set (keys overridden-docs))))))))
+      (into overridden-docs (db/-fetch-docs doc-store (set/difference (set ids) (set (keys overridden-docs))))))))
 
 (defn new-docs [doc-store]
   @(:!docs doc-store))

--- a/crux-core/src/crux/kv/document_store.clj
+++ b/crux-core/src/crux/kv/document_store.clj
@@ -37,7 +37,7 @@
 
 (defrecord KvDocumentStore [kv-store]
   db/DocumentStore
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (cio/with-nippy-thaw-all
       (with-open [snapshot (kv/new-snapshot kv-store)]
         (persistent!

--- a/crux-core/test/crux/eventually_consistent_doc_store_test.clj
+++ b/crux-core/test/crux/eventually_consistent_doc_store_test.clj
@@ -13,7 +13,7 @@
                        (vary-meta update ::insert-times
                                   merge (zipmap (keys new-docs) (repeat (Instant/now))))))))
 
-  (fetch-docs [_ ids]
+  (-fetch-docs [_ ids]
     (let [docs @!docs
           insert-times (::insert-times (meta docs))
           now (Instant/now)]

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -100,7 +100,7 @@
             (insert-event! tx id doc "docs")
             (update-doc! tx id doc))))))
 
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (cio/with-nippy-thaw-all
       (->> (for [id-batch (partition-all 100 ids)
                  row (jdbc/execute! pool (into [(format "SELECT EVENT_KEY, V FROM tx_events WHERE TOPIC = 'docs' AND EVENT_KEY IN (%s) AND COMPACTED = 0"

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -103,7 +103,7 @@
   (-fetch-docs [this ids]
     (cio/with-nippy-thaw-all
       (->> (for [id-batch (partition-all 100 ids)
-                 row (jdbc/execute! pool (into [(format "SELECT EVENT_KEY, V FROM tx_events WHERE TOPIC = 'docs' AND EVENT_KEY IN (%s) AND COMPACTED = 0"
+                 row (jdbc/execute! pool (into [(format "SELECT EVENT_KEY, V FROM tx_events WHERE TOPIC = 'docs' AND EVENT_KEY IN (%s)"
                                                         (->> (repeat (count id-batch) "?") (str/join ", ")))]
                                                (map (comp str c/new-id) id-batch))
                                     {:builder-fn jdbcr/as-unqualified-lower-maps})]

--- a/crux-kafka/src/crux/kafka.clj
+++ b/crux-kafka/src/crux/kafka.clj
@@ -1,6 +1,5 @@
 (ns crux.kafka
   (:require [clojure.java.io :as io]
-            [clojure.set :as set]
             [clojure.tools.logging :as log]
             [crux.codec :as c]
             [crux.db :as db]
@@ -8,8 +7,7 @@
             [crux.status :as status]
             [crux.system :as sys]
             [crux.tx :as tx])
-  (:import crux.db.DocumentStore
-           [crux.kafka.nippy NippyDeserializer NippySerializer]
+  (:import [crux.kafka.nippy NippyDeserializer NippySerializer]
            java.io.Closeable
            java.nio.file.Path
            java.time.Duration
@@ -247,8 +245,8 @@
   (submit-docs [this id-and-docs]
     (submit-docs id-and-docs this))
 
-  (fetch-docs [this ids]
-    (db/fetch-docs local-document-store ids)))
+  (-fetch-docs [this ids]
+    (db/-fetch-docs local-document-store ids)))
 
 (defn- read-doc-offsets [index-store]
   (->> (db/read-index-meta index-store :crux.tx-log/consumer-state)
@@ -335,7 +333,7 @@
   (submit-docs [this id-and-docs]
     (submit-docs id-and-docs this))
 
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (throw (UnsupportedOperationException. "Can't fetch docs from ingest-only Kafka document store"))))
 
 (defn ->ingest-only-document-store {::sys/deps {:kafka-config `->kafka-config

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -91,7 +91,7 @@
     (put-objects this (for [[id doc] docs]
                         (MapEntry/create id (AsyncRequestBody/fromBytes (.freeze configurator doc))))))
 
-  (fetch-docs [this ids]
+  (-fetch-docs [this ids]
     (cio/with-nippy-thaw-all
       (->> (get-objects this (for [id ids]
                                (MapEntry/create id (AsyncResponseTransformer/toBytes))))

--- a/crux-test/src/crux/doc_store_test.clj
+++ b/crux-test/src/crux/doc_store_test.clj
@@ -16,10 +16,10 @@
     (db/submit-docs *doc-store* people)
 
     (t/is (= {alice-key alice}
-             (db/fetch-docs *doc-store* #{alice-key})))
+             (db/-fetch-docs *doc-store* #{alice-key})))
 
     (t/is (= people
-             (db/fetch-docs *doc-store* (conj (keys people) max-key))))
+             (db/-fetch-docs *doc-store* (conj (keys people) max-key))))
 
     (let [evicted-alice {:crux.db/id :alice, :crux.db/evicted? true}]
       (db/submit-docs *doc-store* {alice-key evicted-alice})

--- a/crux-test/src/crux/doc_store_test.clj
+++ b/crux-test/src/crux/doc_store_test.clj
@@ -25,7 +25,7 @@
       (db/submit-docs *doc-store* {alice-key evicted-alice})
 
       (t/is (= {alice-key evicted-alice, bob-key bob}
-               (db/fetch-docs *doc-store* (keys people)))))))
+               (db/-fetch-docs *doc-store* (keys people)))))))
 
 (defn test-doc-store [ns]
   (let [once-fixture-fn (t/join-fixtures (::t/once-fixtures (meta ns)))

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -47,8 +47,9 @@
 
     (t/testing "Eviction"
       (db/submit-docs doc-store [[doc-hash {:crux.db/id :some-id, :crux.db/evicted? true}]])
-      (t/is (nil? (-> (db/fetch-docs doc-store #{doc-hash})
-                      (get doc-hash)))))
+      (t/is (= {:crux.db/id :some-id, :crux.db/evicted? true}
+               (-> (db/-fetch-docs doc-store #{doc-hash})
+                   (get doc-hash)))))
 
     (t/testing "Resurrect Document"
       (fix/submit+await-tx [[:crux.tx/put doc]])

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -1065,7 +1065,7 @@
         ->mocked-doc-store (fn [_opts]
                              (reify db/DocumentStore
                                (submit-docs [_ docs])
-                               (fetch-docs [_ ids]
+                               (-fetch-docs [_ ids]
                                  (->> ids
                                       (into {} (map (juxt identity
                                                           (some-fn {(c/new-id put-fn) put-fn


### PR DESCRIPTION
related to #1178, paired with @refset 

Rather than polling waiting for eventually consistent doc stores to become consistent during transaction ingest, we now wait when the documents are actually required (for `entity`, `eql/project`, etc)

Existing test still applies here, it's at https://github.com/jarohen/crux/blob/fetch-docs-sync-read/crux-core/test/crux/eventually_consistent_doc_store_test.clj

NB - had to update the semantics of the JDBC doc store here. All the other doc stores return the tombstone of evicted docs, JDBC was filtering them out (returning nil). Worked fine before, but now we interpret the absence of a document as 'the doc store hasn't got the doc yet' (i.e. it's eventually consistent), and block waiting for it.