### PR TITLE
Query with `nil` eid yielding results, #1486

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -551,7 +551,7 @@
                            or-join-vars)}))
 
 (defn- new-binary-index [{:keys [e a v] :as clause} {:keys [entity-resolver-fn]} index-snapshot {:keys [vars-in-join-order]}]
-  (let [order (keep #{e v} vars-in-join-order)
+  (let [order (filter #(contains? #{e v} %) vars-in-join-order)
         nested-index-snapshot (db/open-nested-index-snapshot index-snapshot)
         attr-buffer (mem/copy-to-unpooled-buffer (c/->id-buffer a))]
     (if (= v (first order))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3784,7 +3784,6 @@
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id 1 :foo nil}]
                         [:crux.tx/put {:crux.db/id 2 :foo nil}]])
 
-  #_ ; yields #{[1] [2]}
   (t/is (= #{}
            (api/q (api/db *api*)
                   '{:find [?v]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3779,3 +3779,18 @@
            fut)
          (finally
            (.close node))))))
+
+(t/deftest nil-in-entity-position-shouldnt-yield-results-1486
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id 1 :foo nil}]
+                        [:crux.tx/put {:crux.db/id 2 :foo nil}]])
+
+  #_ ; yields #{[1] [2]}
+  (t/is (= #{}
+           (api/q (api/db *api*)
+                  '{:find [?v]
+                    :where [[nil :foo ?v]]})))
+
+  (t/is (= #{}
+           (api/q (api/db *api*)
+                  '{:find [?v]
+                    :where [[#{nil} :foo ?v]]}))))


### PR DESCRIPTION
With `nil` provided as either E or V in a `:where` triple, we were filtering the join var out of the binary index order, essentially flipping an AEV to an AVE. 

Fun one!