### PR TITLE
Getting TX ingestion to react to interrupts per tx-event

### DIFF
--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -104,13 +104,13 @@
   Closeable
   (close [_]
     (try
-      (.shutdown tx-submit-executor)
+      (.shutdownNow tx-submit-executor)
       (catch Exception e
         (log/warn e "Error shutting down tx-submit-executor")))
 
     (when tx-ingest-executor
       (try
-        (.shutdown tx-ingest-executor)
+        (.shutdownNow tx-ingest-executor)
         (catch Exception e
           (log/warn e "Error shutting down tx-ingest-executor"))))
 

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -316,7 +316,9 @@
                                  (when-let [docs (seq (concat docs tombstones))]
                                    (db/submit-docs document-store-tx docs)))
 
-                               (recur (concat new-tx-events more-tx-events)))))))]
+                               (if (Thread/interrupted)
+                                 (throw (InterruptedException.))
+                                 (recur (concat new-tx-events more-tx-events))))))))]
           (when abort?
             (reset! !tx-state :abort-only))
 


### PR DESCRIPTION
This change gets the TX ingestion to check for interrupts after every tx-event, so that we don't wait for the whole transaction to finish ingesting if the node's shutting down - if the transaction continued ingesting into RocksDB after the awaitTermination timeout, this would cause a segfault as seen in #1316. (There aren't any persistent writes until commit, so no transactions were harmed in the making of this PR.)

I have another query-related branch where I'm hoping to do the same for outstanding queries, but safe to say this is more complex, worth banking this one.