### PR TITLE
Enable Lucene predicates to apply limits for raw and returned results

### DIFF
--- a/crux-lucene/src/crux/lucene/multi_field.clj
+++ b/crux-lucene/src/crux/lucene/multi_field.clj
@@ -59,7 +59,7 @@
 (defmethod q/pred-constraint 'lucene-text-search [_ {::l/keys [lucene-store] :as pred-ctx}]
   (when-not (instance? LuceneMultiFieldIndexer (:indexer lucene-store))
     (throw (IllegalStateException. "Lucene multi field indexer not configured, consult the docs.")))
-  (l/pred-constraint #'build-lucene-text-query #'resolve-search-results-content-hash pred-ctx))
+  (l/pred-constraint #'build-lucene-text-query #'resolve-search-results-content-hash pred-ctx false))
 
 (defn ->indexer
   [_]


### PR DESCRIPTION
A candidate resolution for #1424 

Whilst contemplating implementing equivalent `limit` functionality on top of the new `l/search` API (and also doing the temporal filtering in userspace), I thought it would be best to have something to that compare to.