### PR TITLE
discounting vars as leaf vars if they're used in fn-clauses too, fixes #1523

### DIFF
--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1318,7 +1318,6 @@
                           db]
   (let [collected-vars (collect-vars type->clauses)
         pred-vars (set (for [{:keys [pred return]} pred-clauses
-                             :when (not return)
                              arg (:args pred)
                              :when (logic-var? arg)]
                          arg))


### PR DESCRIPTION
fixes #1523

what seems to be happening is that the join order is first calculated on the triple clauses (`[?foo ?bar ?a ?a-name]` in this case), and then these are entered as dependencies in the var dependency graph. `?foo-val` is being treated as a leaf-val because it's not used outside of the pred-fn and, because the pred-fn has a return, the usage in the pred-fn is also discounted - `?foo-val` is hence allowed to be a leaf var.

Things that might mean I haven't yet fixed the issue:
- [x] is this only fixed because we've come down to one predicate? will try a range
- [x] leaf vars were introduced for performance reasons rather than correctness - does this change introduce a significant performance regression? (I'd guess it doesn't impact any queries outside of this specific case of leaf-vars being used as params to fn clauses)
- [x] I'll try repro it in a query without leaf vars
- [x] the original test was quite contrived, largely because changing it even slightly no longer repro'd the issue - is there another combination of dependencies that still isn't fixed?