### PR TITLE
Support multiple Lucene stores via pred opts map with :lucene-store-k

### DIFF
--- a/crux-lucene/src/crux/lucene/multi_field.clj
+++ b/crux-lucene/src/crux/lucene/multi_field.clj
@@ -54,11 +54,9 @@
         search-results))
 
 (defmethod q/pred-args-spec 'lucene-text-search [_]
-  (s/cat :pred-fn #{'lucene-text-search} :args (s/spec (s/cat :query (some-fn string? symbol?) :bindings (s/* :crux.query/binding))) :return (s/? :crux.query/binding)))
+  (s/cat :pred-fn #{'lucene-text-search} :args (s/spec (s/cat :query (some-fn string? q/logic-var?) :bindings (s/* (some-fn string? q/logic-var?)) :opts (s/? (some-fn map? q/logic-var?)))) :return (s/? :crux.query/binding)))
 
-(defmethod q/pred-constraint 'lucene-text-search [_ {::l/keys [lucene-store] :as pred-ctx}]
-  (when-not (instance? LuceneMultiFieldIndexer (:indexer lucene-store))
-    (throw (IllegalStateException. "Lucene multi field indexer not configured, consult the docs.")))
+(defmethod q/pred-constraint 'lucene-text-search [_ pred-ctx]
   (l/pred-constraint #'build-lucene-text-query #'resolve-search-results-content-hash pred-ctx))
 
 (defn ->indexer

--- a/crux-lucene/test/crux/lucene/extension_test.clj
+++ b/crux-lucene/test/crux/lucene/extension_test.clj
@@ -1,0 +1,26 @@
+(ns crux.lucene.extension-test
+  (:require  [clojure.test :as t]
+             [clojure.spec.alpha :as s]
+             [crux.api :as c]
+             [crux.checkpoint :as cp]
+             [crux.db :as db]
+             [crux.fixtures :as fix :refer [*api* submit+await-tx]]
+             [crux.fixtures.lucene :as lf]
+             [crux.lucene :as l]))
+
+(require 'crux.lucene.multi-field :reload) ; for dev, due to changing protocols
+
+(t/deftest test-multiple-lucene-stores
+  (with-open [node (c/start-node {:ave {:crux/module 'crux.lucene/->lucene-store
+                                        :analyzer 'crux.lucene/->analyzer
+                                        :indexer 'crux.lucene/->indexer}
+                                  :multi {:crux/module 'crux.lucene/->lucene-store
+                                          :analyzer 'crux.lucene/->analyzer
+                                          :indexer 'crux.lucene.multi-field/->indexer}})]
+    (submit+await-tx node [[:crux.tx/put {:crux.db/id :ivan
+                                          :firstname "Fred"
+                                          :surname "Smith"}]])
+    (with-open [db (c/open-db node)]
+      (t/is (seq (c/q db '{:find [?e]
+                           :where [[(text-search :firstname "Fre*" {:lucene-store-k :ave}) [[?e]]]
+                                   [(lucene-text-search "firstname:%s AND surname:%s" "Fred" "Smith" {:lucene-store-k :multi}) [[?e]]]]}))))))

--- a/crux-lucene/test/crux/lucene_test.clj
+++ b/crux-lucene/test/crux/lucene_test.clj
@@ -356,14 +356,6 @@
     (t/is (= #{[:ivan] [:fred]} (c/q db {:find '[?e]
                                          :where '[[(or-text-search :name #{"Ivan" "Fred"}) [[?e ?v]]]]})))))
 
-(t/deftest test-cannot-use-multi-field-lucene-queries
-  (require 'crux.lucene.multi-field) ; for defmethods
-
-  (t/is (thrown-with-msg? java.lang.IllegalStateException #"Lucene multi field indexer not configured, consult the docs."
-                          (with-open [db (c/open-db *api*)]
-                            (c/q db {:find '[?e]
-                                     :where '[[(lucene-text-search "firstname: Fred") [[?e]]]]})))))
-
 (t/deftest results-not-limited-to-1000
   (submit+await-tx (for [n (range 1001)] [:crux.tx/put {:crux.db/id n, :description (str "Entity " n)}]))
   (with-open [db (c/open-db *api*)]


### PR DESCRIPTION
Enabled by the recent secondary indexes changes in https://github.com/juxt/crux/pull/1555