### PR TITLE
Pull recursion cycles, #1352

### DIFF
--- a/crux-core/src/crux/eql_project.clj
+++ b/crux-core/src/crux/eql_project.clj
@@ -2,8 +2,7 @@
   (:require [crux.codec :as c]
             [crux.db :as db]
             [edn-query-language.core :as eql]
-            [clojure.string :as string]
-            [clojure.set :as set])
+            [clojure.string :as string])
   (:import clojure.lang.MapEntry))
 
 (defn- recognise-union [child]
@@ -44,56 +43,58 @@
            raise-doc-lookup-out-of-coll))
     coll))
 
-(defrecord RecurseState [^long recurse-depth child-fns])
-
-(defn- project-child [v db ^RecurseState recurse-state]
-  (->> (mapv (fn [f]
-               (f v db recurse-state))
-             (.child-fns recurse-state))
-       (raise-doc-lookup-out-of-coll)
-       (after-doc-lookup (fn [res]
-                           (into {} (mapcat identity) res)))))
+(defrecord RecurseState [seen-vs child-fns])
 
 (declare project-child-fns)
 
-(defn- ->next-recurse-state-fn [{:keys [query] :as join}]
-  (cond
-    (= '... query) (fn [^RecurseState recurse-state]
-                     (-> recurse-state (update :recurse-depth inc)))
-    (int? query) (fn [^RecurseState recurse-state]
-                   (when (< (.recurse-depth recurse-state) ^long query)
-                     (-> recurse-state (update :recurse-depth inc))))
-    :else (constantly (RecurseState. 0 (project-child-fns join)))))
+(defn- ->project-child [{:keys [query] :as join}]
+  (letfn [(project-child [v db ^RecurseState recurse-state]
+            (if (contains? (.seen-vs recurse-state) v)
+              {:crux.db/id v}
+              (let [recurse-state ^RecurseState (update recurse-state :seen-vs conj v)]
+                (->> (mapv (fn [f]
+                             (f v db recurse-state))
+                           (.child-fns recurse-state))
+                     (raise-doc-lookup-out-of-coll)
+                     (after-doc-lookup (fn [res]
+                                         (into {} (mapcat identity) res)))))))]
+    (cond
+      (= '... query) project-child
+      (int? query) (fn [v db ^RecurseState recurse-state]
+                     (when (<= (count (.seen-vs recurse-state)) ^long query)
+                       (project-child v db recurse-state)))
+      :else (let [recurse-state (RecurseState. #{} (project-child-fns join))]
+              (fn [v db _]
+                (project-child v db recurse-state))))))
 
 (defn- forward-joins-child-fn [{:keys [props special forward-joins unions]}]
   (when-not (every? empty? [props special forward-joins unions])
     (let [forward-join-child-fns (for [{:keys [dispatch-key] :as join} forward-joins]
                                    (let [into-coll (get-in join [:params :into])
                                          limit (get-in join [:params :limit])
-                                         next-recurse-state (->next-recurse-state-fn join)
+                                         project-child (->project-child join)
                                          k (or (get-in join [:params :as] dispatch-key))]
                                      (fn [doc db recurse-state]
                                        (when-let [v (get doc dispatch-key)]
-                                         (when-let [recurse-state (next-recurse-state recurse-state)]
-                                           (->> (if (c/multiple-values? v)
-                                                  (->> (cond->> v
-                                                         limit (take limit))
-                                                       (mapv #(project-child % db recurse-state))
-                                                       (raise-doc-lookup-out-of-coll))
-                                                  (project-child v db recurse-state))
-                                                (after-doc-lookup (fn [res]
+                                         (->> (if (c/multiple-values? v)
+                                                (->> (cond->> v
+                                                       limit (take limit))
+                                                     (mapv #(project-child % db recurse-state))
+                                                     (raise-doc-lookup-out-of-coll))
+                                                (project-child v db recurse-state))
+                                              (after-doc-lookup (fn [res]
+                                                                  (when res
                                                                     (MapEntry/create k (cond->> res
                                                                                          into-coll (into into-coll)))))))))))
 
           union-child-fns (for [{:keys [dispatch-key children]} unions
                                 {:keys [union-key] :as child} (get-in children [0 :children])]
-                            (let [next-recurse-state (->next-recurse-state-fn child)]
+                            (let [project-child (->project-child child)]
                               (fn [value doc db recurse-state]
                                 (->> (c/vectorize-value (get doc dispatch-key))
                                      (keep (fn [v]
                                              (when (= v union-key)
-                                               (when-let [recurse-state (next-recurse-state recurse-state)]
-                                                 (project-child value db recurse-state)))))))))
+                                               (project-child value db recurse-state))))))))
 
           prop-child-fns (->> (for [{:keys [dispatch-key params]} props]
                                 (let [{into-coll :into, :keys [as limit]} params
@@ -138,21 +139,20 @@
                                          forward-key (keyword (namespace dispatch-key)
                                                               (subs (name dispatch-key) 1))
                                          one? (= :one (get-in join [:params :cardinality]))
-                                         next-recurse-state (->next-recurse-state-fn join)
+                                         project-child (->project-child join)
                                          k (or (get-in join [:params :as]) dispatch-key)]
                                      (fn [value-buffer {:keys [index-snapshot entity-resolver-fn] :as db} recurse-state]
-                                       (when-let [recurse-state (next-recurse-state recurse-state)]
-                                         (->> (vec (for [v (cond->> (db/ave index-snapshot (c/->id-buffer forward-key) value-buffer nil entity-resolver-fn)
-                                                             one? (take 1)
-                                                             limit (take limit)
-                                                             :always vec)]
-                                                     (project-child (db/decode-value index-snapshot v) db recurse-state)))
-                                              (raise-doc-lookup-out-of-coll)
-                                              (after-doc-lookup (fn [res]
-                                                                  (when (seq res)
-                                                                    (MapEntry/create k (cond->> res
-                                                                                         into-coll (into into-coll)
-                                                                                         one? first))))))))))]
+                                       (->> (vec (for [v (cond->> (db/ave index-snapshot (c/->id-buffer forward-key) value-buffer nil entity-resolver-fn)
+                                                           one? (take 1)
+                                                           limit (take limit)
+                                                           :always vec)]
+                                                   (project-child (db/decode-value index-snapshot v) db recurse-state)))
+                                            (raise-doc-lookup-out-of-coll)
+                                            (after-doc-lookup (fn [res]
+                                                                (when-let [res (seq (remove nil? res))]
+                                                                  (MapEntry/create k (cond->> res
+                                                                                       into-coll (into into-coll)
+                                                                                       one? first)))))))))]
       (fn [value db recurse-state]
         (let [value-buffer (c/->value-buffer value)]
           (->> reverse-join-child-fns
@@ -177,9 +177,9 @@
          (remove nil?))))
 
 (defn compile-project-spec [project-spec]
-  (let [recurse-state (RecurseState. 0 (project-child-fns (eql/query->ast project-spec)))]
+  (let [project-child (->project-child (eql/query->ast project-spec))]
     (fn [value db]
-      (project-child value db recurse-state))))
+      (project-child value db nil))))
 
 (defn ->project-result [db compiled-find q-conformed res]
   (->> res

--- a/crux-core/src/crux/eql_project.clj
+++ b/crux-core/src/crux/eql_project.clj
@@ -115,9 +115,10 @@
                              (into {}))]
 
       (fn [value {:keys [entity-resolver-fn] :as db} recurse-state]
-        (when-let [content-hash (entity-resolver-fn (c/->id-buffer value))]
+        (when-let [content-hash (some-> (entity-resolver-fn (c/->id-buffer value))
+                                        c/new-id)]
           (let-docs [docs #{content-hash}]
-            (let [doc (get docs (c/new-id content-hash))]
+            (let [doc (get docs content-hash)]
               (->> (concat (->> forward-join-child-fns (map (fn [f] (f doc db recurse-state))))
                            (->> union-child-fns (mapcat (fn [f] (f value doc db recurse-state)))))
                    (raise-doc-lookup-out-of-coll)

--- a/crux-core/src/crux/eql_project.clj
+++ b/crux-core/src/crux/eql_project.clj
@@ -58,12 +58,11 @@
 
 (defn- ->next-recurse-state-fn [{:keys [query] :as join}]
   (cond
-    ;; TODO temporarily feature flagging recursion until it passes Datascript tests, see #1220
-    ;; (= '... query) (fn [^RecurseState recurse-state]
-    ;;                  (-> recurse-state (update :recurse-depth inc)))
-    ;; (int? query) (fn [^RecurseState recurse-state]
-    ;;                (when (< (.recurse-depth recurse-state) ^long query)
-    ;;                  (-> recurse-state (update :recurse-depth inc))))
+    (= '... query) (fn [^RecurseState recurse-state]
+                     (-> recurse-state (update :recurse-depth inc)))
+    (int? query) (fn [^RecurseState recurse-state]
+                   (when (< (.recurse-depth recurse-state) ^long query)
+                     (-> recurse-state (update :recurse-depth inc))))
     :else (constantly (RecurseState. 0 (project-child-fns join)))))
 
 (defn- forward-joins-child-fn [{:keys [props special forward-joins unions]}]

--- a/crux-core/test/crux/datascript_pull_test.clj
+++ b/crux-core/test/crux/datascript_pull_test.clj
@@ -208,16 +208,13 @@
                           :where [[?e :crux.db/id :lucy]]}))
           "Multiple recursion specs in one pattern")
 
-    ;; TODO recursion cycles
-    #_
-    (let [db (crux/with-tx db [:crux.tx/put [{:crux.db/id :kerri, :name "Kerri", :friend #{:lucy}}]])]
-      (t/is (= (update-in friends (take 8 (cycle [:friend 0]))
-                          assoc :friend [{:name "Lucy" :friend [:elizabeth]}])
+    (let [db (crux/with-tx db [[:crux.tx/put {:crux.db/id :kerri, :name "Kerri", :friend #{:lucy}}]])]
+      (t/is (= #{[(assoc-in friends (take 7 (cycle [:friend 0])) [{:name "Kerri" :friend [{:crux.db/id :lucy}]}])]}
                (crux/q db '{:find [(eql/project ?e [:name {:friend ...}])]
                             :where [[?e :crux.db/id :lucy]]}))
-            "Cycles are handled by returning only the :db/id of entities which have been seen before"))))
+            "Cycles are handled by returning only the :crux.db/id of entities which have been seen before"))))
 
-;; TODO recursion cycles
+;; TODO
 #_
 (t/deftest test-dual-recursion
   (let [db (submit-test-docs [{:crux.db/id 1, :part 2, :spec 2}

--- a/crux-core/test/crux/datascript_pull_test.clj
+++ b/crux-core/test/crux/datascript_pull_test.clj
@@ -172,14 +172,10 @@
                  (crux/q db '{:find [(eql/project ?e [:part-name {:_part-of [:part-name]}])]
                               :where [[?e :crux.db/id :a]]})))
 
-        ;; TODO temporarily feature flagging recursion until it passes Datascript tests, see #1220
-        #_
         (t/is (= parts
                  (crux/q db '{:find [(eql/project ?e [:part-name {:_part-of 1}])]
                               :where [[?e :crux.db/id :a]]})))))))
 
-;; TODO temporarily feature flagging recursion until it passes Datascript tests, see #1220
-#_
 (t/deftest test-pull-recursion
   (let [db (submit-test-docs people-docs)
         friends {:name "Lucy"

--- a/crux-core/test/crux/eql_project_test.clj
+++ b/crux-core/test/crux/eql_project_test.clj
@@ -176,8 +176,7 @@
                                               :crux.db/id])]
                      :where [[?it :crux.db/id]]}))))
 
-;; TODO temporarily feature flagging recursion until it passes Datascript tests, see #1220
-#_(t/deftest test-recursive
+(t/deftest test-recursive
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :root}]
                         [:crux.tx/put {:crux.db/id :a
                                        :parent :root}]

--- a/crux-core/test/crux/eql_project_test.clj
+++ b/crux-core/test/crux/eql_project_test.clj
@@ -237,3 +237,10 @@
                      :in [?e]
                      :timeout 500}
                    "doesntexist"))))
+
+(t/deftest test-with-speculative-doc-store
+  (let [db (crux/with-tx (crux/db *api*) [[:crux.tx/put {:crux.db/id :foo}]])]
+    (t/is (= #{[{:crux.db/id :foo}]}
+             (crux/q db
+                     '{:find [(eql/project ?e [*])]
+                       :where [[?e :crux.db/id :foo]]})))))

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -483,8 +483,6 @@ Crux supports a handful of custom https://edn-query-language.org/eql/1.0.0/speci
 * `:cardinality` (reverse joins) - by default, reverse joins put their values in a collection - for many-to-one/one-to-one reverse joins, specify `{:cardinality :one}` to return a single value.
 
 For full details on what's supported in the projection-spec, see the https://edn-query-language.org/eql/1.0.0/specification.html[EQL specification^]
-// TODO temporarily feature flagging recursion until it passes Datascript tests, see #1220
-Crux does not (yet) support recursive queries.
 
 [#ordering-and-pagination]
 == Ordering and Pagination


### PR DESCRIPTION
Fixes #1352 - see that issue for the the use case.

* Reverts the recursion feature flag from #1311. Doesn't pass _all_ the Datascript recursion tests, but enough that I wouldn't mind releasing it. #1353 still to go.
* Fixes an unrelated issue with projections on speculative DBs, with test - we weren't dealing with `#crux/id`s correctly
* Main implementation note is that we now keep a stack of values we've seen so far in the recursion, so that if there is a cycle, we know not to continue the recursion. Done by combining `project-child` and `->next-recurse-state-fn` into `->project-child`.
