### PR TITLE
Minor cleanup

### DIFF
--- a/crux-core/test/crux/codec_test.clj
+++ b/crux-core/test/crux/codec_test.clj
@@ -148,7 +148,7 @@
                   :where [[e #crux/id "http://xmlns.com/foaf/0.1/firstName" "Pablo"]]})))
 
   (t/testing "URL and keyword are same id"
-    (t/is (= (c/new-id :http://xmlns.com/foaf/0.1/firstName)
+    (t/is (= (c/new-id (keyword "http://xmlns.com/foaf/0.1/firstName"))
              #crux/id "http://xmlns.com/foaf/0.1/firstName"))
     (t/is (= (c/new-id (URL. "http://xmlns.com/foaf/0.1/firstName"))
              #crux/id ":http://xmlns.com/foaf/0.1/firstName"))

--- a/crux-rdf/test/crux/rdf_test.clj
+++ b/crux-rdf/test/crux/rdf_test.clj
@@ -10,38 +10,38 @@
                          (rdf/->maps-by-id))]
     (t/is (= 7 (count iri->entity)))
 
-    (let [artist (:http://example.org/Picasso iri->entity)
-          painting (:http://example.org/creatorOf artist)]
+    (let [artist ((keyword "http://example.org/Picasso") iri->entity)
+          painting ((keyword "http://example.org/creatorOf") artist)]
 
-      (t/is (= :http://example.org/guernica painting))
+      (t/is (= (keyword "http://example.org/guernica") painting))
       (t/is (= "oil on canvas"
                (-> painting
                    iri->entity
-                   :http://example.org/technique)))
+                   (get (keyword "http://example.org/technique")))))
 
-      (t/is (= {:http://example.org/street "31 Art Gallery",
-                :http://example.org/city "Madrid",
-                :http://example.org/country "Spain"}
+      (t/is (= {(keyword "http://example.org/street") "31 Art Gallery",
+                (keyword "http://example.org/city") "Madrid",
+                (keyword "http://example.org/country") "Spain"}
                (-> artist
-                   :http://example.org/homeAddress
+                   (get (keyword "http://example.org/homeAddress"))
                    iri->entity
                    (dissoc :crux.db/id)))))))
 
 (t/deftest test-can-parse-dbpedia-entity
   (let [picasso (-> (->> (rdf/ntriples "crux/Pablo_Picasso.ntriples")
                          (rdf/->maps-by-id))
-                    :http://dbpedia.org/resource/Pablo_Picasso)]
+                    (get (keyword "http://dbpedia.org/resource/Pablo_Picasso")))]
     (t/is (= 48 (count picasso)))
-    (t/is (= {:http://xmlns.com/foaf/0.1/givenName #crux.rdf.Lang{:en "Pablo"}
-              :http://xmlns.com/foaf/0.1/surname #crux.rdf.Lang{:en "Picasso"}
-              :http://dbpedia.org/ontology/birthDate #inst "1881-10-25"}
+    (t/is (= {(keyword "http://xmlns.com/foaf/0.1/givenName") #crux.rdf.Lang{:en "Pablo"}
+              (keyword "http://xmlns.com/foaf/0.1/surname") #crux.rdf.Lang{:en "Picasso"}
+              (keyword "http://dbpedia.org/ontology/birthDate") #inst "1881-10-25"}
              (select-keys picasso
-                          [:http://xmlns.com/foaf/0.1/givenName
-                           :http://xmlns.com/foaf/0.1/surname
-                           :http://dbpedia.org/ontology/birthDate])))
+                          [(keyword "http://xmlns.com/foaf/0.1/givenName")
+                           (keyword "http://xmlns.com/foaf/0.1/surname")
+                           (keyword "http://dbpedia.org/ontology/birthDate")])))
 
-    (t/is (= {:http://xmlns.com/foaf/0.1/givenName "Pablo"
-              :http://xmlns.com/foaf/0.1/surname "Picasso"}
+    (t/is (= {(keyword "http://xmlns.com/foaf/0.1/givenName") "Pablo"
+              (keyword "http://xmlns.com/foaf/0.1/surname") "Picasso"}
              (select-keys (rdf/use-default-language picasso :en)
-                          [:http://xmlns.com/foaf/0.1/givenName
-                           :http://xmlns.com/foaf/0.1/surname])))))
+                          [(keyword "http://xmlns.com/foaf/0.1/givenName")
+                           (keyword "http://xmlns.com/foaf/0.1/surname")])))))

--- a/crux-rdf/test/crux/sparql_test.clj
+++ b/crux-rdf/test/crux/sparql_test.clj
@@ -73,9 +73,9 @@ WHERE
 
     (t/is (= '{:find [?name],
                :where
-               [[?x :http://xmlns.com/foaf/0.1/givenName ?name]
-                [?x :http://xmlns.com/foaf/0.1/knows ?y]
-                [(== ?y #{:http://example.org/A :http://example.org/B})]]}
+               [[?x #=(keyword "http://xmlns.com/foaf/0.1/givenName") ?name]
+                [?x #=(keyword "http://xmlns.com/foaf/0.1/knows") ?y]
+                [(== ?y #{#=(keyword "http://example.org/A") #=(keyword "http://example.org/B")})]]}
              (sparql/sparql->datalog
               "
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -89,10 +89,10 @@ WHERE
 
     (t/is (= '{:find [?name],
                :where
-               [[?x :http://xmlns.com/foaf/0.1/givenName ?name]
-                [?x :http://xmlns.com/foaf/0.1/knows ?y]
-                [(!= ?y :http://example.org/A)]
-                [(!= ?y :http://example.org/B)]]}
+               [[?x #=(keyword "http://xmlns.com/foaf/0.1/givenName") ?name]
+                [?x #=(keyword "http://xmlns.com/foaf/0.1/knows") ?y]
+                [(!= ?y #=(keyword "http://example.org/A"))]
+                [(!= ?y #=(keyword "http://example.org/B"))]]}
              (sparql/sparql->datalog
               "
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -110,8 +110,8 @@ WHERE
     (t/is
      (= '{:find [?title],
           :where
-          [[:http://example.org/book/book1
-            :http://purl.org/dc/elements/1.1/title
+          [[#=(keyword "http://example.org/book/book1")
+            #=(keyword "http://purl.org/dc/elements/1.1/title")
             ?title]]}
         (sparql/sparql->datalog
          "SELECT ?title
@@ -123,8 +123,8 @@ WHERE
     (t/is
      (= '{:find [?name ?mbox],
           :where
-          [[?x :http://xmlns.com/foaf/0.1/name ?name]
-           [?x :http://xmlns.com/foaf/0.1/mbox ?mbox]]}
+          [[?x #=(keyword "http://xmlns.com/foaf/0.1/name") ?name]
+           [?x #=(keyword "http://xmlns.com/foaf/0.1/mbox") ?mbox]]}
         (sparql/sparql->datalog
          "PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
 SELECT ?name ?mbox
@@ -139,16 +139,16 @@ WHERE
     (t/is
      (= '{:find [?v],
           :where
-          [[?v :http://xmlns.com/foaf/0.1/givenName "cat"]]}
+          [[?v #=(keyword "http://xmlns.com/foaf/0.1/givenName") "cat"]]}
         (sparql/sparql->datalog
          "SELECT ?v WHERE { ?v <http://xmlns.com/foaf/0.1/givenName> \"cat\"@en }")))
 
     (t/is
      (= '{:find [?name],
           :where
-          [[?P :http://xmlns.com/foaf/0.1/givenName ?G]
-           [?P :http://xmlns.com/foaf/0.1/surname ?S]
-           [(http://www.w3.org/2005/xpath-functions#concat ?G " " ?S) ?name]]}
+          [[?P #=(keyword "http://xmlns.com/foaf/0.1/givenName") ?G]
+           [?P #=(keyword "http://xmlns.com/foaf/0.1/surname") ?S]
+           [(#=(symbol "http://www.w3.org/2005/xpath-functions#concat") ?G " " ?S) ?name]]}
         (sparql/sparql->datalog
          "
 PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
@@ -162,9 +162,9 @@ WHERE  {
     (t/is
      (= '{:find [?name],
           :where
-          [[?P :http://xmlns.com/foaf/0.1/givenName ?G]
-           [?P :http://xmlns.com/foaf/0.1/surname ?S]
-           [(http://www.w3.org/2005/xpath-functions#concat ?G " " ?S) ?name]]}
+          [[?P #=(keyword "http://xmlns.com/foaf/0.1/givenName") ?G]
+           [?P #=(keyword "http://xmlns.com/foaf/0.1/surname") ?S]
+           [(#=(symbol "http://www.w3.org/2005/xpath-functions#concat") ?G " " ?S) ?name]]}
         (sparql/sparql->datalog
          "
 PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
@@ -174,7 +174,7 @@ WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S }
 
     (t/is (= (cio/pr-edn-str '{:find [?title],
                        :where
-                       [[?x :http://purl.org/dc/elements/1.1/title ?title]
+                       [[?x #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
                         [(re-find #"^SPARQL" ?title)]]})
              (cio/pr-edn-str (sparql/sparql->datalog
                       "
@@ -186,7 +186,7 @@ WHERE   { ?x dc:title ?title
 
     (t/is (= (cio/pr-edn-str '{:find [?title],
                        :where
-                       [[?x :http://purl.org/dc/elements/1.1/title ?title]
+                       [[?x #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
                         [(re-find #"(?i)web" ?title)]]})
              (cio/pr-edn-str (sparql/sparql->datalog
                       "
@@ -198,8 +198,8 @@ WHERE   { ?x dc:title ?title
 
     (t/is (= '{:find [?title ?price],
                :where
-               [[?x :http://example.org/ns#price ?price]
-                [?x :http://purl.org/dc/elements/1.1/title ?title]
+               [[?x #=(keyword "http://example.org/ns#price") ?price]
+                [?x #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
                 [(< ?price 30.5M)]]}
              (sparql/sparql->datalog
               "
@@ -212,12 +212,12 @@ WHERE   { ?x ns:price ?price .
 
     (t/is (= '{:find [?name ?mbox],
                :where
-               [[?x :http://xmlns.com/foaf/0.1/name ?name]
+               [[?x #=(keyword "http://xmlns.com/foaf/0.1/name") ?name]
                 (or-join
                  [?mbox ?x]
-                 [?x :http://xmlns.com/foaf/0.1/mbox ?mbox]
+                 [?x #=(keyword "http://xmlns.com/foaf/0.1/mbox") ?mbox]
                  (and [(identity :crux.sparql/optional) ?mbox]
-                      (not [?x :http://xmlns.com/foaf/0.1/mbox])))]}
+                      (not [?x #=(keyword "http://xmlns.com/foaf/0.1/mbox")])))]}
              (sparql/sparql->datalog
               "
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -228,11 +228,11 @@ WHERE  { ?x foaf:name  ?name .
 
     (t/is (= '{:find [?title ?price],
                :where
-               [[?x :http://purl.org/dc/elements/1.1/title ?title]
+               [[?x #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
                 (or-join
                  [?x ?price]
-                 (and [?x :http://example.org/ns#price ?price] [(< ?price 30)])
-                 (and (not [?x :http://example.org/ns#price])
+                 (and [?x #=(keyword "http://example.org/ns#price") ?price] [(< ?price 30)])
+                 (and (not [?x #=(keyword "http://example.org/ns#price")])
                       [(identity :crux.sparql/optional) ?price]))]}
              (sparql/sparql->datalog "
 PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
@@ -245,8 +245,8 @@ WHERE   { ?x dc:title ?title .
     (t/is (= '{:find [?title],
                :where
                [(or
-                 [?book :http://purl.org/dc/elements/1.0/title ?title]
-                 [?book :http://purl.org/dc/elements/1.1/title ?title])]}
+                 [?book #=(keyword "http://purl.org/dc/elements/1.0/title") ?title]
+                 [?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?title])]}
              (sparql/sparql->datalog "
 PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
 PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
@@ -259,8 +259,8 @@ WHERE  { { ?book dc10:title  ?title } UNION { ?book dc11:title  ?title } }")))
     (t/is (= '{:find [?book],
                :where
                [(or-join [?book]
-                         [?book :http://purl.org/dc/elements/1.0/title ?x]
-                         [?book :http://purl.org/dc/elements/1.1/title ?y])]}
+                         [?book #=(keyword "http://purl.org/dc/elements/1.0/title") ?x]
+                         [?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?y])]}
              (sparql/sparql->datalog "
 PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
 PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
@@ -271,10 +271,10 @@ WHERE  { { ?book dc10:title ?x } UNION { ?book dc11:title  ?y } }")))
 
     (t/is (= '{:find [?title ?author],
                :where
-               [(or (and [?book :http://purl.org/dc/elements/1.0/title ?title]
-                         [?book :http://purl.org/dc/elements/1.0/creator ?author])
-                    (and [?book :http://purl.org/dc/elements/1.1/title ?title]
-                         [?book :http://purl.org/dc/elements/1.1/creator ?author]))]}
+               [(or (and [?book #=(keyword "http://purl.org/dc/elements/1.0/title") ?title]
+                         [?book #=(keyword "http://purl.org/dc/elements/1.0/creator") ?author])
+                    (and [?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
+                         [?book #=(keyword "http://purl.org/dc/elements/1.1/creator") ?author]))]}
              (sparql/sparql->datalog "
 PREFIX dc10:  <http://purl.org/dc/elements/1.0/>
 PREFIX dc11:  <http://purl.org/dc/elements/1.1/>
@@ -290,8 +290,8 @@ WHERE  { { ?book dc10:title ?title .  ?book dc10:creator ?author }
                  :where
                  [[?person
                    :rdf/type
-                   :http://xmlns.com/foaf/0.1/Person]
-                  (not-join [?person] [?person :http://xmlns.com/foaf/0.1/name ?name])]})
+                   #=(keyword "http://xmlns.com/foaf/0.1/Person")]
+                  (not-join [?person] [?person #=(keyword "http://xmlns.com/foaf/0.1/name") ?name])]})
              (sparql/sparql->datalog "
 PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX  foaf:   <http://xmlns.com/foaf/0.1/>
@@ -308,8 +308,8 @@ WHERE
                  :where
                  [[?person
                    :rdf/type
-                   :http://xmlns.com/foaf/0.1/Person]
-                  [?person :http://xmlns.com/foaf/0.1/name ?name]]})
+                   #=(keyword "http://xmlns.com/foaf/0.1/Person")]
+                  [?person #=(keyword "http://xmlns.com/foaf/0.1/name") ?name]]})
              (sparql/sparql->datalog "
 PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX  foaf:   <http://xmlns.com/foaf/0.1/>
@@ -338,13 +338,13 @@ WHERE {
     ;; NOTE: Adapted to remove first rdf:type/ part of the path which
     ;; simply expands to a blank node with a random id.
     (t/is (= '{:find [?x ?type],
-               :where [(http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR ?x ?type)]
-               :rules [[(http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR ?s ?o)
-                        [?s :http://www.w3.org/2000/01/rdf-schema#subClassOf ?o]]
-                       [(http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR ?s ?o)
-                        [?s :http://www.w3.org/2000/01/rdf-schema#subClassOf ?t]
-                        (http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR ?t ?o)]
-                       [(http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR ?s ?o)
+               :where [(#=(symbol "http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR") ?x ?type)]
+               :rules [[(#=(symbol "http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR") ?s ?o)
+                        [?s #=(keyword "http://www.w3.org/2000/01/rdf-schema#subClassOf") ?o]]
+                       [(#=(symbol "http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR") ?s ?o)
+                        [?s #=(keyword "http://www.w3.org/2000/01/rdf-schema#subClassOf") ?t]
+                        (#=(symbol "http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR") ?t ?o)]
+                       [(#=(symbol "http://www.w3.org/2000/01/rdf-schema#subClassOf-STAR") ?s ?o)
                         [?s :crux.db/id]
                         [(identity :crux.sparql/zero-matches) ?o]]]}
              (sparql/sparql->datalog "
@@ -356,12 +356,12 @@ SELECT ?x ?type
 }")))
 
     (t/is (= '{:find [?person],
-               :where [(http://xmlns.com/foaf/0.1/knows-PLUS :http://example/x ?person)]
-               :rules [[(http://xmlns.com/foaf/0.1/knows-PLUS ?s ?o)
-                        [?s :http://xmlns.com/foaf/0.1/knows ?o]]
-                       [(http://xmlns.com/foaf/0.1/knows-PLUS ?s ?o)
-                        [?s :http://xmlns.com/foaf/0.1/knows ?t]
-                        (http://xmlns.com/foaf/0.1/knows-PLUS ?t ?o)]]}
+               :where [(#=(symbol "http://xmlns.com/foaf/0.1/knows-PLUS") #=(keyword "http://example/x") ?person)]
+               :rules [[(#=(symbol "http://xmlns.com/foaf/0.1/knows-PLUS") ?s ?o)
+                        [?s #=(keyword "http://xmlns.com/foaf/0.1/knows") ?o]]
+                       [(#=(symbol "http://xmlns.com/foaf/0.1/knows-PLUS") ?s ?o)
+                        [?s #=(keyword "http://xmlns.com/foaf/0.1/knows") ?t]
+                        (#=(symbol "http://xmlns.com/foaf/0.1/knows-PLUS") ?t ?o)]]}
              (sparql/sparql->datalog "
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX :     <http://example/>
@@ -375,9 +375,9 @@ SELECT ?person
     (t/is (= '{:find [?person],
                :where
                [(or-join [?person]
-                         (and [:http://example/x :crux.db/id]
+                         (and [#=(keyword "http://example/x") :crux.db/id]
                               [(identity :crux.sparql/zero-matches) ?person])
-                         [:http://example/x :http://xmlns.com/foaf/0.1/knows ?person])]}
+                         [#=(keyword "http://example/x") #=(keyword "http://xmlns.com/foaf/0.1/knows") ?person])]}
              (sparql/sparql->datalog "
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX :     <http://example/>
@@ -403,11 +403,11 @@ SELECT  ?title ?price
 
     (t/is (= '{:find [?book ?title ?price],
                :where
-               [[?book :http://purl.org/dc/elements/1.1/title ?title]
-                [?book :http://example.org/ns#price ?price]],
+               [[?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
+                [?book #=(keyword "http://example.org/ns#price") ?price]],
                :args
-               [{?book :http://example.org/book/book1}
-                {?book :http://example.org/book/book3}]}
+               [{?book #=(keyword "http://example.org/book/book1")}
+                {?book #=(keyword "http://example.org/book/book3")}]}
              (sparql/sparql->datalog "
 PREFIX dc:   <http://purl.org/dc/elements/1.1/>
 PREFIX :     <http://example.org/book/>
@@ -422,11 +422,11 @@ SELECT ?book ?title ?price
 
     (t/is (= '{:find [?book ?title ?price],
                :where
-               [[?book :http://purl.org/dc/elements/1.1/title ?title]
-                [?book :http://example.org/ns#price ?price]],
+               [[?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
+                [?book #=(keyword "http://example.org/ns#price") ?price]],
                :args
                [{?book :crux.sparql/undefined, ?title "SPARQL Tutorial"}
-                {?book :http://example.org/book/book2, ?title :crux.sparql/undefined}]}
+                {?book #=(keyword "http://example.org/book/book2"), ?title :crux.sparql/undefined}]}
              (sparql/sparql->datalog "
 PREFIX dc:   <http://purl.org/dc/elements/1.1/>
 PREFIX :     <http://example.org/book/>
@@ -442,11 +442,11 @@ SELECT ?book ?title ?price
 
     (t/is (= '{:find [?book ?title ?price],
                :where
-               [[?book :http://purl.org/dc/elements/1.1/title ?title]
-                [?book :http://example.org/ns#price ?price]],
+               [[?book #=(keyword "http://purl.org/dc/elements/1.1/title") ?title]
+                [?book #=(keyword "http://example.org/ns#price") ?price]],
                :args
                [{?book :crux.sparql/undefined, ?title "SPARQL Tutorial"}
-                {?book :http://example.org/book/book2, ?title :crux.sparql/undefined}]}
+                {?book #=(keyword "http://example.org/book/book2") ?title :crux.sparql/undefined}]}
              (sparql/sparql->datalog "
 PREFIX dc:   <http://purl.org/dc/elements/1.1/>
 PREFIX :     <http://example.org/book/>
@@ -463,7 +463,7 @@ VALUES (?book ?title)
 }")))
 
     (t/is (= '{:find [?name],
-               :where [[?x :http://xmlns.com/foaf/0.1/name ?name]]
+               :where [[?x #=(keyword "http://xmlns.com/foaf/0.1/name") ?name]]
                :limit 20
                :order-by [[?name :asc]]}
              (sparql/sparql->datalog
@@ -479,11 +479,11 @@ LIMIT 20
     (t/is (= (rdf/with-prefix {:wsdbm "http://db.uwaterloo.ca/~galuc/wsdbm/"}
                '{:find [?v0 ?v1 ?v5 ?v2 ?v3]
                  :where [[?v0 :wsdbm/gender :wsdbm/Gender1]
-                         [?v0 :http://purl.org/dc/terms/Location ?v1]
+                         [?v0 #=(keyword "http://purl.org/dc/terms/Location") ?v1]
                          [?v0 :wsdbm/follows ?v0]
                          [?v0 :wsdbm/userId ?v5]
-                         [?v1 :http://www.geonames.org/ontology#parentCountry ?v2]
-                         [?v3 :http://purl.org/ontology/mo/performed_in ?v1]]})
+                         [?v1 #=(keyword "http://www.geonames.org/ontology#parentCountry") ?v2]
+                         [?v3 #=(keyword "http://purl.org/ontology/mo/performed_in") ?v1]]})
              (sparql/sparql->datalog "
 SELECT * WHERE {
    ?v0 <http://db.uwaterloo.ca/~galuc/wsdbm/gender> <http://db.uwaterloo.ca/~galuc/wsdbm/Gender1> .

--- a/crux-sql/test/crux/calcite_microbench_test.clj
+++ b/crux-sql/test/crux/calcite_microbench_test.clj
@@ -4,8 +4,7 @@
             [crux.api :as c]
             [crux.fixtures :as fix :refer [*api*]]
             [crux.fixtures.calcite :as cf]
-            [crux.fixtures.tpch :as tf]
-            [user :as user])
+            [crux.fixtures.tpch :as tf])
   (:import io.airlift.tpch.TpchTable
            java.sql.DriverManager
            java.sql.PreparedStatement))
@@ -34,6 +33,7 @@
     (->> rs resultset-seq (into []))))
 
 (comment
+  (require 'user)
   (load-docs! (user/crux-node))
   (fix/transact! (user/crux-node) (tf/tpch-tables->crux-sql-schemas))
   (def db (c/db (user/crux-node)))

--- a/crux-test/test/crux/dbpedia_test.clj
+++ b/crux-test/test/crux/dbpedia_test.clj
@@ -15,7 +15,7 @@
                                     (rdf/->tx-ops (rdf/ntriples "crux/Guernica_(Picasso).ntriples")))
                             (rdf/->default-language)))
 
-  (t/is (= #{[:http://dbpedia.org/resource/Pablo_Picasso]}
+  (t/is (= #{[(keyword "http://dbpedia.org/resource/Pablo_Picasso")]}
            (crux/q (crux/db *api*)
                    (rdf/with-prefix {:foaf "http://xmlns.com/foaf/0.1/"}
                      '{:find [e]

--- a/crux-test/test/crux/lubm_test.clj
+++ b/crux-test/test/crux/lubm_test.clj
@@ -40,15 +40,15 @@
 ;; This query bears large input and high selectivity. It queries about just one class and
 ;; one property and does not assume any hierarchy information or inference.
 (t/deftest test-lubm-query-01
-  (t/is (= #{[:http://www.Department0.University0.edu/GraduateStudent101]
-             [:http://www.Department0.University0.edu/GraduateStudent124]
-             [:http://www.Department0.University0.edu/GraduateStudent142]
-             [:http://www.Department0.University0.edu/GraduateStudent44]}
+  (t/is (= #{[(keyword "http://www.Department0.University0.edu/GraduateStudent101")]
+             [(keyword "http://www.Department0.University0.edu/GraduateStudent124")]
+             [(keyword "http://www.Department0.University0.edu/GraduateStudent142")]
+             [(keyword "http://www.Department0.University0.edu/GraduateStudent44")]}
            (api/q (api/db *api*)
                   (rdf/with-prefix {:ub "http://swat.cse.lehigh.edu/onto/univ-bench.owl#"}
                     '{:find [x]
                       :where [[x :rdf/type :ub/GraduateStudent]
-                              [x :ub/takesCourse :http://www.Department0.University0.edu/GraduateCourse0]]})))))
+                              [x :ub/takesCourse #=(keyword "http://www.Department0.University0.edu/GraduateCourse0")]]})))))
 
 ;; TODO: subOrganizationOf is transitive, should use rules.
 
@@ -67,12 +67,12 @@
 
 ;; This query is similar to Query 1 but class Publication has a wide hierarchy.
 (t/deftest test-lubm-query-03
-  (t/is (= #{[:http://www.Department0.University0.edu/AssistantProfessor0/Publication0]
-             [:http://www.Department0.University0.edu/AssistantProfessor0/Publication1]
-             [:http://www.Department0.University0.edu/AssistantProfessor0/Publication2]
-             [:http://www.Department0.University0.edu/AssistantProfessor0/Publication3]
-             [:http://www.Department0.University0.edu/AssistantProfessor0/Publication4]
-             [:http://www.Department0.University0.edu/AssistantProfessor0/Publication5]}
+  (t/is (= #{[(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication0")]
+             [(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication1")]
+             [(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication2")]
+             [(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication3")]
+             [(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication4")]
+             [(keyword "http://www.Department0.University0.edu/AssistantProfessor0/Publication5")]}
            (api/q (api/db *api*)
                   (rdf/with-prefix {:ub "http://swat.cse.lehigh.edu/onto/univ-bench.owl#"}
                     '{:find [x]
@@ -84,7 +84,7 @@
                       :where [[x :rdf/type t]
                               (sub-class-of? t :ub/Publication)
                               [x :ub/publicationAuthor
-                               :http://www.Department0.University0.edu/AssistantProfessor0]]})))))
+                               #=(keyword "http://www.Department0.University0.edu/AssistantProfessor0")]]})))))
 
 
 ;; This query has small input and high selectivity. It assumes subClassOf relationship
@@ -102,12 +102,12 @@
                                    (sub-class-of? supertype root-type)]]
                           :where [[x :rdf/type t]
                                   (sub-class-of? t :ub/Professor)
-                                  [x :ub/worksFor :http://www.Department0.University0.edu]
+                                  [x :ub/worksFor #=(keyword "http://www.Department0.University0.edu")]
                                   [x :ub/name y1]
                                   [x :ub/emailAddress y2]
                                   [x :ub/telephone y3]]}))]
     (t/is (= 34 (count result)))
-    #_(t/is (contains? result [:http://www.Department0.University0.edu/AssistantProfessor0
+    #_(t/is (contains? result [(keyword ":http://www.Department0.University0.edu/AssistantProfessor0")
                                "AssistantProfessor0"
                                "AssistantProfessor0@Department0.University0.edu"
                                "xxx-xxx-xxxx"]))))
@@ -132,8 +132,8 @@
                                  :where [[x :rdf/type t]
                                          (person? t)
                                          ;; [x :ub/memberOf :http://www.Department0.University0.edu]
-                                         (or [x :ub/memberOf :http://www.Department0.University0.edu]
-                                             [x :ub/worksFor :http://www.Department0.University0.edu])]}))))))
+                                         (or [x :ub/memberOf #=(keyword "http://www.Department0.University0.edu")]
+                                             [x :ub/worksFor #=(keyword "http://www.Department0.University0.edu")])]}))))))
 
 ;; TODO: Should use rules. Should return 7790 with lubm10.ntriples.
 
@@ -168,7 +168,7 @@
                                         (or [y :rdf/type :ub/Course]
                                             [y :rdf/type :ub/GraduateCourse])
                                         [x :ub/takesCourse y]
-                                        [:http://www.Department0.University0.edu/AssociateProfessor0
+                                        [#=(keyword "http://www.Department0.University0.edu/AssociateProfessor0")
                                          :ub/teacherOf
                                          y]]}))))))
 
@@ -187,7 +187,7 @@
                                              [x :rdf/type :ub/GraduateStudent])
                                          [y :rdf/type :ub/Department]
                                          [x :ub/memberOf y]
-                                         [y :ub/subOrganizationOf :http://www.University0.edu]
+                                         [y :ub/subOrganizationOf #=(keyword "http://www.University0.edu")]
                                          [x :ub/emailAddress z]]}))))))
 
 ;; TODO: Should use rules.
@@ -236,7 +236,7 @@
                                        (or [x :rdf/type :ub/Student]
                                            [x :rdf/type :ub/UndergraduateStudent]
                                            [x :rdf/type :ub/GraduateStudent])
-                                       [x :ub/takesCourse :http://www.Department0.University0.edu/GraduateCourse0]]}))))))
+                                       [x :ub/takesCourse #=(keyword "http://www.Department0.University0.edu/GraduateCourse0")]]}))))))
 
 ;; TODO: should use transitive rule.
 ;; Should return 224 with lubm10.ntriples.
@@ -256,7 +256,7 @@
                                         [x :ub/subOrganizationOf d]
                                         [d :rdf/type :ub/Department]
                                         ;; [x :ub/subOrganizationOf :http://www.University0.edu]
-                                        [d :ub/subOrganizationOf :http://www.University0.edu]]}))))))
+                                        [d :ub/subOrganizationOf #=(keyword "http://www.University0.edu")]]}))))))
 
 ;; TODO: FullProfessor should really be Chair.
 ;; Should return 15 with lubm10.ntriples.
@@ -274,7 +274,7 @@
                                 :where [[x :rdf/type :ub/FullProfessor]
                                         [y :rdf/type :ub/Department]
                                         [x :ub/worksFor y]
-                                        [y :ub/subOrganizationOf :http://www.University0.edu]]})))))
+                                        [y :ub/subOrganizationOf #=(keyword "http://www.University0.edu")]]})))))
 
   ;; TODO: actual result, should use rules.
   #_(t/is (= 1 (count (api/q (api/db *api*)
@@ -282,7 +282,7 @@
                                '{:find [x y]
                                  :where [[y :rdf/type :ub/Department]
                                          [x :ub/headOf y]
-                                         [y :ub/subOrganizationOf :http://www.University0.edu]]}))))))
+                                         [y :ub/subOrganizationOf (keyword "http://www.University0.edu")]]}))))))
 
 ;; TODO: should use rules.
 
@@ -293,7 +293,7 @@
 ;; hasAlumnus. Therefore, this query assumes subPropertyOf relationships between
 ;; degreeFrom and its subproperties, and also requires inference about inverseOf.
 (t/deftest test-lubm-query-13
-  (t/is (= #{[:http://www.Department0.University0.edu/AssistantProfessor2]}
+  (t/is (= #{[(keyword "http://www.Department0.University0.edu/AssistantProfessor2")]}
            (api/q (api/db *api*)
                   (rdf/with-prefix {:rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                                     :ub "http://swat.cse.lehigh.edu/onto/univ-bench.owl#"}
@@ -319,9 +319,9 @@
                                   [x :rdf/type :ub/TeachingAssistant]
                                   [x :rdf/type :ub/ResearchAssistant])
                               ;; [:http://www.University0.edu :ub/hasAlumnus x]
-                              (or [x :ub/undergraduateDegreeFrom :http://www.University0.edu]
-                                  [x :ub/mastersDegreeFrom :http://www.University0.edu]
-                                  [x :ub/doctoralDegreeFrom :http://www.University0.edu])]})))))
+                              (or [x :ub/undergraduateDegreeFrom #=(keyword "http://www.University0.edu")]
+                                  [x :ub/mastersDegreeFrom #=(keyword "http://www.University0.edu")]
+                                  [x :ub/doctoralDegreeFrom #=(keyword "http://www.University0.edu")])]})))))
 
 ;; TODO: Should return 5916 with lubm10.ntriples, which we do.
 

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -28,7 +28,7 @@
     (f)
     (#'tx/reset-tx-fn-error)))
 
-(def picasso-id :http://dbpedia.org/resource/Pablo_Picasso)
+(def picasso-id (keyword "http://dbpedia.org/resource/Pablo_Picasso"))
 (def picasso-eid (c/new-id picasso-id))
 
 (def picasso
@@ -53,15 +53,15 @@
                                    :vt valid-time
                                    :tt tx-time
                                    :tx-id tx-id})
-                 (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso tx-time tx-id))))
+                 (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") tx-time tx-id))))
 
       (t/testing "cannot see entity before valid or transact time"
-        (t/is (nil? (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso #inst "2018-05-20" tx-id)))
-        (t/is (nil? (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso tx-time -1))))
+        (t/is (nil? (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") #inst "2018-05-20" tx-id)))
+        (t/is (nil? (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") tx-time -1))))
 
       (t/testing "can see entity after valid or transact time"
-        (t/is (some? (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso #inst "2018-05-22" tx-id)))
-        (t/is (some? (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso tx-time tx-id))))
+        (t/is (some? (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") #inst "2018-05-22" tx-id)))
+        (t/is (some? (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") tx-time tx-id))))
 
       (t/testing "can see entity history"
         (t/is (= [(c/map->EntityTx {:eid picasso-eid
@@ -69,7 +69,7 @@
                                     :vt valid-time
                                     :tt tx-time
                                     :tx-id tx-id})]
-                 (db/entity-history index-snapshot :http://dbpedia.org/resource/Pablo_Picasso :desc {})))))
+                 (db/entity-history index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") :desc {})))))
 
     (t/testing "add new version of entity in the past"
       (let [new-picasso (assoc picasso :foo :bar)
@@ -85,9 +85,9 @@
                                      :vt new-valid-time
                                      :tt new-tx-time
                                      :tx-id new-tx-id})
-                   (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-id)))
+                   (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time new-tx-id)))
 
-          (t/is (nil? (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso #inst "2018-05-20" -1))))))
+          (t/is (nil? (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") #inst "2018-05-20" -1))))))
 
     (t/testing "add new version of entity in the future"
       (let [new-picasso (assoc picasso :baz :boz)
@@ -103,13 +103,13 @@
                                      :vt new-valid-time
                                      :tt new-tx-time
                                      :tx-id new-tx-id})
-                   (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-id)))
+                   (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time new-tx-id)))
           (t/is (= (c/map->EntityTx {:eid picasso-eid
                                      :content-hash content-hash
                                      :vt valid-time
                                      :tt tx-time
                                      :tx-id tx-id})
-                   (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso new-valid-time tx-id))))
+                   (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time tx-id))))
 
         (t/testing "can correct entity at earlier valid time"
           (let [new-picasso (assoc picasso :bar :foo)
@@ -127,24 +127,24 @@
                                          :vt new-valid-time
                                          :tt new-tx-time
                                          :tx-id new-tx-id})
-                       (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-id)))
+                       (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time new-tx-id)))
 
               (t/is (= prev-tx-id
-                       (:tx-id (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso prev-tx-time prev-tx-id)))))))
+                       (:tx-id (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") prev-tx-time prev-tx-id)))))))
 
         (t/testing "can delete entity"
           (let [new-valid-time #inst "2018-05-23"
                 {new-tx-time :crux.tx/tx-time
                  new-tx-id   :crux.tx/tx-id}
-                (fix/submit+await-tx [[:crux.tx/delete :http://dbpedia.org/resource/Pablo_Picasso new-valid-time]])]
+                (fix/submit+await-tx [[:crux.tx/delete (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time]])]
             (with-open [index-snapshot (db/open-index-snapshot (:index-store *api*))]
-              (t/is (nil? (.content-hash (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso new-valid-time new-tx-id))))
+              (t/is (nil? (.content-hash (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") new-valid-time new-tx-id))))
               (t/testing "first version of entity is still visible in the past"
-                (t/is (= tx-id (:tx-id (db/entity-as-of index-snapshot :http://dbpedia.org/resource/Pablo_Picasso valid-time new-tx-id))))))))))
+                (t/is (= tx-id (:tx-id (db/entity-as-of index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") valid-time new-tx-id))))))))))
 
     (t/testing "can retrieve history of entity"
       (with-open [index-snapshot (db/open-index-snapshot (:index-store *api*))]
-        (t/is (= 5 (count (db/entity-history index-snapshot :http://dbpedia.org/resource/Pablo_Picasso :desc
+        (t/is (= 5 (count (db/entity-history index-snapshot (keyword "http://dbpedia.org/resource/Pablo_Picasso") :desc
                                              {:with-corrections? true}))))))))
 
 (t/deftest test-can-cas-entity


### PR DESCRIPTION
## Context

I'm trying to add Crux (as a git submodule) to the [Eastwood](https://github.com/jonase/eastwood) build, since it's a very interesting project (as it's large, uses `lein-sub`, has many dependencies, type hints, etc).

This PR adds the things for the project to be readable to it; it doesn't try fixing the linting faults it found (some of which are pretty interesting!).

## Commit summary

* `crux.calcite-microbench-test`: don't require `user` ns which isn't necessarily present
* Ensure all keywords and symbols can be read by tools.reader
  * tools.reader is slightly more strict than the Clojure compiler, which doesn't always enforce its constraints due to backwards compatibility concerns ([ref](https://clojure.org/guides/faq#keyword_number)).
  * By making the codebase play better with tools.reader, one can consume Crux while making full use of various tooling.