### PR TITLE
Asynchronousification of TxLog and DocStore

### DIFF
--- a/crux-bench/src/crux/bench/ts_devices.clj
+++ b/crux-bench/src/crux/bench/ts_devices.clj
@@ -66,14 +66,14 @@
       (let [info-tx-ops (vec (for [info-doc @info-docs]
                                [:crux.tx/put info-doc]))
             _ (crux/submit-tx node info-tx-ops)
-            last-tx (with-readings-docs
-                      (fn [readings-docs]
-                        (->> readings-docs
-                             (partition-all readings-chunk-size)
-                             (reduce (fn [last-tx chunk]
-                                       (crux/submit-tx node (vec (for [{:keys [reading/time] :as reading-doc} chunk]
-                                                                   [:crux.tx/put reading-doc time]))))
-                                     nil))))]
+            last-tx @(with-readings-docs
+                       (fn [readings-docs]
+                         (->> readings-docs
+                              (partition-all readings-chunk-size)
+                              (reduce (fn [last-tx chunk]
+                                        (crux/submit-tx-async node (vec (for [{:keys [reading/time] :as reading-doc} chunk]
+                                                                          [:crux.tx/put reading-doc time]))))
+                                      nil))))]
         (crux/await-tx node last-tx (Duration/ofMinutes 20))
         {:success? true}))))
 

--- a/crux-bench/src/crux/bench/ts_weather.clj
+++ b/crux-bench/src/crux/bench/ts_weather.clj
@@ -52,15 +52,15 @@
       (let [location-tx-ops (vec (for [location-doc @location-docs]
                                    [:crux.tx/put location-doc]))
             _ (api/submit-tx node location-tx-ops)
-            last-tx (with-condition-docs
-                      (fn [condition-docs]
-                        (->> condition-docs
-                             (partition-all conditions-chunk-size)
-                             (reduce (fn [last-tx chunk]
-                                       (api/submit-tx node
-                                                      (vec (for [{:keys [condition/time] :as condition-doc} chunk]
-                                                             [:crux.tx/put condition-doc time]))))
-                                     nil))))]
+            last-tx @(with-condition-docs
+                       (fn [condition-docs]
+                         (->> condition-docs
+                              (partition-all conditions-chunk-size)
+                              (reduce (fn [_last-tx chunk]
+                                        (api/submit-tx-async node
+                                                             (vec (for [{:keys [condition/time] :as condition-doc} chunk]
+                                                                    [:crux.tx/put condition-doc time]))))
+                                      nil))))]
         (api/await-tx node last-tx (Duration/ofMinutes 20))
         {:success? true}))))
 

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -58,7 +58,7 @@
 
 ;; tag::TxLog[]
 (defprotocol TxLog
-  (submit-tx [this tx-events])
+  (^java.util.concurrent.CompletableFuture submit-tx-async [this tx-events])
   (open-tx-log ^crux.api.ICursor [this after-tx-id])
   (latest-submitted-tx [this]))
 ;; end::TxLog[]
@@ -73,6 +73,6 @@
   (abort [in-flight-tx]))
 
 (defprotocol DocumentStore
-  "Once `submit-docs` function returns successfully, any call to `fetch-docs` across the cluster must return the submitted docs."
-  (submit-docs [this id-and-docs])
-  (fetch-docs [this ids]))
+  "Once the future returned from `submit-docs-async` completes successfully, any call to `fetch-docs-async` across the cluster must return the submitted docs."
+  (^java.util.concurrent.CompletableFuture submit-docs-async [this id-and-docs])
+  (^java.util.concurrent.CompletableFuture fetch-docs-async [this ids]))

--- a/crux-core/src/crux/document_store.clj
+++ b/crux-core/src/crux/document_store.clj
@@ -1,23 +1,21 @@
 (ns ^:no-doc crux.document-store
-  (:require [clojure.java.io :as io]
-            [crux.io :as cio]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
+            [crux.cache :as cache]
             [crux.codec :as c]
             [crux.db :as db]
-            [crux.cache :as cache]
+            [crux.io :as cio]
             [crux.memory :as mem]
-            [taoensso.nippy :as nippy]
-            [crux.system :as sys])
+            [crux.system :as sys]
+            [taoensso.nippy :as nippy])
   (:import clojure.lang.MapEntry
-           (java.io Closeable DataInputStream DataOutputStream FileInputStream FileOutputStream)
-           (java.nio.file Files LinkOption OpenOption StandardOpenOption Path)
+           [java.io Closeable DataInputStream DataOutputStream]
+           [java.nio.file Files LinkOption OpenOption Path StandardOpenOption]
            java.nio.file.attribute.FileAttribute
-           (java.util.concurrent CompletableFuture Executors ExecutorService TimeUnit)
-           (java.util.function Supplier)))
+           [java.util.concurrent CompletableFuture Executors ExecutorService TimeUnit]
+           [java.util.function Function Supplier]))
 
 (defn- completable-future {:style/indent 1} ^java.util.concurrent.CompletableFuture
   [pool f]
-
   (CompletableFuture/supplyAsync
    (reify Supplier
      (get [_]
@@ -26,7 +24,7 @@
 
 (defrecord CachedDocumentStore [cache document-store]
   db/DocumentStore
-  (fetch-docs [this ids]
+  (fetch-docs-async [_ ids]
     (let [ids (set ids)
           cached-id->docs (persistent!
                            (reduce
@@ -34,23 +32,26 @@
                               (if-let [doc (get cache (c/->id-buffer id))]
                                 (assoc! acc id doc)
                                 acc))
-                            (transient {}) ids))
-          missing-ids (set/difference ids (set (keys cached-id->docs)))
-          missing-id->docs (db/fetch-docs document-store missing-ids)]
-      (persistent!
-       (reduce-kv
-        (fn [acc id doc]
-          (assoc! acc id (cache/compute-if-absent
-                          cache
-                          (c/->id-buffer id)
-                          mem/copy-to-unpooled-buffer
-                          (fn [_]
-                            doc))))
-        (transient cached-id->docs)
-        missing-id->docs))))
+                            (transient {}) ids))]
+      (if-let [missing-ids (not-empty (set/difference ids (set (keys cached-id->docs))))]
+        (-> (db/fetch-docs-async document-store missing-ids)
+            (.thenApply (reify Function
+                          (apply [_ missing-id->docs]
+                            (persistent!
+                             (reduce-kv
+                              (fn [acc id doc]
+                                (assoc! acc id (cache/compute-if-absent
+                                                cache
+                                                (c/->id-buffer id)
+                                                mem/copy-to-unpooled-buffer
+                                                (fn [_]
+                                                  doc))))
+                              (transient cached-id->docs)
+                              missing-id->docs))))))
+        (CompletableFuture/completedFuture cached-id->docs))))
 
-  (submit-docs [this id-and-docs]
-    (db/submit-docs
+  (submit-docs-async [_ id-and-docs]
+    (db/submit-docs-async
      document-store
      (vec (for [[id doc] id-and-docs]
             (do
@@ -69,23 +70,25 @@
 
 (defrecord NIODocumentStore [^Path root-path, ^ExecutorService pool]
   db/DocumentStore
-  (fetch-docs [_this ids]
-    (let [futs (vec (for [id ids]
-                      (let [doc-path (.resolve root-path (str (c/new-id id)))]
-                        (completable-future pool
-                          (fn []
-                            (when (Files/exists doc-path (make-array LinkOption 0))
-                              (with-open [in (Files/newInputStream doc-path (into-array OpenOption #{StandardOpenOption/READ}))]
-                                (cio/with-nippy-thaw-all
-                                  (MapEntry/create id
-                                                   (some->> in
-                                                            (DataInputStream.)
-                                                            (nippy/thaw-from-in!)))))))))))]
+  (fetch-docs-async [_this ids]
+    (let [futs (for [id ids]
+                 (let [doc-path (.resolve root-path (str (c/new-id id)))]
+                   (completable-future pool
+                                       (fn []
+                                         (when (Files/exists doc-path (make-array LinkOption 0))
+                                           (with-open [in (Files/newInputStream doc-path (into-array OpenOption #{StandardOpenOption/READ}))]
+                                             (cio/with-nippy-thaw-all
+                                               (MapEntry/create id
+                                                                (some->> in
+                                                                         (DataInputStream.)
+                                                                         (nippy/thaw-from-in!))))))))))]
 
-      @(CompletableFuture/allOf (into-array CompletableFuture futs))
-      (into {} (map deref) futs)))
+      (-> (CompletableFuture/allOf (into-array CompletableFuture futs))
+          (.thenApply (reify Function
+                        (apply [_ _]
+                          (into {} (map deref) futs)))))))
 
-  (submit-docs [_this id-and-docs]
+  (submit-docs-async [_this id-and-docs]
     (let [futs (vec (for [[id doc] id-and-docs
                           :let [doc-key (str (c/new-id id))]]
                       (completable-future pool
@@ -97,7 +100,7 @@
                                               DataOutputStream.)]
                             (nippy/freeze-to-out! out doc))))))]
 
-      @(CompletableFuture/allOf (into-array CompletableFuture futs))))
+      (CompletableFuture/allOf (into-array CompletableFuture futs))))
 
   Closeable
   (close [_]

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -330,14 +330,3 @@
         result)
       (catch UnsatisfiedLinkError e
         (log/debug "Could not call glibc mallopt")))))
-
-(defn future->completable-future ^java.util.concurrent.CompletableFuture [fut]
-  (CompletableFuture/supplyAsync
-   (reify Supplier
-     (get [_]
-       (try
-         @fut
-         (catch ExecutionException e
-           (throw (CompletionException. (.getCause e))))
-         (catch InterruptedException _
-           (throw (CompletionException. "interrupted"))))))))

--- a/crux-core/src/crux/pull.clj
+++ b/crux-core/src/crux/pull.clj
@@ -17,7 +17,7 @@
 
 (defn- lookup-docs [v {:keys [document-store]}]
   (when-let [hashes (not-empty (::hashes (meta v)))]
-    (db/fetch-docs document-store hashes)))
+    @(db/fetch-docs-async document-store hashes)))
 
 (defmacro let-docs {:style/indent 1} [[binding hashes] & body]
   `(-> (fn ~'let-docs [~binding]

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -197,7 +197,7 @@
        (remove #{c/nil-id-buffer})))
 
 (defn tx-events->tx-ops [document-store tx-events]
-  (let [docs (db/fetch-docs document-store (tx-events->doc-hashes tx-events))]
+  (let [docs @(db/fetch-docs-async document-store (tx-events->doc-hashes tx-events))]
     (for [[op id & args] tx-events]
       (into [op]
             (concat (when (contains? #{:crux.tx/delete :crux.tx/evict :crux.tx/fn} op)

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -238,7 +238,7 @@
                 (fn [ev]
                   (with-open [index-writer (index-writer lucene-store)]
                     (when (= :crux.tx/committing-tx (:crux/event-type ev))
-                      (index! indexer index-writer (db/fetch-docs document-store (:doc-ids ev)))
+                      (index! indexer index-writer @(db/fetch-docs-async document-store (:doc-ids ev)))
                       (when-let [evicting-eids (not-empty (:evicting-eids ev))]
                         (evict! indexer index-writer evicting-eids)))
                     (index-tx! index-writer (:submitted-tx ev)))))

--- a/crux-s3/src/crux/s3.clj
+++ b/crux-s3/src/crux/s3.clj
@@ -1,66 +1,60 @@
 (ns crux.s3
-  (:require [crux.db :as db]
-            [crux.io :as cio]
-            [crux.document-store :as ds]
-            [crux.node :as n]
-            [clojure.spec.alpha :as s]
-            [taoensso.nippy :as nippy]
+  (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [crux.db :as db]
+            [crux.document-store :as ds]
+            [crux.io :as cio]
             [crux.system :as sys])
-  (:import (crux.s3 S3Configurator)
-           (clojure.lang MapEntry)
-           (java.io Closeable)
-           (java.util.concurrent CompletableFuture)
-           (java.util.function BiFunction)
-           (software.amazon.awssdk.core ResponseBytes)
-           (software.amazon.awssdk.core.async AsyncRequestBody AsyncResponseTransformer)
-           (software.amazon.awssdk.services.s3 S3AsyncClient)
-           (software.amazon.awssdk.services.s3.model GetObjectRequest PutObjectRequest
-                                                     ListObjectsV2Request ListObjectsV2Response
-                                                     CommonPrefix S3Object
-                                                     NoSuchKeyException)))
+  (:import clojure.lang.MapEntry
+           crux.s3.S3Configurator
+           java.io.Closeable
+           java.util.concurrent.CompletableFuture
+           [java.util.function BiFunction Function]
+           [software.amazon.awssdk.core.async AsyncRequestBody AsyncResponseTransformer]
+           software.amazon.awssdk.core.ResponseBytes
+           [software.amazon.awssdk.services.s3.model CommonPrefix GetObjectRequest ListObjectsV2Request ListObjectsV2Response NoSuchKeyException PutObjectRequest S3Object]
+           software.amazon.awssdk.services.s3.S3AsyncClient))
 
-(defn ^:no-doc put-objects [{:keys [^S3Configurator configurator ^S3AsyncClient client bucket prefix]} objs]
-  (->> (for [[path ^AsyncRequestBody request-body] objs]
-         (.putObject client
-                     (-> (PutObjectRequest/builder)
-                         (.bucket bucket)
-                         (.key (str prefix path))
-                         (->> (.configurePut configurator))
-                         ^PutObjectRequest (.build))
-                     request-body))
-       vec
-       (run! (fn [^CompletableFuture req]
-               (.get req)))))
+(defn ^:no-doc put-objects-async ^java.util.concurrent.CompletableFuture [{:keys [^S3Configurator configurator ^S3AsyncClient client bucket prefix]} objs]
+  (CompletableFuture/allOf
+   (into-array CompletableFuture
+               (for [[path ^AsyncRequestBody request-body] objs]
+                 (.putObject client
+                             (-> (PutObjectRequest/builder)
+                                 (.bucket bucket)
+                                 (.key (str prefix path))
+                                 (->> (.configurePut configurator))
+                                 ^PutObjectRequest (.build))
+                             request-body)))))
 
-(defn ^:no-doc get-objects [{:keys [^S3Configurator configurator ^S3AsyncClient client bucket prefix]} reqs]
-  (->> (for [[path ^AsyncResponseTransformer response-transformer] reqs]
-         (let [s3-key (str prefix path)]
-           [path (-> (.getObject client
-                                 (-> (GetObjectRequest/builder)
-                                     (.bucket bucket)
-                                     (.key s3-key)
-                                     (->> (.configureGet configurator))
-                                     ^GetObjectRequest (.build))
-                                 response-transformer)
+(defn ^:no-doc get-objects-async ^java.util.concurrent.CompletableFuture [{:keys [^S3Configurator configurator ^S3AsyncClient client bucket prefix]} reqs]
+  (let [futs (->> (for [[path ^AsyncResponseTransformer response-transformer] reqs]
+                    (let [s3-key (str prefix path)]
+                      (-> (.getObject client
+                                      (-> (GetObjectRequest/builder)
+                                          (.bucket bucket)
+                                          (.key s3-key)
+                                          (->> (.configureGet configurator))
+                                          ^GetObjectRequest (.build))
+                                      response-transformer)
 
-                     (.handle (reify BiFunction
-                                (apply [_ resp e]
-                                  (if e
-                                    (try
-                                      (throw (.getCause ^Throwable e))
-                                      (catch NoSuchKeyException e
-                                        (log/warn "S3 key not found: " s3-key))
-                                      (catch Exception e
-                                        (log/warnf e "Error fetching S3 object: s3://%s/%s" bucket (str prefix path))))
+                          (.handle (reify BiFunction
+                                     (apply [_ resp e]
+                                       (if e
+                                         (try
+                                           (throw (.getCause ^Throwable e))
+                                           (catch NoSuchKeyException _
+                                             (log/warn "S3 key not found: " s3-key))
+                                           (catch Exception e
+                                             (log/warnf e "Error fetching S3 object: s3://%s/%s" bucket (str prefix path))))
 
-                                    resp)))))]))
-
-         (into {})
-         (into {} (keep (fn [[path ^CompletableFuture fut]]
-                          (when-let [resp (.get fut)]
-                            [path resp]))))))
+                                         (MapEntry/create path resp))))))))
+                  (into-array CompletableFuture))]
+    (-> (CompletableFuture/allOf futs)
+        (.thenApply (reify Function
+                      (apply [_ _]
+                        (into {} (map deref) futs)))))))
 
 (defn ^:no-doc list-objects [{:keys [^S3Configurator configurator ^S3AsyncClient client bucket prefix]}
                              {:keys [path recursive?]}]
@@ -87,18 +81,20 @@
 
 (defrecord S3DocumentStore [^S3Configurator configurator ^S3AsyncClient client bucket prefix]
   db/DocumentStore
-  (submit-docs [this docs]
-    (put-objects this (for [[id doc] docs]
-                        (MapEntry/create id (AsyncRequestBody/fromBytes (.freeze configurator doc))))))
+  (submit-docs-async [this docs]
+    (put-objects-async this (for [[id doc] docs]
+                              (MapEntry/create id (AsyncRequestBody/fromBytes (.freeze configurator doc))))))
 
-  (fetch-docs [this ids]
+  (fetch-docs-async [this ids]
     (cio/with-nippy-thaw-all
-      (->> (get-objects this (for [id ids]
-                               (MapEntry/create id (AsyncResponseTransformer/toBytes))))
-
-           (into {} (map (fn [[id ^ResponseBytes resp]]
-                           [id (-> (.asByteArray ^ResponseBytes resp)
-                                   (->> (.thaw configurator)))]))))))
+      (-> (get-objects-async this (for [id ids]
+                                    (MapEntry/create id (AsyncResponseTransformer/toBytes))))
+          (.thenApply (reify Function
+                        (apply [_ resps]
+                          (->> resps
+                               (into {} (map (fn [[id ^ResponseBytes resp]]
+                                               [id (-> (.asByteArray ^ResponseBytes resp)
+                                                       (->> (.thaw configurator)))]))))))))))
 
   Closeable
   (close [_]

--- a/crux-s3/test/crux/s3_test.clj
+++ b/crux-s3/test/crux/s3_test.clj
@@ -10,7 +10,8 @@
 
 (def test-s3-bucket
   (or (System/getProperty "crux.s3.test-bucket")
-      (System/getenv "CRUX_S3_TEST_BUCKET")))
+      (System/getenv "CRUX_S3_TEST_BUCKET")
+      "jms-crux-test"))
 
 (def test-s3-region
   (or (System/getProperty "crux.s3.test-region")

--- a/crux-test/src/crux/fixtures/document_store.clj
+++ b/crux-test/src/crux/fixtures/document_store.clj
@@ -11,16 +11,16 @@
         max-key (c/new-id {:crux.db/id :max, :name "Max"})
         people {alice-key alice, bob-key bob}]
 
-    (db/submit-docs doc-store people)
+    @(db/submit-docs-async doc-store people)
 
     (t/is (= {alice-key alice}
-             (db/fetch-docs doc-store #{alice-key})))
+             @(db/fetch-docs-async doc-store #{alice-key})))
 
     (t/is (= people
-             (db/fetch-docs doc-store (conj (keys people) max-key))))
+             @(db/fetch-docs-async doc-store (conj (keys people) max-key))))
 
     (let [evicted-alice {:crux.db/id :alice, :crux.db/evicted? true}]
-      (db/submit-docs doc-store {alice-key evicted-alice})
+      @(db/submit-docs-async doc-store {alice-key evicted-alice})
 
       (t/is (= {alice-key evicted-alice, bob-key bob}
-               (db/fetch-docs doc-store (keys people)))))))
+               @(db/fetch-docs-async doc-store (keys people)))))))

--- a/crux-test/test/crux/jdbc_test.clj
+++ b/crux-test/test/crux/jdbc_test.clj
@@ -34,28 +34,28 @@
 
         _ (fix/submit+await-tx [[:crux.tx/put doc]])
 
-        docs (db/fetch-docs doc-store #{doc-hash})]
+        docs @(db/fetch-docs-async doc-store #{doc-hash})]
 
     (t/is (= 1 (count docs)))
     (t/is (= doc (get docs doc-hash)))
 
     (t/testing "Compaction"
-      (db/submit-docs doc-store [[doc-hash :some-val]])
+      @(db/submit-docs-async doc-store [[doc-hash :some-val]])
       (t/is (= :some-val
-               (-> (db/fetch-docs doc-store #{doc-hash})
+               (-> @(db/fetch-docs-async doc-store #{doc-hash})
                    (get doc-hash)))))
 
     (t/testing "Eviction"
-      (db/submit-docs doc-store [[doc-hash {:crux.db/id :some-id, :crux.db/evicted? true}]])
+      @(db/submit-docs-async doc-store [[doc-hash {:crux.db/id :some-id, :crux.db/evicted? true}]])
       (t/is (= {:crux.db/id :some-id, :crux.db/evicted? true}
-               (-> (db/fetch-docs doc-store #{doc-hash})
+               (-> @(db/fetch-docs-async doc-store #{doc-hash})
                    (get doc-hash)))))
 
     (t/testing "Resurrect Document"
       (fix/submit+await-tx [[:crux.tx/put doc]])
 
       (t/is (= doc
-               (-> (db/fetch-docs doc-store #{doc-hash})
+               (-> @(db/fetch-docs-async doc-store #{doc-hash})
                    (get doc-hash)))))))
 
 (t/deftest test-micro-bench

--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -65,7 +65,7 @@
       (with-fixtures
         (fn []
           (t/testing "new node can pick-up"
-            (db/submit-docs (:document-store *api*) compacted-docs)
+            @(db/submit-docs-async (:document-store *api*) compacted-docs)
             (api/await-tx *api* submitted-tx)
             (f)))))))
 
@@ -114,9 +114,8 @@
       (fn []
         (t/testing "submitting an oversized document returns proper exception"
           (t/is
-           (thrown-with-msg?
-            java.util.concurrent.ExecutionException
-            #"org.apache.kafka.common.errors.RecordTooLargeException"
+           (thrown?
+            org.apache.kafka.common.errors.RecordTooLargeException
             (api/submit-tx
              *api*
              [[:crux.tx/put


### PR DESCRIPTION
Based on `less-fsyncing` and `doc-store-hanging-1387`, see https://github.com/jarohen/crux/compare/doc-store-hanging-1387...async-things for real diff

Changing the three functions on doc-store and tx-log to be `-async`, using patterns established in other ongoing spikes.  
- `submit-tx` was already async, this is just a rename to `submit-tx-async` and returning a `CompletableFuture`.
- updated ts-devices and ts-weather benchmarks to use asynchronous ingestion to test performance, bench ongoing (TODO)
- third-party implementations of these two will be required to migrate - at a minimum, wrapping their existing implementations in `(CompletableFuture/completedFuture ...)`

TODO
- [ ] post bench results
- [x] need to rebase this on #1470, suspect a few conflicts
- [ ] in the KV implementations, suspect this may even reduce performance unless we queue the actual writes into a single thread - both Rocks and LMDB benefit from single-threaded batch ingest.
- [ ] we may well not want to use the default asynchronous executor throughout - the components may benefit from having their own pools