### PR TITLE
Adds `crux-in-memory.edn` to `clj-uberjar`.

### DIFF
--- a/crux-build/clj-uberjar/.gitignore
+++ b/crux-build/clj-uberjar/.gitignore
@@ -2,5 +2,6 @@
 !.gitignore
 !deps.edn
 !build-uberjar.sh
+!crux-in-memory.edn
 !crux.edn
 !crux-sql.edn

--- a/crux-build/clj-uberjar/crux-in-memory.edn
+++ b/crux-build/clj-uberjar/crux-in-memory.edn
@@ -1,0 +1,2 @@
+{:crux.http-server/server {}
+ :crux.calcite/server {}}


### PR DESCRIPTION
Resolves #1388 - used to create the latest `crux-in-memory.jar` artifact, and confirmed that the SQL server is accessible.