### PR TITLE
Less fsyncing in Rocks/LMDB

### DIFF
--- a/crux-rocksdb/src/crux/rocksdb.clj
+++ b/crux-rocksdb/src/crux/rocksdb.clj
@@ -83,9 +83,11 @@
     (.compactRange db))
 
   (fsync [_]
-    (with-open [flush-options (doto (FlushOptions.)
-                                (.setWaitForFlush true))]
-      (.flush db flush-options)))
+    (when (and (not (.sync write-options))
+               (.disableWAL write-options))
+      (with-open [flush-options (doto (FlushOptions.)
+                                  (.setWaitForFlush true))]
+        (.flush db flush-options))))
 
   (count-keys [_]
     (-> (.getProperty db "rocksdb.estimate-num-keys")


### PR DESCRIPTION
We don't need to fsync in Rocks if sync is already set or the WAL's enabled - this change brings the Rocks ingest benchmarks back into similar territory than they were before #1471. 

Likewise, in LMDB, we don't need to manually sync if `:sync? true` is already set.

This arguably makes `fsync` mis-named, we ideally want to convey something along the lines of 'ensure everything written thus far is made durable', but that seemed a bit of a mouthful.