### PR TITLE
History Options doesn't use Case with Enums

### DIFF
--- a/crux-core/src/crux/history_options.clj
+++ b/crux-core/src/crux/history_options.clj
@@ -2,9 +2,11 @@
   (:import crux.api.HistoryOptions$SortOrder))
 
 (defn <-sort-order [sort-order]
-  (case sort-order
-    (:asc HistoryOptions$SortOrder/ASC) :asc
-    (:desc HistoryOptions$SortOrder/DESC) :desc))
+  (condp = sort-order
+    :asc :asc
+    HistoryOptions$SortOrder/ASC :asc
+    :desc :desc
+    HistoryOptions$SortOrder/DESC :desc))
 
 (defrecord HistoryOptions [sort-order with-corrections? with-docs?
                            start-valid-time start-tx

--- a/crux-test/test/crux/java_api_test.clj
+++ b/crux-test/test/crux/java_api_test.clj
@@ -133,9 +133,7 @@
                                 (.db node)))))))
 
 (t/deftest test-history-options
-  (let [asc-keyword (his/->history-options :asc)
-        asc-enum (his/->history-options HistoryOptions$SortOrder/ASC)
-        desc-keyword (his/->history-options :desc)
-        desc-enum (his/->history-options HistoryOptions$SortOrder/DESC)]
-    (t/is (= asc-keyword asc-enum))
-    (t/is (= desc-keyword desc-enum))))
+  (t/is (= :asc (his/->history-options :asc)))
+  (t/is (= :asc (his/->history-options HistoryOptions$SortOrder/ASC)))
+  (t/is (= :desc (his/->history-options :desc)))
+  (t/is (= :desc (his/->history-options HistoryOptions$SortOrder/DESC))))

--- a/crux-test/test/crux/java_api_test.clj
+++ b/crux-test/test/crux/java_api_test.clj
@@ -2,8 +2,9 @@
   (:require [clojure.java.io :as io]
             [clojure.test :as t]
             [crux.fixtures :as fix]
-            [crux.kv :as kv])
-  (:import [crux.api Crux ICruxAsyncIngestAPI ICruxAPI ModuleConfigurator NodeConfigurator]
+            [crux.kv :as kv]
+            [crux.history-options :as his])
+  (:import [crux.api Crux ICruxAsyncIngestAPI ICruxAPI ModuleConfigurator NodeConfigurator HistoryOptions$SortOrder]
            [crux.api.alpha CasOperation CruxId CruxNode DeleteOperation Document EvictOperation PutOperation Query]
            java.util.function.Consumer))
 
@@ -130,3 +131,11 @@
         (t/is (thrown-with-msg? IllegalStateException
                                 #"Crux node is closed"
                                 (.db node)))))))
+
+(t/deftest test-history-options
+  (let [asc-keyword (his/->history-options :asc)
+        asc-enum (his/->history-options HistoryOptions$SortOrder/ASC)
+        desc-keyword (his/->history-options :desc)
+        desc-enum (his/->history-options HistoryOptions$SortOrder/DESC)]
+    (t/is (= asc-keyword asc-enum))
+    (t/is (= desc-keyword desc-enum))))

--- a/crux-test/test/crux/java_api_test.clj
+++ b/crux-test/test/crux/java_api_test.clj
@@ -133,7 +133,7 @@
                                 (.db node)))))))
 
 (t/deftest test-history-options
-  (t/is (= :asc (his/->history-options :asc)))
-  (t/is (= :asc (his/->history-options HistoryOptions$SortOrder/ASC)))
-  (t/is (= :desc (his/->history-options :desc)))
-  (t/is (= :desc (his/->history-options HistoryOptions$SortOrder/DESC))))
+  (t/is (= :asc (his/<-sort-order :asc)))
+  (t/is (= :asc (his/<-sort-order HistoryOptions$SortOrder/ASC)))
+  (t/is (= :desc (his/<-sort-order :desc)))
+  (t/is (= :desc (his/<-sort-order HistoryOptions$SortOrder/DESC))))


### PR DESCRIPTION
The clojure `case` statement doesn't play well with Java enums as `case` test constants must be compile time literals.

One way of using `case` is to use the ordinal of the enum, but this won't work nicely here as `<-sort-order` is intended to take either the enum or keyword so the most readable solution is to change to condp