### PR TITLE
Ensuring that evict clears the bitemp index.

### DIFF
--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -25,7 +25,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def index-version 16)
+(def index-version 17)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -62,7 +62,7 @@
       (t/is (empty? (api/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 16}
+  (t/is (= (merge {:crux.index/index-version 17}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))


### PR DESCRIPTION
Fix mutability issue calling `all-keys-in-prefix` without eagerly evaluating the seq.

`all-keys-in-prefix` was doing a `kv/seek` on the provided iterator _before_ calling `lazy-seq`, which meant that multiple calls caused the shared iterator to be mutated concurrently.

This unfortunately requires an index version bump.
Users that re-use entity ids (i.e. put-evict-put) _are_ required to update
Otherwise, the impact of _not_ bumping are that the metadata (content-hash/valid-time/tx-time) of evicted entities may still show in `entity-history` and `entity-tx`, but `entity` and `q` are unaffected.
We were correctly removing all personally identifiable entity data from the document store.