### PR TITLE
Adds support for single find arg, #1449

### DIFF
--- a/crux-core/src/crux/api/ICruxDatasource.java
+++ b/crux-core/src/crux/api/ICruxDatasource.java
@@ -37,6 +37,8 @@ public interface ICruxDatasource extends Closeable {
      * This function will return a set of result tuples if you do not specify `:order-by`, `:limit` or `:offset`;
      * otherwise, it will return a vector of result tuples.
      *
+     * NOTE: This function does not support the single find-arg variant - `:find` arguments must be wrapped in a vector.
+     *
      * @param query the query in map, vector or string form.
      * @param args  bindings for in.
      * @return      a set or vector of result tuples.
@@ -45,6 +47,8 @@ public interface ICruxDatasource extends Closeable {
 
     /**
      * Queries the db lazily.
+     *
+     * NOTE: This function does not support the single find-arg variant - `:find` arguments must be wrapped in a vector.
      *
      * @param query the query in map, vector or string form.
      * @param args  bindings for in.

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -23,18 +23,20 @@
                                     {:crux.db/id :petr :name "Petr" :last-name "Petrov"}]))
 
   (t/testing "Can query value by single field"
-    (t/is (= #{["Ivan"]} (api/q (api/db *api*) '{:find [name]
-                                                 :where [[e :name "Ivan"]
-                                                         [e :name name]]})))
-    (t/is (= #{["Petr"]} (api/q (api/db *api*) '{:find [name]
-                                                 :where [[e :name "Petr"]
-                                                         [e :name name]]}))))
+    (t/is (= #{"Ivan"} (api/q (api/db *api*) '{:find name
+                                               :where [[e :name "Ivan"]
+                                                       [e :name name]]})))
+    (t/is (= #{"Petr"} (api/q (api/db *api*) '{:find name
+                                               :where [[e :name "Petr"]
+                                                       [e :name name]]}))))
 
   (t/testing "Can query entity by single field"
-    (t/is (= #{[:ivan]} (api/q (api/db *api*) '{:find [e]
-                                                :where [[e :name "Ivan"]]})))
-    (t/is (= #{[:petr]} (api/q (api/db *api*) '{:find [e]
-                                                :where [[e :name "Petr"]]}))))
+    (t/is (= #{:ivan}
+             (api/q (api/db *api*) '{:find e
+                                     :where [[e :name "Ivan"]]})))
+    (t/is (= #{:petr}
+             (api/q (api/db *api*) '{:find e
+                                     :where [[e :name "Petr"]]}))))
 
   (t/testing "Can query using multiple terms"
     (t/is (= #{["Ivan" "Ivanov"]} (api/q (api/db *api*) '{:find [name last-name]

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -20,21 +20,16 @@ To gain an understanding of edn see xref:tutorials::essential-edn.adoc[Essential
 
 Note that all Crux Datalog queries run using a point-in-time view of the database which means the query capabilities and patterns presented in this section are not aware of valid times or transaction times.
 
-A Datalog query consists of a set of variables and a set of clauses. The result
-of running a query is a result set of the possible combinations of values that
-satisfy all of the clauses at the same time. These combinations of values are
-referred to as "tuples".
+A Datalog query consists of a set of variables and a set of clauses.
+The result of running a query is a result set of the possible combinations of values that satisfy all of the clauses at the same time.
+These combinations of values are referred to as "tuples".
 
-The possible values within the result tuples are derived from your database of
-documents. The documents themselves are represented in the database indexes as
-"entity–attribute–value" (EAV) facts. For example, a single document
-`{:crux.db/id :myid :color "blue" :age 12}` is transformed into two facts
-`[[:myid :color "blue"][:myid :age 12]]`.
+The possible values within the result tuples are derived from your database of documents.
+The documents themselves are represented in the database indexes as "entity–attribute–value" (EAV) facts.
+For example, a single document `{:crux.db/id :myid, :color "blue", :age 12}` is transformed into two facts `[[:myid :color "blue"][:myid :age 12]]`.
 
-In the most basic case, a Datalog query works by searching for "subgraphs" in
-the database that match the pattern defined by the clauses. The values within
-these subgraphs are then returned according to the list of return variables
-requested in the `:find` vector within the query.
+In the most basic case, a Datalog query works by searching for "subgraphs" in the database that match the pattern defined by the clauses.
+The values within these subgraphs are then returned according to the list of return variables requested in the `:find` vector within the query.
 
 [#structure]
 == Basic Structure
@@ -56,7 +51,7 @@ The query map accepts the following Keywords
 |===
 |Key|Type|Purpose
 
-|<<#find,`:find`>>|Vector|Specify values to be returned
+|<<#find,`:find`>>|Single argument or vector of arguments|Specify values to be returned
 |<<#where,`:where`>>|Vector|Restrict the results of the query
 |<<#in,`:in`>>|Vector|Specify external arguments
 |<<#ordering-and-pagination,`:order-by`>>|Vector|Control the result order
@@ -70,7 +65,9 @@ The query map accepts the following Keywords
 [#find]
 == Find
 
-The find clause of a query specifies what values to be returned. These will be returned as a list.
+The find clause of a query specifies what variables will be returned.
+If supplied as a vector of arguments, each element in the result will be a vector.
+If you only require one output variable, you can specify a single argument (without wrapping it in a vector) - each element in the result will then be a value.
 
 [#find-logic-variable]
 === Logic Variable


### PR DESCRIPTION
NOTE: we cannot support single find-args in Java, because the return type is specified to be `Collection<List<?>>`. Given we're planning to re-visit the Java query API shortly, I've left it as unsupported for now.