### PR TITLE
Adding attribute distinct cardinalities using HyperLogLog statistics, #1296

### DIFF
--- a/crux-bench/src/crux/bench/tpch.clj
+++ b/crux-bench/src/crux/bench/tpch.clj
@@ -30,19 +30,3 @@
 
         (bench/run-bench :queries-warm
           {:success? (run-tpch-queries node opts)})))))
-
-(comment
-  ;; SF 0.01
-  (tpch/load-docs! (dev/crux-node) 0.01 tpch/tpch-entity->pkey-doc)
-
-  ;; SQL:
-  (slurp (io/resource "io/airlift/tpch/queries/q1.sql"))
-  ;; Results:
-  (slurp (io/resource "io/airlift/tpch/queries/q1.result"))
-
-  (let [node (dev/crux-node)]
-    (time
-     (doseq [n (range 1 23)]
-       (time
-        (let [actual (run-tpch-query node n)]
-          (prn n (every? true? (tpch/validate-tpch-query actual (tpch/parse-tpch-result n))))))))))

--- a/crux-core/src/crux/codec.clj
+++ b/crux-core/src/crux/codec.clj
@@ -25,7 +25,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def index-version 17)
+(def index-version 18)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)
@@ -55,6 +55,8 @@
 (def ^:const ae-index-id 11)
 
 (def ^:const tx-time-mapping-id 12)
+
+(def ^:const stats-index-id 13)
 
 (def ^:const value-type-id-size Byte/BYTES)
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -41,6 +41,12 @@
 (defprotocol IndexSnapshotFactory
   (open-index-snapshot ^java.io.Closeable [this]))
 
+(defprotocol AttributeStats
+  (all-attrs [this])
+  (doc-count [this attr])
+  (^double value-cardinality [this attr])
+  (^double eid-cardinality [this attr]))
+
 ;; tag::IndexSnapshot[]
 (defprotocol IndexSnapshot
   (av [this a min-v])
@@ -53,11 +59,7 @@
   (decode-value [this value-buffer])
   (encode-value [this value])
   (resolve-tx [this tx])
-  (open-nested-index-snapshot ^java.io.Closeable [this])
-  (all-attrs [this])
-  (doc-count [this attr])
-  (^double value-cardinality [this attr])
-  (^double eid-cardinality [this attr]))
+  (open-nested-index-snapshot ^java.io.Closeable [this]))
 ;; end::IndexSnapshot[]
 
 ;; tag::TxLog[]

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -54,7 +54,8 @@
   (encode-value [this value])
   (resolve-tx [this tx])
   (open-nested-index-snapshot ^java.io.Closeable [this])
-  (attribute-cardinalities [this])
+  (attribute-stats [this])
+  (attribute-doc-count [this attr])
   (attribute-cardinality [this attr]))
 ;; end::IndexSnapshot[]
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -53,7 +53,9 @@
   (decode-value [this value-buffer])
   (encode-value [this value])
   (resolve-tx [this tx])
-  (open-nested-index-snapshot ^java.io.Closeable [this]))
+  (open-nested-index-snapshot ^java.io.Closeable [this])
+  (attribute-cardinalities [this])
+  (attribute-cardinality [this attr]))
 ;; end::IndexSnapshot[]
 
 ;; tag::TxLog[]

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -54,9 +54,10 @@
   (encode-value [this value])
   (resolve-tx [this tx])
   (open-nested-index-snapshot ^java.io.Closeable [this])
-  (attribute-stats [this])
-  (attribute-doc-count [this attr])
-  (attribute-cardinality [this attr]))
+  (all-attrs [this])
+  (doc-count [this attr])
+  (^double value-cardinality [this attr])
+  (^double eid-cardinality [this attr]))
 ;; end::IndexSnapshot[]
 
 ;; tag::TxLog[]

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -77,11 +77,9 @@
                            capped-valid-time
                            capped-tx-id))
 
-  (attribute-cardinalities [_]
-    (db/attribute-cardinalities index-snapshot))
-
-  (attribute-cardinality [_ attr]
-    (db/attribute-cardinality index-snapshot attr))
+  (attribute-stats [_] (db/attribute-stats index-snapshot))
+  (attribute-doc-count [_ attr] (db/attribute-doc-count index-snapshot attr))
+  (attribute-cardinality [_ attr] (db/attribute-cardinality index-snapshot attr))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]
@@ -156,13 +154,17 @@
                            (db/open-nested-index-snapshot transient-index-snapshot)
                            evicted-eids))
 
-  (attribute-cardinalities [_]
-    (merge (db/attribute-cardinalities persistent-index-snapshot)
-           (db/attribute-cardinalities transient-index-snapshot)))
+  (attribute-stats [_]
+    (merge (db/attribute-stats persistent-index-snapshot)
+           (db/attribute-stats transient-index-snapshot)))
+
+  (attribute-doc-count [_ attr]
+    (or (db/attribute-doc-count transient-index-snapshot attr)
+        (db/attribute-doc-count persistent-index-snapshot attr)))
 
   (attribute-cardinality [_ attr]
-    (or (db/attribute-cardinality persistent-index-snapshot attr)
-        (db/attribute-cardinality transient-index-snapshot attr)))
+    (or (db/attribute-cardinality transient-index-snapshot attr)
+        (db/attribute-cardinality persistent-index-snapshot attr)))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -77,6 +77,12 @@
                            capped-valid-time
                            capped-tx-id))
 
+  (attribute-cardinalities [_]
+    (db/attribute-cardinalities index-snapshot))
+
+  (attribute-cardinality [_ attr]
+    (db/attribute-cardinality index-snapshot attr))
+
   db/IndexMeta
   (-read-index-meta [_ k not-found]
     (db/-read-index-meta index-snapshot k not-found))
@@ -149,6 +155,14 @@
     (->MergedIndexSnapshot (db/open-nested-index-snapshot persistent-index-snapshot)
                            (db/open-nested-index-snapshot transient-index-snapshot)
                            evicted-eids))
+
+  (attribute-cardinalities [_]
+    (merge (db/attribute-cardinalities persistent-index-snapshot)
+           (db/attribute-cardinalities transient-index-snapshot)))
+
+  (attribute-cardinality [_ attr]
+    (or (db/attribute-cardinality persistent-index-snapshot attr)
+        (db/attribute-cardinality transient-index-snapshot attr)))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -77,6 +77,7 @@
                            capped-valid-time
                            capped-tx-id))
 
+  db/AttributeStats
   (all-attrs [_] (db/all-attrs index-snapshot))
   (doc-count [_ attr] (db/doc-count index-snapshot attr))
   (value-cardinality [_ attr] (db/value-cardinality index-snapshot attr))
@@ -155,6 +156,7 @@
                            (db/open-nested-index-snapshot transient-index-snapshot)
                            evicted-eids))
 
+  db/AttributeStats
   (all-attrs [_]
     (set/union (db/all-attrs persistent-index-snapshot)
                (db/all-attrs transient-index-snapshot)))

--- a/crux-core/src/crux/fork.clj
+++ b/crux-core/src/crux/fork.clj
@@ -77,9 +77,10 @@
                            capped-valid-time
                            capped-tx-id))
 
-  (attribute-stats [_] (db/attribute-stats index-snapshot))
-  (attribute-doc-count [_ attr] (db/attribute-doc-count index-snapshot attr))
-  (attribute-cardinality [_ attr] (db/attribute-cardinality index-snapshot attr))
+  (all-attrs [_] (db/all-attrs index-snapshot))
+  (doc-count [_ attr] (db/doc-count index-snapshot attr))
+  (value-cardinality [_ attr] (db/value-cardinality index-snapshot attr))
+  (eid-cardinality [_ attr] (db/eid-cardinality index-snapshot attr))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]
@@ -154,17 +155,21 @@
                            (db/open-nested-index-snapshot transient-index-snapshot)
                            evicted-eids))
 
-  (attribute-stats [_]
-    (merge (db/attribute-stats persistent-index-snapshot)
-           (db/attribute-stats transient-index-snapshot)))
+  (all-attrs [_]
+    (set/union (db/all-attrs persistent-index-snapshot)
+               (db/all-attrs transient-index-snapshot)))
 
-  (attribute-doc-count [_ attr]
-    (or (db/attribute-doc-count transient-index-snapshot attr)
-        (db/attribute-doc-count persistent-index-snapshot attr)))
+  (doc-count [_ attr]
+    (or (db/doc-count transient-index-snapshot attr)
+        (db/doc-count persistent-index-snapshot attr)))
 
-  (attribute-cardinality [_ attr]
-    (or (db/attribute-cardinality transient-index-snapshot attr)
-        (db/attribute-cardinality persistent-index-snapshot attr)))
+  (value-cardinality [_ attr]
+    (or (db/value-cardinality transient-index-snapshot attr)
+        (db/value-cardinality persistent-index-snapshot attr)))
+
+  (eid-cardinality [_ attr]
+    (or (db/eid-cardinality transient-index-snapshot attr)
+        (db/eid-cardinality persistent-index-snapshot attr)))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/hyper_log_log.clj
+++ b/crux-core/src/crux/hyper_log_log.clj
@@ -1,0 +1,77 @@
+(ns crux.hyper-log-log
+  (:require [crux.memory :as mem])
+  (:import [org.agrona DirectBuffer MutableDirectBuffer]
+           java.nio.ByteOrder))
+
+;; http://dimacs.rutgers.edu/~graham/pubs/papers/cacm-sketch.pdf
+
+;; http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
+(defn ->hyper-log-log
+  (^org.agrona.MutableDirectBuffer []
+   (->hyper-log-log 1024))
+  (^org.agrona.MutableDirectBuffer [^long m]
+   (mem/allocate-unpooled-buffer (* Integer/BYTES m))))
+
+(defn hyper-log-log-update ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer hll v]
+  (let [m (/ (.capacity hll) Integer/BYTES)
+        b (Integer/numberOfTrailingZeros m)
+        x (mix-collection-hash (hash v) 0)
+        j (bit-and (bit-shift-right x (- Integer/SIZE b)) (dec m))
+        w (bit-and x (dec (bit-shift-left 1 (- Integer/SIZE b))))]
+    (doto hll
+      (.putInt (* j Integer/BYTES)
+               (max (.getInt hll (* j Integer/BYTES) ByteOrder/BIG_ENDIAN)
+                    (- (inc (Integer/numberOfLeadingZeros w)) b))
+               ByteOrder/BIG_ENDIAN))))
+
+(defn hyper-log-log-estimate ^double [^DirectBuffer hll]
+  (let [m (/ (.capacity hll) Integer/BYTES)
+        z (/ 1.0 (double (loop [n 0
+                                acc 0.0]
+                           (if (< n (.capacity hll))
+                             (recur (+ n Integer/BYTES)
+                                    (+ acc (Math/pow 2.0 (- (.getInt hll n ByteOrder/BIG_ENDIAN)))))
+                             acc))))
+        am (/ 0.7213 (inc (/ 1.079 m)))
+        e (* am (Math/pow m 2.0) z)]
+    (cond
+      (<= e (* (double (/ 5 2)) m))
+      (let [v (long (loop [n 0
+                           acc 0]
+                           (if (< n (.capacity hll))
+                             (recur (+ n Integer/BYTES)
+                                    (+ acc (if (zero? (.getInt hll n ByteOrder/BIG_ENDIAN))
+                                             1
+                                             0)))
+                             acc)))]
+        (if (zero? v)
+          e
+          (* m (Math/log (/ m v)))))
+      (> e (* (double (/ 1 30)) (Integer/toUnsignedLong -1)))
+      (* (Math/pow -2.0 32)
+         (Math/log (- 1 (/ e (Integer/toUnsignedLong -1)))))
+      :else
+      e)))
+
+(defn hyper-log-log-merge ^DirectBuffer [^DirectBuffer hll-a ^DirectBuffer hll-b]
+  (assert (= (.capacity hll-a) (.capacity hll-b)))
+  (loop [n 0
+         result ^MutableDirectBuffer (mem/allocate-unpooled-buffer (.capacity hll-a))]
+    (if (= n (.capacity result))
+      result
+      (recur (+ n Integer/BYTES)
+             (doto result
+               (.putInt n (max (.getInt hll-a n ByteOrder/BIG_ENDIAN)
+                               (.getInt hll-b n ByteOrder/BIG_ENDIAN)) ByteOrder/BIG_ENDIAN))))))
+
+(defn hyper-log-log-estimate-union ^double [^DirectBuffer hll-a ^DirectBuffer hll-b]
+  (hyper-log-log-estimate (hyper-log-log-merge hll-a hll-b)))
+
+(defn hyper-log-log-estimate-intersection ^double [^DirectBuffer hll-a ^DirectBuffer hll-b]
+  (- (+ (hyper-log-log-estimate hll-a)
+        (hyper-log-log-estimate hll-b))
+     (hyper-log-log-estimate-union hll-a hll-b)))
+
+(defn hyper-log-log-estimate-difference ^double [^DirectBuffer hll-a ^DirectBuffer hll-b]
+  (- (hyper-log-log-estimate hll-a)
+     (hyper-log-log-estimate-intersection hll-a hll-b)))

--- a/crux-core/src/crux/hyper_log_log.clj
+++ b/crux-core/src/crux/hyper_log_log.clj
@@ -6,11 +6,7 @@
 ;; http://dimacs.rutgers.edu/~graham/pubs/papers/cacm-sketch.pdf
 ;; http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
 
-(defn ->hyper-log-log
-  (^org.agrona.MutableDirectBuffer []
-   (->hyper-log-log 1024))
-  (^org.agrona.MutableDirectBuffer [^long m]
-   (mem/allocate-unpooled-buffer (* Integer/BYTES m))))
+(def ^{:tag 'int} default-buffer-size (* Integer/BYTES 1024))
 
 (defn add ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer hll v]
   (let [m (/ (.capacity hll) Integer/BYTES)

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -420,7 +420,7 @@
   (mem/slice-buffer k c/index-id-size))
 
 (defn- new-stats-value ^org.agrona.MutableDirectBuffer []
-  (doto ^MutableDirectBuffer (mem/allocate-buffer (+ Long/BYTES hll/default-buffer-size))
+  (doto ^MutableDirectBuffer (mem/allocate-buffer (+ Long/BYTES hll/default-buffer-size hll/default-buffer-size))
     (.putByte 0 c/stats-index-id)
     (.putLong c/index-id-size 0)))
 
@@ -431,26 +431,35 @@
   (doto b
     (.putLong c/index-id-size (inc (decode-stats-value->doc-count-from b)))))
 
-(defn decode-stats-value->hll-buffer-from ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
-  (mem/slice-buffer b Long/BYTES))
+(defn decode-stats-value->eid-hll-buffer-from ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
+  (let [hll-size (/ (- (.capacity b) Long/BYTES) 2)]
+    (mem/slice-buffer b Long/BYTES hll-size)))
+
+(defn decode-stats-value->value-hll-buffer-from ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b]
+  (let [^long hll-size (/ (- (.capacity b) Long/BYTES) 2)]
+    (mem/slice-buffer b (+ Long/BYTES hll-size) hll-size)))
 
 (defn stats-kvs [transient-kv-snapshot persistent-kv-snapshot docs]
   (let [attr-key-bufs (->> docs
                            (into {} (comp (mapcat keys)
                                           (distinct)
                                           (map (juxt identity #(encode-stats-key-to nil (c/->value-buffer %)))))))]
-    (->> (for [doc docs
-               [k v] doc
-               v (c/vectorize-value v)]
-           (MapEntry/create k v))
-         (reduce (fn [acc [k v]]
-                   (let [k-buf (get attr-key-bufs k)]
-                     (assoc! acc k-buf (doto (or (get acc k-buf)
-                                                 (kv/get-value transient-kv-snapshot k-buf)
-                                                 (some-> (kv/get-value persistent-kv-snapshot k-buf) mem/copy-buffer)
-                                                 (new-stats-value))
-                                         (inc-stats-value-doc-count)
-                                         (-> decode-stats-value->hll-buffer-from (hll/add v))))))
+    (->> docs
+         (reduce (fn [acc doc]
+                   (let [e (:crux.db/id doc)]
+                     (->> (for [[k v] doc
+                                v (c/vectorize-value v)]
+                            (MapEntry/create k v))
+                          (reduce (fn [acc [k v]]
+                                    (let [k-buf (get attr-key-bufs k)]
+                                      (assoc! acc k-buf (doto (or (get acc k-buf)
+                                                                  (kv/get-value transient-kv-snapshot k-buf)
+                                                                  (some-> (kv/get-value persistent-kv-snapshot k-buf) mem/copy-buffer)
+                                                                  (new-stats-value))
+                                                          (inc-stats-value-doc-count)
+                                                          (-> decode-stats-value->eid-hll-buffer-from (hll/add e))
+                                                          (-> decode-stats-value->value-hll-buffer-from (hll/add v))))))
+                                  acc))))
                  (transient {}))
          persistent!)))
 
@@ -805,23 +814,26 @@
 
           :else latest-tx))))
 
-  (attribute-stats [_]
+  (all-attrs [_]
     (with-open [i (kv/new-iterator snapshot)]
-      (let [prefix (encode-stats-key-to nil)]
-        (->> (for [[stats-k stats-v] (all-keys-in-prefix i prefix (.capacity prefix) {:entries? true})]
-               (MapEntry/create (c/decode-value-buffer (decode-stats-key->attr-from stats-k))
-                                {:doc-count (decode-stats-value->doc-count-from stats-v)
-                                 :cardinality (hll/estimate (decode-stats-value->hll-buffer-from stats-v))}))
-             (into {})))))
+      (->> (for [stats-k (all-keys-in-prefix i (encode-stats-key-to nil))]
+             (c/decode-value-buffer (decode-stats-key->attr-from stats-k)))
+           (into #{}))))
 
-  (attribute-doc-count [_ attr]
+  (doc-count [_ attr]
     (or (some-> (kv/get-value snapshot (encode-stats-key-to nil (c/->value-buffer attr)))
                 decode-stats-value->doc-count-from)
         0))
 
-  (attribute-cardinality [_ attr]
+  (value-cardinality [_ attr]
     (or (some-> (kv/get-value snapshot (encode-stats-key-to nil (c/->value-buffer attr)))
-                decode-stats-value->hll-buffer-from
+                decode-stats-value->value-hll-buffer-from
+                hll/estimate)
+        0.0))
+
+  (eid-cardinality [_ attr]
+    (or (some-> (kv/get-value snapshot (encode-stats-key-to nil (c/->value-buffer attr)))
+                decode-stats-value->eid-hll-buffer-from
                 hll/estimate)
         0.0))
 

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -814,6 +814,12 @@
 
           :else latest-tx))))
 
+  (open-nested-index-snapshot [_]
+    (let [nested-index-snapshot (new-kv-index-snapshot snapshot false nil cav-cache canonical-buffer-cache temp-hash-cache)]
+      (swap! nested-index-snapshot-state conj nested-index-snapshot)
+      nested-index-snapshot))
+
+  db/AttributeStats
   (all-attrs [_]
     (with-open [i (kv/new-iterator snapshot)]
       (->> (for [stats-k (all-keys-in-prefix i (encode-stats-key-to nil))]
@@ -836,11 +842,6 @@
                 decode-stats-value->eid-hll-buffer-from
                 hll/estimate)
         0.0))
-
-  (open-nested-index-snapshot [_]
-    (let [nested-index-snapshot (new-kv-index-snapshot snapshot false nil cav-cache canonical-buffer-cache temp-hash-cache)]
-      (swap! nested-index-snapshot-state conj nested-index-snapshot)
-      nested-index-snapshot))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/memory.clj
+++ b/crux-core/src/crux/memory.clj
@@ -87,8 +87,11 @@
 (defn copy-to-unpooled-buffer ^org.agrona.MutableDirectBuffer [^DirectBuffer from]
   (copy-buffer from (.capacity from) (allocate-unpooled-buffer (.capacity from))))
 
-(defn slice-buffer ^org.agrona.MutableDirectBuffer [^DirectBuffer buffer ^long offset ^long limit]
-  (UnsafeBuffer. buffer offset limit))
+(defn slice-buffer
+  (^org.agrona.MutableDirectBuffer [^DirectBuffer buffer ^long offset]
+   (slice-buffer buffer offset (- (.capacity buffer) offset)))
+  (^org.agrona.MutableDirectBuffer [^DirectBuffer buffer ^long offset ^long limit]
+   (UnsafeBuffer. buffer offset limit)))
 
 (defn limit-buffer ^org.agrona.MutableDirectBuffer [^DirectBuffer buffer ^long limit]
   (slice-buffer buffer 0 limit))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -182,7 +182,8 @@
   (attribute-stats [this]
     (cio/with-read-lock lock
       (ensure-node-open this)
-      (db/read-index-meta index-store :crux/attribute-stats)))
+      (with-open [snapshot (db/open-index-snapshot index-store)]
+        (db/attribute-cardinalities snapshot))))
 
   (active-queries [_]
     (map qs/->QueryState (vals (:in-progress @!running-queries))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -183,7 +183,7 @@
     (cio/with-read-lock lock
       (ensure-node-open this)
       (with-open [snapshot (db/open-index-snapshot index-store)]
-        (db/attribute-cardinalities snapshot))))
+        (db/attribute-stats snapshot))))
 
   (active-queries [_]
     (map qs/->QueryState (vals (:in-progress @!running-queries))))

--- a/crux-core/src/crux/node.clj
+++ b/crux-core/src/crux/node.clj
@@ -183,7 +183,8 @@
     (cio/with-read-lock lock
       (ensure-node-open this)
       (with-open [snapshot (db/open-index-snapshot index-store)]
-        (db/attribute-stats snapshot))))
+        (->> (db/all-attrs snapshot)
+             (into {} (map (juxt identity #(db/doc-count snapshot %))))))))
 
   (active-queries [_]
     (map qs/->QueryState (vals (:in-progress @!running-queries))))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -576,7 +576,7 @@
 
 (defn- sort-triple-clauses [triple-clauses {:keys [index-snapshot]}]
   (sort-by (fn [{:keys [a]}]
-             (db/attribute-doc-count index-snapshot a)) triple-clauses))
+             (db/doc-count index-snapshot a)) triple-clauses))
 
 (defn- new-literal-index [index-snapshot v]
   (let [encode-value-fn (partial db/encode-value index-snapshot)]
@@ -625,8 +625,7 @@
                                 (Math/pow (/ 0.5 (double (get range-var-frequencies var))))))
         update-cardinality (fn [acc {:keys [e a v] :as clause}]
                              (let [{:keys [self-join? ignore-v?]} (meta clause)
-                                   cardinality (double (db/attribute-doc-count index-snapshot a))
-                                   es (double (cardinality-for-var e (cond->> cardinality
+                                   es (double (cardinality-for-var e (cond->> (double (db/eid-cardinality index-snapshot a))
                                                                        (literal? v) (/ 1.0))))
                                    vs (cond
                                         ignore-v?
@@ -634,7 +633,7 @@
                                         self-join?
                                         (Math/nextUp es)
                                         :else
-                                        (cardinality-for-var v (cond->> cardinality
+                                        (cardinality-for-var v (cond->> (double (db/value-cardinality index-snapshot a))
                                                                  (literal? e) (/ 1.0))))]
                                (-> acc
                                    (update v (fnil min Double/MAX_VALUE) vs)

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -576,7 +576,7 @@
 
 (defn- sort-triple-clauses [triple-clauses {:keys [index-snapshot]}]
   (sort-by (fn [{:keys [a]}]
-             (db/attribute-cardinality index-snapshot a)) triple-clauses))
+             (db/attribute-doc-count index-snapshot a)) triple-clauses))
 
 (defn- new-literal-index [index-snapshot v]
   (let [encode-value-fn (partial db/encode-value index-snapshot)]
@@ -625,7 +625,7 @@
                                 (Math/pow (/ 0.5 (double (get range-var-frequencies var))))))
         update-cardinality (fn [acc {:keys [e a v] :as clause}]
                              (let [{:keys [self-join? ignore-v?]} (meta clause)
-                                   cardinality (double (db/attribute-cardinality index-snapshot a))
+                                   cardinality (double (db/attribute-doc-count index-snapshot a))
                                    es (double (cardinality-for-var e (cond->> cardinality
                                                                        (literal? v) (/ 1.0))))
                                    vs (cond

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -198,8 +198,7 @@
 
   (evict! [_ index-writer eids]
     (with-open [index-snapshot (db/open-index-snapshot index-store)]
-      (let [attrs-id->attr (->> (db/attribute-stats index-snapshot)
-                                keys
+      (let [attrs-id->attr (->> (db/all-attrs index-snapshot)
                                 (map #(vector (->hash-str %) %))
                                 (into {}))
             qs (for [[a v] (db/exclusive-avs index-store eids)

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -196,18 +196,18 @@
                         (.add (StringField. field-crux-attr, (keyword->k k), Field$Store/YES)))]]
       (.updateDocument ^IndexWriter index-writer (Term. field-crux-id id-str) doc)))
 
-  (evict! [this index-writer eids]
-    (let [attrs-id->attr (->> (db/read-index-meta index-store :crux/attribute-stats)
-                              keys
-                              (map #(vector (->hash-str %) %))
-                              (into {}))]
-      (with-open [index-snapshot (db/open-index-snapshot index-store)]
-        (let [qs (for [[a v] (db/exclusive-avs index-store eids)
-                       :let [a (attrs-id->attr (->hash-str a))
-                             v (db/decode-value index-snapshot v)]
-                       :when (not= :crux.db/id a)]
-                   (TermQuery. (Term. field-crux-id (->hash-str (DocumentId. a v)))))]
-          (.deleteDocuments ^IndexWriter index-writer ^"[Lorg.apache.lucene.search.Query;" (into-array Query qs)))))))
+  (evict! [_ index-writer eids]
+    (with-open [index-snapshot (db/open-index-snapshot index-store)]
+      (let [attrs-id->attr (->> (db/attribute-cardinalities index-snapshot)
+                                keys
+                                (map #(vector (->hash-str %) %))
+                                (into {}))
+            qs (for [[a v] (db/exclusive-avs index-store eids)
+                     :let [a (attrs-id->attr (->hash-str a))
+                           v (db/decode-value index-snapshot v)]
+                     :when (not= :crux.db/id a)]
+                 (TermQuery. (Term. field-crux-id (->hash-str (DocumentId. a v)))))]
+        (.deleteDocuments ^IndexWriter index-writer ^"[Lorg.apache.lucene.search.Query;" (into-array Query qs))))))
 
 (defn ->indexer
   {::sys/deps {:index-store :crux/index-store}}

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -198,7 +198,7 @@
 
   (evict! [_ index-writer eids]
     (with-open [index-snapshot (db/open-index-snapshot index-store)]
-      (let [attrs-id->attr (->> (db/attribute-cardinalities index-snapshot)
+      (let [attrs-id->attr (->> (db/attribute-stats index-snapshot)
                                 keys
                                 (map #(vector (->hash-str %) %))
                                 (into {}))

--- a/crux-test/test/crux/api/JCruxNodeTest.java
+++ b/crux-test/test/crux/api/JCruxNodeTest.java
@@ -218,9 +218,9 @@ public class JCruxNodeTest {
         put();
         sync();
         Map<Keyword, ?> stats = node.attributeStats();
-        assertEquals(1, stats.get(DB_ID));
-        assertEquals(1, stats.get(versionId));
-        assertEquals(2, stats.size());
+        assertEquals(1L, stats.get(DB_ID));
+        assertEquals(1L, stats.get(versionId));
+        assertEquals(2L, stats.size());
     }
 
     @Test

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -62,7 +62,7 @@
       (t/is (empty? (api/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:crux.index/index-version 17}
+  (t/is (= (merge {:crux.index/index-version 18}
                   (when (instance? crux.kafka.KafkaTxLog (:tx-log *api*))
                     {:crux.zk/zk-active? true}))
            (select-keys (api/status *api*) [:crux.index/index-version :crux.zk/zk-active?])))

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -223,10 +223,12 @@
 (t/deftest test-statistics
   (letfn [(->stats [index-snapshot-factory]
             (with-open [index-snapshot (db/open-index-snapshot index-snapshot-factory)]
-              (->> (db/attribute-stats index-snapshot)
-                   (into {} (map (juxt key (comp #(update % :cardinality (fn [^double c]
-                                                                           (Math/round c)))
-                                                 val)))))))]
+              (->> (db/all-attrs index-snapshot)
+                   (into {} (map (juxt identity
+                                       (fn [attr]
+                                         {:doc-count (db/doc-count index-snapshot attr)
+                                          :values (Math/round (db/value-cardinality index-snapshot attr))
+                                          :eids (Math/round (db/eid-cardinality index-snapshot attr))})))))))]
     (with-fresh-index-store
       (let [ivan {:crux.db/id :ivan :name "Ivan"}
             ivan2 {:crux.db/id :ivan :name "Ivan2"}
@@ -234,21 +236,21 @@
         (let [index-store-tx (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2021", :tx-id 0} nil)]
 
           (db/index-docs index-store-tx {(c/new-id ivan) ivan})
-          (t/is (= {:doc-count 1, :cardinality 1} (:name (->stats index-store-tx))))
+          (t/is (= {:doc-count 1, :values 1, :eids 1} (:name (->stats index-store-tx))))
 
           (db/index-docs index-store-tx {(c/new-id petr) petr})
-          (t/is (= {:doc-count 2, :cardinality 2} (:name (->stats index-store-tx))))
+          (t/is (= {:doc-count 2, :values 2, :eids 2} (:name (->stats index-store-tx))))
 
           (db/commit-index-tx index-store-tx))
 
-        (t/is (= {:doc-count 2, :cardinality 2} (:name (->stats *index-store*))))
+        (t/is (= {:doc-count 2, :values 2, :eids 2} (:name (->stats *index-store*))))
 
         (t/testing "updated"
           (doto (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2022", :tx-id 1} nil)
             (db/index-docs {(c/new-id ivan2) ivan2})
             (db/commit-index-tx))
 
-          (t/is (= {:doc-count 3, :cardinality 3} (:name (->stats *index-store*)))))))
+          (t/is (= {:doc-count 3, :values 3, :eids 2} (:name (->stats *index-store*)))))))
 
     (with-fresh-index-store
       (let [id-iterator (.iterator ^Iterable (range))]
@@ -269,6 +271,6 @@
             (db/index-docs (mk-docs 50))
             (db/commit-index-tx))))
 
-      (t/is (= {:crux.db/id {:doc-count 3675, :cardinality 3554}
-                :sub-idx {:doc-count 3675, :cardinality 50}}
+      (t/is (= {:crux.db/id {:doc-count 3675, :values 3554, :eids 3554}
+                :sub-idx {:doc-count 3675, :values 50, :eids 3554}}
                (->stats *index-store*))))))

--- a/crux-test/test/crux/kv/index_store_test.clj
+++ b/crux-test/test/crux/kv/index_store_test.clj
@@ -10,9 +10,10 @@
             [crux.fixtures.kv :as fkv]
             [crux.kv.index-store :as kvi]
             [crux.tx :as tx])
-  (:import crux.codec.EntityTx
+  (:import clojure.lang.MapEntry
+           crux.codec.EntityTx
            crux.api.NodeOutOfSyncException
-           java.util.Date))
+           [java.util Date UUID]))
 
 (def ^:dynamic *index-store*)
 
@@ -222,7 +223,10 @@
 (t/deftest test-statistics
   (letfn [(->stats [index-snapshot-factory]
             (with-open [index-snapshot (db/open-index-snapshot index-snapshot-factory)]
-              (db/attribute-cardinalities index-snapshot)))]
+              (->> (db/attribute-stats index-snapshot)
+                   (into {} (map (juxt key (comp #(update % :cardinality (fn [^double c]
+                                                                           (Math/round c)))
+                                                 val)))))))]
     (with-fresh-index-store
       (let [ivan {:crux.db/id :ivan :name "Ivan"}
             ivan2 {:crux.db/id :ivan :name "Ivan2"}
@@ -230,18 +234,41 @@
         (let [index-store-tx (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2021", :tx-id 0} nil)]
 
           (db/index-docs index-store-tx {(c/new-id ivan) ivan})
-          (t/is (= 1 (:name (->stats index-store-tx))))
+          (t/is (= {:doc-count 1, :cardinality 1} (:name (->stats index-store-tx))))
 
           (db/index-docs index-store-tx {(c/new-id petr) petr})
-          (t/is (= 2 (:name (->stats index-store-tx))))
+          (t/is (= {:doc-count 2, :cardinality 2} (:name (->stats index-store-tx))))
 
           (db/commit-index-tx index-store-tx))
 
-        (t/is (= 2 (:name (->stats *index-store*))))
+        (t/is (= {:doc-count 2, :cardinality 2} (:name (->stats *index-store*))))
 
         (t/testing "updated"
           (doto (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2022", :tx-id 1} nil)
             (db/index-docs {(c/new-id ivan2) ivan2})
             (db/commit-index-tx))
 
-          (t/is (= 3 (:name (->stats *index-store*)))))))))
+          (t/is (= {:doc-count 3, :cardinality 3} (:name (->stats *index-store*)))))))
+
+    (with-fresh-index-store
+      (let [id-iterator (.iterator ^Iterable (range))]
+        (letfn [(mk-docs [n]
+                  (for [idx (range n)
+                        sub-idx (range idx)]
+                    (let [doc {:crux.db/id (.next id-iterator)
+                               :sub-idx sub-idx}]
+                      (MapEntry/create (c/new-id doc) doc))))]
+          (doto (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2021", :tx-id 0} nil)
+
+            (db/index-docs (mk-docs 50))
+            (db/index-docs (mk-docs 50))
+
+            (db/commit-index-tx))
+
+          (doto (db/begin-index-tx *index-store* #::tx{:tx-time #inst "2022", :tx-id 1} nil)
+            (db/index-docs (mk-docs 50))
+            (db/commit-index-tx))))
+
+      (t/is (= {:crux.db/id {:doc-count 3675, :cardinality 3554}
+                :sub-idx {:doc-count 3675, :cardinality 50}}
+               (->stats *index-store*))))))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3484,16 +3484,17 @@
                            {f nil, g true}]}))))
 
 (t/deftest test-binds-args-before-entities
-  (t/is (= ['m 'e]
-           (->> (q/query-plan-for {:find '[e]
-                                   :where '[[e :foo/type "type"]
-                                            [e :foo/id m]]
-                                   :args [{'m 1}]}
-                                  c/->value-buffer
-                                  {:foo/type 1
-                                   :foo/id 1})
-                :vars-in-join-order
-                (filter #{'m 'e})))))
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :foo/type "type", :foo/id 1}]])
+
+  (let [db (api/db *api*)]
+    (t/is (= ['m 'e]
+             (->> (q/query-plan-for db
+                                    {:find '[e]
+                                     :where '[[e :foo/type "type"]
+                                              [e :foo/id m]]
+                                     :args [{'m 1}]})
+                  :vars-in-join-order
+                  (filter #{'m 'e}))))))
 
 (t/deftest test-binds-against-false-arg-885
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo, :name "foo", :flag? false}]
@@ -3601,13 +3602,12 @@
   (t/testing "join order avoids cross product"
     (t/is (= '["Oleg" "Ivan" e1 n e2]
              (:vars-in-join-order
-              (q/query-plan-for '{:find [e1]
+              (q/query-plan-for (api/db *api*)
+                                '{:find [e1]
                                   :where [[e1 :my-name "Ivan"]
                                           [e2 :my-name "Oleg"]
                                           [e1 :my-number n]
-                                          [e2 :my-number n]]}
-                                c/->value-buffer
-                                (api/attribute-stats *api*))))))
+                                          [e2 :my-number n]]})))))
 
   ;; Kept low due to caches intervening between the runs, actual
   ;; failure is way beyond this limit.

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -307,19 +307,6 @@
                                vals
                                (remove c/evicted-doc?))))))))))
 
-(t/deftest test-statistics
-  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan"}]
-                        [:crux.tx/put {:crux.db/id :ivan :name "Petr"}]])
-
-  (let [stats (api/attribute-stats *api*)]
-    (t/is (= 2 (:name stats))))
-
-  (t/testing "updated"
-    (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivan2"}]])
-
-    (let [stats (api/attribute-stats *api*)]
-      (t/is (= 3 (:name stats))))))
-
 (t/deftest test-multiple-txs-in-same-ms-441
   (let [ivan {:crux.db/id :ivan}
         ivan1 (assoc ivan :value 1)


### PR DESCRIPTION
resolves #1296 

We now keep [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog) buffers for each attribute on ingestion so that we know, for each attribute, how many distinct values and distinct entity ids we have. This is predominantly to fix the query join order in the case where two attributes have similar doc-counts but very different selectivities. Previously, when a user is filtering both by `:type` (say only a handful of different types) and `:name` (assuming mostly unique between entities), Crux wouldn't necessarily choose to filter first by `:name`. See `picks-more-selective-join-order` test. 

See https://github.com/orgs/juxt/teams/crux-core/discussions/22

Benchmarks-wise, this currently adds 4-5% to ingest (makes sense, we're doing more work, although we may be able to shave off some time), and no appreciable difference in Watdiv nor TPC-H queries.
* NOTE - we could consider caching the stats KVs between transactions so that we don't have to go look them up. This may not be that much of a performance improvement given Rocks et al will likely cache recently changed/accessed KVs in memory. In practice, it seems that the hashing of the values for the HLL dominates this time.
* NOTE - the cache key for `compile-sub-query` doesn't take the relative attribute cardinalities into account. if these change significantly, the cache won't get invalidated, and we may have sub-optimal queries.