### PR TITLE
Added IDocument for Java interop

### DIFF
--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -19,7 +19,7 @@ public interface ICruxDatasource extends Closeable {
      * @param eid an object that can be coerced into an entity id.
      * @return    the entity document map.
      */
-    public Map<Keyword,Object> entity(Object eid);
+    public IDocument entity(Object eid);
 
     /**
      * Returns the transaction details for an entity. Details

--- a/crux-core/src/crux/api/IDocument.java
+++ b/crux-core/src/crux/api/IDocument.java
@@ -1,0 +1,12 @@
+package crux.api;
+
+import clojure.lang.ILookup;
+import clojure.lang.Keyword;
+
+import java.util.Map;
+
+public interface IDocument extends ILookup {
+    Object getDocumentId();
+
+    Map<Keyword, ?> getContents();
+}

--- a/crux-core/src/crux/api/alpha/Database.java
+++ b/crux-core/src/crux/api/alpha/Database.java
@@ -4,6 +4,7 @@ import clojure.lang.Symbol;
 import crux.api.ICruxAPI;
 import crux.api.ICruxDatasource;
 import clojure.lang.Keyword;
+import crux.api.IDocument;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -50,8 +51,7 @@ public class Database {
      * @param id Id of entity to retrieve
      * @return Document representing the entity
      */
-    public Document entity(CruxId id) {
-        Map<Keyword, Object> entityDoc = db.entity(id.toEdn());
-        return Document.document(entityDoc);
+    public IDocument entity(CruxId id) {
+        return db.entity(id.toEdn());
     }
 }

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -4,6 +4,7 @@
             [crux.error :as err]
             [crux.hash :as hash]
             [crux.query-state :as cqs]
+            [crux.document :as doc]
             [crux.io :as cio]
             [crux.memory :as mem]
             [taoensso.nippy :as nippy])
@@ -714,7 +715,8 @@
   (edn/read-string {:readers {'crux/id id-edn-reader
                               'crux/base64 base64-reader
                               'crux/query-state cqs/->QueryState
-                              'crux/query-error cqs/->QueryError}} s))
+                              'crux/query-error cqs/->QueryError
+                              'crux/document doc/->Document}} s))
 
 (def ^:const ^:private base64-print-method-enabled?
   (Boolean/parseBoolean (System/getenv "CRUX_ENABLE_BASE64_PRINT_METHOD")))

--- a/crux-core/src/crux/document.clj
+++ b/crux-core/src/crux/document.clj
@@ -1,0 +1,20 @@
+(ns ^:no-doc crux.document
+  (:import (crux.api IDocument)
+           (java.io Writer)))
+
+(defrecord Document [d]
+  IDocument
+  (getDocumentId [this] (:crux.db/id d))
+  (getContents [this] (dissoc d :crux.db/id)))
+
+(defmethod print-method Document [d ^Writer w]
+  (.write w "#crux/document ")
+  (print-method (into {} d) w))
+
+(defn ?->Document [d]
+  (if (and (map? d) (contains? d :crux.db/id))
+    (->Document d)
+    d))
+
+(defn ->Document [d]
+  (Document. d))

--- a/crux-core/src/crux/document.clj
+++ b/crux-core/src/crux/document.clj
@@ -2,19 +2,26 @@
   (:import (crux.api IDocument)
            (java.io Writer)))
 
-(defrecord Document [d]
+(defrecord Document []
   IDocument
-  (getDocumentId [this] (:crux.db/id d))
-  (getContents [this] (dissoc d :crux.db/id)))
+  (getDocumentId [this] (:crux.db/id this))
+  (getContents [this] (->> :crux.db/id
+                           (dissoc this)
+                           (into {}))))
 
-(defmethod print-method Document [d ^Writer w]
+(defmethod print-method Document [document ^Writer w]
   (.write w "#crux/document ")
-  (print-method (into {} d) w))
+  (print-method (into {} document) w))
 
 (defn ?->Document [d]
-  (if (and (map? d) (contains? d :crux.db/id))
+  (if (and
+        (map? d)
+        (contains? d :crux.db/id)
+        (not (and
+               (contains? d :crux.db/evicted?)
+               (:crux.db/evicted? d))))
     (->Document d)
     d))
 
 (defn ->Document [d]
-  (Document. d))
+  (map->Document d))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -20,7 +20,8 @@
             [taoensso.nippy :as nippy]
             [edn-query-language.core :as eql]
             [crux.system :as sys]
-            [clojure.pprint :as pp])
+            [clojure.pprint :as pp]
+            [crux.document :as doc])
   (:import [clojure.lang Box ExceptionInfo]
            (crux.api ICruxDatasource HistoryOptions HistoryOptions$SortOrder)
            crux.codec.EntityTx
@@ -1714,7 +1715,8 @@
                                   :crux.db/content-hash)]
     (-> (db/fetch-docs document-store #{content-hash})
         (get content-hash)
-        (c/keep-non-evicted-doc))))
+        (c/keep-non-evicted-doc)
+        (doc/?->Document))))
 
 (defn- with-history-bounds [{:keys [sort-order start-tx end-tx] :as opts}
                             {:keys [^long tx-id ^Date valid-time]}

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1833,7 +1833,8 @@
                                            :crux.db/valid-time (.vt etx)
                                            :crux.db/content-hash (.content-hash etx)}
                                     with-docs? (assoc :crux.db/doc (-> (db/fetch-docs document-store #{(.content-hash etx)})
-                                                                       (get (.content-hash etx))))))))))))
+                                                                       (get (.content-hash etx))
+                                                                       (doc/?->Document)))))))))))
 
   (validTime [_] valid-time)
   (transactionTime [_] tx-time)

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -1,7 +1,8 @@
 (ns ^:no-doc crux.tx.conform
   (:require [crux.codec :as c]
             [crux.db :as db]
-            [crux.error :as err])
+            [crux.error :as err]
+            [crux.document :as doc])
   (:import [java.util Date UUID]))
 
 (defn- check-eid [eid]
@@ -214,7 +215,7 @@
                       :crux.tx/match
                       (cons id
                             (for [arg args]
-                              (get docs arg arg)))
+                              (doc/?->Document (get docs arg arg))))
 
                       (for [arg args]
-                        (get docs arg arg))))))))
+                        (doc/?->Document (get docs arg arg)))))))))

--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -8,7 +8,8 @@
             [clojure.test.check.properties :as prop]
             [crux.api :as crux]
             [taoensso.nippy :as nippy]
-            [clojure.spec.alpha :as s])
+            [clojure.spec.alpha :as s]
+            [crux.document :as doc])
   (:import crux.codec.Id
            java.math.BigDecimal
            org.agrona.MutableDirectBuffer
@@ -199,4 +200,4 @@
                :url (java.net.URL. "https://google.com")
                :uuid (java.util.UUID/randomUUID)}]
       (fix/submit+await-tx node [[:crux.tx/put doc]])
-      (t/is (= doc (crux/entity (crux/db node) :foo))))))
+      (t/is (= (doc/->Document doc) (crux/entity (crux/db node) :foo))))))

--- a/crux-core/test/crux/eventually_consistent_doc_store_test.clj
+++ b/crux-core/test/crux/eventually_consistent_doc_store_test.clj
@@ -2,7 +2,8 @@
   (:require [crux.api :as crux]
             [clojure.test :as t]
             [crux.fixtures :as fix :refer [*api*]]
-            [crux.db :as db])
+            [crux.db :as db]
+            [crux.document :as doc])
   (:import (java.time Instant Duration)))
 
 (defrecord ECDocStore [!docs]
@@ -29,5 +30,5 @@
 
 (t/deftest test-eventually-consistent-doc-store
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo}]])
-  (t/is (= {:crux.db/id :foo}
+  (t/is (= (doc/->Document {:crux.db/id :foo})
            (crux/entity (crux/db *api*) :foo))))

--- a/crux-core/test/crux/fork_test.clj
+++ b/crux-core/test/crux/fork_test.clj
@@ -57,8 +57,8 @@
     (t/is (= (crux/valid-time db)
              (:crux.db/valid-time (last history))))
 
-    (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc {:crux.db/id :ivan, :name "Ivna"}}
-              {:crux.tx/tx-id 1, :crux.db/doc {:crux.db/id :ivan, :name "Ivan"}}]
+    (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Ivna"})}
+              {:crux.tx/tx-id 1, :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Ivan"})}]
 
              (->> history
                   (mapv #(select-keys % [::tx/tx-id :crux.db/doc])))))))
@@ -80,8 +80,8 @@
         (t/is (= (doc/->Document ivan0) (crux/entity db1 :ivan)))))
 
     (t/testing "doesn't include original data after the original db cutoff in history"
-      (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc {:crux.db/id :ivan, :name "Ivan0"}}
-                {:crux.tx/tx-id 2, :crux.db/doc {:crux.db/id :ivan, :name "Ivan2"}}]
+      (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Ivan0"})}
+                {:crux.tx/tx-id 2, :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Ivan2"})}]
                (->> (crux/entity-history (crux/with-tx db0 [[:crux.tx/put {:crux.db/id :ivan, :name "Ivan2"}]])
                                          :ivan
                                          :asc
@@ -108,16 +108,16 @@
 
     (t/is (= [{:crux.tx/tx-id 0,
                :crux.db/valid-time (::tx/tx-time present-tx),
-               :crux.db/doc ivan0}
+               :crux.db/doc (doc/->Document ivan0)}
               {:crux.tx/tx-id 2,
                :crux.db/valid-time now+5m,
-               :crux.db/doc {:crux.db/id :ivan, :name "5m Future Ivan"}}
+               :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "5m Future Ivan"})}
               {:crux.tx/tx-id 1,
                :crux.db/valid-time now+10m,
-               :crux.db/doc {:crux.db/id :ivan, :name "Future Ivan"}}
+               :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Future Ivan"})}
               {:crux.tx/tx-id 2,
                :crux.db/valid-time now+10m,
-               :crux.db/doc {:crux.db/id :ivan, :name "Future Ivan 2"}}]
+               :crux.db/doc (doc/->Document {:crux.db/id :ivan, :name "Future Ivan 2"})}]
              (->> (crux/entity-history db
                                        :ivan
                                        :asc
@@ -137,9 +137,10 @@
     (letfn [(entity-history [db eid]
               (->> (crux/entity-history db eid :asc {:with-docs? true})
                    (map #(select-keys % [::tx/tx-id ::db/doc]))))]
-      (t/is (= [{::tx/tx-id 0, ::db/doc ivan}] (entity-history db :ivan)))
-      (t/is (= [{::tx/tx-id 0, ::db/doc petr}] (entity-history db :petr)))
-      (t/is (= [{::tx/tx-id 0, ::db/doc ivan}] (entity-history db+evict :ivan)))
+
+      (t/is (= [{::tx/tx-id 0, ::db/doc (doc/->Document ivan)}] (entity-history db :ivan)))
+      (t/is (= [{::tx/tx-id 0, ::db/doc (doc/->Document petr)}] (entity-history db :petr)))
+      (t/is (= [{::tx/tx-id 0, ::db/doc (doc/->Document ivan)}] (entity-history db+evict :ivan)))
 
       (t/is (nil? (crux/entity db+evict :petr)))
       (t/is (empty? (entity-history db+evict :petr)))

--- a/crux-core/test/crux/fork_test.clj
+++ b/crux-core/test/crux/fork_test.clj
@@ -3,7 +3,8 @@
             [crux.api :as crux]
             [crux.db :as db]
             [crux.fixtures :as fix :refer [*api*]]
-            [crux.tx :as tx])
+            [crux.tx :as tx]
+            [crux.document :as doc])
   (:import java.util.Date))
 
 (t/use-fixtures :each fix/with-node)
@@ -11,7 +12,7 @@
 (t/deftest test-empty-fork
   (let [db (-> (crux/db *api*)
                (crux/with-tx [[:crux.tx/put {:crux.db/id :foo}]]))]
-    (t/is (= {:crux.db/id :foo} (crux/entity db :foo)))))
+    (t/is (= (doc/->Document {:crux.db/id :foo}) (crux/entity db :foo)))))
 
 (t/deftest test-simple-fork
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan, :name "Ivna"}]])
@@ -76,7 +77,7 @@
                   [[:crux.tx/put {:crux.db/id :petr, :name "Petr"}]])]
 
         (t/is (= (crux/valid-time db0) (crux/valid-time db1)))
-        (t/is (= ivan0 (crux/entity db1 :ivan)))))
+        (t/is (= (doc/->Document ivan0) (crux/entity db1 :ivan)))))
 
     (t/testing "doesn't include original data after the original db cutoff in history"
       (t/is (= [{:crux.tx/tx-id 0, :crux.db/doc {:crux.db/id :ivan, :name "Ivan0"}}

--- a/crux-http-client/src/crux/remote_api_client.clj
+++ b/crux-http-client/src/crux/remote_api_client.clj
@@ -5,7 +5,8 @@
             [crux.error :as err]
             [crux.io :as cio]
             [crux.query-state :as qs]
-            [crux.tx :as tx])
+            [crux.tx :as tx]
+            [crux.document :as doc])
   (:import com.nimbusds.jwt.SignedJWT
            [crux.api HistoryOptions$SortOrder ICruxAPI ICruxDatasource RemoteClientOptions NodeOutOfSyncException]
            [java.io Closeable InputStreamReader IOException PushbackReader]
@@ -20,7 +21,8 @@
       (int \() (->> (repeatedly #(try
                                    (edn/read {:readers {'crux/id c/id-edn-reader
                                                         'crux/query-state qs/->QueryState
-                                                        'crux/query-error qs/->QueryError}
+                                                        'crux/query-error qs/->QueryError
+                                                        'crux/document doc/->Document}
                                               :eof ::eof} in)
                                    (catch RuntimeException e
                                      (if (= "Unmatched delimiter: )" (.getMessage e))

--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -7,7 +7,8 @@
             [crux.fixtures.lucene :as lf]
             [crux.lucene :as l]
             [crux.query :as q]
-            [crux.rocksdb :as rocks])
+            [crux.rocksdb :as rocks]
+            [crux.document :as doc])
   (:import org.apache.lucene.analysis.Analyzer
            org.apache.lucene.document.Document
            org.apache.lucene.queryparser.classic.QueryParser
@@ -267,7 +268,7 @@
       (with-lucene-rocks-node {:node-dir node-dir :lucene-dir lucene-dir}
         (submit+await-tx *api* [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]]))
       (with-lucene-rocks-node {:node-dir node-dir :lucene-dir lucene-dir}
-        (t/is (= (c/entity (c/db *api*) :ivan) {:crux.db/id :ivan :name "Ivan"})))))
+        (t/is (= (c/entity (c/db *api*) :ivan) (doc/->Document {:crux.db/id :ivan :name "Ivan"}))))))
 
   (t/testing "restart with partial indices (> lucene-tx-id tx-id)"
     (fix/with-tmp-dirs #{node-dir lucene-dir index-dir}
@@ -277,8 +278,8 @@
         (submit+await-tx *api* [[:crux.tx/put {:crux.db/id :fred :name "Fred"}]]))
       (with-lucene-rocks-node {:node-dir node-dir :lucene-dir lucene-dir :index-dir index-dir}
         (let [db (c/db *api*)]
-          (t/is (= (c/entity db :fred) {:crux.db/id :fred :name "Fred"}))
-          (t/is (= (c/entity db :ivan) {:crux.db/id :ivan :name "Ivan"}))
+          (t/is (= (c/entity db :fred) (doc/->Document{:crux.db/id :fred :name "Fred"})))
+          (t/is (= (c/entity db :ivan) (doc/->Document{:crux.db/id :ivan :name "Ivan"})))
           (t/is (= #{[:fred]} (c/q db {:find '[?e]
                                        :where '[[(text-search :name "Fred") [[?e]]]
                                                 [?e :crux.db/id]]})))

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -3,6 +3,7 @@
             [crux.api :as api]
             [crux.codec :as c]
             [crux.db :as db]
+            [crux.document :as doc]
             [crux.fixtures :as fix :refer [*api*]]
             [crux.fixtures.jdbc :as fj]
             [crux.fixtures.lubm :as fl]
@@ -10,6 +11,9 @@
             [next.jdbc.result-set :as jdbcr]))
 
 (t/use-fixtures :each fj/with-each-jdbc-node fix/with-node)
+
+(defn doc= [expected compare]
+  (= (doc/->Document expected) compare))
 
 (t/deftest test-happy-path-jdbc-event-log
   (let [doc {:crux.db/id :origin-man :name "Adam"}
@@ -92,8 +96,8 @@
                     '{:find [(eql/project ?e [*])]
                       :where [[?e :crux.db/id :foo]]})))
 
-    (t/is (= {:crux.db/id :foo, :foo :bar}
-             (api/entity db :foo)))
+    (t/is (doc= {:crux.db/id :foo, :foo :bar}
+                (api/entity db :foo)))
 
     (t/is (= #{[{:crux.db/id :foo, :foo :bar}]}
              (api/q db

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -7,6 +7,7 @@
             [crux.fixtures :as fix :refer [*api*]]
             [crux.index :as idx]
             [crux.query :as q]
+            [crux.document :as doc]
             [taoensso.nippy :as nippy])
   (:import java.util.Arrays
            java.util.concurrent.TimeoutException))
@@ -1895,8 +1896,8 @@
 
       (t/is (= tx-id (:crux.tx/tx-id (api/entity-tx (api/db *api* tx-time tx-time) :ivan))))
 
-      (t/is (= {:crux.db/id :ivan
-                :name "Ivan 1st"} (api/entity (api/db *api* tx-time tx-time) :ivan)))))
+      (t/is (= (doc/->Document {:crux.db/id :ivan :name "Ivan 1st"})
+               (api/entity (api/db *api* tx-time tx-time) :ivan)))))
 
   (t/testing "cannot create existing user"
     (let [{:crux.tx/keys [tx-time tx-id] :as submitted-tx}

--- a/crux-test/test/crux/space_tutorial_test.clj
+++ b/crux-test/test/crux/space_tutorial_test.clj
@@ -2,11 +2,15 @@
   (:require [clojure.test :as t]
             [crux.api :as crux]
             [crux.io :as cio]
+            [crux.document :as doc]
             [crux.fixtures :as fix :refer [*api*]]
             [clojure.java.io :as io])
   (:import java.io.Closeable))
 
 (t/use-fixtures :each fix/with-node)
+
+(defn doc= [expected compare]
+  (= (doc/->Document expected) compare))
 
 (def manifest
   {:crux.db/id :manifest
@@ -53,13 +57,13 @@
   (t/testing "earth-test"
     (fix/submit+await-tx [[:crux.tx/put manifest]])
 
-    (t/is (= {:crux.db/id :manifest,
-              :pilot-name "Johanna",
-              :id/rocket "SB002-sol",
-              :id/employee "22910x2",
-              :badges "SETUP",
-              :cargo ["stereo" "gold fish" "slippers" "secret note"]}
-             (crux/entity (crux/db *api*) :manifest)))
+    (t/is (doc= {:crux.db/id :manifest,
+                 :pilot-name "Johanna",
+                 :id/rocket "SB002-sol",
+                 :id/employee "22910x2",
+                 :badges "SETUP",
+                 :cargo ["stereo" "gold fish" "slippers" "secret note"]}
+                (crux/entity (crux/db *api*) :manifest)))
 
     (t/is (= #{["secret note"]}
              (crux/q (crux/db *api*)
@@ -127,20 +131,20 @@
                            #inst "2115-02-15T18"
                            #inst "2115-02-19T18"]])
 
-    (t/is (= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 21}
-             (crux/entity (crux/db *api* #inst "2115-02-14") :stock/Pu)))
-    (t/is (= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 22.2}
-             (crux/entity (crux/db *api* #inst "2115-02-18") :stock/Pu)))
+    (t/is (doc= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 21}
+                (crux/entity (crux/db *api* #inst "2115-02-14") :stock/Pu)))
+    (t/is (doc= {:crux.db/id :stock/Pu, :commod :commodity/Pu, :weight-ton 22.2}
+                (crux/entity (crux/db *api* #inst "2115-02-18") :stock/Pu)))
 
     (fix/submit+await-tx [[:crux.tx/put (assoc manifest :badges ["SETUP" "PUT"])]])
 
-    (t/is (= {:crux.db/id :manifest,
-              :pilot-name "Johanna",
-              :id/rocket "SB002-sol",
-              :id/employee "22910x2",
-              :badges ["SETUP" "PUT"],
-              :cargo ["stereo" "gold fish" "slippers" "secret note"]}
-             (crux/entity (crux/db *api*) :manifest))))
+    (t/is (doc= {:crux.db/id :manifest,
+                 :pilot-name "Johanna",
+                 :id/rocket "SB002-sol",
+                 :id/employee "22910x2",
+                 :badges ["SETUP" "PUT"],
+                 :cargo ["stereo" "gold fish" "slippers" "secret note"]}
+                (crux/entity (crux/db *api*) :manifest))))
 
   (t/testing "mercury-tests"
     (put-all! [{:crux.db/id :commodity/Pu
@@ -182,15 +186,15 @@
                 :density 1.73
                 :radioactive false}])
 
-    (t/is (={:crux.db/id :commodity/borax
-             :common-name "Borax"
-             :IUPAC-name "Sodium tetraborate decahydrate"
-             :other-names ["Borax decahydrate" "sodium borate" "sodium tetraborate" "disodium tetraborate"]
-             :type :mineral/solid
-             :appearance "white solid"
-             :density 1.73
-             :radioactive false}
-            (crux/entity (crux/db *api*) :commodity/borax)))
+    (t/is (doc= {:crux.db/id :commodity/borax
+                 :common-name "Borax"
+                 :IUPAC-name "Sodium tetraborate decahydrate"
+                 :other-names ["Borax decahydrate" "sodium borate" "sodium tetraborate" "disodium tetraborate"]
+                 :type :mineral/solid
+                 :appearance "white solid"
+                 :density 1.73
+                 :radioactive false}
+                (crux/entity (crux/db *api*) :commodity/borax)))
     (t/is (= #{[:commodity/Pu] [:commodity/Au]}
              (crux/q (crux/db *api*)
                      '{:find [element]
@@ -247,13 +251,13 @@
 
     (fix/submit+await-tx [[:crux.tx/put (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"])]])
 
-    (t/is (= {:crux.db/id :manifest,
-              :pilot-name "Johanna",
-              :id/rocket "SB002-sol",
-              :id/employee "22910x2",
-              :badges ["SETUP" "PUT" "DATALOG-QUERIES"],
-              :cargo ["stereo" "gold fish" "slippers" "secret note"]}
-             (crux/entity (crux/db *api*) :manifest))))
+    (t/is (doc= {:crux.db/id :manifest,
+                 :pilot-name "Johanna",
+                 :id/rocket "SB002-sol",
+                 :id/employee "22910x2",
+                 :badges ["SETUP" "PUT" "DATALOG-QUERIES"],
+                 :cargo ["stereo" "gold fish" "slippers" "secret note"]}
+                (crux/entity (crux/db *api*) :manifest))))
 
   (t/testing "neptune-test"
     (fix/submit+await-tx [[:crux.tx/put
@@ -327,13 +331,13 @@
                            (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES"
                                                     "BITEMP"])]])
 
-    (t/is (= {:crux.db/id :manifest,
-              :pilot-name "Johanna",
-              :id/rocket "SB002-sol",
-              :id/employee "22910x2",
-              :badges ["SETUP" "PUT" "DATALOG-QUERIES" "BITEMP"],
-              :cargo ["stereo" "gold fish" "slippers" "secret note"]}
-             (crux/entity (crux/db *api*) :manifest))))
+    (t/is (doc= {:crux.db/id :manifest,
+                 :pilot-name "Johanna",
+                 :id/rocket "SB002-sol",
+                 :id/employee "22910x2",
+                 :badges ["SETUP" "PUT" "DATALOG-QUERIES" "BITEMP"],
+                 :cargo ["stereo" "gold fish" "slippers" "secret note"]}
+                (crux/entity (crux/db *api*) :manifest))))
 
   (t/testing "saturn-tests"
     (put-all! [{:crux.db/id :gold-harmony
@@ -454,12 +458,12 @@
 
     (fix/submit+await-tx [[:crux.tx/put (assoc manifest :badges ["SETUP" "PUT" "DATALOG-QUERIES" "BITEMP" "MATCH"])]])
 
-    (t/is (= {:crux.db/id :manifest,
-              :pilot-name "Johanna",
-              :id/rocket "SB002-sol",
-              :id/employee "22910x2",
-              :badges ["SETUP" "PUT" "DATALOG-QUERIES" "BITEMP" "MATCH"],
-              :cargo ["stereo" "gold fish" "slippers" "secret note"]}
+    (t/is (doc= {:crux.db/id :manifest,
+                 :pilot-name "Johanna",
+                 :id/rocket "SB002-sol",
+                 :id/employee "22910x2",
+                 :badges ["SETUP" "PUT" "DATALOG-QUERIES" "BITEMP" "MATCH"],
+                 :cargo ["stereo" "gold fish" "slippers" "secret note"]}
              (crux/entity (crux/db *api*) :manifest))))
 
   (t/testing "jupiter-tests"
@@ -483,9 +487,9 @@
                            #inst "2114-01-01T09"
                            #inst "2115-01-01T09"]])
 
-    (t/is (= {:crux.db/id :kaarlang/clients
-              :clients [:blue-energy :gold-harmony :tombaugh-resources]}
-             (crux/entity (crux/db *api* #inst "2114-01-01T09") :kaarlang/clients)))
+    (t/is (doc= {:crux.db/id :kaarlang/clients
+                 :clients [:blue-energy :gold-harmony :tombaugh-resources]}
+                (crux/entity (crux/db *api* #inst "2114-01-01T09") :kaarlang/clients)))
 
     ;; Check is not nil (that it runs), cannot confirm exact history state as tx-time changing
     (with-open [history (crux/open-entity-history (crux/db *api*) :kaarlang/clients :asc)]


### PR DESCRIPTION
Created the crux.document.Document record which implements IDocument and used it in the following places:

- ICruxDataSource.getEntity
- ICruxDataSource.entityHistory
- openTxLog.openTxLog (when withOps==true)