### PR TITLE
Use Lucene SearcherManager instead of a new IndexWriter per tx

### DIFF
--- a/crux-lucene/test/crux/fixtures/lucene.clj
+++ b/crux-lucene/test/crux/fixtures/lucene.clj
@@ -1,8 +1,7 @@
 (ns crux.fixtures.lucene
   (:require [crux.fixtures :as fix :refer [*api*]]
             [crux.lucene :as l])
-  (:import [org.apache.lucene.index DirectoryReader]
-           [org.apache.lucene.store Directory]))
+  (:import [org.apache.lucene.index DirectoryReader IndexReader IndexWriter]))
 
 (defn with-lucene-module [f]
   (fix/with-tmp-dirs #{db-dir}
@@ -25,6 +24,6 @@
     (l/search lucene-store q)))
 
 (defn doc-count []
-  (let [{:keys [^Directory directory]} (lucene-store)
-        directory-reader (DirectoryReader/open directory)]
-    (.numDocs directory-reader)))
+  (let [{:keys [^IndexWriter index-writer]} (lucene-store)
+        index-reader (DirectoryReader/open index-writer)]
+    (.numDocs index-reader)))

--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -252,7 +252,7 @@
       (t/is (empty? (c/q before-db q))))))
 
 (t/deftest test-ensure-lucene-store-keeps-last-tx
-  (let [latest-tx (fn [] (l/latest-submitted-tx (:crux.lucene/lucene-store @(:!system *api*))))]
+  (let [latest-tx (fn [] (l/latest-completed-tx (:crux.lucene/lucene-store @(:!system *api*))))]
     (t/is (not (latest-tx)))
     (submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivank"}]])
 
@@ -384,7 +384,7 @@
                     [:crux.tx/put {:crux.db/id :test-id :name "2345"}]])
 
   (t/is (= (:crux.tx/tx-id (db/latest-completed-tx (:crux/index-store @(:!system *api*))))
-           (l/latest-submitted-tx (:crux.lucene/lucene-store @(:!system *api*))))))
+           (l/latest-completed-tx (:crux.lucene/lucene-store @(:!system *api*))))))
 
 (comment
   (do


### PR DESCRIPTION
This somewhat improves ingestion performance with `crux-lucene` for small transactions although batching operations into large transactions is still a far better strategy.

In relation to https://github.com/juxt/crux/pull/1468/files#diff-97fb172b1e6d0b14e8f78e6bdcb364d8fef607cf1ad68e42d97e6404744b9e9fR246-R247

- It's _far_ less than ideal to .commit here per transaction (this was essentially happening before this PR also, as the commits happened as part of the `.close` of the short-lived IndexWriters)
- It's approximately the same tradeoff as the `:sync? true` arg for crux.rocksdb/->kv-store (when used for the index-store)
- Removal of the `.commit` here requires alignment/resolution with KV store fsync behaviour to avoid mismatch errors following a crash
- The commit would also have to happen before checkpointing (once that's implemented for crux-lucene)
- It's possible that ControlledRealTimeReopenThread can improve performance further when removing .commit, see https://stackoverflow.com/questions/17993960/lucene-4-4-0-new-controlledrealtimereopenthread-sample-usage (EDIT: actually it looks like it only helps with concurrency/consistency challenges we don't have due to tx-time, ~no performance benefit)
- The .maybeRefreshBlocking here will still be required regardless