### PR TITLE
Fix entity-history doc-hang

### DIFF
--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc crux.db
-  (:require [clojure.set :as set]))
+  (:require [clojure.set :as set]
+            [crux.codec :as c]))
 
 ;; tag::Index[]
 (defprotocol Index
@@ -76,7 +77,8 @@
   (-fetch-docs [this ids]))
 
 (defn fetch-docs [document-store ids]
-  (let [ids (set ids)]
+  (let [ids (->> ids
+                 (into #{} (remove (some-fn nil? #{(c/new-id c/nil-id-buffer)}))))]
     (loop [docs {}]
       (let [missing-ids (set/difference ids (set (keys docs)))
             docs (into docs

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1846,16 +1846,22 @@
       (let [index-snapshot (open-index-snapshot this)
             {:keys [sort-order with-docs?] :as opts} (-> opts (with-history-bounds this index-snapshot))]
         (cio/->cursor #(.close index-snapshot)
-                      (->> (db/entity-history index-snapshot eid sort-order opts)
-                           (map (fn [^EntityTx etx]
-                                  (cond-> {:crux.tx/tx-time (.tt etx)
-                                           :crux.tx/tx-id (.tx-id etx)
-                                           :crux.db/valid-time (.vt etx)
-                                           :crux.db/content-hash (.content-hash etx)}
-                                    with-docs? (assoc :crux.db/doc (when-let [content-hash (.content-hash etx)]
-                                                                     (when-not (= content-hash (c/new-id c/nil-id-buffer))
-                                                                       (-> (db/fetch-docs document-store #{content-hash})
-                                                                           (get content-hash)))))))))))))
+                      (->> (for [history-batch (->> (db/entity-history index-snapshot eid sort-order opts)
+                                                    (partition-all 100))
+                                 :let [docs (when with-docs?
+                                              (db/fetch-docs document-store
+                                                             (->> history-batch
+                                                                  (into #{}
+                                                                        (comp (keep #(.content-hash ^EntityTx %))
+                                                                              (remove #{(c/new-id c/nil-id-buffer)}))))))]]
+                             (->> history-batch
+                                  (map (fn [^EntityTx etx]
+                                         (cond-> {:crux.tx/tx-time (.tt etx)
+                                                  :crux.tx/tx-id (.tx-id etx)
+                                                  :crux.db/valid-time (.vt etx)
+                                                  :crux.db/content-hash (.content-hash etx)}
+                                           with-docs? (assoc :crux.db/doc (get docs (.content-hash etx))))))))
+                           (mapcat seq))))))
 
   (validTime [_] valid-time)
   (transactionTime [_] tx-time)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1852,8 +1852,10 @@
                                            :crux.tx/tx-id (.tx-id etx)
                                            :crux.db/valid-time (.vt etx)
                                            :crux.db/content-hash (.content-hash etx)}
-                                    with-docs? (assoc :crux.db/doc (-> (db/fetch-docs document-store #{(.content-hash etx)})
-                                                                       (get (.content-hash etx))))))))))))
+                                    with-docs? (assoc :crux.db/doc (when-let [content-hash (.content-hash etx)]
+                                                                     (when-not (= content-hash (c/new-id c/nil-id-buffer))
+                                                                       (-> (db/fetch-docs document-store #{content-hash})
+                                                                           (get content-hash)))))))))))))
 
   (validTime [_] valid-time)
   (transactionTime [_] tx-time)


### PR DESCRIPTION
Pull in fix from @AlistairONeill's #1374 PR, https://github.com/juxt/crux/commit/11c713498d34715fa400db64d6f270e71098332d

Have also updated the Jupiter space-tutorial test so that it checks the entity history, and updated `entity-history` so that it fetches docs from the doc-store in batches.