### PR TITLE
Making bus/await asynchronous

### DIFF
--- a/crux-core/test/crux/bus_test.clj
+++ b/crux-core/test/crux/bus_test.clj
@@ -1,11 +1,8 @@
 (ns crux.bus-test
-  (:require [crux.bus :as bus]
+  (:require [clojure.spec.alpha :as s]
             [clojure.test :as t]
-            [clojure.spec.alpha :as s]
-            [clojure.string :as str]
-            [crux.api :as crux])
-  (:import (java.io Closeable)
-           (java.time Duration)))
+            [crux.bus :as bus])
+  (:import java.io.Closeable))
 
 (t/deftest test-bus
   (let [!events (atom [])]
@@ -34,24 +31,23 @@
 (t/deftest test-await
   (let [bus (bus/->bus {})]
     (t/testing "ready already"
-      (t/is (= ::ready (bus/await bus {:crux/event-types #{::foo}
-                                       :->result (fn [] ::ready)}))))
+      (t/is (= ::ready @(bus/await bus {:crux/event-types #{::foo}
+                                        :->result (fn [] ::ready)}))))
 
     (t/testing "times out"
-      (t/is (= ::timeout (bus/await bus {:crux/event-types #{::foo}
-                                         :->result (constantly nil)
-                                         :timeout (Duration/ofMillis 10)
-                                         :timeout-value ::timeout}))))
+      (t/is (= ::timeout (deref (bus/await bus {:crux/event-types #{::foo}
+                                                :->result (constantly nil)})
+                                10 ::timeout))))
 
     (t/testing "eventually works"
       (future
         (Thread/sleep 100)
         (bus/send bus {:crux/event-type ::foo}))
 
-      (t/is (= ::done (bus/await bus {:crux/event-types #{::foo}
-                                      :->result (fn
-                                                  ([] nil)
-                                                  ([ev] ::done))}))))
+      (t/is (= ::done @(bus/await bus {:crux/event-types #{::foo}
+                                       :->result (fn
+                                                   ([] nil)
+                                                   ([_ev] ::done))}))))
 
     (t/testing "times out if it's not quite ready"
       (let [!latch (promise)]
@@ -59,26 +55,25 @@
           (Thread/sleep 100)
           (bus/send bus {:crux/event-type ::bar}))
 
-        (t/is (= ::timeout (bus/await bus {:crux/event-types #{::bar}
-                                           :->result (fn
-                                                       ([] nil)
-                                                       ([ev] ::done))
-                                           :timeout (Duration/ofMillis 10)
-                                           :timeout-value ::timeout})))))
+        (t/is (= ::timeout (deref (bus/await bus {:crux/event-types #{::bar}
+                                                  :->result (fn
+                                                              ([] nil)
+                                                              ([_ev] ::done))})
+                                  10 ::timeout)))))
 
     (t/testing "throws if ->result throws on the pool"
       (t/is (thrown-with-msg? Exception #"boom"
-                              (bus/await bus {:crux/event-types #{::baz}
-                                              :->result (let [caller-thread (Thread/currentThread)]
-                                                          (fn []
-                                                            (when (not= caller-thread (Thread/currentThread))
-                                                              (throw (Exception. "boom")))))})))
+                              @(bus/await bus {:crux/event-types #{::baz}
+                                               :->result (let [caller-thread (Thread/currentThread)]
+                                                           (fn []
+                                                             (when (not= caller-thread (Thread/currentThread))
+                                                               (throw (Exception. "boom")))))})))
       (future
         (Thread/sleep 100)
         (bus/send bus {:crux/event-type ::baz}))
 
       (t/is (thrown-with-msg? Exception #"boom"
-                              (bus/await bus {:crux/event-types #{::baz}
-                                              :->result (fn
-                                                          ([] nil)
-                                                          ([evt] (throw (Exception. "boom"))))}))))))
+                              @(bus/await bus {:crux/event-types #{::baz}
+                                               :->result (fn
+                                                           ([] nil)
+                                                           ([evt] (throw (Exception. "boom"))))}))))))

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -168,13 +168,12 @@
         (t/is (= tx1 (await-tx tx1 nil)))))
 
     (t/testing "times out if it's not quite ready"
-      (let [!latch (promise)]
-        (future
-          (Thread/sleep 100)
-          (bus/send bus (assoc-in tx-evt [:submitted-tx ::tx/tx-id] 0)))
+      (future
+        (Thread/sleep 100)
+        (bus/send bus (assoc-in tx-evt [:submitted-tx ::tx/tx-id] 0)))
 
-        (with-latest-tx nil
-          (t/is (thrown? TimeoutException (await-tx tx1 (Duration/ofMillis 500)))))))
+      (with-latest-tx nil
+        (t/is (thrown? TimeoutException (await-tx tx1 (Duration/ofMillis 500))))))
 
     (t/testing "throws on ingester error"
       (future
@@ -189,7 +188,7 @@
     (t/testing "throws if node closed"
       (future
         (Thread/sleep 100)
-        (bus/send bus {:crux/event-type ::n/node-closed}))
+        (bus/send bus {:crux/event-type ::n/node-closing}))
 
       (with-latest-tx nil
         (t/is (thrown? InterruptedException (await-tx tx1 nil)))))))

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -1211,21 +1211,21 @@
 
 (t/deftest node-shutdown-interrupts-tx-ingestion
   (let [op-count 10
-        !calls (atom 0)]
+        !calls (atom 0)
+        node (crux/start-node {})]
     (with-redefs [tx/index-tx-event (let [f tx/index-tx-event]
                                       (fn [& args]
                                         (let [target-time (+ (System/currentTimeMillis) 200)]
                                           (while (< (System/currentTimeMillis) target-time)))
                                         (swap! !calls inc)
                                         (apply f args)))]
-      @(with-open [node (crux/start-node {})]
+      @(try
          (let [tx (crux/submit-tx node (repeat op-count [:crux.tx/put {:crux.db/id :foo}]))
                await-fut (future
-                           (t/is (thrown? InterruptedException
-                                          (try
-                                            (crux/await-tx node tx)
-                                            (catch Throwable t
-                                              (throw (.getCause t)))))))]
+                           (t/is (thrown? InterruptedException (crux/await-tx node tx))))]
            (Thread/sleep 100) ; to ensure the await starts before the node closes
-           await-fut)))
+           await-fut)
+         (finally
+           (.close node))))
+    (t/is (instance? InterruptedException (db/ingester-error (:tx-ingester node))))
     (t/is (< @!calls op-count))))


### PR DESCRIPTION
This PR makes `bus/await` (predominantly used in `await-tx`) asynchronous, returning a `CompleteableFuture`, so that we have the option of later extending `await-tx` to also be asynchronous. 