### PR TITLE
Fixing intermittent Kafka tx-fn arg doc replacement test, #1256

### DIFF
--- a/crux-test/test/crux/kafka_test.clj
+++ b/crux-test/test/crux/kafka_test.clj
@@ -30,7 +30,6 @@
         (let [submitted-tx (api/submit-tx *api* [[:crux.tx/put evicted-doc]
                                                  [:crux.tx/put non-evicted-doc]])
               _ (api/await-tx *api* submitted-tx)
-              evicted-doc-hash (:crux.db/content-hash (api/entity-tx (api/db *api*) :to-be-evicted))
               _ (api/submit-tx *api* [[:crux.tx/evict (:crux.db/id evicted-doc)]])
               submitted-tx (api/submit-tx *api* [[:crux.tx/put after-evict-doc]])
               _ (api/await-tx *api* submitted-tx nil)]


### PR DESCRIPTION
Fast-tracking tx-fn doc replacements straight to the Kafka local doc-store, fixes #1256