### PR TITLE
Nil only binds to documents with a `nil` value, #1487

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -417,7 +417,7 @@
 (defn- normalize-triple-clause [{:keys [e a v] :as clause}]
   (cond-> clause
     (or (blank-var? v)
-        (nil? v))
+        (not (contains? clause :v)))
     (-> (assoc :v (gensym "_")) (with-meta {:ignore-v? true}))
     (blank-var? e)
     (assoc :e (gensym "_"))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -551,7 +551,7 @@
                            or-join-vars)}))
 
 (defn- new-binary-index [{:keys [e a v] :as clause} {:keys [entity-resolver-fn]} index-snapshot {:keys [vars-in-join-order]}]
-  (let [order (keep #{e v} vars-in-join-order)
+  (let [order (filter #(contains? #{e v} %) vars-in-join-order)
         nested-index-snapshot (db/open-nested-index-snapshot index-snapshot)
         attr-buffer (mem/copy-to-unpooled-buffer (c/->id-buffer a))]
     (if (= v (first order))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3784,7 +3784,6 @@
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id 1 :foo nil}]
                         [:crux.tx/put {:crux.db/id 2 :foo nil}]])
 
-  #_ ; yields #{[1] [2]}
   (t/is (= #{}
            (api/q (api/db *api*)
                   '{:find [?v]

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3779,3 +3779,18 @@
            fut)
          (finally
            (.close node))))))
+
+(t/deftest nil-in-entity-position-shouldnt-yield-results-1486
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id 1 :foo nil}]
+                        [:crux.tx/put {:crux.db/id 2 :foo nil}]])
+
+  #_ ; yields #{[1] [2]}
+  (t/is (= #{}
+           (api/q (api/db *api*)
+                  '{:find [?v]
+                    :where [[nil :foo ?v]]})))
+
+  (t/is (= #{}
+           (api/q (api/db *api*)
+                  '{:find [?v]
+                    :where [[#{nil} :foo ?v]]}))))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3793,3 +3793,34 @@
            (api/q (api/db *api*)
                   '{:find [?v]
                     :where [[#{nil} :foo ?v]]}))))
+
+(t/deftest literal-nil-value-in-triple-clause-should-only-match-nil-1487
+  (fix/submit+await-tx [[:crux.tx/put {:crux.db/id 1 :foo nil}]
+                        [:crux.tx/put {:crux.db/id 2 :foo 2}]])
+  (t/is (= #{[1] [2]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo]]})))
+  (t/is (= #{[1] [2]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo _]]})))
+
+  #_ ; yields #{[1] [2]}
+  (t/is (= #{[1]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo nil]]})))
+
+  (t/is (= #{[1]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo #{nil}]]})))
+  (t/is (= #{[1] [2]}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo #{nil 2}]]})))
+  (t/is (= #{}
+           (api/q (api/db *api*)
+                  '{:find [?e]
+                    :where [[?e :foo #{}]]}))))

--- a/crux-test/test/crux/query_test.clj
+++ b/crux-test/test/crux/query_test.clj
@@ -3805,13 +3805,10 @@
            (api/q (api/db *api*)
                   '{:find [?e]
                     :where [[?e :foo _]]})))
-
-  #_ ; yields #{[1] [2]}
   (t/is (= #{[1]}
            (api/q (api/db *api*)
                   '{:find [?e]
                     :where [[?e :foo nil]]})))
-
   (t/is (= #{[1]}
            (api/q (api/db *api*)
                   '{:find [?e]


### PR DESCRIPTION
Making the distinction between `:where [[?e :a]]` and `:where [[?e :a nil]]`, the latter only binding against documents with `{:a nil}`.

This is more of a breaking change than #1488 - there might well be users out there with queries assuming that nil in the value position is a wildcard...? RFC.

Depends on #1488, real diff [here](https://github.com/jarohen/crux/compare/query-nil-eid-yielding-results-1486...nil-only-binds-to-nil-1487)