### PR TITLE
Re-enable :in binding args for crux-http-server

### DIFF
--- a/crux-http-server/src/crux/http_server/json.clj
+++ b/crux-http-server/src/crux/http_server/json.clj
@@ -61,3 +61,6 @@
                          crux-object-mapper)
           (finally
             (cio/try-close results)))))))
+
+(defn write-str [v]
+  (j/write-value-as-string v))

--- a/crux-http-server/test/crux/http_server/json_test.clj
+++ b/crux-http-server/test/crux/http_server/json_test.clj
@@ -90,6 +90,35 @@
                :qps {"queryEdn" (pr-str '{:find [(pull e [*])]
                                           :where [[e :firstName "Sally"]]})}})))
 
+    (t/is (= [[{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]
+              [{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]
+              [{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]]
+             (json-get
+              {:url "/_crux/query"
+               :qps {"queryEdn" (pr-str '{:find [(pull e [*])]
+                                          :in [n c k s [i ...] m]
+                                          ;; :limit 1 ;; can use this to mitigate streaming open-q bag effect
+                                          :where [[e :firstName n]
+                                                  [(= c 123)]
+                                                  [(= k :firstName)]
+                                                  [(contains? s i)]
+                                                  [(= m {:a {:b {:c :d :e "f"}}})]]})
+                     "inArgsEdn" (pr-str ["Sally" 123 :firstName [0 1 2] [0 1 2] {:a {:b {:c :d :e "f"}}}])}})))
+
+    (t/is (= [[{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]
+              [{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]
+              [{"crux.db/id" "sal", "firstName" "Sally", "lastName" "Example"}]]
+             (json-get
+              {:url "/_crux/query"
+               :qps {"queryEdn" (pr-str '{:find [(pull e [*])]
+                                          :in [n c k s [i ...] m]
+                                          :where [[e :firstName n]
+                                                  [(= c 123)]
+                                                  [(= k "firstName")]
+                                                  [(contains? s i)]
+                                                  [(= m {:a {:b {:c "d" :e "f"}}})]]})
+                     "inArgsJson" (json/write-value-as-string ["Sally" 123 "firstName" [0 1 2] [0 1 2] {"a" {"b" {"c" "d" "e" "f"}}}])}})))
+
     (t/testing "pull"
       (let [{:strs [txId] :as tx} (submit-tx [["put" {"crux.db/id" "link", "linking" "jed"}]])]
         (t/is (= tx

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -106,6 +106,11 @@
                                      :in [n]
                                      :where [[e :name n]]}
                                    "Ivan"))))
+      (t/testing "query ?pull [*]"
+        (t/is (= #{[{:crux.db/id :ivan :name "Ivan"}]}
+                 (api/q (api/db *api*)
+                        '{:find [(pull e [*])]
+                          :where [[e :name "Ivan"]]}))))
 
       (t/testing "query string"
         (t/is (= #{[:ivan]} (api/q db "{:find [e] :where [[e :name \"Ivan\"]]}"))))

--- a/crux-test/test/crux/api_test.clj
+++ b/crux-test/test/crux/api_test.clj
@@ -100,6 +100,13 @@
                           '{:find [e]
                             :where [[e :name "Ivan"]]})))
 
+      (t/testing "query :in args"
+        (t/is (= #{[:ivan]} (api/q (api/db *api*)
+                                   '{:find [e]
+                                     :in [n]
+                                     :where [[e :name n]]}
+                                   "Ivan"))))
+
       (t/testing "query string"
         (t/is (= #{[:ivan]} (api/q db "{:find [e] :where [[e :name \"Ivan\"]]}"))))
 

--- a/docs/reference/modules/ROOT/pages/http.adoc
+++ b/docs/reference/modules/ROOT/pages/http.adoc
@@ -435,6 +435,8 @@ curl -g \
 * `valid-time` (date, defaulting to now)
 * `tx-time` (date, defaulting to latest transaction time)
 * `tx-id` (date, defaulting to latest transaction id)
+* `in-args-edn` (EDN URL encoded :in binding arguments)
+* `in-args-json` (JSON URL encoded :in binding arguments)
 
 ==== Response
 
@@ -486,6 +488,9 @@ You can also accept `application/json` from this endpoint, but currently the onl
 
 .*Required Parameters*
 * `query` (EDN encoded datalog query)
+
+.*Optional Parameters*
+* `in-args` (EDN encoded :in binding arguments)
 
 ===== Query Parameters
 


### PR DESCRIPTION
This issue was reported via #1506 and here is the background:
1. Support for `:in` bindings, including use via `crux-http-server`, was added correctly in PR https://github.com/juxt/crux/pull/1099, specifically https://github.com/juxt/crux/pull/1099/commits/da33146d22262d426cb906ab9547fc54ded43354#diff-34510033ce6b20631fcf93dce84fa0a0140be6828350f2ad0bdc72c8d47ad872L125-R127
2. Unfortunately however, this PR only added `:in` test coverage to `query_test.clj`, and not `api_test.clj` (which is run against multiple API implementations by default, including `:remote`)
3. The subsequent commit to `http_server.clj` was part of a very large PR and accidentally broke the use of `:in` args for `crux-http-server`, presumably whilst consolidating `q`/`open-q` calls, e.g. there should probably have been references to `args` somewhere around here https://github.com/juxt/crux/commit/e7e3b1c5f83c89804151dbd40370c050bc18f7b0#diff-e80d14b2675646aa754c45c247fbf90a0a4652097ea0e03cec17e586c64d6c7fR137-R146

The fix as implemented in this PR isn't ideal. There is potentially some much cleaner Reitit/Ring and/or `spec-tools` way to handle coercion of body params, e.g. something like this:
```clojure
;; unfortunately neither the inline spec conformer or st :decode/string are sufficient, therefore try-decode-edn coercion also takes place data-browser-query
(s/def ::args
  (st/spec
   {:spec
    (s/and
     (s/conformer (fn [x] (util/try-decode-edn x)))
     (s/coll-of any? :kind vector?))
    :swagger/example (pr-str '["foo" 123])
    :description "EDN formatted :in binding arguments"
    :decode/string (fn [_ a] (util/try-decode-edn a))}))
```

In general it seems best to use these tools for such coercions, but the obvious configurations haven't helped in this case. We may well want to change strategy in this area altogether before worrying about finding a cleaner resolution here.

Whilst investigating and fixing this I noted some outstanding questions about crux-http-server:
1. Should the JSON-over-HTTP `/_crux/query` calls be non-lazy by default? The bag semantics are undocumented and likely to be surprising, and the deduplication should probably happen on the server. Replacing https://github.com/refset/crux/commit/2bfab4838856411c8b0af31ab1225d7278c5e3d4#diff-e80d14b2675646aa754c45c247fbf90a0a4652097ea0e03cec17e586c64d6c7fR76 with `(cio/->cursor (fn []) (apply crux/q db query in-args))` will demonstrate this alternative behaviour
2. Should `query` be coerced/normalised before hitting `crux/q`? Currently it is being passed as a string
3. Could it be sensible to differentiate between `args` and `args-edn`/`args-json`? i.e. similarly to `query-edn`. Are there some tests we could add to explore this?

Additionally, could/should we run `query_test.clj` against all API implementations also?

(Thank you again @danmason for the pairing and input!)