### PR TITLE
Ensures that the logback.xml configuration file is included in custom-build deployments

### DIFF
--- a/crux-build/deps.edn
+++ b/crux-build/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+{:paths ["resources"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
 
         ;; Logging
         org.slf4j/slf4j-api {:mvn/version "1.7.29"}

--- a/crux-build/docker/Dockerfile
+++ b/crux-build/docker/Dockerfile
@@ -6,6 +6,8 @@ ENTRYPOINT ["clojure", "-m", "crux.main"]
 EXPOSE 3000
 
 ADD deps.edn deps.edn
+RUN mkdir /usr/lib/crux/resources
+ADD resources/logback.xml resources/logback.xml
 RUN clojure -Sforce -Spath >/dev/null
 
 ENV MALLOC_ARENA_MAX=2

--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -27,3 +27,7 @@ All of the below commands should be run in the *root* of the Crux repo.
 The recommended way of running the full test suite is `lein build`.
 
 The test suite relies on the `timeout` command line utility, this comes as a default on Linux but isn't preinstalled on MacOS. You can get it with `brew install coreutils && echo 'alias timeout=gtimeout' >> ~/.bashrc'`
+
+[NOTE]
+====
+The GNU version of `sed` is required for some scripts in this project. If developing on Mac (or other BSD variants), install GNU sed.


### PR DESCRIPTION
This `ADD`s the file to the Docker distros and includes resources in the path for the configuration.