### PR TITLE
JDBC migrations for #1463

### DIFF
--- a/crux-jdbc/src/crux/jdbc/h2.clj
+++ b/crux-jdbc/src/crux/jdbc/h2.clj
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS tx_events (
   v BINARY NOT NULL,
   compacted INTEGER NOT NULL)"])
 
-        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx ON tx_events(event_key)"])
+        (jdbc/execute! ["DROP INDEX IF EXISTS tx_events_event_key_idx"])
+        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])
         (check-tx-time-col)))))
 
 (defmethod j/->date :h2 [^TimestampWithTimeZone d _]

--- a/crux-jdbc/src/crux/jdbc/mysql.clj
+++ b/crux-jdbc/src/crux/jdbc/mysql.clj
@@ -13,6 +13,17 @@
     (log/warn (str "`tx_time` column not in UTC format. "
                    "See https://github.com/juxt/crux/releases/tag/20.09-1.12.1 for more details."))))
 
+(defn- idx-exists? [ds idx-name]
+  (pos? (-> (jdbc/execute! ds ["
+SELECT COUNT(1) IdxPresent
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE table_schema=DATABASE()
+  AND table_name='tx_events'
+  AND index_name=?"
+                               idx-name])
+            first
+            :IdxPresent)))
+
 (defn ->dialect [_]
   (reify j/Dialect
     (db-type [_] :mysql)
@@ -26,13 +37,10 @@ CREATE TABLE IF NOT EXISTS tx_events (
   v LONGBLOB NOT NULL,
   compacted INTEGER NOT NULL)"])
 
-      (when (zero? (-> (jdbc/execute! ds ["
-SELECT COUNT(1) IdxPresent
-FROM INFORMATION_SCHEMA.STATISTICS
-WHERE table_schema=DATABASE() AND table_name='tx_events' AND index_name='tx_events_event_key_idx'"])
-                       first
-                       :IdxPresent))
+      (when (idx-exists? ds "tx_events_event_key_idx")
+        (jdbc/execute! ds ["DROP INDEX tx_events_event_key_idx"]))
 
-        (jdbc/execute! ds ["CREATE INDEX tx_events_event_key_idx ON tx_events(event_key)"]))
+      (when-not (idx-exists? ds "tx_events_event_key_idx_2")
+        (jdbc/execute! ds ["CREATE INDEX tx_events_event_key_idx_2 ON tx_events(compacted, event_key)"]))
 
       (check-tx-time-col ds))))

--- a/crux-jdbc/src/crux/jdbc/psql.clj
+++ b/crux-jdbc/src/crux/jdbc/psql.clj
@@ -33,5 +33,6 @@ CREATE TABLE IF NOT EXISTS tx_events (
   v BYTEA NOT NULL,
   compacted INTEGER NOT NULL)"])
 
-        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx ON tx_events(event_key)"])
+        (jdbc/execute! ["DROP INDEX IF EXISTS tx_events_event_key_idx"])
+        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])
         (check-tx-time-col)))))

--- a/crux-jdbc/src/crux/jdbc/sqlite.clj
+++ b/crux-jdbc/src/crux/jdbc/sqlite.clj
@@ -34,4 +34,5 @@ CREATE TABLE IF NOT EXISTS tx_events (
   v BINARY NOT NULL,
   compacted INTEGER NOT NULL)"])
 
-        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx ON tx_events(event_key)"])))))
+        (jdbc/execute! ["DROP INDEX IF EXISTS tx_events_event_key_idx"])
+        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])))))


### PR DESCRIPTION
After discussions with users using JDBC in production, it seems most pragmatic to do these at node startup, on the understanding that may take table locks when they're first run. We'll ensure we document this prominently in the release notes!

If table locks are out of the question, there are options in most of the database dialects to run the new index creation in the background before deployed the Crux upgrade - the important thing is for there to be an index called `tx_events_event_key_idx_2` on the `event_key` column of `tx_events` by the time the upgraded Crux node starts up. In Postgres, for example, this is done with `CREATE INDEX CONCURRENTLY IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)`.