### PR TITLE
Region as Macro

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -366,7 +366,7 @@
        (ExpandableDirectByteBuffer. 32)))))
 
 (defn ->value-buffer ^org.agrona.DirectBuffer [x]
-  (mem/copy-buffer (value->buffer x (.get value-buffer-tl))))
+  (mem/copy-to-unpooled-buffer (value->buffer x (.get value-buffer-tl))))
 
 (defn value-buffer-type-id ^org.agrona.DirectBuffer [^DirectBuffer buffer]
   (mem/limit-buffer buffer value-type-id-size))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -366,7 +366,7 @@
        (ExpandableDirectByteBuffer. 32)))))
 
 (defn ->value-buffer ^org.agrona.DirectBuffer [x]
-  (mem/copy-to-unpooled-buffer (value->buffer x (.get value-buffer-tl))))
+  (mem/copy-buffer (value->buffer x (.get value-buffer-tl))))
 
 (defn value-buffer-type-id ^org.agrona.DirectBuffer [^DirectBuffer buffer]
   (mem/limit-buffer buffer value-type-id-size))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -372,7 +372,7 @@
                           (if (empty? acc)
                             tail
                             (concat acc tail))))))
-                (ArrayList.) (.poll queue))
+                (ArrayList.) (.poll queue timeout-ms TimeUnit/MILLISECONDS))
                (catch Throwable t
                  (future-cancel f)
                  (throw t))))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -3,6 +3,7 @@
             [crux.memory :as mem])
   (:import [clojure.lang Box IDeref IPersistentVector]
            java.util.function.Function
+           java.lang.ref.WeakReference
            [java.util ArrayList Arrays Collection Comparator Iterator List NavigableSet NavigableMap TreeMap TreeSet]
            [java.util.concurrent ArrayBlockingQueue BlockingQueue ExecutionException LinkedBlockingQueue TimeUnit TimeoutException]
            org.agrona.DirectBuffer))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -4,7 +4,7 @@
   (:import [clojure.lang Box IDeref IPersistentVector]
            java.util.function.Function
            [java.util ArrayList Arrays Collection Comparator Iterator List NavigableSet NavigableMap TreeMap TreeSet]
-           [java.util.concurrent ArrayBlockingQueue BlockingQueue LinkedBlockingQueue TimeUnit TimeoutException]
+           [java.util.concurrent ArrayBlockingQueue BlockingQueue ExecutionException LinkedBlockingQueue TimeUnit TimeoutException]
            org.agrona.DirectBuffer))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -370,7 +370,9 @@
                 (ArrayList.) (.poll queue timeout-ms TimeUnit/MILLISECONDS))
                (catch Throwable t
                  (future-cancel f)
-                 (throw t))))
+                 (if (instance? ExecutionException t)
+                   (throw (.getCause t))
+                   (throw t)))))
            (do (mem/with-region
                  (produce-step 0 true))
                (seq queue))))))))

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -304,7 +304,9 @@
 
 (defn layered-idx->seq
   ([idx]
-   (layered-idx->seq idx vec false))
+   (layered-idx->seq idx vec))
+  ([idx t-fn]
+   (layered-idx->seq idx t-fn false))
   ([idx t-fn async?]
    (layered-idx->seq idx t-fn async? nil))
   ([idx t-fn async? limit]

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -299,7 +299,7 @@
                                   (doto (ArrayList.)
                                     (.addAll (repeat (count indexes) nil))))))
 
-(def ^:private ^:const timeout-ms 5000)
+(def ^:private ^:const timeout-ms 1000)
 (def ^:private ^:const queue-size 128)
 
 (defn layered-idx->seq

--- a/crux-core/src/crux/index.clj
+++ b/crux-core/src/crux/index.clj
@@ -316,7 +316,7 @@
            ^BlockingQueue queue (if async?
                                   (ArrayBlockingQueue. queue-size)
                                   (LinkedBlockingQueue.))
-           quere-ref (WeakReference. queue)
+           queue-ref (WeakReference. queue)
            max-depth (long (db/max-depth idx))
            done-fn (if async?
                      (fn [^BlockingQueue queue]

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -16,7 +16,7 @@
            java.nio.file.attribute.FileAttribute
            java.text.SimpleDateFormat
            java.time.Duration
-           [java.util Collections Comparator Date IdentityHashMap Iterator PriorityQueue Properties]
+           [java.util Collections Comparator Date IdentityHashMap Iterator Map PriorityQueue Properties]
            [java.util.concurrent ThreadFactory]
            java.util.concurrent.locks.StampedLock))
 
@@ -25,7 +25,7 @@
 ;; TODO: Replace with java.lang.ref.Cleaner in Java 9.
 ;; We currently still support Java 8.
 (def ^:private ^ReferenceQueue reference-queue (ReferenceQueue.))
-(def ^:private ^IdentityHashMap ref->cleanup-action (Collections/synchronizedMap (IdentityHashMap.)))
+(def ^:private ^HashMap ref->cleanup-action (Collections/synchronizedMap (IdentityHashMap.)))
 
 (defn- cleanup-loop []
   (try

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -25,7 +25,7 @@
 ;; TODO: Replace with java.lang.ref.Cleaner in Java 9.
 ;; We currently still support Java 8.
 (def ^:private ^ReferenceQueue reference-queue (ReferenceQueue.))
-(def ^:private ^HashMap ref->cleanup-action (Collections/synchronizedMap (IdentityHashMap.)))
+(def ^:private ^Map ref->cleanup-action (Collections/synchronizedMap (IdentityHashMap.)))
 
 (defn- cleanup-loop []
   (try

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -16,7 +16,7 @@
            java.nio.file.attribute.FileAttribute
            java.text.SimpleDateFormat
            java.time.Duration
-           [java.util Comparator Date IdentityHashMap Iterator PriorityQueue Properties]
+           [java.util Collections Comparator Date IdentityHashMap Iterator PriorityQueue Properties]
            [java.util.concurrent ThreadFactory]
            java.util.concurrent.locks.StampedLock))
 
@@ -25,7 +25,7 @@
 ;; TODO: Replace with java.lang.ref.Cleaner in Java 9.
 ;; We currently still support Java 8.
 (def ^:private ^ReferenceQueue reference-queue (ReferenceQueue.))
-(def ^:private ^IdentityHashMap ref->cleanup-action (IdentityHashMap.))
+(def ^:private ^IdentityHashMap ref->cleanup-action (Collections/synchronizedMap (IdentityHashMap.)))
 
 (defn- cleanup-loop []
   (try

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -34,10 +34,11 @@
    :crux.tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
 
 (defn- ingest-tx [tx-ingester tx tx-events]
-  (let [in-flight-tx (db/begin-tx tx-ingester tx)]
-    (if (db/index-tx-events in-flight-tx tx-events)
-      (db/commit in-flight-tx)
-      (db/abort in-flight-tx))))
+  (mem/with-region
+    (let [in-flight-tx (db/begin-tx tx-ingester tx)]
+      (if (db/index-tx-events in-flight-tx tx-events)
+        (db/commit in-flight-tx)
+        (db/abort in-flight-tx)))))
 
 (defn- submit-tx [tx-events
                   {:keys [^ExecutorService tx-submit-executor

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -34,11 +34,10 @@
    :crux.tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
 
 (defn- ingest-tx [tx-ingester tx tx-events]
-  (mem/with-region
-    (let [in-flight-tx (db/begin-tx tx-ingester tx)]
-      (if (db/index-tx-events in-flight-tx tx-events)
-        (db/commit in-flight-tx)
-        (db/abort in-flight-tx)))))
+  (let [in-flight-tx (db/begin-tx tx-ingester tx)]
+    (if (db/index-tx-events in-flight-tx tx-events)
+      (db/commit in-flight-tx)
+      (db/abort in-flight-tx))))
 
 (defn- submit-tx [tx-events
                   {:keys [^ExecutorService tx-submit-executor

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -8,6 +8,7 @@
            java.nio.ByteBuffer
            java.util.Comparator
            java.util.function.Supplier
+           [java.lang.ref Reference WeakReference]
            [org.agrona BufferUtil DirectBuffer ExpandableDirectByteBuffer MutableDirectBuffer]
            org.agrona.concurrent.UnsafeBuffer
            [org.agrona.io DirectBufferInputStream ExpandableDirectBufferOutputStream]
@@ -86,16 +87,16 @@
                  *allocate-pooled-buffer* (fn [^long size#]
                                             (let [buffer# (allocate-pooled-buffer size#)]
                                               (set! *chunk-size* (min max-chunk-size (* 2 (long *chunk-size*))))
-                                              (.add buffers# (java.lang.ref.WeakReference. buffer#))
+                                              (.add buffers# (WeakReference. buffer#))
                                               buffer#))]
          (.set chunk-tl# (.byteBuffer ^DirectBuffer empty-buffer))
          ~@body)
        (finally
          (.set chunk-tl# prev-chunk#)
          (doseq [ref# buffers#
-                 :let [buffer# (.get ^java.lang.ref.Reference ref#)]
+                 :let [buffer# (.get ^Reference ref#)]
                  :when buffer#]
-           (org.agrona.BufferUtil/free ^java.nio.ByteBuffer buffer#))))))
+           (org.agrona.BufferUtil/free ^ByteBuffer buffer#))))))
 
 (defn copy-buffer
   (^org.agrona.MutableDirectBuffer [^DirectBuffer from]

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -26,7 +26,8 @@
 
   (^long capacity [this]))
 
-(def ^:dynamic *chunk-size* (* 128 1024))
+(def ^:const max-chunk-size (* 128 1024))
+(def ^:dynamic *chunk-size* max-chunk-size)
 (defonce ^:private pool-allocation-stats (atom {:allocated 0
                                                 :deallocated 0}))
 
@@ -84,7 +85,7 @@
        (binding [*chunk-size* 2048
                  *allocate-pooled-buffer* (fn [^long size#]
                                             (let [buffer# (allocate-pooled-buffer size#)]
-                                              (set! *chunk-size* (* 2 (long *chunk-size*)))
+                                              (set! *chunk-size* (min max-chunk-size  (* 2 (long *chunk-size*))))
                                               (.add buffers# (java.lang.ref.WeakReference. buffer#))
                                               buffer#))]
          (.set chunk-tl# (.byteBuffer ^DirectBuffer empty-buffer))

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -14,6 +14,8 @@
            [org.agrona.io DirectBufferInputStream ExpandableDirectBufferOutputStream]
            crux.ByteUtils))
 
+(set! *unchecked-math* :warn-on-boxed)
+
 (defprotocol MemoryRegion
   (->on-heap ^bytes [this])
 
@@ -63,7 +65,7 @@
         new-aligned-offset (bit-and-not (+ offset size alignment-round-mask)
                                         alignment-round-mask)]
     (cond
-      (> size (quot *chunk-size* 4))
+      (> size (quot (long *chunk-size*) 4))
       (allocate-unpooled-buffer size)
 
       (> new-aligned-offset (.capacity chunk))

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -6,7 +6,7 @@
             [taoensso.nippy :as nippy])
   (:import [java.io DataInputStream DataOutputStream]
            java.nio.ByteBuffer
-           java.util.Comparator
+           [java.util ArrayList Comparator]
            java.util.function.Supplier
            [java.lang.ref Reference WeakReference]
            [org.agrona BufferUtil DirectBuffer ExpandableDirectByteBuffer MutableDirectBuffer]

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -98,7 +98,7 @@
          (doseq [ref# buffers#
                  :let [buffer# (.get ^Reference ref#)]
                  :when buffer#]
-           (org.agrona.BufferUtil/free ^ByteBuffer buffer#))))))
+           (BufferUtil/free ^ByteBuffer buffer#))))))
 
 (defn copy-buffer
   (^org.agrona.MutableDirectBuffer [^DirectBuffer from]

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -85,7 +85,7 @@
        (binding [*chunk-size* 2048
                  *allocate-pooled-buffer* (fn [^long size#]
                                             (let [buffer# (allocate-pooled-buffer size#)]
-                                              (set! *chunk-size* (min max-chunk-size  (* 2 (long *chunk-size*))))
+                                              (set! *chunk-size* (min max-chunk-size (* 2 (long *chunk-size*))))
                                               (.add buffers# (java.lang.ref.WeakReference. buffer#))
                                               buffer#))]
          (.set chunk-tl# (.byteBuffer ^DirectBuffer empty-buffer))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1124,8 +1124,7 @@
                                                                                       (fn [^List join-keys]
                                                                                         (mapv (fn [^VarBinding var-binding]
                                                                                                 (bound-result-for-var index-snapshot var-binding join-keys))
-                                                                                              free-vars-in-join-order-bindings))
-                                                                                      false))]
+                                                                                              free-vars-in-join-order-bindings))))]
                                               (if has-free-vars?
                                                 idx-seq
                                                 []))))))))]
@@ -1159,7 +1158,7 @@
                              [(vec (for [var-binding not-var-bindings]
                                      (bound-result-for-var index-snapshot var-binding join-keys)))])
                    {:keys [n-ary-join]} (build-sub-query index-snapshot db not-clause not-in-bindings in-args rule-name->rules stats)]
-               (empty? (idx/layered-idx->seq n-ary-join identity false)))))})))
+               (empty? (idx/layered-idx->seq n-ary-join identity)))))})))
 
 (defn- calculate-join-order [pred-clauses or-clause+idx-id+or-branches var->joins triple-join-deps project-only-leaf-vars]
   (let [g (->> (keys var->joins)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1708,7 +1708,9 @@
                                         (mapv (fn [^VarBinding var-binding]
                                                 (bound-result-for-var index-snapshot var-binding join-keys))
                                               var-bindings))
-                                      (not (:sync? q)))
+                                      (not (:sync? q))
+                                      (when limit
+                                        (+ (long (or offset 0)) (long limit))))
 
          aggregate? (aggregate-result compiled-find)
          order-by (cio/external-sort (order-by-comparator find order-by))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1812,6 +1812,7 @@
       (->> (try
              (crux.query/query db conformed-query args)
              (catch Exception e
+               (cio/try-close index-snapshot)
                (when bus
                  (bus/send bus {:crux/event-type ::failed-query
                                 ::query safe-query

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1709,7 +1709,7 @@
                                                 (bound-result-for-var index-snapshot var-binding join-keys))
                                               var-bindings))
                                       (not (:sync? q))
-                                      (when limit
+                                      (when (and limit (not aggregate?))
                                         (+ (long (or offset 0)) (long limit))))
 
          aggregate? (aggregate-result compiled-find)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1708,7 +1708,7 @@
                                                 (bound-result-for-var index-snapshot var-binding join-keys))
                                               var-bindings))
                                       (not (:sync? q))
-                                      (when (and limit (not aggregate?))
+                                      (when (and limit (not aggregate?) (not order-by))
                                         (+ (long (or offset 0)) (long limit))))
 
          aggregate? (aggregate-result compiled-find)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -460,11 +460,12 @@
 
                                   (s/assert ::txe/tx-events tx-events)
 
-                                  (let [in-flight-tx (db/begin-tx tx-ingester tx)
-                                        res (db/index-tx-events in-flight-tx tx-events)]
-                                    (if res
-                                      (db/commit in-flight-tx)
-                                      (db/abort in-flight-tx)))
+                                  (mem/with-region
+                                    (let [in-flight-tx (db/begin-tx tx-ingester tx)
+                                          res (db/index-tx-events in-flight-tx tx-events)]
+                                      (if res
+                                        (db/commit in-flight-tx)
+                                        (db/abort in-flight-tx))))
 
                                   (when (Thread/interrupted)
                                     (throw (InterruptedException.))))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -460,12 +460,11 @@
 
                                   (s/assert ::txe/tx-events tx-events)
 
-                                  (mem/with-region
-                                    (let [in-flight-tx (db/begin-tx tx-ingester tx)
-                                          res (db/index-tx-events in-flight-tx tx-events)]
-                                      (if res
-                                        (db/commit in-flight-tx)
-                                        (db/abort in-flight-tx))))
+                                  (let [in-flight-tx (db/begin-tx tx-ingester tx)
+                                        res (db/index-tx-events in-flight-tx tx-events)]
+                                    (if res
+                                      (db/commit in-flight-tx)
+                                      (db/abort in-flight-tx)))
 
                                   (when (Thread/interrupted)
                                     (throw (InterruptedException.))))


### PR DESCRIPTION
A different take on regions, using a macro and optional producer thread. Experimental. Related to #1308 but doesn't change `crux.memory` as much.

Introduces dynamic vars to control the existing bump allocator, and a `crux.memory/with-region` macro that starts with small chunks and grows them larger. The region frees all allocated chunks on exit.

This PR as a side effect introduces a few other changes to how `crux.index/layered-idx->seq` works, all buffers live within the region, and the tuples are realised within the scope of a region, and the lazy result never sees these buffers and only contains normal tuples.

Regions are used for both queries and transactions. The history API is left untouched.

The main questions here are if this is worth it, especially the extra complexity of the producer thread.
Want to compare memory and CPU usage with master. Initial impression is quite good.

I further plan to change the producer/consumer setup so more tuples are realised in a batch before they are passed over to the consumer. As one now has controlled scope for the regions thanks to the producer/consumer setup, one could more easily move this part to use Netty reference counted buffers and their Jemalloc Java implementation as a further step.

That said, this is an experimental PR, and might not be merged. Keeping it as DRAFT for now.