### PR TITLE
Reconstructing docs in the query indices, #1511

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1732,12 +1732,10 @@
     (some-> (db/entity-as-of index-snapshot eid valid-time tx-id)
             (c/entity-tx->edn))))
 
-(defn- entity [{:keys [document-store] :as db} index-snapshot eid]
+(defn- entity [db index-snapshot eid]
   (when-let [content-hash (some-> (entity-tx db index-snapshot eid)
                                   :crux.db/content-hash)]
-    (-> (db/fetch-docs document-store #{content-hash})
-        (get content-hash)
-        (c/keep-non-evicted-doc))))
+    (db/entity index-snapshot eid content-hash)))
 
 (defn- with-history-bounds [{:keys [sort-order start-tx end-tx] :as opts}
                             {:keys [^long tx-id ^Date valid-time]}

--- a/crux-test/test/crux/api/DocumentTest.java
+++ b/crux-test/test/crux/api/DocumentTest.java
@@ -63,8 +63,8 @@ public class DocumentTest {
         data.put("foo", "bar");
         compare.put(foo, "bar");
 
-        data.put("bar", 0);
-        compare.put(bar, 0);
+        data.put("bar", 0L);
+        compare.put(bar, 0L);
 
         CruxDocument document = CruxDocument.create(documentId, data);
 
@@ -99,8 +99,8 @@ public class DocumentTest {
 
         compare.put(foo, "bar");
         data.put("foo", "bar");
-        compare.put(bar, 0);
-        data.put("bar", 0);
+        compare.put(bar, 0L);
+        data.put("bar", 0L);
 
         CruxDocument document = CruxDocument.create(documentId).plusAll(data);
         CruxDocument builtDocument = build(documentId, doc -> {

--- a/crux-test/test/crux/api/JCruxDatasourceTest.java
+++ b/crux-test/test/crux/api/JCruxDatasourceTest.java
@@ -18,8 +18,8 @@ public class JCruxDatasourceTest {
     private static final Keyword pullId1 = Keyword.intern("pull1");
     private static final Keyword pullId2 = Keyword.intern("pull2");
 
-    private static final CruxDocument pullDocument1 = CruxDocument.create(pullId1).plus("foo", "foo").plus("bar", 1);
-    private static final CruxDocument pullDocument2 = CruxDocument.create(pullId2).plus("foo", "bar").plus("bar", 2);
+    private static final CruxDocument pullDocument1 = CruxDocument.create(pullId1).plus("foo", "foo").plus("bar", 1L);
+    private static final CruxDocument pullDocument2 = CruxDocument.create(pullId2).plus("foo", "bar").plus("bar", 2L);
 
     private static ICruxAPI node;
 

--- a/crux-test/test/crux/api/TestUtils.java
+++ b/crux-test/test/crux/api/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils {
     static final String documentId = "myDoc";
     static final String versionId = "version";
 
-    static CruxDocument testDocument(int version) {
+    static CruxDocument testDocument(long version) {
         CruxDocument document = CruxDocument.create(documentId);
         return document.plus(versionId, version);
     }

--- a/docs/reference/modules/ROOT/examples/test/crux/docs/examples/transactions/TransactionsTest.java
+++ b/docs/reference/modules/ROOT/examples/test/crux/docs/examples/transactions/TransactionsTest.java
@@ -40,7 +40,7 @@ public class TransactionsTest {
 
     private final ICruxAPI node = Crux.startNode();
 
-    private static CruxDocument createDocument(int version) {
+    private static CruxDocument createDocument(long version) {
         return CruxDocument.create(documentId).plus("version", version);
     }
 


### PR DESCRIPTION
We use the value in the ECAV index to reconstruct entities using the query indices alone. Resolves #1511. 

Pros:
- no need to go to doc-store for `entity` or `pull`. we could also remove the recommendation to keep an as-full-as-possible local doc-store cache, which will reduce per-node disk space reqmts.
- `pull` is vastly simpler - can get rid of the monadic doc-store lookup batching

Cons:
- entity reconstruction from the query indices is more involved than simply deserialising it out of the doc-store

Notes:
- Java API now returns longs in documents if ints are passed in, because the docs are reconstructed from the indices which transform numbers to longs/doubles.
- I've added the distinction between hashing which needs to preserve consistent ids and hashing which needs to preserve consistent values - the former is so that hashing behaviour is preserved for hashes that go on the log/in the doc-store; the latter for values hashed in the indices. The distinction means that we can fix some hashing behaviours in the indices on an index version bump, rather than holding off because the hashes are on the tx-log. RFC.