### PR TITLE
Add 'pred-ctx' to query engine s.t. we don't have to rely on globals in Lucene, #1218

### DIFF
--- a/crux-lucene/src/crux/lucene/multi_field.clj
+++ b/crux-lucene/src/crux/lucene/multi_field.clj
@@ -54,8 +54,8 @@
 (defmethod q/pred-args-spec 'lucene-text-search [_]
   (s/cat :pred-fn #{'lucene-text-search} :args (s/spec (s/cat :query string? :bindings (s/* :crux.query/binding))) :return (s/? :crux.query/binding)))
 
-(defmethod q/pred-constraint 'lucene-text-search [_ pred-ctx]
-  (when-not (instance? LuceneMultiFieldIndexer (:indexer l/*lucene-store*))
+(defmethod q/pred-constraint 'lucene-text-search [_ {::l/keys [lucene-store] :as pred-ctx}]
+  (when-not (instance? LuceneMultiFieldIndexer (:indexer lucene-store))
     (throw (IllegalStateException. "Lucene multi field indexer not configured, consult the docs.")))
   (l/pred-constraint #'build-lucene-text-query #'resolve-search-results-content-hash pred-ctx))
 

--- a/crux-lucene/test/crux/fixtures/lucene.clj
+++ b/crux-lucene/test/crux/fixtures/lucene.clj
@@ -1,20 +1,30 @@
 (ns crux.fixtures.lucene
-  (:require [crux.fixtures :as fix :refer [with-tmp-dir]]
-            [crux.fixtures :refer [*api*]]
-            [crux.lucene :as l]))
+  (:require [crux.fixtures :as fix :refer [*api*]]
+            [crux.lucene :as l])
+  (:import [org.apache.lucene.index DirectoryReader]
+           [org.apache.lucene.store Directory]))
 
 (defn with-lucene-module [f]
-  (with-tmp-dir "lucene" [db-dir]
+  (fix/with-tmp-dirs #{db-dir}
     (fix/with-opts {::l/lucene-store {:db-dir db-dir}}
       f)))
 
 (defn with-lucene-opts [lucene-opts]
   (fn [f]
-    (with-tmp-dir "lucene" [db-dir]
+    (fix/with-tmp-dirs #{db-dir}
       (fix/with-opts {::l/lucene-store (merge {:db-dir db-dir} lucene-opts)}
         f))))
 
+(defn- lucene-store []
+  (:crux.lucene/lucene-store @(:!system *api*)))
+
 (defn ^crux.api.ICursor search [f & args]
-  (let [analyzer (:analyzer (:crux.lucene/lucene-store @(:!system *api*)))
+  (let [lucene-store (lucene-store)
+        analyzer (:analyzer lucene-store)
         q (apply f analyzer args)]
-    (l/search (:crux.lucene/lucene-store @(:!system *api*)) q)))
+    (l/search lucene-store q)))
+
+(defn doc-count []
+  (let [{:keys [^Directory directory]} (lucene-store)
+        directory-reader (DirectoryReader/open directory)]
+    (.numDocs directory-reader)))

--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -13,6 +13,9 @@
            org.apache.lucene.queryparser.classic.QueryParser
            [org.apache.lucene.search BooleanClause$Occur BooleanQuery$Builder Query]))
 
+;; tests in this namespace depend on the `(defmethod q/pred-constraint 'lucene-text-search ...)`
+(require 'crux.lucene.multi-field)
+
 (t/use-fixtures :each lf/with-lucene-module fix/with-node)
 
 (t/deftest test-can-search-string
@@ -168,7 +171,7 @@
     (submit+await-tx [[:crux.tx/put {:crux.db/id "ivan" :name "Ivan"}]])
     (submit+await-tx [[:crux.tx/put {:crux.db/id "ivan" :name "Ivan"}]])
 
-    (t/is (= 2 (l/doc-count)))
+    (t/is (= 2 (lf/doc-count)))
 
     (with-open [db (c/open-db *api*)]
       (t/is (= prior-score (c/q db q))))))


### PR DESCRIPTION
Fixes #1218 - naming RFC.
