### PR TITLE
TxLog subscribe

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -231,6 +231,7 @@
                                             :crux/index-store 'crux.kv.index-store/->kv-index-store
                                             :crux/bus 'crux.bus/->bus
                                             :crux/tx-ingester 'crux.tx/->tx-ingester
+                                            :crux/tx-indexer 'crux.tx/->tx-indexer
                                             :crux/document-store 'crux.kv.document-store/->document-store
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
                                             :crux/query-engine 'crux.query/->query-engine}]

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -22,7 +22,9 @@
   (exclusive-avs [this eids])
   (store-index-meta [this k v])
   (tx-failed? [this tx-id])
-  (begin-index-tx [index-store tx fork-at])
+  (begin-index-tx [index-store tx fork-at]))
+
+(defprotocol LatestCompletedTx
   (latest-completed-tx [this]))
 
 (defprotocol IndexMeta

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -2,18 +2,14 @@
   (:require [clojure.set :as set]
             [crux.codec :as c]))
 
-;; tag::Index[]
 (defprotocol Index
   (seek-values [this k])
   (next-values [this]))
-;; end::Index[]
 
-;; tag::LayeredIndex[]
 (defprotocol LayeredIndex
   (open-level [this])
   (close-level [this])
   (max-depth [this]))
-;; end::LayeredIndex[]
 
 (defprotocol IndexStoreTx
   (index-docs [this docs])
@@ -22,14 +18,12 @@
   (commit-index-tx [this])
   (abort-index-tx [this]))
 
-;; tag::IndexStore[]
 (defprotocol IndexStore
   (exclusive-avs [this eids])
   (store-index-meta [this k v])
-  (latest-completed-tx [this])
   (tx-failed? [this tx-id])
-  (begin-index-tx [index-store tx fork-at]))
-;; end::IndexStore[]
+  (begin-index-tx [index-store tx fork-at])
+  (latest-completed-tx [this]))
 
 (defprotocol IndexMeta
   (-read-index-meta [this k not-found]))
@@ -47,7 +41,6 @@
   (^double value-cardinality [this attr])
   (^double eid-cardinality [this attr]))
 
-;; tag::IndexSnapshot[]
 (defprotocol IndexSnapshot
   (av [this a min-v])
   (ave [this a v min-e entity-resolver-fn])
@@ -61,23 +54,25 @@
   (encode-value [this value])
   (resolve-tx [this tx])
   (open-nested-index-snapshot ^java.io.Closeable [this]))
-;; end::IndexSnapshot[]
 
-;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-events])
   (open-tx-log ^crux.api.ICursor [this after-tx-id])
-  (latest-submitted-tx [this]))
-;; end::TxLog[]
-
-(defprotocol TxIngester
-  (begin-tx [tx-ingester tx fork-at])
-  (ingester-error [tx-ingester]))
+  (latest-submitted-tx [this])
+  (^java.util.concurrent.CompletableFuture subscribe [_ after-tx-id f]
+   "f takes Future + tx - complete the future to stop the subscription.
+    or, outside of f, complete the future returned from this function to stop the subscription."))
 
 (defprotocol InFlightTx
   (index-tx-events [in-flight-tx tx-events])
   (commit [in-flight-tx])
   (abort [in-flight-tx]))
+
+(defprotocol TxIndexer
+  (begin-tx [tx-indexer tx fork-at]))
+
+(defprotocol TxIngester
+  (ingester-error [tx-ingester]))
 
 (defprotocol DocumentStore
   "Once `submit-docs` function returns successfully, any call to `fetch-docs` across the cluster must return the submitted docs."

--- a/crux-core/src/crux/ingest_client.clj
+++ b/crux-core/src/crux/ingest_client.clj
@@ -41,7 +41,7 @@
   (let [system (-> (sys/prep-system (into [{:crux/ingest-client `->ingest-client
                                             :crux/bus 'crux.bus/->bus
                                             :crux/document-store 'crux.kv.document-store/->document-store
-                                            :crux/tx-log 'crux.kv.tx-log/->ingest-only-tx-log}]
+                                            :crux/tx-log 'crux.kv.tx-log/->tx-log}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]
     (-> (:crux/ingest-client system)

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -254,7 +254,7 @@
   (when-not (Thread/getDefaultUncaughtExceptionHandler)
     (Thread/setDefaultUncaughtExceptionHandler uncaught-exception-handler)))
 
-(defn thread-factory [name-prefix]
+(defn thread-factory ^java.util.concurrent.ThreadFactory [name-prefix]
   (let [idx (atom 0)]
     (reify ThreadFactory
       (newThread [_ r]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -1110,12 +1110,13 @@
   (store-index-meta [_ k v]
     (store-meta kv-store k v))
 
-  (latest-completed-tx [_]
-    (latest-completed-tx kv-store))
-
   (tx-failed? [_ tx-id]
     (with-open [snapshot (kv/new-snapshot kv-store)]
       (some? (kv/get-value snapshot (encode-failed-tx-id-key-to nil tx-id)))))
+
+  db/LatestCompletedTx
+  (latest-completed-tx [_]
+    (latest-completed-tx kv-store))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -8,14 +8,14 @@
             [crux.memory :as mem]
             [crux.system :as sys]
             [crux.tx :as tx]
-            [crux.tx.event :as txe])
+            [crux.tx.subscribe :as tx-sub])
   (:import java.io.Closeable
            java.nio.ByteOrder
            [java.util.concurrent ExecutorService LinkedBlockingQueue RejectedExecutionHandler ThreadPoolExecutor TimeUnit]
            java.util.Date
            [org.agrona DirectBuffer MutableDirectBuffer]))
 
-(defn encode-tx-event-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b, {:crux.tx/keys [tx-id tx-time]}]
+(defn encode-tx-event-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b, {::tx/keys [tx-id tx-time]}]
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (+ c/index-id-size Long/BYTES Long/BYTES)))]
     (doto b
       (.putByte 0 c/tx-events-index-id)
@@ -30,42 +30,48 @@
 (defn decode-tx-event-key-from [^DirectBuffer k]
   (assert (= (+ c/index-id-size Long/BYTES Long/BYTES) (.capacity k)) (mem/buffer->hex k))
   (assert (tx-event-key? k))
-  {:crux.tx/tx-id (.getLong k c/index-id-size ByteOrder/BIG_ENDIAN)
-   :crux.tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
+  {::tx/tx-id (.getLong k c/index-id-size ByteOrder/BIG_ENDIAN)
+   ::tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
 
-(defn- ingest-tx [tx-ingester tx tx-events]
-  (let [in-flight-tx (db/begin-tx tx-ingester tx nil)]
-    (if (db/index-tx-events in-flight-tx tx-events)
-      (db/commit in-flight-tx)
-      (db/abort in-flight-tx))))
+(defn- latest-submitted-tx [kv-store]
+  (when-let [tx-id (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id)]
+    {::tx/tx-id tx-id}))
 
-(defn- submit-tx [tx-events
-                  {:keys [^ExecutorService tx-submit-executor
-                          ^ExecutorService tx-ingest-executor
-                          kv-store tx-ingester fsync?]}]
+(defn- submit-tx [tx-events {:keys [^ExecutorService tx-submit-executor kv-store fsync? subscriber-handler]}]
   (if (.isShutdown tx-submit-executor)
     ::closed
 
     ;; this needs to remain `:crux.kv-tx-log/latest-submitted-tx-id` because we're a TxLog
     (let [tx-time (Date.)
           tx-id (inc (or (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id) -1))
-          next-tx {:crux.tx/tx-id tx-id, :crux.tx/tx-time tx-time}]
+          next-tx {::tx/tx-id tx-id, ::tx/tx-time tx-time}]
       (kv/store kv-store [[(encode-tx-event-key-to nil next-tx)
                            (mem/->nippy-buffer tx-events)]
                           (kvi/meta-kv :crux.kv-tx-log/latest-submitted-tx-id tx-id)])
 
-      (when (and tx-ingest-executor tx-ingester)
-        (.submit tx-ingest-executor
-                 ^Runnable #(ingest-tx tx-ingester next-tx tx-events)))
-
       (when fsync?
         (kv/fsync kv-store))
 
+      (tx-sub/notify-tx! subscriber-handler next-tx)
+
       next-tx)))
 
+(defn- txs-after [{:keys [kv-store]} after-tx-id {:keys [limit], :or {limit 100}}]
+  (with-open [snapshot (kv/new-snapshot kv-store)
+              iterator (kv/new-iterator snapshot)]
+    (letfn [(tx-log [k]
+              (lazy-seq
+               (when (some-> k (tx-event-key?))
+                 (cons (assoc (decode-tx-event-key-from k)
+                              :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
+                       (tx-log (kv/next iterator))))))]
+      (let [after-tx-id (or (some-> after-tx-id (+ 1)) 0)]
+        (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id after-tx-id})))
+             (take limit)
+             vec)))))
+
 (defrecord KvTxLog [^ExecutorService tx-submit-executor
-                    ^ExecutorService tx-ingest-executor
-                    kv-store tx-ingester fsync?]
+                    kv-store fsync? subscriber-handler]
   db/TxLog
   (submit-tx [this tx-events]
     (when (.isShutdown tx-submit-executor)
@@ -79,30 +85,21 @@
 
           submitted-tx))))
 
-  (latest-submitted-tx [this]
-    (when-let [tx-id (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id)]
-      {::tx/tx-id tx-id}))
+  (latest-submitted-tx [_]
+    (latest-submitted-tx kv-store))
 
   (open-tx-log [this after-tx-id]
     (let [batch-size 100]
       (letfn [(tx-log [after-tx-id]
                 (lazy-seq
-                 (let [txs (with-open [snapshot (kv/new-snapshot kv-store)
-                                       iterator (kv/new-iterator snapshot)]
-                             (letfn [(tx-log [k]
-                                       (lazy-seq
-                                        (when (some-> k (tx-event-key?))
-                                          (cons (assoc (decode-tx-event-key-from k)
-                                                       :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
-                                                (tx-log (kv/next iterator))))))]
-                               (let [after-tx-id (or (some-> after-tx-id (+ 1)) 0)]
-                                 (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id after-tx-id})))
-                                      (take batch-size)
-                                      vec))))]
+                 (let [txs (txs-after this after-tx-id {:limit batch-size})]
                    (concat txs
                            (when (= batch-size (count txs))
                              (tx-log (::tx/tx-id (last txs))))))))]
         (cio/->cursor (fn []) (tx-log after-tx-id)))))
+
+  (subscribe [this after-tx-id f]
+    (tx-sub/handle-notifying-subscriber subscriber-handler this after-tx-id f))
 
   Closeable
   (close [_]
@@ -111,18 +108,8 @@
       (catch Exception e
         (log/warn e "Error shutting down tx-submit-executor")))
 
-    (when tx-ingest-executor
-      (try
-        (.shutdownNow tx-ingest-executor)
-        (catch Exception e
-          (log/warn e "Error shutting down tx-ingest-executor"))))
-
     (or (.awaitTermination tx-submit-executor 5 TimeUnit/SECONDS)
-        (log/warn "waited 5s for tx-submit-executor to exit, no dice."))
-
-    (when tx-ingest-executor
-      (or (.awaitTermination tx-ingest-executor 5 TimeUnit/SECONDS)
-          (log/warn "waited 5s for tx-ingest-executor to exit, no dice.")))))
+        (log/warn "waited 5s for tx-submit-executor to exit, no dice."))))
 
 (defn- bounded-solo-thread-pool [^long queue-size thread-factory]
   (let [queue (LinkedBlockingQueue. queue-size)]
@@ -134,33 +121,8 @@
                            (rejectedExecution [_ runnable executor]
                              (.put queue runnable))))))
 
-(defn ->ingest-only-tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}}
+(defn ->tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}}
   [{:keys [kv-store]}]
   (map->KvTxLog {:tx-submit-executor (bounded-solo-thread-pool 16 (cio/thread-factory "crux-standalone-submit-tx"))
-                 :kv-store kv-store}))
-
-(defn ->tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                            :tx-ingester :crux/tx-ingester
-                            :index-store :crux/index-store}
-                ::sys/args {:fsync? {:spec ::sys/boolean
-                                     :required? true
-                                     :default true}}}
-  [{:keys [tx-ingester index-store kv-store fsync?]}]
-  (let [^ExecutorService ingest-executor (bounded-solo-thread-pool 1024 (cio/thread-factory "crux-standalone-tx-ingest"))
-        tx-log (->KvTxLog (bounded-solo-thread-pool 16 (cio/thread-factory "crux-standalone-submit-tx"))
-                          ingest-executor
-                          kv-store
-                          tx-ingester
-                          fsync?)
-        latest-submitted-tx-id (::tx/tx-id (db/latest-submitted-tx tx-log))
-        latest-completed-tx-id (::tx/tx-id (db/latest-completed-tx index-store))]
-    (when (not= latest-submitted-tx-id latest-completed-tx-id)
-      (.submit ingest-executor
-               ^Runnable (fn []
-                           (with-open [txs (db/open-tx-log tx-log latest-completed-tx-id)]
-                             (doseq [tx (iterator-seq txs)
-                                     :while (<= (::tx/tx-id tx) latest-submitted-tx-id)]
-                               (ingest-tx tx-ingester
-                                          (select-keys tx [::tx/tx-id ::tx/tx-time])
-                                          (::txe/tx-events tx)))))))
-    tx-log))
+                 :kv-store kv-store
+                 :subscriber-handler (tx-sub/->notifying-subscriber-handler (latest-submitted-tx kv-store))}))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1757,7 +1757,7 @@
                               (with-upper-bound :asc (inc tx-id))))
         (dissoc :start-tx :end-tx))))
 
-(defrecord QueryDatasource [document-store index-store bus tx-ingester
+(defrecord QueryDatasource [document-store index-store bus tx-indexer
                             ^Date valid-time ^Date tx-time ^Long tx-id
                             ^ScheduledExecutorService interrupt-executor
                             conform-cache query-cache pull-cache
@@ -1903,15 +1903,14 @@
                       {::tx/tx-time (Date.)
                        ::tx/tx-id 0}))
           conformed-tx-ops (map txc/conform-tx-op tx-ops)
-          in-flight-tx (db/begin-tx tx-ingester tx {::db/valid-time valid-time
+          in-flight-tx (db/begin-tx tx-indexer tx {::db/valid-time valid-time
                                                     ::tx/tx-time tx-time
                                                     ::tx/tx-id tx-id})]
 
       (db/submit-docs in-flight-tx (into {} (mapcat :docs) conformed-tx-ops))
 
       (when (db/index-tx-events in-flight-tx (map txc/->tx-event conformed-tx-ops))
-        (api/db in-flight-tx valid-time))))
-  )
+        (api/db in-flight-tx valid-time)))))
 
 (defmethod print-method QueryDatasource [{:keys [valid-time tx-id]} ^Writer w]
   (.write w (format "#<CruxDB %s>" (cio/pr-edn-str {:crux.db/valid-time valid-time, :crux.tx/tx-id tx-id}))))
@@ -1941,13 +1940,12 @@
           resolved-tx (with-open [index-snapshot (db/open-index-snapshot index-store)]
                         (db/resolve-tx index-snapshot (:crux.tx/tx basis)))]
 
-      ;; we create a new tx-ingester mainly so that it doesn't share state with the main one (!error)
-      ;; we couldn't have QueryEngine depend on the main one anyway, because of a cyclic dependency
+      ;; we can't have QueryEngine depend on the main tx-indexer, because of a cyclic dependency
       (map->QueryDatasource (assoc this
-                                   :tx-ingester (tx/->tx-ingester {:index-store index-store
-                                                                   :document-store document-store
-                                                                   :bus bus
-                                                                   :query-engine this})
+                                   :tx-indexer (tx/->tx-indexer {:index-store index-store
+                                                                 :document-store document-store
+                                                                 :bus bus
+                                                                 :query-engine this})
                                    :pred-ctx @!pred-ctx
                                    :valid-time valid-time
                                    :tx-time (:crux.tx/tx-time resolved-tx)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -414,9 +414,12 @@
   [deps]
   (map->TxIndexer deps))
 
-(defrecord TxIngester [!error ^Future job]
+(defrecord TxIngester [index-store !error ^Future job]
   db/TxIngester
   (ingester-error [_] @!error)
+
+  db/LatestCompletedTx
+  (latest-completed-tx [_] (db/latest-completed-tx index-store))
 
   Closeable
   (close [_]
@@ -444,4 +447,4 @@
                                 (reset! !error t)
                                 (bus/send bus {:crux/event-type ::ingester-error, :ingester-error t})
                                 (throw t)))))]
-    (->TxIngester !error job)))
+    (->TxIngester index-store !error job)))

--- a/crux-core/src/crux/tx/subscribe.clj
+++ b/crux-core/src/crux/tx/subscribe.clj
@@ -1,0 +1,125 @@
+(ns crux.tx.subscribe
+  (:require [clojure.tools.logging :as log]
+            [crux.db :as db]
+            [crux.io :as cio]
+            [crux.tx :as tx])
+  (:import crux.api.ICursor
+           java.time.Duration
+           [java.util.concurrent CompletableFuture Semaphore]
+           java.util.function.BiConsumer))
+
+(def ^java.util.concurrent.ThreadFactory subscription-thread-factory
+  (cio/thread-factory "crux-tx-subscription"))
+
+(defn- completable-thread [f]
+  (let [fut (CompletableFuture.)
+        thread (doto (.newThread subscription-thread-factory
+                                 (fn []
+                                   (try
+                                     (f fut)
+                                     (.complete fut nil)
+                                     (catch Throwable t
+                                       (.completeExceptionally fut t)))))
+                 (.start))]
+    (doto fut
+      (.whenComplete (reify BiConsumer
+                       (accept [_ v e]
+                         (when-not (instance? InterruptedException e)
+                           (.interrupt thread))))))))
+
+(defn- tx-handler [f ^CompletableFuture fut]
+  (fn [_last-tx-id tx]
+    (when (Thread/interrupted)
+      (throw (InterruptedException.)))
+
+    (when (.isDone fut)
+      (reduced nil))
+
+    (f fut tx)
+
+    (::tx/tx-id tx)))
+
+(defn handle-polling-subscription [tx-log after-tx-id {:keys [^Duration poll-sleep-duration]} f]
+  (completable-thread
+   (fn [^CompletableFuture fut]
+     (loop [after-tx-id after-tx-id]
+       (let [last-tx-id (if-let [^ICursor log (try
+                                                (db/open-tx-log tx-log after-tx-id)
+                                                (catch InterruptedException e (throw e))
+                                                (catch Exception e
+                                                  (log/warn e "Error polling for txs, will retry")))]
+                          (try
+                            (reduce (tx-handler f fut)
+                                    after-tx-id
+                                    (some-> log iterator-seq))
+                            (finally
+                              (.close log)))
+
+                          after-tx-id)]
+         (cond
+           (.isDone fut) nil
+           (Thread/interrupted) (throw (InterruptedException.))
+           :else (do
+                   (when (= after-tx-id last-tx-id)
+                     (Thread/sleep (.toMillis poll-sleep-duration)))
+                   (recur last-tx-id))))))))
+
+(defprotocol PNotifyingSubscriberHandler
+  (notify-tx! [_ tx])
+  (handle-notifying-subscriber [_ tx-log after-tx-id f]))
+
+(defrecord NotifyingSubscriberHandler [!latest-submitted-tx-id !semaphores]
+  PNotifyingSubscriberHandler
+  (notify-tx! [_ tx]
+    (let [semaphores (dosync
+                      (ref-set !latest-submitted-tx-id (::tx/tx-id tx))
+                      @!semaphores)]
+      (doseq [^Semaphore semaphore semaphores]
+        (.release semaphore))))
+
+  (handle-notifying-subscriber [_ tx-log after-tx-id f]
+    (let [semaphore (Semaphore. 0)
+          latest-submitted-tx-id (dosync
+                                  (alter !semaphores conj semaphore)
+                                  @!latest-submitted-tx-id)]
+
+      (completable-thread
+       (fn [^CompletableFuture fut]
+         (try
+           (loop [after-tx-id after-tx-id]
+             (let [last-tx-id (if (and latest-submitted-tx-id
+                                       (or (nil? after-tx-id)
+                                           (< after-tx-id latest-submitted-tx-id)))
+                                ;; catching up
+                                (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                  (reduce (tx-handler f fut)
+                                          after-tx-id
+                                          (->> (iterator-seq log)
+                                               (take-while #(<= (::tx/tx-id %) latest-submitted-tx-id)))))
+
+                                ;; running live
+                                (reduce (tx-handler f fut)
+                                        [after-tx-id nil]
+                                        (let [permits (do
+                                                        (.acquire semaphore)
+                                                        (inc (.drainPermits semaphore)))
+                                              limit (if (> permits 100)
+                                                      (do
+                                                        (.release semaphore (- permits 100))
+                                                        100)
+                                                      permits)]
+                                          (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                            (->> (iterator-seq log)
+                                                 (into [] (take limit)))))))]
+               (cond
+                 (.isDone fut) nil
+                 (Thread/interrupted) (throw (InterruptedException.))
+                 :else (recur last-tx-id))))
+
+           (finally
+             (dosync
+              (alter !semaphores disj semaphore)))))))))
+
+(defn ->notifying-subscriber-handler [latest-submitted-tx]
+  (->NotifyingSubscriberHandler (ref (::tx/tx-id latest-submitted-tx))
+                                (ref #{})))

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -11,10 +11,12 @@
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.connection :as jdbcc]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.result-set :as jdbcr]
-            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy])
+            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
+            [crux.tx.subscribe :as tx-sub])
   (:import [com.zaxxer.hikari HikariConfig HikariDataSource]
            java.io.Closeable
            java.sql.Timestamp
+           java.time.Duration
            java.util.Date))
 
 (defprotocol Dialect
@@ -128,12 +130,12 @@
 
 (defrecord JdbcTxLog [pool dialect ^Closeable tx-consumer]
   db/TxLog
-  (submit-tx [this tx-events]
+  (submit-tx [_ tx-events]
     (let [tx (-> (insert-event! pool nil tx-events "txs")
                  (tx-result->tx-data pool dialect))]
       (delay tx)))
 
-  (open-tx-log [this after-tx-id]
+  (open-tx-log [_ after-tx-id]
     (let [conn (jdbc/get-connection pool)
           stmt (jdbc/prepare conn
                              ["SELECT EVENT_OFFSET, TX_TIME, V, TOPIC FROM tx_events WHERE TOPIC = 'txs' and EVENT_OFFSET > ? ORDER BY EVENT_OFFSET"
@@ -146,7 +148,10 @@
                                  :crux.tx/tx-time (-> (:tx_time y) (->date dialect))
                                  :crux.tx.event/tx-events (-> (:v y) (<-blob dialect))}))))))
 
-  (latest-submitted-tx [this]
+  (subscribe [this after-tx-id f]
+    (tx-sub/handle-polling-subscription this after-tx-id {:poll-sleep-duration (Duration/ofMillis 100)} f))
+
+  (latest-submitted-tx [_]
     (when-let [max-offset (-> (jdbc/execute-one! pool ["SELECT max(EVENT_OFFSET) AS max_offset FROM tx_events WHERE topic = 'txs'"]
                                                  {:builder-fn jdbcr/as-unqualified-lower-maps})
                               :max_offset)]
@@ -156,17 +161,6 @@
   (close [_]
     (cio/try-close tx-consumer)))
 
-(defn ->ingest-only-tx-log {::sys/deps {:connection-pool `->connection-pool}}
+(defn ->tx-log {::sys/deps {:connection-pool `->connection-pool}}
   [{{:keys [pool dialect]} :connection-pool}]
   (map->JdbcTxLog {:pool pool, :dialect dialect}))
-
-(defn ->tx-log {::sys/deps (merge (::sys/deps (meta #'tx/->polling-tx-consumer))
-                                  (::sys/deps (meta #'->ingest-only-tx-log)))
-                ::sys/args (merge (::sys/args (meta #'tx/->polling-tx-consumer))
-                                  (::sys/args (meta #'->ingest-only-tx-log)))}
-  [opts]
-  (let [tx-log (->ingest-only-tx-log opts)]
-    (-> tx-log
-        (assoc :tx-consumer (tx/->polling-tx-consumer opts
-                                                      (fn [after-tx-id]
-                                                        (db/open-tx-log tx-log after-tx-id)))))))

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -48,9 +48,9 @@
 
 (t/deftest test-can-set-indexes-kv-store
   (f/with-tmp-dir "data" [data-dir]
-    (with-open [n (api/start-node {:crux/tx-log {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "tx-log")}
-                                   :crux/document-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "doc-store")}
-                                   :crux/index-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "indexes")}})]
+    (with-open [n (api/start-node {:crux/tx-log {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "tx-log")}}
+                                   :crux/document-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "doc-store")}}
+                                   :crux/index-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "indexes")}}})]
       (t/is n))))
 
 (t/deftest start-node-from-java

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -11,7 +11,8 @@
             [crux.node :as n]
             [crux.rocksdb :as rocks]
             [crux.tx :as tx]
-            [crux.tx.event :as txe])
+            [crux.tx.event :as txe]
+            [crux.db :as db])
   (:import [crux.api Crux ICruxAPI CruxDocument]
            [crux.api.tx Transaction]
            java.time.Duration
@@ -134,14 +135,17 @@
                                     :where [[e :name "Ivan"]]}
                                   (object-array 0)))))))
 
+(def ^:private ^:dynamic *latest-completed-tx*)
+
 (defmacro with-latest-tx [latest-tx & body]
-  `(with-redefs [api/latest-completed-tx (fn [node#]
-                                           ~latest-tx)]
+  `(binding [*latest-completed-tx* ~latest-tx]
      ~@body))
 
 (t/deftest test-await-tx
   (let [bus (bus/->bus {})
-        tx-ingester (tx/map->TxIngester {:!error (atom nil)})
+        tx-ingester (reify
+                      db/TxIngester (ingester-error [_] nil)
+                      db/LatestCompletedTx (latest-completed-tx [_] *latest-completed-tx*))
         await-tx (fn [tx timeout]
                    (#'n/await-tx {:bus bus :tx-ingester tx-ingester} ::tx/tx-id tx timeout))
         tx1 {::tx/tx-id 1

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -266,8 +266,8 @@
           (t/is (empty? history)))))))
 
 (defn index-tx [tx tx-events]
-  (let [{:keys [tx-ingester]} *api*
-        in-flight-tx (db/begin-tx tx-ingester tx nil)]
+  (let [{:keys [crux/tx-indexer]} @(:!system *api*)
+        in-flight-tx (db/begin-tx tx-indexer tx nil)]
     (db/index-tx-events in-flight-tx tx-events)
     (db/commit in-flight-tx)))
 

--- a/docs/reference/modules/ROOT/pages/jdbc.adoc
+++ b/docs/reference/modules/ROOT/pages/jdbc.adoc
@@ -102,8 +102,6 @@ EDN::
 ----
 ====
 
-If you do not want the local node to index transactions, you can use the xref:#ingest-only-tx-log[`+crux.jdbc/->ingest-only-tx-log+`] module.
-
 === JDBC as a Document Store
 
 [tabs]
@@ -227,11 +225,6 @@ EDN::
 
 * `connection-pool`
 * `poll-sleep-duration` (string/`Duration`, default 100 milliseconds, `"PT0.1S"`): time to sleep between each poll, if the previous poll didn't yield any transactions.
-
-[#ingest-only-tx-log]
-=== Ingest-only transaction log (`+crux.jdbc/->ingest-only-tx-log+`)
-
-* `connection-pool`
 
 === Document store (`+crux.jdbc/->document-store+`)
 

--- a/docs/reference/modules/ROOT/pages/kafka.adoc
+++ b/docs/reference/modules/ROOT/pages/kafka.adoc
@@ -90,8 +90,6 @@ EDN::
 ----
 ====
 
-If you do not want the local node to index transactions, you can use the xref:ingest-only-tx-log[`+crux.kafka/->ingest-only-tx-log+`] module.
-
 === Kafka as a Document Store
 
 [tabs]
@@ -298,12 +296,6 @@ EDN::
 * `tx-topic-opts` (topic options)
 * `poll-wait-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to wait on each Kafka poll.
 * `poll-sleep-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to sleep between each poll, if the previous poll didn't yield any transactions.
-
-[#ingest-only-tx-log]
-=== Ingest-only transaction log (`+crux.kafka/->ingest-only-tx-log+`)
-
-* `kafka-config` (connection config)
-* `tx-topic-opts` (topic options)
 
 === Document store (`+crux.kafka/->document-store+`)
 

--- a/examples/soak/src/crux/soak/ingest.clj
+++ b/examples/soak/src/crux/soak/ingest.clj
@@ -80,7 +80,7 @@
   (n/set-defaults! {:secret-keys {:soak (config/load-secret-key)}})
 
   (let [mode (first args)]
-    (with-open [node (crux/new-ingest-client [{:crux/tx-log {:crux/module `k/->ingest-only-tx-log}
+    (with-open [node (crux/new-ingest-client [{:crux/tx-log {:crux/module `k/->tx-log}
                                                :crux/document-store {:crux/module `k/->ingest-only-document-store}}
                                               (config/crux-node-config)])]
       (crux/submit-tx node


### PR DESCRIPTION
A brief refactoring ahead of the #1426 work to add a `subscribe` function to the TxLog protocol. Notes:

- Most of this PR is decoupling the tx-log, tx-indexer and tx-ingester. The latter two have been split out to decouple the `begin-tx`/`index-tx-events`/`commit` API from any notion of ingestion processes - there are use cases for the former (e.g. speculative txs, or as a target for more bespoke ingestion processes) and the latter (e.g. Lucene doesn't have this same ability to stop and take a break mid-transaction).
- Now that this is split out, TxLogs don't need to worry about indexing/submit-only nodes - this is done by including (or not!) the tx-ingester in the node. Calling `crux/start-node` includes it, starting an ingest-client (for a submit-only node - rather confusingly named now!) doesn't.
- TxLogs must now implement `subscribe`, which takes a tx-id and a callback, returning `CompletableFuture`. This is trivially implemented for tx-logs - implementers can call `tx-sub/handle-polling-subscription` or, if the tx-log supports some kind of 'notify', it can use `tx-sub/->notify-subscriber-handler`.

This is hence a breaking change for TxLog authors :rotating_light: 
- [ ] Worth running past the folk that we know have created their own TxLogs.