### PR TITLE
Change logging to WARN for match failures (instead of DEBUG)

### DIFF
--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -106,7 +106,7 @@
                                                tx-id)
         match? (= (c/new-id content-hash) (c/new-id v))]
     (when-not match?
-      (log/debug "crux.tx/match failure:" (cio/pr-edn-str match-op) "was:" (c/new-id content-hash)))
+      (log/warn "crux.tx/match failure:" (cio/pr-edn-str match-op) "was:" (c/new-id content-hash) "tx-id:" tx-id))
 
     {:abort? (not match?)}))
 

--- a/crux-core/src/crux/tx.clj
+++ b/crux-core/src/crux/tx.clj
@@ -13,13 +13,10 @@
             [crux.tx.conform :as txc]
             [crux.tx.event :as txe])
   (:import clojure.lang.MapEntry
-           crux.api.ICursor
            crux.codec.EntityTx
            java.io.Closeable
-           java.time.Duration
-           [java.util.concurrent CompletableFuture Future]
-           java.util.Date
-           java.util.function.BiConsumer))
+           [java.util.concurrent Future]
+           java.util.Date))
 
 (set! *unchecked-math* :warn-on-boxed)
 

--- a/docs/reference/modules/ROOT/pages/transactions.adoc
+++ b/docs/reference/modules/ROOT/pages/transactions.adoc
@@ -154,6 +154,10 @@ include::example$test/crux/docs/examples/transactions/transactions_test.clj[tags
 
 Match checks the state of an entity - if the entity doesn't match the provided document, the transaction will not continue.
 
+Use the `tx-committed?` API to check whether the transaction was successfully committed or not due to a failed match opeation.
+
+Failures are logged (WARN level).
+
 [tabs]
 ====
 Java::
@@ -184,7 +188,7 @@ include::example$test/crux/docs/examples/transactions/transactions_test.clj[tags
 <3> (optional) <<valid-time,`valid time`>>
 <4> Operation(s) to perform if the document is matched
 
-If the document supplied is `nil`, the match only passes if there does not exist a Document with the given ID.
+If the document supplied is `nil`, the match only passes if there does not exist a document with the given ID.
 --
 ====
 
@@ -224,6 +228,8 @@ It is important to note that Evict is the only operation which will have effects
 Transaction functions are user-supplied functions that run on the individual Crux nodes when a transaction is being ingested.
 
 Transaction functions can be used, for example, to safely check the current database state before applying a transaction, for integrity checks, or to patch an entity.
+
+Failures are logged (WARN level).
 
 [#transaction-functions-anatomy]
 ==== Anatomy


### PR DESCRIPTION
This brings match in line with transaction function and CAS logging.