### PR TITLE
Fail faster on Kafka doc-store when we're missing docs

### DIFF
--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -426,8 +426,7 @@
           (api/await-tx *api* tx (Duration/ofNanos 1))))))))
 
 (t/deftest missing-doc-halts-tx-ingestion
-  ;; TODO hangs for Kafka, see KafkaDocumentStore
-  (when-not (contains? #{:remote :local-kafka :local-kafka-transit} *node-type*)
+  (when-not (contains? #{:remote} *node-type*)
     (let [tx (db/submit-tx (:tx-log *api*) [[:crux.tx/put (c/new-id :foo) (c/new-id {:crux.db/id :foo})]])]
       (t/is (thrown-with-msg?
              IllegalStateException


### PR DESCRIPTION
resolves #1479, see #1470

We check Kafka doc-topic end-offsets when we fetch-docs so that we can fail faster (correcting previous infinite loop) in the unlikely case that the document's not present in the doc-store.