### PR TITLE
Create new Lucene analyzers per query

### DIFF
--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -154,7 +154,7 @@
           search-results))
 
 (defmethod q/pred-args-spec 'text-search [_]
-  (s/cat :pred-fn  #{'text-search} :args (s/spec (s/cat :attr keyword? :v (some-fn string? symbol?))) :return (s/? :crux.query/binding)))
+  (s/cat :pred-fn  #{'text-search} :args (s/spec (s/cat :attr keyword? :v (some-fn string? q/logic-var?))) :return (s/? :crux.query/binding)))
 
 (defmethod q/pred-constraint 'text-search [_ pred-ctx]
   (let [resolver (partial resolve-search-results-a-v (second (:arg-bindings pred-ctx)))]
@@ -182,7 +182,7 @@
     (.build b)))
 
 (defmethod q/pred-args-spec 'wildcard-text-search [_]
-  (s/cat :pred-fn #{'wildcard-text-search} :args (s/spec (s/cat :v (some-fn string? symbol?))) :return (s/? :crux.query/binding)))
+  (s/cat :pred-fn #{'wildcard-text-search} :args (s/spec (s/cat :v (some-fn string? q/logic-var?))) :return (s/? :crux.query/binding)))
 
 (defmethod q/pred-constraint 'wildcard-text-search [_ pred-ctx]
   (pred-constraint #'build-query-wildcard #'resolve-search-results-a-v-wildcard pred-ctx))

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -120,7 +120,7 @@
               (parse-query lucene-store query opts)))))
 
 (defn pred-constraint [query-builder results-resolver {:keys [arg-bindings idx-id return-type tuple-idxs-in-join-order ::lucene-store]}]
-  (fn pred-get-attr-constraint [index-snapshot db idx-id->idx join-keys]
+  (fn pred-lucene-constraint [index-snapshot db idx-id->idx join-keys]
     (let [arg-bindings (map (fn [a]
                               (if (instance? VarBinding a)
                                 (q/bound-result-for-var index-snapshot a join-keys)

--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -201,7 +201,7 @@
                                  (for [v (cc/vectorize-value v)
                                        :when (string? v)]
                                    [a v]))))
-            :let [id-str (->hash-str (DocumentId. e a v))
+            :let [id-str (->hash-str (->DocumentId e a v))
                   doc (doto (Document.)
                         ;; To search for triples by e-a-v for deduping
                         (.add (StringField. field-crux-id, id-str, Field$Store/NO))

--- a/crux-lucene/src/crux/lucene/multi_field.clj
+++ b/crux-lucene/src/crux/lucene/multi_field.clj
@@ -5,7 +5,7 @@
             [crux.lucene :as l]
             [crux.memory :as mem]
             [crux.query :as q])
-  (:import org.apache.lucene.analysis.Analyzer
+  (:import org.apache.lucene.analysis.standard.StandardAnalyzer
            [org.apache.lucene.document Document Field Field$Store StoredField StringField TextField]
            [org.apache.lucene.index IndexWriter Term]
            org.apache.lucene.queryparser.classic.QueryParser
@@ -37,10 +37,10 @@
       (.deleteDocuments ^IndexWriter index-writer ^"[Lorg.apache.lucene.search.Query;" (into-array Query [q])))))
 
 (defn ^Query build-lucene-text-query
-  [^Analyzer analyzer, [q & args]]
+  [[q & args]]
   (when-not (string? q)
     (throw (IllegalArgumentException. "lucene-text-search query must be String")))
-  (.parse (QueryParser. "" analyzer) (apply format q args)))
+  (.parse (QueryParser. "" (StandardAnalyzer.)) (apply format q args)))
 
 (defn- resolve-search-results-content-hash
   "Given search results each containing a content-hash, perform a


### PR DESCRIPTION
On the basis of https://stackoverflow.com/a/34498217 ...it seems Lucene's analyzers are not thread-safe, so queries may currently conflict with each other and the indexer. It should be fine to still use the long-lived analyzer created at startup (as a module dep) for index writing, but each query should generate its own new one instead.

I also included a few small tidy ups of the ns.