### PR TITLE
Secondary indices for 'async Lucene' #1426

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -234,7 +234,8 @@
                                             :crux/tx-indexer 'crux.tx/->tx-indexer
                                             :crux/document-store 'crux.kv.document-store/->document-store
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
-                                            :crux/query-engine 'crux.query/->query-engine}]
+                                            :crux/query-engine 'crux.query/->query-engine
+                                            :crux/secondary-indices 'crux.tx/->secondary-indices}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]
     (when (and (nil? @cio/malloc-arena-max)

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -19,7 +19,6 @@
   (abort-index-tx [this]))
 
 (defprotocol IndexStore
-  (exclusive-avs [this eids])
   (store-index-meta [this k v])
   (tx-failed? [this tx-id])
   (begin-index-tx [index-store tx fork-at]))

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -1089,24 +1089,6 @@
                         (atom #{}) thread-mgr
                         (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}) (HashMap.))))
 
-  ;; TODO, make use of this fn in unindex-eids
-  (exclusive-avs [_ eids]
-    (with-open [snapshot (kv/new-snapshot kv-store)
-                ecav-i (kv/new-iterator snapshot)
-                av-i (kv/new-iterator snapshot)]
-      (doall
-       (for [eid eids
-             :let [eid-value-buffer (c/->value-buffer eid)]
-             ecav-key (all-keys-in-prefix ecav-i (encode-ecav-key-to nil eid-value-buffer))
-             :let [quad ^Quad (decode-ecav-key-from ecav-key (.capacity eid-value-buffer))
-                   attr-buf (c/->id-buffer (.attr quad))
-                   value-buf ^DirectBuffer (.value quad)
-                   ave-k (encode-ave-key-to nil attr-buf value-buf)]
-             :when (empty? (->> (all-keys-in-prefix av-i ave-k)
-                                (remove (comp #(= eid-value-buffer %)
-                                              #(decode-ave-key->e-from % (.capacity value-buf))))))]
-         [attr-buf value-buf]))))
-
   (store-index-meta [_ k v]
     (store-meta kv-store k v))
 

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -190,11 +190,15 @@
 (defmethod <-tx-event :crux.tx/fn [evt]
   (zipmap [:op :fn-eid :args-content-hash] evt))
 
+(defn conformed-tx-events->doc-hashes [tx-events]
+  (->> tx-events
+       (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
+       (remove #{c/nil-id-buffer})))
+
 (defn tx-events->doc-hashes [tx-events]
   (->> tx-events
        (map <-tx-event)
-       (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
-       (remove #{c/nil-id-buffer})))
+       (conformed-tx-events->doc-hashes)))
 
 (defn tx-events->tx-ops [document-store tx-events]
   (let [docs (db/fetch-docs document-store (tx-events->doc-hashes tx-events))]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -988,7 +988,7 @@
 (t/deftest raises-tx-events-422
   (let [!events (atom [])
         !latch (promise)]
-    (bus/listen (:bus *api*) {:crux/event-types #{::tx/indexing-tx ::tx/committing-tx ::tx/indexed-tx}}
+    (bus/listen (:bus *api*) {:crux/event-types #{::tx/indexing-tx ::tx/indexed-tx}}
                 (fn [evt]
                   (swap! !events conj evt)
                   (when (= ::tx/indexed-tx (:crux/event-type evt))
@@ -1003,10 +1003,6 @@
         (t/is false))
 
       (t/is (= [{:crux/event-type ::tx/indexing-tx, :submitted-tx submitted-tx}
-                {:crux/event-type ::tx/committing-tx,
-                 :submitted-tx submitted-tx,
-                 :evicting-eids #{}
-                 :doc-ids doc-ids}
                 {:crux/event-type ::tx/indexed-tx,
                  :submitted-tx submitted-tx,
                  :committed? true
@@ -1019,7 +1015,7 @@
                                    #crux/id "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
                                    #crux/id "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
                (-> (vec @!events)
-                   (update 2 dissoc :bytes-indexed)))))))
+                   (update 1 dissoc :bytes-indexed)))))))
 
 (t/deftest await-fails-quickly-738
   (with-redefs [tx/index-tx-event (fn [_ _ _]

--- a/docs/reference/modules/ROOT/pages/lucene.adoc
+++ b/docs/reference/modules/ROOT/pages/lucene.adoc
@@ -46,7 +46,7 @@ JSON::
 ----
 {
   "crux.lucene/lucene-store": {
-        "db-dir": "lucene",
+    "db-dir": "lucene",
   }
 }
 ----
@@ -67,12 +67,6 @@ EDN::
  :crux.lucene/lucene-store {:db-dir "lucene-dir"}}
 ----
 ====
-
-[WARNING]
-You must have a fresh node to add Lucene configuration to.
-If you add Lucene configuration to a populated Crux node, you will receive an exception when the node starts up: `Lucene store latest tx mismatch`.
-To remedy this, you must wipe the index directories for the Crux node and restart.
-The Lucene index will then be populated as part of the normal Crux node ingestion process.
 
 == Querying
 
@@ -117,8 +111,8 @@ It's possible to supply var bindings to use in `text-search`:
 
 [source,clojure]
 ----
-(c/q db '{:find  [?v]
-          :in    [input]
+(c/q db '{:find [?v]
+          :in [input]
           :where [[(text-search :name input) [[?e ?v]]]]}
      "Ivan")
 ----


### PR DESCRIPTION
Based on #1554, real diff here: https://github.com/jarohen/crux/compare/subscribe-async...jarohen:secondary-indices-1426. Replaces #1535.

This PR adds the ability to register 'secondary indices' with the Crux transaction ingester. 

- Secondary indices are 'caught up' to the Crux node on startup (blocking startup until the secondary indices are at least at the same transaction as the Crux indices), and then, when further transactions come in, these are passed to the secondary index before the Crux transaction commits.
- Calls to `await-tx` return after all registered secondary indices have indexed the transaction.
- This looks similar to but isn't quite two-phase commit (2PC), largely because we can't guarantee that secondary indices will support a notion of transactionality. The upshot of this is that, should one of the secondary indices throw an exception when indexing a transaction, other secondary indices may already have committed the change. 
 
In short:
- Crux 'prepares' the transaction, the secondary indices (hopefully) all commit, then Crux commits its own transaction. 
- If any of the secondary indices fail, the transaction is not committed to the Crux indices and Crux ingestion stops abruptly, in order for the user to manually resolve the situation.

Lucene is the first example of such a secondary index. This means that Lucene no longer needs to be in lockstep with Crux on startup (no more 'Lucene tx mismatch' - resolves #1426).

- [x] Bring over tidy-up commits from the other PR
- [ ] Worth running past a few folk that we know are using `crux-lucene`
