### PR TITLE
Ingest performance part 2

### DIFF
--- a/crux-bench/src/crux/bench.clj
+++ b/crux-bench/src/crux/bench.clj
@@ -65,7 +65,7 @@
                               :bytes-indexed 0
                               :doc-count 0})]
     (bus/listen (:bus node)
-                {:crux/event-types #{:crux.tx/indexed-docs}}
+                {:crux/event-types #{:crux.tx/indexed-tx}}
                 (fn [{:keys [doc-ids av-count bytes-indexed]}]
                   (swap! !index-metrics (fn [index-metrics-map]
                                           (-> index-metrics-map

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -8,7 +8,7 @@
            org.agrona.DirectBuffer
            java.util.Date))
 
-(defn- merge-seqs
+(defn merge-seqs
   ([persistent transient] (merge-seqs persistent transient #(.compare mem/buffer-comparator %1 %2)))
   ([persistent transient compare]
    (letfn [(merge-seqs* [persistent transient]

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -18,6 +18,7 @@
                 (cond
                   (empty? persistent) transient
                   (empty? transient) persistent
+
                   :else (let [cmp (compare i1 m1)]
                           (cond
                             (neg? cmp) (cons i1 (merge-seqs* more-persistent transient))
@@ -38,23 +39,66 @@
 (defn- inc-date [^Date d1]
   (Date. (inc (.getTime d1))))
 
-(defrecord ForkedIndexSnapshot [persistent-index-snapshot close-persistent-index-snapshot? transient-index-snapshot
-                                evicted-eids
-                                capped-valid-time capped-tx-id]
+(defrecord CappedIndexSnapshot [index-snapshot capped-valid-time capped-tx-id]
   db/IndexSnapshot
-  (av [this a min-v]
+  (av [_ a min-v] (db/av index-snapshot a min-v))
+  (ave [_ a v min-e entity-resolver-fn] (db/ave index-snapshot a v min-e entity-resolver-fn))
+  (ae [_ a min-e] (db/ae index-snapshot a min-e))
+  (aev [_ a e min-v entity-resolver-fn] (db/aev index-snapshot a e min-v entity-resolver-fn))
+
+  (entity-as-of-resolver [this eid valid-time tx-id]
+    (some-> ^EntityTx (db/entity-as-of this eid valid-time tx-id)
+            (.content-hash)
+            c/->id-buffer))
+
+  (entity-as-of [_ eid valid-time tx-id]
+    (when capped-tx-id
+      (db/entity-as-of index-snapshot eid
+                       (date-min valid-time capped-valid-time)
+                       (long-min tx-id capped-tx-id))))
+
+  (entity-history [_ eid sort-order opts]
+    (when capped-tx-id
+      (db/entity-history index-snapshot eid sort-order
+                         (case sort-order
+                           :asc (-> opts
+                                    (cond-> capped-valid-time (update :end-valid-time date-min (inc-date capped-valid-time)))
+                                    (update :end-tx-id long-min (inc capped-tx-id)))
+                           :desc (-> opts
+                                     (cond-> capped-valid-time (update :start-valid-time date-min capped-valid-time))
+                                     (update :start-tx-id long-min capped-tx-id))))))
+
+  (decode-value [_ value-buffer] (db/decode-value index-snapshot value-buffer))
+  (encode-value [_ value] (db/encode-value index-snapshot value))
+  (resolve-tx [_ tx] (db/resolve-tx index-snapshot tx))
+
+  (open-nested-index-snapshot ^java.io.Closeable [_]
+    (->CappedIndexSnapshot (db/open-nested-index-snapshot index-snapshot)
+                           capped-valid-time
+                           capped-tx-id))
+
+  db/IndexMeta
+  (-read-index-meta [_ k not-found]
+    (db/-read-index-meta index-snapshot k not-found))
+
+  java.io.Closeable
+  (close [_] (cio/try-close index-snapshot)))
+
+(defrecord MergedIndexSnapshot [persistent-index-snapshot transient-index-snapshot evicted-eids]
+  db/IndexSnapshot
+  (av [_ a min-v]
     (merge-seqs (db/av persistent-index-snapshot a min-v)
                 (db/av transient-index-snapshot a min-v)))
 
-  (ave [this a v min-e entity-resolver-fn]
+  (ave [_ a v min-e entity-resolver-fn]
     (merge-seqs (db/ave persistent-index-snapshot a v min-e entity-resolver-fn)
                 (db/ave transient-index-snapshot a v min-e entity-resolver-fn)))
 
-  (ae [this a min-e]
+  (ae [_ a min-e]
     (merge-seqs (db/ae persistent-index-snapshot a min-e)
                 (db/ae transient-index-snapshot a min-e)))
 
-  (aev [this a e min-v entity-resolver-fn]
+  (aev [_ a e min-v entity-resolver-fn]
     (merge-seqs (db/aev persistent-index-snapshot a e min-v entity-resolver-fn)
                 (db/aev transient-index-snapshot a e min-v entity-resolver-fn)))
 
@@ -70,27 +114,16 @@
               c/->id-buffer)))
 
   (entity-as-of [this eid valid-time tx-id]
-    (->> [(when capped-tx-id
-            (when-not (contains? (into #{} (map #(c/->id-buffer %)) evicted-eids) (c/->id-buffer eid))
-              (db/entity-as-of persistent-index-snapshot eid
-                               (date-min valid-time capped-valid-time)
-                               (long-min tx-id capped-tx-id))))
+    (->> [(when-not (contains? (into #{} (map #(c/->id-buffer %)) evicted-eids) (c/->id-buffer eid))
+            (db/entity-as-of persistent-index-snapshot eid valid-time tx-id))
           (db/entity-as-of transient-index-snapshot eid valid-time tx-id)]
          (remove nil?)
          (sort-by (juxt #(.vt ^EntityTx %) #(.tx-id ^EntityTx %)))
          last))
 
   (entity-history [this eid sort-order opts]
-    (merge-seqs (when capped-tx-id
-                  (when-not (contains? evicted-eids eid)
-                    (db/entity-history persistent-index-snapshot eid sort-order
-                                       (case sort-order
-                                         :asc (-> opts
-                                                  (cond-> capped-valid-time (update :end-valid-time date-min (inc-date capped-valid-time)))
-                                                  (update :end-tx-id long-min (inc capped-tx-id)))
-                                         :desc (-> opts
-                                                   (cond-> capped-valid-time (update :start-valid-time date-min capped-valid-time))
-                                                   (update :start-tx-id long-min capped-tx-id))))))
+    (merge-seqs (when-not (contains? evicted-eids eid)
+                  (db/entity-history persistent-index-snapshot eid sort-order opts))
                 (db/entity-history transient-index-snapshot eid sort-order opts)
 
                 (case [sort-order (boolean (:with-corrections? opts))]
@@ -101,27 +134,24 @@
                   [:desc true] #(compare [(.vt ^EntityTx %2) (.tx-id ^EntityTx %2)]
                                          [(.vt ^EntityTx %1) (.tx-id ^EntityTx %1)]))))
 
-  (decode-value [this value-buffer]
+  (decode-value [_ value-buffer]
     (or (db/decode-value transient-index-snapshot value-buffer)
         (db/decode-value persistent-index-snapshot value-buffer)))
 
-  (encode-value [this value]
+  (encode-value [_ value]
     (db/encode-value transient-index-snapshot value))
 
-  (resolve-tx [this tx]
+  (resolve-tx [_ tx]
     (or (db/resolve-tx transient-index-snapshot tx)
         (db/resolve-tx persistent-index-snapshot tx)))
 
-  (open-nested-index-snapshot ^java.io.Closeable [this]
-    (->ForkedIndexSnapshot (db/open-nested-index-snapshot persistent-index-snapshot)
-                           true
+  (open-nested-index-snapshot ^java.io.Closeable [_]
+    (->MergedIndexSnapshot (db/open-nested-index-snapshot persistent-index-snapshot)
                            (db/open-nested-index-snapshot transient-index-snapshot)
-                           evicted-eids
-                           capped-valid-time
-                           capped-tx-id))
+                           evicted-eids))
 
   db/IndexMeta
-  (-read-index-meta [this k not-found]
+  (-read-index-meta [_ k not-found]
     (let [v (db/read-index-meta transient-index-snapshot k ::not-found)]
       (if (not= v ::not-found)
         v
@@ -130,83 +160,11 @@
   java.io.Closeable
   (close [_]
     (cio/try-close transient-index-snapshot)
-    (when close-persistent-index-snapshot?
-      (cio/try-close persistent-index-snapshot))))
+    (cio/try-close persistent-index-snapshot)))
 
-(defrecord ForkedIndexStore [persistent-index-store persistent-index-snapshot transient-index-store
-                             !indexed-docs !evicted-eids !etxs
-                             capped-valid-time capped-tx-id]
-  db/IndexStore
-  (index-docs [this docs]
-    (swap! !indexed-docs into docs)
-    (db/index-docs transient-index-store docs))
-
-  (unindex-eids [this eids]
-    (swap! !evicted-eids set/union (set eids))
-    (db/unindex-eids transient-index-store eids)
-
-    (with-open [transient-index-snapshot (db/open-index-snapshot transient-index-store)]
-      (let [tombstones (->> (for [eid eids
-                                  etx (concat (db/entity-history persistent-index-snapshot eid :asc
-                                                                 {:with-corrections? true})
-                                              (db/entity-history transient-index-snapshot eid :asc
-                                                                 {:with-corrections? true}))
-                                  :let [content-hash (.content-hash ^EntityTx etx)]
-                                  :when content-hash]
-                              [content-hash {:crux.db/id eid, :crux.db/evicted? true}])
-                            (into {}))]
-        {:tombstones tombstones})))
-
-  (index-entity-txs [this tx entity-txs]
-    (swap! !etxs into (->> entity-txs
-                           (into {} (map (juxt (fn [^EntityTx etx]
-                                                 [(.eid etx) (.vt etx) (.tt etx) (.tx-id etx)])
-                                               identity)))))
-    (db/index-entity-txs transient-index-store tx entity-txs))
-
-  (store-index-meta [this k v]
-    (db/store-index-meta transient-index-store k v))
-
-  (latest-completed-tx [this]
-    (or (db/latest-completed-tx transient-index-store)
-        (db/latest-completed-tx persistent-index-store)))
-
-  (mark-tx-as-failed [this tx]
-    (db/mark-tx-as-failed transient-index-store tx))
-
-  (tx-failed? [this tx-id]
-    (or (db/tx-failed? transient-index-store tx-id)
-        (db/tx-failed? persistent-index-store tx-id)))
-
-  db/IndexMeta
-  (-read-index-meta [this k not-found]
-    (let [v (db/read-index-meta transient-index-store k ::not-found)]
-      (if (not= v ::not-found)
-        v
-        (db/read-index-meta persistent-index-store k not-found))))
-
-  (open-index-snapshot ^java.io.Closeable [this]
-    (->ForkedIndexSnapshot (or persistent-index-snapshot (db/open-index-snapshot persistent-index-store))
-                           (nil? persistent-index-snapshot)
-                           (db/open-index-snapshot transient-index-store)
-                           @!evicted-eids
-                           capped-valid-time
-                           capped-tx-id)))
-
-(defn indexed-docs [index-store]
-  @(:!indexed-docs index-store))
-
-(defn newly-evicted-eids [index-store]
-  @(:!evicted-eids index-store))
-
-(defn new-etxs [index-store]
-  (vals @(:!etxs index-store)))
-
-(defn ->forked-index-store [persistent-index-store transient-index-store
-                            capped-valid-time capped-tx-id]
-  (->ForkedIndexStore persistent-index-store nil transient-index-store
-                      (atom {}) (atom #{}) (atom {})
-                      capped-valid-time capped-tx-id))
+(defprotocol DocumentStoreTx
+  (abort-doc-store-tx [document-store-tx])
+  (commit-doc-store-tx [document-store-tx]))
 
 (defrecord ForkedDocumentStore [doc-store !docs]
   db/DocumentStore
@@ -215,10 +173,16 @@
 
   (-fetch-docs [_ ids]
     (let [overridden-docs (select-keys @!docs ids)]
-      (into overridden-docs (db/-fetch-docs doc-store (set/difference (set ids) (set (keys overridden-docs))))))))
+      (into overridden-docs (db/-fetch-docs doc-store (set/difference (set ids) (set (keys overridden-docs)))))))
 
-(defn new-docs [doc-store]
-  @(:!docs doc-store))
+  DocumentStoreTx
+  (abort-doc-store-tx [_]
+    (when-let [docs (not-empty (->> @!docs (into {} (filter (comp :crux.db.fn/failed? val)))))]
+      (db/submit-docs doc-store docs)))
 
-(defn ->forked-document-store [doc-store]
+  (commit-doc-store-tx [_]
+    (when-let [docs (not-empty @!docs)]
+      (db/submit-docs doc-store docs))))
+
+(defn begin-document-store-tx [doc-store]
   (->ForkedDocumentStore doc-store (atom {})))

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -34,7 +34,7 @@
    :crux.tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
 
 (defn- ingest-tx [tx-ingester tx tx-events]
-  (let [in-flight-tx (db/begin-tx tx-ingester tx)]
+  (let [in-flight-tx (db/begin-tx tx-ingester tx nil)]
     (if (db/index-tx-events in-flight-tx tx-events)
       (db/commit in-flight-tx)
       (db/abort in-flight-tx))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -47,8 +47,8 @@
                                              {:ingester-error ingester-error})))
                                       ([{:keys [crux/event-type] :as ev}]
                                        (case event-type
-                                         ::tx/indexed-tx (tx->result (::tx/submitted-tx ev))
-                                         ::tx/ingester-error {:ingester-error (::tx/ingester-error ev)}
+                                         ::tx/indexed-tx (tx->result (:submitted-tx ev))
+                                         ::tx/ingester-error {:ingester-error (:ingester-error ev)}
                                          ::node-closed {:node-closed? true}))))
                         :timeout timeout
                         :timeout-value {:timeout? true}})]
@@ -192,7 +192,7 @@
       :crux/indexed-tx
       (bus/listen bus
                   (assoc event-opts :crux/event-types #{::tx/indexed-tx})
-                  (fn [{:keys [::tx/submitted-tx ::txe/tx-events] :as ev}]
+                  (fn [{:keys [submitted-tx ::txe/tx-events] :as ev}]
                     (.accept ^Consumer consumer
                              (merge {:crux/event-type :crux/indexed-tx}
                                     (select-keys ev [:committed?])

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1847,10 +1847,7 @@
                   :crux.tx/tx-id tx-id}})
 
   (withTx [this tx-ops]
-    (let [tx (merge {:fork-at {::db/valid-time valid-time
-                               ::tx/tx-time tx-time
-                               ::tx/tx-id tx-id}
-                     ::db/valid-time valid-time}
+    (let [tx (merge {::db/valid-time valid-time}
                     (if-let [latest-completed-tx (db/latest-completed-tx index-store)]
                       {::tx/tx-id (inc (long (::tx/tx-id latest-completed-tx)))
                        ::tx/tx-time (Date. (max (System/currentTimeMillis)
@@ -1858,7 +1855,9 @@
                       {::tx/tx-time (Date.)
                        ::tx/tx-id 0}))
           conformed-tx-ops (map txc/conform-tx-op tx-ops)
-          in-flight-tx (db/begin-tx tx-ingester tx)]
+          in-flight-tx (db/begin-tx tx-ingester tx {::db/valid-time valid-time
+                                                    ::tx/tx-time tx-time
+                                                    ::tx/tx-id tx-id})]
 
       (db/submit-docs in-flight-tx (into {} (mapcat :docs) conformed-tx-ops))
 

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -222,20 +222,14 @@
         lucene-store (LuceneNode. directory analyzer indexer)]
     (validate-lucene-store-up-to-date index-store lucene-store)
     (alter-var-root #'*lucene-store* (constantly lucene-store))
-    (bus/listen bus {:crux/event-types #{:crux.tx/indexing-tx-pre-commit :crux.tx/indexed-docs :crux.tx/unindexing-eids}
+    (bus/listen bus {:crux/event-types #{:crux.tx/committing-tx}
                      :crux.bus/executor (reify java.util.concurrent.Executor
                                           (execute [_ f]
                                             (.run f)))}
                 (fn [ev]
                   (with-open [index-writer (index-writer lucene-store)]
-                    (case (:crux/event-type ev)
-
-                      :crux.tx/indexing-tx-pre-commit
-                      (index-tx! index-writer (:crux.tx/submitted-tx ev))
-
-                      :crux.tx/indexed-docs
-                      (index! indexer index-writer (db/fetch-docs document-store (:doc-ids ev)))
-
-                      :crux.tx/unindexing-eids
-                      (evict! indexer index-writer (:eids ev))))))
+                    (index! indexer index-writer (db/fetch-docs document-store (:doc-ids ev)))
+                    (when-let [evicting-eids (not-empty (:evicting-eids ev))]
+                      (evict! indexer index-writer evicting-eids))
+                    (index-tx! index-writer (:submitted-tx ev)))))
     lucene-store))

--- a/crux-metrics/src/crux/metrics/index_store.clj
+++ b/crux-metrics/src/crux/metrics/index_store.clj
@@ -15,8 +15,8 @@
 (defn assign-tx-latency-gauge [registry {:crux/keys [bus]}]
   (let [!last-tx-lag (atom 0)]
     (bus/listen bus
-                {:crux/event-types #{:crux.tx/indexed-tx}}
-                (fn [{::tx/keys [submitted-tx]}]
+                {:crux/event-types #{::tx/indexed-tx}}
+                (fn [{:keys [submitted-tx]}]
                   (reset! !last-tx-lag (- (System/currentTimeMillis)
                                           (.getTime ^Date (::tx/tx-time submitted-tx))))))
     (dropwizard/gauge registry
@@ -24,43 +24,31 @@
                       (fn []
                         (first (reset-vals! !last-tx-lag 0))))))
 
-(defn assign-doc-meter [registry {:crux/keys [bus]}]
-  (let [meter (dropwizard/meter registry ["index-store" "indexed-docs"])]
+(defn assign-doc-meters [registry {:crux/keys [bus]}]
+  (let [docs-ingested-meter (dropwizard/meter registry ["index-store" "indexed-docs"])
+        av-ingested-meter (dropwizard/meter registry ["index-store" "indexed-avs"])
+        bytes-ingested-meter (dropwizard/meter registry ["index-store" "indexed-bytes"])]
     (bus/listen bus
-                {:crux/event-types #{:crux.tx/indexed-docs}}
-                (fn [{:keys [doc-ids]}]
-                  (dropwizard/mark! meter (count doc-ids))))
-
-    meter))
-
-(defn assign-av-meter [registry {:crux/keys [bus]}]
-  (let [meter (dropwizard/meter registry ["index-store" "indexed-avs"])]
-    (bus/listen bus
-                {:crux/event-types #{:crux.tx/indexed-docs}}
-                (fn [{:keys [av-count]}]
-                  (dropwizard/mark! meter av-count)))
-    meter))
-
-(defn assign-bytes-meter [registry {:crux/keys [bus]}]
-  (let [meter (dropwizard/meter registry ["index-store" "indexed-bytes"])]
-    (bus/listen bus
-                {:crux/event-types #{:crux.tx/indexed-docs}}
-                (fn [{:keys [bytes-indexed]}]
-                  (dropwizard/mark! meter bytes-indexed)))
-
-    meter))
+                {:crux/event-types #{::tx/indexed-tx}}
+                (fn [{:keys [doc-ids av-count bytes-indexed]}]
+                  (dropwizard/mark! docs-ingested-meter (count doc-ids))
+                  (dropwizard/mark! av-ingested-meter av-count)
+                  (dropwizard/mark! bytes-ingested-meter bytes-indexed)))
+    {:docs-ingested-meter docs-ingested-meter
+     :av-ingested-meter av-ingested-meter
+     :bytes-ingested-meter bytes-ingested-meter}))
 
 (defn assign-tx-timer [registry {:crux/keys [bus]}]
   (let [timer (dropwizard/timer registry ["index-store" "indexed-txs"])
         !timer-store (atom {})]
     (bus/listen bus
-                {:crux/event-types #{:crux.tx/indexing-tx :crux.tx/indexed-tx}}
-                (fn [{:keys [crux/event-type crux.tx/submitted-tx]}]
+                {:crux/event-types #{::tx/indexing-tx ::tx/indexed-tx}}
+                (fn [{:keys [crux/event-type submitted-tx]}]
                   (case event-type
-                    :crux.tx/indexing-tx
+                    ::tx/indexing-tx
                     (swap! !timer-store assoc submitted-tx (dropwizard/start timer))
 
-                    :crux.tx/indexed-tx
+                    ::tx/indexed-tx
                     (when-let [timer-context (get @!timer-store submitted-tx)]
                       (dropwizard/stop timer-context)
                       (swap! !timer-store dissoc submitted-tx)))))
@@ -70,9 +58,7 @@
   "Assigns listeners to an event bus for a given node.
   Returns an atom containing updating metrics"
   [registry deps]
-  {:tx-id-lag (assign-tx-id-lag registry deps)
-   :tx-latency-gauge (assign-tx-latency-gauge registry deps)
-   :docs-ingested-meter (assign-doc-meter registry deps)
-   :av-ingested-meter (assign-av-meter registry deps)
-   :bytes-ingested-meter (assign-bytes-meter registry deps)
-   :tx-ingest-timer (assign-tx-timer registry deps)})
+  (merge (assign-doc-meters registry deps)
+         {:tx-id-lag (assign-tx-id-lag registry deps)
+          :tx-latency-gauge (assign-tx-latency-gauge registry deps)
+          :tx-ingest-timer (assign-tx-timer registry deps)}))

--- a/crux-test/src/crux/fixtures.clj
+++ b/crux-test/src/crux/fixtures.clj
@@ -70,8 +70,8 @@
   ([api entities]
    (transact! api entities (Date.)))
   ([^ICruxAPI api entities ts]
-   (doto (crux/submit-tx api (maps->tx-ops entities ts))
-     (->> (crux/await-tx api)))
+   (let [tx (crux/submit-tx api (maps->tx-ops entities ts))]
+     (crux/await-tx api tx))
    entities))
 
 (defn random-person []

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -180,26 +180,6 @@
           (finally
             (.shutDown repo)))))))
 
-(t/deftest test-statistics
-  (let [^ExecutorService stats-executor (get-in (or *http-server-api* *api*) [:tx-ingester :stats-executor])]
-    (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]])]
-      (api/await-tx *api* submitted-tx))
-
-    @(.submit stats-executor ^Runnable (fn []))
-
-    (let [stats (api/attribute-stats *api*)]
-      (t/is (= 1 (:name stats))))
-
-    (t/testing "updated"
-      (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"}]])]
-        (t/is (= submitted-tx (api/await-tx *api* submitted-tx)))
-        (t/is (true? (api/tx-committed? *api* submitted-tx))))
-
-      @(.submit stats-executor ^Runnable (fn []))
-
-      (let [stats (api/attribute-stats *api*)]
-        (t/is (= 2 (:name stats)))))))
-
 (t/deftest test-adding-back-evicted-document
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
   (t/is (api/entity (api/db *api*) :foo))

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -141,7 +141,7 @@
         tx1 {::tx/tx-id 1
              ::tx/tx-time (Date.)}
         tx-evt {:crux/event-type ::tx/indexed-tx
-                ::tx/submitted-tx tx1
+                :submitted-tx tx1
                 ::txe/tx-events []
                 :committed? true}]
 
@@ -165,7 +165,7 @@
       (let [!latch (promise)]
         (future
           (Thread/sleep 100)
-          (bus/send bus (assoc-in tx-evt [::tx/submitted-tx ::tx/tx-id] 0)))
+          (bus/send bus (assoc-in tx-evt [:submitted-tx ::tx/tx-id] 0)))
 
         (with-latest-tx nil
           (t/is (thrown? TimeoutException (await-tx tx1 (Duration/ofMillis 500)))))))
@@ -174,7 +174,7 @@
       (future
         (Thread/sleep 100)
         (bus/send bus {:crux/event-type ::tx/ingester-error
-                       ::tx/ingester-error (ex-info "Ingester error" {})}))
+                       :ingester-error (ex-info "Ingester error" {})}))
 
       (with-latest-tx nil
         (t/is (thrown-with-msg? Exception #"Transaction ingester aborted."

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -296,6 +296,19 @@
                                vals
                                (remove c/evicted-doc?))))))))))
 
+(t/deftest test-statistics
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]
+                        [:crux.tx/put {:crux.db/id :ivan :name "Petr"}]])
+
+  (let [stats (api/attribute-stats *api*)]
+    (t/is (= 2 (:name stats))))
+
+  (t/testing "updated"
+    (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"}]])
+
+    (let [stats (api/attribute-stats *api*)]
+      (t/is (= 3 (:name stats))))))
+
 (t/deftest test-multiple-txs-in-same-ms-441
   (let [ivan {:crux.db/id :ivan}
         ivan1 (assoc ivan :value 1)

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -1114,8 +1114,6 @@
                       :where '[[?e :name ?name]]
                       :args [{:?e (int 10)}]})))))
 
-;; TODO fails, see #1337
-#_
 (t/deftest test-put-evict-in-same-transaction-1337
   (t/testing "put then evict"
     (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :test1/a, :test1? true}]])
@@ -1155,6 +1153,8 @@
       (t/is (= {:crux.db/id :test3/b, :test3? true} (crux/entity db :test3/b)))
       (t/is (= #{[:test3/b]} (crux/q db '{:find [?e], :where [[?e :test3? true]]})))))
 
+  ;; TODO fails, see #1337
+  #_
   (t/testing "evict then re-put"
     (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :test4, :test4? true}]])
 


### PR DESCRIPTION
This is the second half of #1309 - watdiv ingest down 30% on master, 10-15% quicker than pre-regression too

Implementation notes:

* It's now the index store that's responsible for the in-memory transaction, so that it can re-use the encoded documents - previously, we were calling `->content-idx-kvs` and `etx->kvs` twice for all the documents/tx-events respectively. Because we're working at a lower-level, we can pipe the encoded KVs in the in-memory KV store straight into Rocks.
* Stats are now updated synchronously - before/after wasn't conclusive on this one on my microbench, but makes the code simpler.
* `put-evict-same-transaction` was a pain for this - required me to index docs per tx-event, so that evicting the docs didn't remove too many/too few AVs from the index. Cases:
  * put then evict - we want to evict the AVs we've just put too
  * evict then put - we don't want to accidentally evict the AVs from the later tx-event just because we've indexed all the docs at the beginning of the transaction
  * indexing docs at the beginning/end of the transaction would have fallen foul to one or the other of these, so we index them throughout. we do fetch them all beforehand in one batch for performance.
* Lucene, though, evicts eids first before indexes docs - this is because we know that any evicted content present in the index before the transaction needs to be removed, and we can trust that the main indexer has correctly handled the case of evict-then-put/put-then-evict when it passes Lucene documents to index.