### PR TITLE
Second Chance Cache Downsizing

### DIFF
--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -57,12 +57,13 @@
                                (let [k (stored-key-fn k)
                                      v (if-some [v (.valAt cold k)]
                                          v
-                                         (f k))]
-                                 (.computeIfAbsent hot k (reify Function
-                                                           (apply [_ k]
-                                                             (ValuePointer. v))))))
+                                         (f k))
+                                     vp (.computeIfAbsent hot k (reify Function
+                                                                  (apply [_ k]
+                                                                    (ValuePointer. v))))]
+                                 (resize-cache this)
+                                 vp))
           v (.swizzle vp)]
-      (resize-cache this)
       v))
 
   (evict [this k]

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -91,6 +91,7 @@
 (defn move-to-cooling-state [^SecondChanceCache cache]
   (let [hot ^ConcurrentHashMap (.getHot cache)
         cooling ^Queue (.cooling cache)]
+    (.maybeResizeCache cache)
     (while (< (.size cooling)
               (long (Math/ceil (* (.cooling-factor cache) (.size hot)))))
       (when-let [e (random-entry hot)]
@@ -139,7 +140,6 @@
   (let [resize-semaphore ^Semaphore (.resize-semaphore cache)]
     (when (.tryAcquire resize-semaphore)
       (try
-        (.maybeResizeCache cache)
         (move-to-cooling-state cache)
         (move-to-cold-state cache)
         (finally

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -121,18 +121,17 @@
         (.setDaemon true))))
 
 (defn- move-to-cold-state [^SecondChanceCache cache]
-  (let [hot ^ConcurrentHashMap (.getHot cache)
-        cooling ^Queue (.cooling cache)
+  (let [cooling ^Queue (.cooling cache)
         cold ^ICache (.cold cache)
         hot-target-size (if (.adaptive-sizing? cache)
                           (long (Math/pow (.size cache)
                                           (+ (.adaptive-break-even-level cache)
                                              (double (.get free-memory-ratio)))))
                           (.size cache))]
-    (while (> (.size hot) hot-target-size)
+    (while (> (.size (.getHot cache)) hot-target-size)
       (when-let [vp ^ValuePointer (.poll cooling)]
         (when-some [k (.getKey vp)]
-          (.remove hot k)
+          (.remove (.getHot cache) k)
           (.computeIfAbsent cold k identity (constantly (.getValue vp)))))
       (move-to-cooling-state cache))))
 

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -89,9 +89,9 @@
     (.clear cooling)))
 
 (defn move-to-cooling-state [^SecondChanceCache cache]
+  (.maybeResizeCache cache)
   (let [hot ^ConcurrentHashMap (.getHot cache)
         cooling ^Queue (.cooling cache)]
-    (.maybeResizeCache cache)
     (while (< (.size cooling)
               (long (Math/ceil (* (.cooling-factor cache) (.size hot)))))
       (when-let [e (random-entry hot)]

--- a/crux-core/src/crux/cache/second_chance.clj
+++ b/crux-core/src/crux/cache/second_chance.clj
@@ -50,7 +50,8 @@
     (when-not (.isEmpty hot)
       (when-let [table (ConcurrentHashMapTableAccess/getConcurrentHashMapTable hot)]
         (when (< (double (/ (.size hot) (alength table))) resize-load-factor)
-          (set! (.hot this) (ConcurrentHashMap. hot))))))
+          (set! (.hot this) (doto (ConcurrentHashMap. 0)
+                              (.putAll hot)))))))
 
   ICache
   (computeIfAbsent [this k stored-key-fn f]
@@ -165,7 +166,7 @@
                             cooling-factor 0.1
                             adaptive-break-even-level 0.8}
                        :as opts}]
-  (let [hot (ConcurrentHashMap.)
+  (let [hot (ConcurrentHashMap. 0)
         cooling (LinkedBlockingQueue.)
         cold (or cold-cache (crux.cache.nop/->nop-cache opts))]
     (when adaptive-sizing?

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -6,6 +6,7 @@
             [clojure.java.io :as io]
             [com.stuartsierra.dependency :as dep]
             [crux.cache :as cache]
+            [crux.cache.lru :as lru]
             [crux.codec :as c]
             [crux.db :as db]
             [crux.index :as idx]
@@ -1544,7 +1545,7 @@
     (db/open-index-snapshot index-store)))
 
 (defn- with-entity-resolver-cache [entity-resolver-fn {:keys [entity-cache-size]}]
-  (let [entity-cache (cache/->cache {:cache-size entity-cache-size})]
+  (let [entity-cache (lru/->lru-cache {:cache-size entity-cache-size})]
     (fn [k]
       (cache/compute-if-absent entity-cache k mem/copy-to-unpooled-buffer entity-resolver-fn))))
 


### PR DESCRIPTION
Shrink down cache again if it gets small to avoid having to scan a large empty map when finding random entries to evict.
ConcurrentHashMap doesn't itself seem to shrink the array when elements are removed from the map.