### PR TITLE
Creating 'community' Antora component

### DIFF
--- a/docs/about/antora.yml
+++ b/docs/about/antora.yml
@@ -3,4 +3,5 @@ title: Crux
 version: master
 start_page: ROOT:what-is-crux.adoc
 nav:
-  - modules/ROOT/nav.adoc
+  - modules/ROOT/articles-nav.adoc
+  - modules/ROOT/about-nav.adoc

--- a/docs/about/antora.yml
+++ b/docs/about/antora.yml
@@ -3,4 +3,4 @@ title: Crux
 version: master
 start_page: ROOT:what-is-crux.adoc
 nav:
-  - nav.adoc
+  - modules/ROOT/nav.adoc

--- a/docs/about/modules/ROOT/about-nav.adoc
+++ b/docs/about/modules/ROOT/about-nav.adoc
@@ -1,0 +1,3 @@
+.About Crux
+* xref:support.adoc[Support]
+* xref:references.adoc[References]

--- a/docs/about/modules/ROOT/articles-nav.adoc
+++ b/docs/about/modules/ROOT/articles-nav.adoc
@@ -1,5 +1,3 @@
-.About Crux
+.Articles
 * xref:what-is-crux.adoc[What is Crux?]
 * xref:bitemporality.adoc[Bitemporality]
-* xref:support.adoc[Support]
-* xref:references.adoc[References]

--- a/docs/about/modules/ROOT/nav.adoc
+++ b/docs/about/modules/ROOT/nav.adoc
@@ -1,7 +1,5 @@
 .About Crux
 * xref:what-is-crux.adoc[What is Crux?]
 * xref:bitemporality.adoc[Bitemporality]
-* xref:faq.adoc[FAQs]
-* xref:contributing.adoc[Contributing]
 * xref:support.adoc[Support]
 * xref:references.adoc[References]

--- a/docs/antora-playbook-blog.yml
+++ b/docs/antora-playbook-blog.yml
@@ -11,6 +11,9 @@ content:
       start_path: docs/training
       branches: HEAD
     - url: ../
+      start_path: docs/support
+      branches: HEAD
+    - url: ../
       start_path: docs/about
       branches: HEAD
     - url: ../

--- a/docs/antora-playbook-blog.yml
+++ b/docs/antora-playbook-blog.yml
@@ -14,6 +14,9 @@ content:
       start_path: docs/about
       branches: HEAD
     - url: ../
+      start_path: docs/community
+      branches: HEAD
+    - url: ../
       start_path: docs/tutorials
       branches: HEAD
     - url: ../../crux-site

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -11,6 +11,9 @@ content:
       start_path: docs/training
       branches: HEAD
     - url: ../
+      start_path: docs/support
+      branches: HEAD
+    - url: ../
       start_path: docs/about
       branches: HEAD
     - url: ../

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -14,6 +14,9 @@ content:
       start_path: docs/about
       branches: HEAD
     - url: ../
+      start_path: docs/community
+      branches: HEAD
+    - url: ../
       start_path: docs/tutorials
       branches: HEAD
     - url: ../

--- a/docs/bin/build.sh
+++ b/docs/bin/build.sh
@@ -10,14 +10,14 @@ while [[ "$#" -gt 0 ]]; do
         --with-local-bundle)
             OPTS+=" --ui-bundle-url=../../crux-site/build/ui-bundle.zip"
             shift;;
-	--with-blog)
-	    PLAYBOOK="antora-playbook-blog.yml"
-	    shift;;
+        --with-blog)
+            PLAYBOOK="antora-playbook-blog.yml"
+            shift;;
         *) echo "Unknown parameter passed: $1"; exit 1;;
     esac
 done
 
 (
     cd $(dirname "$0")/..
-    antora --clean --fetch $OPTS $PLAYBOOK
+    antora --clean --redirect-facility static --fetch $OPTS $PLAYBOOK
 )

--- a/docs/community/antora.yml
+++ b/docs/community/antora.yml
@@ -1,0 +1,8 @@
+name: community
+title: Crux
+version: master
+start_page: ROOT:faq.adoc
+nav:
+  - modules/ROOT/nav.adoc
+urls:
+  redirect_facility: static

--- a/docs/community/modules/ROOT/nav.adoc
+++ b/docs/community/modules/ROOT/nav.adoc
@@ -1,0 +1,3 @@
+.Community
+* xref:faq.adoc[FAQs]
+* xref:contributing.adoc[Contributing]

--- a/docs/community/modules/ROOT/pages/contributing.adoc
+++ b/docs/community/modules/ROOT/pages/contributing.adoc
@@ -1,3 +1,6 @@
+= Contributing
+:page-aliases: about::contributing.adoc
+
 == Thanks
 
 Crux would not exist without the community of vibrant open source projects on which it depends, and we hope that the Crux community will serve to extend and reflect our gratitude.

--- a/docs/community/modules/ROOT/pages/faq.adoc
+++ b/docs/community/modules/ROOT/pages/faq.adoc
@@ -1,4 +1,5 @@
 = FAQs
+:page-aliases: about::faq.adoc
 
 [qanda]
 

--- a/docs/support/antora.yml
+++ b/docs/support/antora.yml
@@ -1,0 +1,4 @@
+name: support
+title: Crux
+version: master
+start_page: ROOT:support.adoc

--- a/docs/support/modules/ROOT/pages/support.adoc
+++ b/docs/support/modules/ROOT/pages/support.adoc
@@ -1,0 +1,3 @@
+= Support
+:page-layout: support
+:page-nav: black-nav


### PR DESCRIPTION
- first step in carving up the "about" page
- requires redirects from old Antora pages since we can't commit
  changes to `crux` and `crux-site` synchronously