### PR TITLE
Not shutting down IndexStore til all the snapshots are closed

### DIFF
--- a/crux-core/src/crux/bus.clj
+++ b/crux-core/src/crux/bus.clj
@@ -96,12 +96,12 @@
   EventSink
   (send [_ {:crux/keys [event-type] :as event}]
     (s/assert ::event event)
-    (doseq [{:keys [^Executor executor f] :as listener} (get @!listeners event-type)]
-      (if sync?
-        (try
+    (doseq [{:keys [^Executor executor f]} (get @!listeners event-type)]
+      (try
+        (if sync?
           (f event)
-          (catch Exception e))
-        (.execute executor ^Runnable #(f event)))))
+          (.execute executor ^Runnable #(f event)))
+        (catch Exception _))))
 
   Closeable
   (close [_]

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -104,13 +104,13 @@
   Closeable
   (close [_]
     (try
-      (.shutdown tx-submit-executor)
+      (.shutdownNow tx-submit-executor)
       (catch Exception e
         (log/warn e "Error shutting down tx-submit-executor")))
 
     (when tx-ingest-executor
       (try
-        (.shutdown tx-ingest-executor)
+        (.shutdownNow tx-ingest-executor)
         (catch Exception e
           (log/warn e "Error shutting down tx-ingest-executor"))))
 

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -97,7 +97,7 @@
   (db [this valid-time-or-basis]
     (if (instance? Date valid-time-or-basis)
       (api/db this {:crux.db/valid-time valid-time-or-basis})
-      (api/open-db this valid-time-or-basis)))
+      (api/db query-engine valid-time-or-basis)))
   (db [this valid-time tx-time]
     (api/db this {:crux.db/valid-time valid-time, :crux.tx/tx-time tx-time}))
 

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1974,8 +1974,8 @@
   (close [_]
     (when interrupt-executor
       (doto interrupt-executor
-        (.shutdown)
-        (.awaitTermination 60000 TimeUnit/MILLISECONDS)))))
+        (.shutdownNow)
+        (.awaitTermination 5000 TimeUnit/MILLISECONDS)))))
 
 (def default-allow-list
   (->> (slurp (io/resource "query-allowlist.edn"))

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -316,7 +316,9 @@
                                  (when-let [docs (seq (concat docs tombstones))]
                                    (db/submit-docs document-store-tx docs)))
 
-                               (recur (concat new-tx-events more-tx-events)))))))]
+                               (if (Thread/interrupted)
+                                 (throw (InterruptedException.))
+                                 (recur (concat new-tx-events more-tx-events))))))))]
           (when abort?
             (reset! !tx-state :abort-only))
 

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -20,7 +20,9 @@
 
 (defmacro with-fresh-index-store [& body]
   `(fkv/with-kv-store [kv-store#]
-     (binding [*index-store* (kvi/->KvIndexStore kv-store# (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}))]
+     (binding [*index-store* (kvi/->kv-index-store {:kv-store kv-store#
+                                                    :cav-cache  (nop-cache/->nop-cache {})
+                                                    :canonical-buffer-cache (nop-cache/->nop-cache {})})]
        ~@body)))
 
 ;; NOTE: These tests does not go via the TxLog, but writes its own


### PR DESCRIPTION
related to #1316, #1445 (merge after #1445, diff of this PR: https://github.com/jarohen/crux/compare/ingest-segfault-1316...jarohen:index-store-thread-cleanup)

We keep track of the open snapshots in the IndexStore. When the IndexStore is then closed, it interrupts any threads that haven't closed their snapshots, so that they can get on and close them. This then means that the KV store doesn't shut down til all snapshots are shut, which prevents segfaults in Rocks caused by use-after-close bugs.

Also fixed a snapshot leak in node/db, unearthed by the test's index-store not closing :confused: 