### PR TITLE
Adds GCS document-store and checkpoint-store support

### DIFF
--- a/crux-google-cloud-storage/README.adoc
+++ b/crux-google-cloud-storage/README.adoc
@@ -1,0 +1,23 @@
+= crux-google-cloud-storage
+
+This Crux module allows you to use Google's Cloud Storage as Crux's 'document store' and/or 'checkpoint store'.
+
+.deps.edn
+[source,clojure]
+----
+juxt/crux-google-cloud-storage {:mvn/version "21.02-1.15.0-alpha"}
+----
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>juxt</groupId>
+    <artifactId>crux-google-cloud-storage</artifactId>
+    <version>21.02-1.15.0-alpha</version>
+</dependency>
+----
+
+Follow the GCS https://github.com/googleapis/google-cloud-java#authentication[Authentication Guide] to get set up.
+
+For more details, see the https://opencrux.com/reference/google-cloud-storage.html[Google Cloud Storage documentation]

--- a/crux-google-cloud-storage/project.clj
+++ b/crux-google-cloud-storage/project.clj
@@ -1,0 +1,27 @@
+(defproject juxt/crux-google-cloud-storage "crux-git-version-alpha"
+  :description "Crux Google Cloud Storage Document Store"
+  :url "https://github.com/juxt/crux"
+  :license {:name "The MIT License"
+            :url "http://opensource.org/licenses/MIT"}
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/tools.logging "1.1.0"]
+                 [juxt/crux-core "crux-git-version-beta"]
+                 [com.google.cloud/google-cloud-nio "0.122.4"]
+
+                 ;; dep resolution
+                 [com.google.api-client/google-api-client "1.31.1"]]
+
+  :profiles {:test {:dependencies [[juxt/crux-test "crux-git-version"]]}}
+
+  :middleware [leiningen.project-version/middleware]
+
+  :jvm-opts ["-Dlogback.configurationFile=../resources/logback-test.xml"]
+
+  :java-source-paths ["src"]
+  :javac-options ["-source" "8" "-target" "8"
+                  "-XDignore.symbol.file"
+                  "-Xlint:all,-options,-path"
+                  "-Werror"
+                  "-proc:none"]
+
+  :pedantic? :warn)

--- a/crux-google-cloud-storage/src/crux/google/cloud_storage.clj
+++ b/crux-google-cloud-storage/src/crux/google/cloud_storage.clj
@@ -1,0 +1,14 @@
+(ns crux.google.cloud-storage
+  (:require [crux.system :as sys]
+            [crux.document-store :as ds]
+            [crux.checkpoint :as cp]))
+
+(defn ->document-store {::sys/deps (::sys/deps (meta #'ds/->nio-document-store))
+                        ::sys/args (::sys/args (meta #'ds/->nio-document-store))}
+  [opts]
+  (ds/->nio-document-store opts))
+
+(defn ->checkpoint-store {::sys/deps (::sys/deps (meta #'cp/->filesystem-checkpoint-store))
+                          ::sys/args (::sys/args (meta #'cp/->filesystem-checkpoint-store))}
+  [opts]
+  (cp/->filesystem-checkpoint-store opts))

--- a/crux-google-cloud-storage/test/crux/google/cloud_storage_test.clj
+++ b/crux-google-cloud-storage/test/crux/google/cloud_storage_test.clj
@@ -1,0 +1,27 @@
+(ns crux.google.cloud-storage-test
+  (:require [crux.google.cloud-storage :as gcs]
+            [clojure.test :as t]
+            [crux.fixtures.document-store :as fix.ds]
+            [crux.fixtures.checkpoint-store :as fix.cp]
+            [crux.system :as sys])
+  (:import java.util.UUID))
+
+(def test-bucket
+  (System/getProperty "crux.google.cloud-storage-test.bucket"))
+
+(t/use-fixtures :once
+  (fn [f]
+    (when test-bucket
+      (f))))
+
+(t/deftest test-doc-store
+  (with-open [sys (-> (sys/prep-system {::gcs/document-store {:root-path (format "gs://%s/test-%s" test-bucket (UUID/randomUUID))}})
+                      (sys/start-system))]
+
+    (fix.ds/test-doc-store (::gcs/document-store sys))))
+
+(t/deftest test-cp-store
+  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:path (format "gs://%s/test-%s" test-bucket (UUID/randomUUID))}})
+                      (sys/start-system))]
+
+    (fix.cp/test-checkpoint-store (::gcs/checkpoint-store sys))))

--- a/docs/reference/modules/ROOT/nav.adoc
+++ b/docs/reference/modules/ROOT/nav.adoc
@@ -21,6 +21,7 @@
 * Persistence Modules
 ** xref:s3.adoc[AWS S3]
 ** xref:azure-blobs.adoc[Azure Blobs]
+** xref:google-cloud-storage.adoc[Google Cloud Storage]
 ** xref:kafka.adoc[Kafka]
 ** xref:jdbc.adoc[JDBC]
 ** xref:lmdb.adoc[LMDB]

--- a/docs/reference/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/reference/modules/ROOT/pages/checkpointing.adoc
@@ -6,7 +6,11 @@ Crux nodes that join a cluster have to obtain a local set of query indices befor
 These can be built by replaying the transaction log from the beginning, although this may be slow for clusters with a lot of history.
 Checkpointing allows the nodes in a cluster to share checkpoints into a central 'checkpoint store', so that nodes joining a cluster can retrieve a recent checkpoint of the query indices, rather than replaying the whole history.
 
-The checkpoint store is a pluggable module - Java's NIO FileSystem and AWS's xref::s3.adoc#checkpoint-store[S3] are the first officially-supported implementations.
+The checkpoint store is a pluggable module - there are a number of officially supported implementations:
+
+- Java's NIO FileSystem (below)
+- AWS's xref::s3.adoc#checkpoint-store[S3]
+- GCP's xref::google-cloud-storage.adoc#checkpoint-store[Cloud Storage]
 
 Crux nodes in a cluster don't explicitly communicate regarding which one is responsible for creating a checkpoint - instead, they check at random intervals to see whether any other node has recently created a checkpoint, and create one if necessary.
 The desired frequency of checkpoints can be set using `approx-frequency`.

--- a/docs/reference/modules/ROOT/pages/configuration.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration.adoc
@@ -75,6 +75,7 @@ All three are backed by local KV stores by default, but they can be independentl
 
 | xref:s3.adoc[AWS S3] | | ✓ |
 | xref:azure-blobs.adoc[Azure Blobs] | | ✓ |
+| xref:google-cloud-storage.adoc[Google Cloud Storage] | | ✓ |
 | xref:kafka.adoc[Kafka] | ✓ | ✓ |
 | xref:jdbc.adoc[JDBC] | ✓ | ✓ |
 | In-memory KV | ✓ | ✓ | ✓

--- a/docs/reference/modules/ROOT/pages/google-cloud-storage.adoc
+++ b/docs/reference/modules/ROOT/pages/google-cloud-storage.adoc
@@ -1,0 +1,94 @@
+= Crux Google Cloud Storage
+
+You can use Google's Cloud Storage (GCS) as Crux's 'document store' or 'checkpoint store'.
+
+Documents are serialized via https://github.com/ptaoussanis/nippy[Nippy].
+
+== Project Dependency
+
+In order to use GCS within Crux, you must first add this module as a project dependency:
+
+[tabs]
+====
+deps.edn::
++
+[source,clojure, subs=attributes+]
+----
+juxt/crux-google-cloud-storage {:mvn/version "{crux_version}-alpha"}
+----
+
+pom.xml::
++
+[source,xml, subs=attributes+]
+----
+<dependency>
+    <groupId>juxt</groupId>
+    <artifactId>crux-google-cloud-storage</artifactId>
+    <version>{crux_version}-alpha</version>
+</dependency>
+----
+====
+
+== Using GCS
+
+Replace the implementation of the document store with `+crux.google.cloud-storage/->document-store+`
+
+[tabs]
+====
+JSON::
++
+[source,json]
+----
+{
+  "crux/document-store": {
+    "crux/module": "crux.google.cloud-storage/->document-store",
+    "root-path": "gs://bucket/prefix"
+  },
+}
+----
+
+Clojure::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module 'crux.google.cloud-storage/->document-store
+                       :root-path "gs://bucket/prefix"}}
+----
+
+EDN::
++
+[source,clojure]
+----
+{:crux/document-store {:crux/module crux.google.cloud-storage/->document-store
+                       :root-path "gs://bucket/prefix"}}
+----
+====
+
+Follow the GCS https://github.com/googleapis/google-cloud-java#authentication[Authentication Guide] to get set up.
+
+== Parameters
+
+* `root-path` (string/`Path`, required): path where documents will be stored, `gs://bucket/prefix`
+* `doc-cache-size` (int): size of in-memory document cache
+* `pool-size` (int, default 4): size of thread-pool for GCS operations
+
+
+[#checkpoint-store]
+== Checkpoint store
+
+GCS can be used as a query index xref:checkpointing.adoc[checkpoint store].
+
+Checkpoints aren't GC'd by Crux - we recommend you set a lifecycle policy on GCS to remove older checkpoints.
+
+[source,clojure]
+----
+;; under :crux/index-store -> :kv-store -> :checkpointer
+;; see the Checkpointing guide for other parameters
+{:checkpointer {...
+                :store {:crux/module 'crux.google.cloud-storage/->checkpoint-store
+                        :path "gs://bucket/prefix"}}
+----
+
+=== Parameters
+
+* `path` (string/`URI`, required): URI of the form `"gs://bucket/prefix"`

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
    "crux-test"
    "crux-s3"
    "crux-azure-blobs"
+   "crux-google-cloud-storage"
    "crux-bench"])
 
 (defproject juxt/crux-dev "crux-dev-SNAPSHOT"
@@ -37,6 +38,7 @@
    [juxt/crux-rdf "crux-git-version-alpha"]
    [juxt/crux-sql "crux-git-version-alpha"]
    [juxt/crux-azure-blobs "crux-git-version-alpha"]
+   [juxt/crux-google-cloud-storage "crux-git-version-alpha"]
    [juxt/crux-lucene "crux-git-version-alpha"]
    [juxt/crux-test "crux-git-version"]
    [juxt/crux-bench "crux-git-version"]
@@ -105,6 +107,7 @@
                "crux-metrics/test"
                "crux-s3/test"
                "crux-azure-blobs/test"
+               "crux-google-cloud-storage/test"
                "crux-sql/test"
                "crux-lucene/test"
                "crux-bench/test"
@@ -123,6 +126,7 @@
   :profiles {:attach-yourkit {:jvm-opts ["-agentpath:/opt/yourkit/bin/linux-x86-64/libyjpagent.so"]}
              :with-s3-tests {:jvm-opts ["-Dcrux.s3.test-bucket=crux-s3-test"]}
              :with-azure-blobs-tests {:jvm-opts ["-Dcrux.azure.blobs.test-storage-account=crux-azure-blobs-test-storage-account"
-                                                 "-Dcrux.azure.blobs.test-container=crux-azure-blobs-test-container"]}}
+                                                 "-Dcrux.azure.blobs.test-container=crux-azure-blobs-test-container"]}
+             :with-google-cloud-storage-test {:jvm-opts ["-Dcrux.google.cloud-storage-test.bucket=crux-gcs-test"]}}
 
   :pedantic? :warn)


### PR DESCRIPTION
Based on #1408 (cut-down diff here: https://github.com/jarohen/crux/compare/file-system-doc-store...gcs-support), adds Google Cloud Storage document-store and checkpoint-store support based on the NIO FileSystem implementation at https://github.com/googleapis/java-storage-nio