### PR TITLE
Lucene infrequent fsyncing, #1500

### DIFF
--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -231,6 +231,7 @@
                                             :crux/index-store 'crux.kv.index-store/->kv-index-store
                                             :crux/bus 'crux.bus/->bus
                                             :crux/tx-ingester 'crux.tx/->tx-ingester
+                                            :crux/tx-indexer 'crux.tx/->tx-indexer
                                             :crux/document-store 'crux.kv.document-store/->document-store
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
                                             :crux/query-engine 'crux.query/->query-engine}]

--- a/crux-core/src/crux/api.clj
+++ b/crux-core/src/crux/api.clj
@@ -234,7 +234,8 @@
                                             :crux/tx-indexer 'crux.tx/->tx-indexer
                                             :crux/document-store 'crux.kv.document-store/->document-store
                                             :crux/tx-log 'crux.kv.tx-log/->tx-log
-                                            :crux/query-engine 'crux.query/->query-engine}]
+                                            :crux/query-engine 'crux.query/->query-engine
+                                            :crux/secondary-indices 'crux.tx/->secondary-indices}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]
     (when (and (nil? @cio/malloc-arena-max)

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -19,7 +19,6 @@
   (abort-index-tx [this]))
 
 (defprotocol IndexStore
-  (exclusive-avs [this eids])
   (store-index-meta [this k v])
   (tx-failed? [this tx-id])
   (begin-index-tx [index-store tx fork-at]))

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -22,7 +22,9 @@
   (exclusive-avs [this eids])
   (store-index-meta [this k v])
   (tx-failed? [this tx-id])
-  (begin-index-tx [index-store tx fork-at])
+  (begin-index-tx [index-store tx fork-at]))
+
+(defprotocol LatestCompletedTx
   (latest-completed-tx [this]))
 
 (defprotocol IndexMeta

--- a/crux-core/src/crux/db.clj
+++ b/crux-core/src/crux/db.clj
@@ -2,18 +2,14 @@
   (:require [clojure.set :as set]
             [crux.codec :as c]))
 
-;; tag::Index[]
 (defprotocol Index
   (seek-values [this k])
   (next-values [this]))
-;; end::Index[]
 
-;; tag::LayeredIndex[]
 (defprotocol LayeredIndex
   (open-level [this])
   (close-level [this])
   (max-depth [this]))
-;; end::LayeredIndex[]
 
 (defprotocol IndexStoreTx
   (index-docs [this docs])
@@ -22,14 +18,12 @@
   (commit-index-tx [this])
   (abort-index-tx [this]))
 
-;; tag::IndexStore[]
 (defprotocol IndexStore
   (exclusive-avs [this eids])
   (store-index-meta [this k v])
-  (latest-completed-tx [this])
   (tx-failed? [this tx-id])
-  (begin-index-tx [index-store tx fork-at]))
-;; end::IndexStore[]
+  (begin-index-tx [index-store tx fork-at])
+  (latest-completed-tx [this]))
 
 (defprotocol IndexMeta
   (-read-index-meta [this k not-found]))
@@ -47,7 +41,6 @@
   (^double value-cardinality [this attr])
   (^double eid-cardinality [this attr]))
 
-;; tag::IndexSnapshot[]
 (defprotocol IndexSnapshot
   (av [this a min-v])
   (ave [this a v min-e entity-resolver-fn])
@@ -61,23 +54,25 @@
   (encode-value [this value])
   (resolve-tx [this tx])
   (open-nested-index-snapshot ^java.io.Closeable [this]))
-;; end::IndexSnapshot[]
 
-;; tag::TxLog[]
 (defprotocol TxLog
   (submit-tx [this tx-events])
   (open-tx-log ^crux.api.ICursor [this after-tx-id])
-  (latest-submitted-tx [this]))
-;; end::TxLog[]
-
-(defprotocol TxIngester
-  (begin-tx [tx-ingester tx fork-at])
-  (ingester-error [tx-ingester]))
+  (latest-submitted-tx [this])
+  (^java.util.concurrent.CompletableFuture subscribe [_ after-tx-id f]
+   "f takes Future + tx - complete the future to stop the subscription.
+    or, outside of f, complete the future returned from this function to stop the subscription."))
 
 (defprotocol InFlightTx
   (index-tx-events [in-flight-tx tx-events])
   (commit [in-flight-tx])
   (abort [in-flight-tx]))
+
+(defprotocol TxIndexer
+  (begin-tx [tx-indexer tx fork-at]))
+
+(defprotocol TxIngester
+  (ingester-error [tx-ingester]))
 
 (defprotocol DocumentStore
   "Once `submit-docs` function returns successfully, any call to `fetch-docs` across the cluster must return the submitted docs."

--- a/crux-core/src/crux/ingest_client.clj
+++ b/crux-core/src/crux/ingest_client.clj
@@ -41,7 +41,7 @@
   (let [system (-> (sys/prep-system (into [{:crux/ingest-client `->ingest-client
                                             :crux/bus 'crux.bus/->bus
                                             :crux/document-store 'crux.kv.document-store/->document-store
-                                            :crux/tx-log 'crux.kv.tx-log/->ingest-only-tx-log}]
+                                            :crux/tx-log 'crux.kv.tx-log/->tx-log}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]
     (-> (:crux/ingest-client system)

--- a/crux-core/src/crux/io.clj
+++ b/crux-core/src/crux/io.clj
@@ -254,7 +254,7 @@
   (when-not (Thread/getDefaultUncaughtExceptionHandler)
     (Thread/setDefaultUncaughtExceptionHandler uncaught-exception-handler)))
 
-(defn thread-factory [name-prefix]
+(defn thread-factory ^java.util.concurrent.ThreadFactory [name-prefix]
   (let [idx (atom 0)]
     (reify ThreadFactory
       (newThread [_ r]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -1110,12 +1110,13 @@
   (store-index-meta [_ k v]
     (store-meta kv-store k v))
 
-  (latest-completed-tx [_]
-    (latest-completed-tx kv-store))
-
   (tx-failed? [_ tx-id]
     (with-open [snapshot (kv/new-snapshot kv-store)]
       (some? (kv/get-value snapshot (encode-failed-tx-id-key-to nil tx-id)))))
+
+  db/LatestCompletedTx
+  (latest-completed-tx [_]
+    (latest-completed-tx kv-store))
 
   db/IndexMeta
   (-read-index-meta [_ k not-found]

--- a/crux-core/src/crux/kv/index_store.clj
+++ b/crux-core/src/crux/kv/index_store.clj
@@ -1089,24 +1089,6 @@
                         (atom #{}) thread-mgr
                         (nop-cache/->nop-cache {}) (nop-cache/->nop-cache {}) (HashMap.))))
 
-  ;; TODO, make use of this fn in unindex-eids
-  (exclusive-avs [_ eids]
-    (with-open [snapshot (kv/new-snapshot kv-store)
-                ecav-i (kv/new-iterator snapshot)
-                av-i (kv/new-iterator snapshot)]
-      (doall
-       (for [eid eids
-             :let [eid-value-buffer (c/->value-buffer eid)]
-             ecav-key (all-keys-in-prefix ecav-i (encode-ecav-key-to nil eid-value-buffer))
-             :let [quad ^Quad (decode-ecav-key-from ecav-key (.capacity eid-value-buffer))
-                   attr-buf (c/->id-buffer (.attr quad))
-                   value-buf ^DirectBuffer (.value quad)
-                   ave-k (encode-ave-key-to nil attr-buf value-buf)]
-             :when (empty? (->> (all-keys-in-prefix av-i ave-k)
-                                (remove (comp #(= eid-value-buffer %)
-                                              #(decode-ave-key->e-from % (.capacity value-buf))))))]
-         [attr-buf value-buf]))))
-
   (store-index-meta [_ k v]
     (store-meta kv-store k v))
 

--- a/crux-core/src/crux/kv/tx_log.clj
+++ b/crux-core/src/crux/kv/tx_log.clj
@@ -8,14 +8,14 @@
             [crux.memory :as mem]
             [crux.system :as sys]
             [crux.tx :as tx]
-            [crux.tx.event :as txe])
+            [crux.tx.subscribe :as tx-sub])
   (:import java.io.Closeable
            java.nio.ByteOrder
            [java.util.concurrent ExecutorService LinkedBlockingQueue RejectedExecutionHandler ThreadPoolExecutor TimeUnit]
            java.util.Date
            [org.agrona DirectBuffer MutableDirectBuffer]))
 
-(defn encode-tx-event-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b, {:crux.tx/keys [tx-id tx-time]}]
+(defn encode-tx-event-key-to ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer b, {::tx/keys [tx-id tx-time]}]
   (let [^MutableDirectBuffer b (or b (mem/allocate-buffer (+ c/index-id-size Long/BYTES Long/BYTES)))]
     (doto b
       (.putByte 0 c/tx-events-index-id)
@@ -30,42 +30,48 @@
 (defn decode-tx-event-key-from [^DirectBuffer k]
   (assert (= (+ c/index-id-size Long/BYTES Long/BYTES) (.capacity k)) (mem/buffer->hex k))
   (assert (tx-event-key? k))
-  {:crux.tx/tx-id (.getLong k c/index-id-size ByteOrder/BIG_ENDIAN)
-   :crux.tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
+  {::tx/tx-id (.getLong k c/index-id-size ByteOrder/BIG_ENDIAN)
+   ::tx/tx-time (c/reverse-time-ms->date (.getLong k (+ c/index-id-size Long/BYTES) ByteOrder/BIG_ENDIAN))})
 
-(defn- ingest-tx [tx-ingester tx tx-events]
-  (let [in-flight-tx (db/begin-tx tx-ingester tx nil)]
-    (if (db/index-tx-events in-flight-tx tx-events)
-      (db/commit in-flight-tx)
-      (db/abort in-flight-tx))))
+(defn- latest-submitted-tx [kv-store]
+  (when-let [tx-id (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id)]
+    {::tx/tx-id tx-id}))
 
-(defn- submit-tx [tx-events
-                  {:keys [^ExecutorService tx-submit-executor
-                          ^ExecutorService tx-ingest-executor
-                          kv-store tx-ingester fsync?]}]
+(defn- submit-tx [tx-events {:keys [^ExecutorService tx-submit-executor kv-store fsync? subscriber-handler]}]
   (if (.isShutdown tx-submit-executor)
     ::closed
 
     ;; this needs to remain `:crux.kv-tx-log/latest-submitted-tx-id` because we're a TxLog
     (let [tx-time (Date.)
           tx-id (inc (or (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id) -1))
-          next-tx {:crux.tx/tx-id tx-id, :crux.tx/tx-time tx-time}]
+          next-tx {::tx/tx-id tx-id, ::tx/tx-time tx-time}]
       (kv/store kv-store [[(encode-tx-event-key-to nil next-tx)
                            (mem/->nippy-buffer tx-events)]
                           (kvi/meta-kv :crux.kv-tx-log/latest-submitted-tx-id tx-id)])
 
-      (when (and tx-ingest-executor tx-ingester)
-        (.submit tx-ingest-executor
-                 ^Runnable #(ingest-tx tx-ingester next-tx tx-events)))
-
       (when fsync?
         (kv/fsync kv-store))
 
+      (tx-sub/notify-tx! subscriber-handler next-tx)
+
       next-tx)))
 
+(defn- txs-after [{:keys [kv-store]} after-tx-id {:keys [limit], :or {limit 100}}]
+  (with-open [snapshot (kv/new-snapshot kv-store)
+              iterator (kv/new-iterator snapshot)]
+    (letfn [(tx-log [k]
+              (lazy-seq
+               (when (some-> k (tx-event-key?))
+                 (cons (assoc (decode-tx-event-key-from k)
+                              :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
+                       (tx-log (kv/next iterator))))))]
+      (let [after-tx-id (or (some-> after-tx-id (+ 1)) 0)]
+        (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id after-tx-id})))
+             (take limit)
+             vec)))))
+
 (defrecord KvTxLog [^ExecutorService tx-submit-executor
-                    ^ExecutorService tx-ingest-executor
-                    kv-store tx-ingester fsync?]
+                    kv-store fsync? subscriber-handler]
   db/TxLog
   (submit-tx [this tx-events]
     (when (.isShutdown tx-submit-executor)
@@ -79,30 +85,21 @@
 
           submitted-tx))))
 
-  (latest-submitted-tx [this]
-    (when-let [tx-id (kvi/read-meta kv-store :crux.kv-tx-log/latest-submitted-tx-id)]
-      {::tx/tx-id tx-id}))
+  (latest-submitted-tx [_]
+    (latest-submitted-tx kv-store))
 
   (open-tx-log [this after-tx-id]
     (let [batch-size 100]
       (letfn [(tx-log [after-tx-id]
                 (lazy-seq
-                 (let [txs (with-open [snapshot (kv/new-snapshot kv-store)
-                                       iterator (kv/new-iterator snapshot)]
-                             (letfn [(tx-log [k]
-                                       (lazy-seq
-                                        (when (some-> k (tx-event-key?))
-                                          (cons (assoc (decode-tx-event-key-from k)
-                                                       :crux.tx.event/tx-events (mem/<-nippy-buffer (kv/value iterator)))
-                                                (tx-log (kv/next iterator))))))]
-                               (let [after-tx-id (or (some-> after-tx-id (+ 1)) 0)]
-                                 (->> (tx-log (kv/seek iterator (encode-tx-event-key-to nil {::tx/tx-id after-tx-id})))
-                                      (take batch-size)
-                                      vec))))]
+                 (let [txs (txs-after this after-tx-id {:limit batch-size})]
                    (concat txs
                            (when (= batch-size (count txs))
                              (tx-log (::tx/tx-id (last txs))))))))]
         (cio/->cursor (fn []) (tx-log after-tx-id)))))
+
+  (subscribe [this after-tx-id f]
+    (tx-sub/handle-notifying-subscriber subscriber-handler this after-tx-id f))
 
   Closeable
   (close [_]
@@ -111,18 +108,8 @@
       (catch Exception e
         (log/warn e "Error shutting down tx-submit-executor")))
 
-    (when tx-ingest-executor
-      (try
-        (.shutdownNow tx-ingest-executor)
-        (catch Exception e
-          (log/warn e "Error shutting down tx-ingest-executor"))))
-
     (or (.awaitTermination tx-submit-executor 5 TimeUnit/SECONDS)
-        (log/warn "waited 5s for tx-submit-executor to exit, no dice."))
-
-    (when tx-ingest-executor
-      (or (.awaitTermination tx-ingest-executor 5 TimeUnit/SECONDS)
-          (log/warn "waited 5s for tx-ingest-executor to exit, no dice.")))))
+        (log/warn "waited 5s for tx-submit-executor to exit, no dice."))))
 
 (defn- bounded-solo-thread-pool [^long queue-size thread-factory]
   (let [queue (LinkedBlockingQueue. queue-size)]
@@ -134,33 +121,8 @@
                            (rejectedExecution [_ runnable executor]
                              (.put queue runnable))))))
 
-(defn ->ingest-only-tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}}
+(defn ->tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store}}
   [{:keys [kv-store]}]
   (map->KvTxLog {:tx-submit-executor (bounded-solo-thread-pool 16 (cio/thread-factory "crux-standalone-submit-tx"))
-                 :kv-store kv-store}))
-
-(defn ->tx-log {::sys/deps {:kv-store 'crux.mem-kv/->kv-store
-                            :tx-ingester :crux/tx-ingester
-                            :index-store :crux/index-store}
-                ::sys/args {:fsync? {:spec ::sys/boolean
-                                     :required? true
-                                     :default true}}}
-  [{:keys [tx-ingester index-store kv-store fsync?]}]
-  (let [^ExecutorService ingest-executor (bounded-solo-thread-pool 1024 (cio/thread-factory "crux-standalone-tx-ingest"))
-        tx-log (->KvTxLog (bounded-solo-thread-pool 16 (cio/thread-factory "crux-standalone-submit-tx"))
-                          ingest-executor
-                          kv-store
-                          tx-ingester
-                          fsync?)
-        latest-submitted-tx-id (::tx/tx-id (db/latest-submitted-tx tx-log))
-        latest-completed-tx-id (::tx/tx-id (db/latest-completed-tx index-store))]
-    (when (not= latest-submitted-tx-id latest-completed-tx-id)
-      (.submit ingest-executor
-               ^Runnable (fn []
-                           (with-open [txs (db/open-tx-log tx-log latest-completed-tx-id)]
-                             (doseq [tx (iterator-seq txs)
-                                     :while (<= (::tx/tx-id tx) latest-submitted-tx-id)]
-                               (ingest-tx tx-ingester
-                                          (select-keys tx [::tx/tx-id ::tx/tx-time])
-                                          (::txe/tx-events tx)))))))
-    tx-log))
+                 :kv-store kv-store
+                 :subscriber-handler (tx-sub/->notifying-subscriber-handler (latest-submitted-tx kv-store))}))

--- a/crux-core/src/crux/query.clj
+++ b/crux-core/src/crux/query.clj
@@ -1757,7 +1757,7 @@
                               (with-upper-bound :asc (inc tx-id))))
         (dissoc :start-tx :end-tx))))
 
-(defrecord QueryDatasource [document-store index-store bus tx-ingester
+(defrecord QueryDatasource [document-store index-store bus tx-indexer
                             ^Date valid-time ^Date tx-time ^Long tx-id
                             ^ScheduledExecutorService interrupt-executor
                             conform-cache query-cache pull-cache
@@ -1903,15 +1903,14 @@
                       {::tx/tx-time (Date.)
                        ::tx/tx-id 0}))
           conformed-tx-ops (map txc/conform-tx-op tx-ops)
-          in-flight-tx (db/begin-tx tx-ingester tx {::db/valid-time valid-time
+          in-flight-tx (db/begin-tx tx-indexer tx {::db/valid-time valid-time
                                                     ::tx/tx-time tx-time
                                                     ::tx/tx-id tx-id})]
 
       (db/submit-docs in-flight-tx (into {} (mapcat :docs) conformed-tx-ops))
 
       (when (db/index-tx-events in-flight-tx (map txc/->tx-event conformed-tx-ops))
-        (api/db in-flight-tx valid-time))))
-  )
+        (api/db in-flight-tx valid-time)))))
 
 (defmethod print-method QueryDatasource [{:keys [valid-time tx-id]} ^Writer w]
   (.write w (format "#<CruxDB %s>" (cio/pr-edn-str {:crux.db/valid-time valid-time, :crux.tx/tx-id tx-id}))))
@@ -1941,13 +1940,12 @@
           resolved-tx (with-open [index-snapshot (db/open-index-snapshot index-store)]
                         (db/resolve-tx index-snapshot (:crux.tx/tx basis)))]
 
-      ;; we create a new tx-ingester mainly so that it doesn't share state with the main one (!error)
-      ;; we couldn't have QueryEngine depend on the main one anyway, because of a cyclic dependency
+      ;; we can't have QueryEngine depend on the main tx-indexer, because of a cyclic dependency
       (map->QueryDatasource (assoc this
-                                   :tx-ingester (tx/->tx-ingester {:index-store index-store
-                                                                   :document-store document-store
-                                                                   :bus bus
-                                                                   :query-engine this})
+                                   :tx-indexer (tx/->tx-indexer {:index-store index-store
+                                                                 :document-store document-store
+                                                                 :bus bus
+                                                                 :query-engine this})
                                    :pred-ctx @!pred-ctx
                                    :valid-time valid-time
                                    :tx-time (:crux.tx/tx-time resolved-tx)

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -414,9 +414,12 @@
   [deps]
   (map->TxIndexer deps))
 
-(defrecord TxIngester [!error ^Future job]
+(defrecord TxIngester [index-store !error ^Future job]
   db/TxIngester
   (ingester-error [_] @!error)
+
+  db/LatestCompletedTx
+  (latest-completed-tx [_] (db/latest-completed-tx index-store))
 
   Closeable
   (close [_]
@@ -444,4 +447,4 @@
                                 (reset! !error t)
                                 (bus/send bus {:crux/event-type ::ingester-error, :ingester-error t})
                                 (throw t)))))]
-    (->TxIngester !error job)))
+    (->TxIngester index-store !error job)))

--- a/crux-core/src/crux/tx/conform.clj
+++ b/crux-core/src/crux/tx/conform.clj
@@ -190,11 +190,15 @@
 (defmethod <-tx-event :crux.tx/fn [evt]
   (zipmap [:op :fn-eid :args-content-hash] evt))
 
+(defn conformed-tx-events->doc-hashes [tx-events]
+  (->> tx-events
+       (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
+       (remove #{c/nil-id-buffer})))
+
 (defn tx-events->doc-hashes [tx-events]
   (->> tx-events
        (map <-tx-event)
-       (mapcat #(keep % [:content-hash :old-content-hash :new-content-hash :args-content-hash]))
-       (remove #{c/nil-id-buffer})))
+       (conformed-tx-events->doc-hashes)))
 
 (defn tx-events->tx-ops [document-store tx-events]
   (let [docs (db/fetch-docs document-store (tx-events->doc-hashes tx-events))]

--- a/crux-core/src/crux/tx/subscribe.clj
+++ b/crux-core/src/crux/tx/subscribe.clj
@@ -1,0 +1,125 @@
+(ns crux.tx.subscribe
+  (:require [clojure.tools.logging :as log]
+            [crux.db :as db]
+            [crux.io :as cio]
+            [crux.tx :as tx])
+  (:import crux.api.ICursor
+           java.time.Duration
+           [java.util.concurrent CompletableFuture Semaphore]
+           java.util.function.BiConsumer))
+
+(def ^java.util.concurrent.ThreadFactory subscription-thread-factory
+  (cio/thread-factory "crux-tx-subscription"))
+
+(defn- completable-thread [f]
+  (let [fut (CompletableFuture.)
+        thread (doto (.newThread subscription-thread-factory
+                                 (fn []
+                                   (try
+                                     (f fut)
+                                     (.complete fut nil)
+                                     (catch Throwable t
+                                       (.completeExceptionally fut t)))))
+                 (.start))]
+    (doto fut
+      (.whenComplete (reify BiConsumer
+                       (accept [_ v e]
+                         (when-not (instance? InterruptedException e)
+                           (.interrupt thread))))))))
+
+(defn- tx-handler [f ^CompletableFuture fut]
+  (fn [_last-tx-id tx]
+    (when (Thread/interrupted)
+      (throw (InterruptedException.)))
+
+    (when (.isDone fut)
+      (reduced nil))
+
+    (f fut tx)
+
+    (::tx/tx-id tx)))
+
+(defn handle-polling-subscription [tx-log after-tx-id {:keys [^Duration poll-sleep-duration]} f]
+  (completable-thread
+   (fn [^CompletableFuture fut]
+     (loop [after-tx-id after-tx-id]
+       (let [last-tx-id (if-let [^ICursor log (try
+                                                (db/open-tx-log tx-log after-tx-id)
+                                                (catch InterruptedException e (throw e))
+                                                (catch Exception e
+                                                  (log/warn e "Error polling for txs, will retry")))]
+                          (try
+                            (reduce (tx-handler f fut)
+                                    after-tx-id
+                                    (some-> log iterator-seq))
+                            (finally
+                              (.close log)))
+
+                          after-tx-id)]
+         (cond
+           (.isDone fut) nil
+           (Thread/interrupted) (throw (InterruptedException.))
+           :else (do
+                   (when (= after-tx-id last-tx-id)
+                     (Thread/sleep (.toMillis poll-sleep-duration)))
+                   (recur last-tx-id))))))))
+
+(defprotocol PNotifyingSubscriberHandler
+  (notify-tx! [_ tx])
+  (handle-notifying-subscriber [_ tx-log after-tx-id f]))
+
+(defrecord NotifyingSubscriberHandler [!latest-submitted-tx-id !semaphores]
+  PNotifyingSubscriberHandler
+  (notify-tx! [_ tx]
+    (let [semaphores (dosync
+                      (ref-set !latest-submitted-tx-id (::tx/tx-id tx))
+                      @!semaphores)]
+      (doseq [^Semaphore semaphore semaphores]
+        (.release semaphore))))
+
+  (handle-notifying-subscriber [_ tx-log after-tx-id f]
+    (let [semaphore (Semaphore. 0)
+          latest-submitted-tx-id (dosync
+                                  (alter !semaphores conj semaphore)
+                                  @!latest-submitted-tx-id)]
+
+      (completable-thread
+       (fn [^CompletableFuture fut]
+         (try
+           (loop [after-tx-id after-tx-id]
+             (let [last-tx-id (if (and latest-submitted-tx-id
+                                       (or (nil? after-tx-id)
+                                           (< after-tx-id latest-submitted-tx-id)))
+                                ;; catching up
+                                (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                  (reduce (tx-handler f fut)
+                                          after-tx-id
+                                          (->> (iterator-seq log)
+                                               (take-while #(<= (::tx/tx-id %) latest-submitted-tx-id)))))
+
+                                ;; running live
+                                (reduce (tx-handler f fut)
+                                        [after-tx-id nil]
+                                        (let [permits (do
+                                                        (.acquire semaphore)
+                                                        (inc (.drainPermits semaphore)))
+                                              limit (if (> permits 100)
+                                                      (do
+                                                        (.release semaphore (- permits 100))
+                                                        100)
+                                                      permits)]
+                                          (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                            (->> (iterator-seq log)
+                                                 (into [] (take limit)))))))]
+               (cond
+                 (.isDone fut) nil
+                 (Thread/interrupted) (throw (InterruptedException.))
+                 :else (recur last-tx-id))))
+
+           (finally
+             (dosync
+              (alter !semaphores disj semaphore)))))))))
+
+(defn ->notifying-subscriber-handler [latest-submitted-tx]
+  (->NotifyingSubscriberHandler (ref (::tx/tx-id latest-submitted-tx))
+                                (ref #{})))

--- a/crux-jdbc/src/crux/jdbc.clj
+++ b/crux-jdbc/src/crux/jdbc.clj
@@ -11,10 +11,12 @@
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.connection :as jdbcc]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.result-set :as jdbcr]
-            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy])
+            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
+            [crux.tx.subscribe :as tx-sub])
   (:import [com.zaxxer.hikari HikariConfig HikariDataSource]
            java.io.Closeable
            java.sql.Timestamp
+           java.time.Duration
            java.util.Date))
 
 (defprotocol Dialect
@@ -128,12 +130,12 @@
 
 (defrecord JdbcTxLog [pool dialect ^Closeable tx-consumer]
   db/TxLog
-  (submit-tx [this tx-events]
+  (submit-tx [_ tx-events]
     (let [tx (-> (insert-event! pool nil tx-events "txs")
                  (tx-result->tx-data pool dialect))]
       (delay tx)))
 
-  (open-tx-log [this after-tx-id]
+  (open-tx-log [_ after-tx-id]
     (let [conn (jdbc/get-connection pool)
           stmt (jdbc/prepare conn
                              ["SELECT EVENT_OFFSET, TX_TIME, V, TOPIC FROM tx_events WHERE TOPIC = 'txs' and EVENT_OFFSET > ? ORDER BY EVENT_OFFSET"
@@ -146,7 +148,10 @@
                                  :crux.tx/tx-time (-> (:tx_time y) (->date dialect))
                                  :crux.tx.event/tx-events (-> (:v y) (<-blob dialect))}))))))
 
-  (latest-submitted-tx [this]
+  (subscribe [this after-tx-id f]
+    (tx-sub/handle-polling-subscription this after-tx-id {:poll-sleep-duration (Duration/ofMillis 100)} f))
+
+  (latest-submitted-tx [_]
     (when-let [max-offset (-> (jdbc/execute-one! pool ["SELECT max(EVENT_OFFSET) AS max_offset FROM tx_events WHERE topic = 'txs'"]
                                                  {:builder-fn jdbcr/as-unqualified-lower-maps})
                               :max_offset)]
@@ -156,17 +161,6 @@
   (close [_]
     (cio/try-close tx-consumer)))
 
-(defn ->ingest-only-tx-log {::sys/deps {:connection-pool `->connection-pool}}
+(defn ->tx-log {::sys/deps {:connection-pool `->connection-pool}}
   [{{:keys [pool dialect]} :connection-pool}]
   (map->JdbcTxLog {:pool pool, :dialect dialect}))
-
-(defn ->tx-log {::sys/deps (merge (::sys/deps (meta #'tx/->polling-tx-consumer))
-                                  (::sys/deps (meta #'->ingest-only-tx-log)))
-                ::sys/args (merge (::sys/args (meta #'tx/->polling-tx-consumer))
-                                  (::sys/args (meta #'->ingest-only-tx-log)))}
-  [opts]
-  (let [tx-log (->ingest-only-tx-log opts)]
-    (-> tx-log
-        (assoc :tx-consumer (tx/->polling-tx-consumer opts
-                                                      (fn [after-tx-id]
-                                                        (db/open-tx-log tx-log after-tx-id)))))))

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -45,28 +45,15 @@
 (defn- ^IndexWriter ->index-writer [^Directory directory ^Analyzer analyzer]
   (IndexWriter. directory, (IndexWriterConfig. analyzer)))
 
-(defn- complete-tx! [^IndexWriter index-writer tx]
-  (let [t (Term. "meta" "latest-completed-tx")
-        d (doto (Document.)
-            (.add (StringField. "meta", "latest-completed-tx" Field$Store/NO))
-            (.add (StoredField. "latest-completed-tx" ^long (:crux.tx/tx-id tx))))]
-    (.updateDocument index-writer t d)))
-
 (defn- ->index-searcher [lucene-store]
   (let [^SearcherManager searcher-manager (:searcher-manager lucene-store)
         s (.acquire searcher-manager)]
     [s (fn [] (.release searcher-manager s))]))
 
-(defn latest-completed-tx [lucene-store]
-  (let [[^IndexSearcher index-searcher index-searcher-release-fn] (->index-searcher lucene-store)]
-    (try
-      (let [q (TermQuery. (Term. "meta" "latest-completed-tx"))]
-        (when-let [^ScoreDoc d (first (.-scoreDocs (.search index-searcher q 1)))]
-          (some-> (.doc index-searcher (.-doc d))
-                  (.get "latest-completed-tx")
-                  (Long/parseLong))))
-      (finally
-        (index-searcher-release-fn)))))
+(defn latest-completed-tx-id [^IndexWriter index-writer]
+  (some-> (into {} (.getLiveCommitData index-writer))
+          (get "crux.tx/tx-id")
+          (Long/parseLong)))
 
 (defn search [lucene-store, ^Query q]
   (assert lucene-store)
@@ -274,15 +261,15 @@
     (q/assoc-pred-ctx! query-engine ::lucene-store lucene-store)
 
     (tx/register-index! secondary-indices
-                        (latest-completed-tx lucene-store)
-                        (fn [{:keys [::txe/tx-events committing?] :as tx}]
+                        (latest-completed-tx-id index-writer)
+                        (fn [{:keys [::tx/tx-id ::txe/tx-events committing?]}]
                           (when committing?
                             (let [{:keys [docs evicted-eids]} (transform-tx-events document-store tx-events)]
                               (when-let [evicting-eids (not-empty evicted-eids)]
                                 (evict! indexer index-writer evicting-eids))
                               (index! indexer index-writer docs)))
 
-                          (complete-tx! index-writer tx)
+                          (.setLiveCommitData index-writer {"crux.tx/tx-id" (str tx-id)})
                           (.maybeRefreshBlocking searcher-manager)))
 
     lucene-store))

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -12,6 +12,7 @@
   (:import crux.query.VarBinding
            java.io.Closeable
            java.nio.file.Path
+           java.time.Duration
            org.apache.lucene.analysis.Analyzer
            org.apache.lucene.analysis.standard.StandardAnalyzer
            [org.apache.lucene.document Document Field$Store StoredField StringField TextField]
@@ -21,10 +22,11 @@
            [org.apache.lucene.search BooleanClause$Occur BooleanQuery$Builder DoubleValuesSource IndexSearcher Query ScoreDoc SearcherManager TermQuery TopDocs]
            [org.apache.lucene.store Directory FSDirectory]))
 
-(defrecord LuceneNode [directory analyzer index-writer searcher-manager indexer]
+(defrecord LuceneNode [directory analyzer index-writer searcher-manager indexer ^Thread fsync-thread]
   Closeable
-  (close [this]
-    (.close ^IndexWriter index-writer)
+  (close [_]
+    (doto fsync-thread (.interrupt) (.join))
+    (cio/try-close index-writer)
     (cio/try-close directory)))
 
 (defn- ^String ->hash-str [eid]
@@ -224,21 +226,49 @@
              :evicted-eids #{}}
             conformed-tx-events)))
 
+(defn- fsync-loop [^IndexWriter index-writer ^Duration fsync-frequency]
+  (log/debug "Starting Lucene fsync-loop...")
+  (try
+    (while true
+      (try
+        (Thread/sleep (.toMillis fsync-frequency))
+        (log/debug "Committing Lucene IndexWriter...")
+        (.commit index-writer)
+        (log/debug "Committed Lucene IndexWriter.")
+
+        (catch InterruptedException e
+          (throw e))
+
+        (catch Throwable t
+          (log/warn t "error during Lucene IndexWriter commit"))))
+
+    (catch InterruptedException _
+      (log/debug "Stopped Lucene fsync-loop."))))
+
 (defn ->lucene-store
   {::sys/args {:db-dir {:doc "Lucene DB Dir"
                         :required? true
-                        :spec ::sys/path}}
+                        :spec ::sys/path}
+               :fsync-frequency {:required? true
+                                 :spec ::sys/duration
+                                 :default "PT5M"}}
    ::sys/deps {:document-store :crux/document-store
                :query-engine :crux/query-engine
                :indexer `->indexer
                :analyzer `->analyzer
                :secondary-indices :crux/secondary-indices}
    ::sys/before #{[:crux/tx-ingester]}}
-  [{:keys [^Path db-dir document-store analyzer indexer query-engine secondary-indices]}]
+  [{:keys [^Path db-dir document-store analyzer indexer query-engine secondary-indices fsync-frequency]}]
   (let [directory (FSDirectory/open db-dir)
         index-writer (->index-writer directory analyzer)
         searcher-manager (SearcherManager. index-writer false false nil)
-        lucene-store (LuceneNode. directory analyzer index-writer searcher-manager indexer)]
+        lucene-store (LuceneNode. directory analyzer
+                                  index-writer searcher-manager
+                                  indexer
+                                  (doto (.newThread (cio/thread-factory "crux-lucene")
+                                                    #(fsync-loop index-writer fsync-frequency))
+                                    (.start)))]
+
     ;; Ensure lucene index exists for immediate queries:
     (.commit index-writer)
     (q/assoc-pred-ctx! query-engine ::lucene-store lucene-store)
@@ -253,7 +283,6 @@
                               (index! indexer index-writer docs)))
 
                           (complete-tx! index-writer tx)
-                          (.commit index-writer) ; TODO aware of #1500
                           (.maybeRefreshBlocking searcher-manager)))
 
     lucene-store))

--- a/crux-lucene/test/crux/fixtures/lucene.clj
+++ b/crux-lucene/test/crux/fixtures/lucene.clj
@@ -18,10 +18,9 @@
   (:crux.lucene/lucene-store @(:!system *api*)))
 
 (defn ^crux.api.ICursor search [f & args]
-  (let [lucene-store (lucene-store)
-        analyzer (:analyzer lucene-store)
+  (let [{:keys [analyzer searcher-manager]} (lucene-store)
         q (apply f analyzer args)]
-    (l/search lucene-store q)))
+    (l/search searcher-manager q)))
 
 (defn doc-count []
   (let [{:keys [^IndexWriter index-writer]} (lucene-store)

--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -201,7 +201,7 @@
     (submit+await-tx [[:crux.tx/put {:crux.db/id "ivan" :name "Ivan"}]])
     (submit+await-tx [[:crux.tx/put {:crux.db/id "ivan" :name "Ivan"}]])
 
-    (t/is (= 2 (lf/doc-count)))
+    (t/is (= 1 (lf/doc-count)))
 
     (with-open [db (c/open-db *api*)]
       (t/is (= prior-score (c/q db q))))))
@@ -239,7 +239,9 @@
       (t/is (empty? (c/q before-db q))))))
 
 (t/deftest test-ensure-lucene-store-keeps-last-tx
-  (let [latest-tx (fn [] (l/latest-completed-tx (:crux.lucene/lucene-store @(:!system *api*))))]
+  (letfn [(latest-tx []
+            (l/latest-completed-tx-id (-> @(:!system *api*)
+                                          (get-in [:crux.lucene/lucene-store :index-writer]))))]
     (t/is (not (latest-tx)))
     (submit+await-tx [[:crux.tx/put {:crux.db/id :ivan :name "Ivank"}]])
 
@@ -371,7 +373,8 @@
                     [:crux.tx/put {:crux.db/id :test-id :name "2345"}]])
 
   (t/is (= (:crux.tx/tx-id (db/latest-completed-tx (:crux/index-store @(:!system *api*))))
-           (l/latest-completed-tx (:crux.lucene/lucene-store @(:!system *api*))))))
+           (l/latest-completed-tx-id (-> @(:!system *api*)
+                                         (get-in [::l/lucene-store :index-writer]))))))
 
 (defn escape-lucene-string [s]
   ;; note this does not handle all cases if spaces are involved, e.g. a trailing " OR" will not be accepted by the QueryParser

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -48,9 +48,9 @@
 
 (t/deftest test-can-set-indexes-kv-store
   (f/with-tmp-dir "data" [data-dir]
-    (with-open [n (api/start-node {:crux/tx-log {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "tx-log")}
-                                   :crux/document-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "doc-store")}
-                                   :crux/index-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "indexes")}})]
+    (with-open [n (api/start-node {:crux/tx-log {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "tx-log")}}
+                                   :crux/document-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "doc-store")}}
+                                   :crux/index-store {:kv-store {:crux/module `rocks/->kv-store, :db-dir (io/file data-dir "indexes")}}})]
       (t/is n))))
 
 (t/deftest start-node-from-java

--- a/crux-test/test/crux/node_test.clj
+++ b/crux-test/test/crux/node_test.clj
@@ -11,7 +11,8 @@
             [crux.node :as n]
             [crux.rocksdb :as rocks]
             [crux.tx :as tx]
-            [crux.tx.event :as txe])
+            [crux.tx.event :as txe]
+            [crux.db :as db])
   (:import [crux.api Crux ICruxAPI CruxDocument]
            [crux.api.tx Transaction]
            java.time.Duration
@@ -134,14 +135,17 @@
                                     :where [[e :name "Ivan"]]}
                                   (object-array 0)))))))
 
+(def ^:private ^:dynamic *latest-completed-tx*)
+
 (defmacro with-latest-tx [latest-tx & body]
-  `(with-redefs [api/latest-completed-tx (fn [node#]
-                                           ~latest-tx)]
+  `(binding [*latest-completed-tx* ~latest-tx]
      ~@body))
 
 (t/deftest test-await-tx
   (let [bus (bus/->bus {})
-        tx-ingester (tx/map->TxIngester {:!error (atom nil)})
+        tx-ingester (reify
+                      db/TxIngester (ingester-error [_] nil)
+                      db/LatestCompletedTx (latest-completed-tx [_] *latest-completed-tx*))
         await-tx (fn [tx timeout]
                    (#'n/await-tx {:bus bus :tx-ingester tx-ingester} ::tx/tx-id tx timeout))
         tx1 {::tx/tx-id 1

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -988,7 +988,7 @@
 (t/deftest raises-tx-events-422
   (let [!events (atom [])
         !latch (promise)]
-    (bus/listen (:bus *api*) {:crux/event-types #{::tx/indexing-tx ::tx/committing-tx ::tx/indexed-tx}}
+    (bus/listen (:bus *api*) {:crux/event-types #{::tx/indexing-tx ::tx/indexed-tx}}
                 (fn [evt]
                   (swap! !events conj evt)
                   (when (= ::tx/indexed-tx (:crux/event-type evt))
@@ -1003,10 +1003,6 @@
         (t/is false))
 
       (t/is (= [{:crux/event-type ::tx/indexing-tx, :submitted-tx submitted-tx}
-                {:crux/event-type ::tx/committing-tx,
-                 :submitted-tx submitted-tx,
-                 :evicting-eids #{}
-                 :doc-ids doc-ids}
                 {:crux/event-type ::tx/indexed-tx,
                  :submitted-tx submitted-tx,
                  :committed? true
@@ -1019,7 +1015,7 @@
                                    #crux/id "62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
                                    #crux/id "f2cb628efd5123743c30137b08282b9dee82104a"]]}]
                (-> (vec @!events)
-                   (update 2 dissoc :bytes-indexed)))))))
+                   (update 1 dissoc :bytes-indexed)))))))
 
 (t/deftest await-fails-quickly-738
   (with-redefs [tx/index-tx-event (fn [_ _ _]

--- a/crux-test/test/crux/tx_test.clj
+++ b/crux-test/test/crux/tx_test.clj
@@ -266,8 +266,8 @@
           (t/is (empty? history)))))))
 
 (defn index-tx [tx tx-events]
-  (let [{:keys [tx-ingester]} *api*
-        in-flight-tx (db/begin-tx tx-ingester tx nil)]
+  (let [{:keys [crux/tx-indexer]} @(:!system *api*)
+        in-flight-tx (db/begin-tx tx-indexer tx nil)]
     (db/index-tx-events in-flight-tx tx-events)
     (db/commit in-flight-tx)))
 

--- a/docs/reference/modules/ROOT/pages/jdbc.adoc
+++ b/docs/reference/modules/ROOT/pages/jdbc.adoc
@@ -102,8 +102,6 @@ EDN::
 ----
 ====
 
-If you do not want the local node to index transactions, you can use the xref:#ingest-only-tx-log[`+crux.jdbc/->ingest-only-tx-log+`] module.
-
 === JDBC as a Document Store
 
 [tabs]
@@ -227,11 +225,6 @@ EDN::
 
 * `connection-pool`
 * `poll-sleep-duration` (string/`Duration`, default 100 milliseconds, `"PT0.1S"`): time to sleep between each poll, if the previous poll didn't yield any transactions.
-
-[#ingest-only-tx-log]
-=== Ingest-only transaction log (`+crux.jdbc/->ingest-only-tx-log+`)
-
-* `connection-pool`
 
 === Document store (`+crux.jdbc/->document-store+`)
 

--- a/docs/reference/modules/ROOT/pages/kafka.adoc
+++ b/docs/reference/modules/ROOT/pages/kafka.adoc
@@ -90,8 +90,6 @@ EDN::
 ----
 ====
 
-If you do not want the local node to index transactions, you can use the xref:ingest-only-tx-log[`+crux.kafka/->ingest-only-tx-log+`] module.
-
 === Kafka as a Document Store
 
 [tabs]
@@ -298,12 +296,6 @@ EDN::
 * `tx-topic-opts` (topic options)
 * `poll-wait-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to wait on each Kafka poll.
 * `poll-sleep-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to sleep between each poll, if the previous poll didn't yield any transactions.
-
-[#ingest-only-tx-log]
-=== Ingest-only transaction log (`+crux.kafka/->ingest-only-tx-log+`)
-
-* `kafka-config` (connection config)
-* `tx-topic-opts` (topic options)
 
 === Document store (`+crux.kafka/->document-store+`)
 

--- a/docs/reference/modules/ROOT/pages/lucene.adoc
+++ b/docs/reference/modules/ROOT/pages/lucene.adoc
@@ -46,7 +46,7 @@ JSON::
 ----
 {
   "crux.lucene/lucene-store": {
-        "db-dir": "lucene",
+    "db-dir": "lucene",
   }
 }
 ----
@@ -67,12 +67,6 @@ EDN::
  :crux.lucene/lucene-store {:db-dir "lucene-dir"}}
 ----
 ====
-
-[WARNING]
-You must have a fresh node to add Lucene configuration to.
-If you add Lucene configuration to a populated Crux node, you will receive an exception when the node starts up: `Lucene store latest tx mismatch`.
-To remedy this, you must wipe the index directories for the Crux node and restart.
-The Lucene index will then be populated as part of the normal Crux node ingestion process.
 
 == Querying
 
@@ -117,8 +111,8 @@ It's possible to supply var bindings to use in `text-search`:
 
 [source,clojure]
 ----
-(c/q db '{:find  [?v]
-          :in    [input]
+(c/q db '{:find [?v]
+          :in [input]
           :where [[(text-search :name input) [[?e ?v]]]]}
      "Ivan")
 ----

--- a/examples/soak/src/crux/soak/ingest.clj
+++ b/examples/soak/src/crux/soak/ingest.clj
@@ -80,7 +80,7 @@
   (n/set-defaults! {:secret-keys {:soak (config/load-secret-key)}})
 
   (let [mode (first args)]
-    (with-open [node (crux/new-ingest-client [{:crux/tx-log {:crux/module `k/->ingest-only-tx-log}
+    (with-open [node (crux/new-ingest-client [{:crux/tx-log {:crux/module `k/->tx-log}
                                                :crux/document-store {:crux/module `k/->ingest-only-document-store}}
                                               (config/crux-node-config)])]
       (crux/submit-tx node


### PR DESCRIPTION
Based on #1555, see most recent commit on this branch for real diff.

Only 'committing' (fsyncing) Lucene's IndexWriter every so often (5m, by default) now that the Lucene index doesn't need to be kept strictly in sync with the main Crux indices.

Resolves #1500.