### PR TITLE
Correct lein-sub script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@6.7.0
   aws-s3: circleci/aws-s3@1.0.15
   node: circleci/node@1.1.6
+  shellcheck: circleci/shellcheck@2.2.3
   crux:
     orbs:
       go: circleci/go@0.2.0
@@ -65,6 +66,7 @@ jobs:
 
     steps:
       - checkout
+      - shellcheck/install
 
       - run: md5sum **/project.clj > .circleci-cache-key
 
@@ -73,6 +75,8 @@ jobs:
           - v1-dependencies-{{ checksum ".circleci-cache-key" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
+
+      - run: shellcheck ./lein-sub
 
       - run:
           command: |

--- a/lein-sub
+++ b/lein-sub
@@ -3,10 +3,10 @@
 set -e
 
 (
-  cd $(dirname $0)
+  cd "$(dirname "$0")"
 
   if [ "$1" == "-s" ]; then
-      MODULES=$(echo $2 | tr ":" "\n" )
+      MODULES=$(echo "$2" | tr ":" "\n" )
       shift 2;
   else
       MODULES="crux-core
@@ -31,9 +31,9 @@ crux-bench"
 
   for MODULE in $MODULES; do
       (
-          echo --$MODULE
-          cd $MODULE > /dev/null
-          lein $@
+          echo --"$MODULE"
+          cd "$MODULE" > /dev/null
+          lein "$@"
       )
   done
 )


### PR DESCRIPTION
The `lein "$@"` change makes complex invocations like `lein update-in ...` work again

This would allow me to proceed with the goal described in https://github.com/juxt/crux/pull/1545

https://app.circleci.com/pipelines/github/reducecombine/crux/7/workflows/3aa9a898-e94f-4b59-81fa-d7cadbde667b appears to be running fine