### PR TITLE
Corda release

### DIFF
--- a/.run/IOUFlowTests.run.xml
+++ b/.run/IOUFlowTests.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="IOUFlowTests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/labs/crux-corda" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value=":examples:iou-workflow:test --tests &quot;com.example.workflow.IOUFlowTests&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/labs/crux-corda/build.gradle.kts
+++ b/labs/crux-corda/build.gradle.kts
@@ -9,6 +9,7 @@ allprojects {
         jcenter()
         maven { url = uri("https://ci-artifactory.corda.r3cev.com/artifactory/corda") }
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
+        maven { url = uri("https://repo.clojars.org") }
     }
 
     tasks.withType(KotlinCompile::class.java).all {

--- a/labs/crux-corda/build.gradle.kts
+++ b/labs/crux-corda/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
     group = "pro.juxt.crux-labs"
-    version = "0.0.1-SNAPSHOT"
+    version = System.getenv("CRUX_VERSION") ?: "dev-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/labs/crux-corda/crux-corda-state/build.gradle.kts
+++ b/labs/crux-corda/crux-corda-state/build.gradle.kts
@@ -39,7 +39,7 @@ publishing {
             name = "ossrh"
             val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
             val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = uri(if (project.hasProperty("release")) releasesRepoUrl else snapshotsRepoUrl)
+            url = uri(if (!version.toString().endsWith("-SNAPSHOT")) releasesRepoUrl else snapshotsRepoUrl)
 
             credentials {
                 username = project.properties["ossrhUsername"] as String

--- a/labs/crux-corda/crux-corda/build.gradle.kts
+++ b/labs/crux-corda/crux-corda/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
             name = "ossrh"
             val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
             val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = uri(if (project.hasProperty("release")) releasesRepoUrl else snapshotsRepoUrl)
+            url = uri(if (!version.toString().endsWith("-SNAPSHOT")) releasesRepoUrl else snapshotsRepoUrl)
 
             credentials {
                 username = project.properties["ossrhUsername"] as String

--- a/labs/crux-corda/crux-corda/build.gradle.kts
+++ b/labs/crux-corda/crux-corda/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val cordaGroup = "net.corda"
-val cordaVersion = "4.5"
+val cordaVersion = "4.8"
 
 dependencies {
     implementation("org.clojure", "clojure", "1.10.0")

--- a/labs/crux-corda/crux-corda/build.gradle.kts
+++ b/labs/crux-corda/crux-corda/build.gradle.kts
@@ -10,16 +10,9 @@ plugins {
 val cordaGroup = "net.corda"
 val cordaVersion = "4.5"
 
-cordapp {
-    workflow {
-        targetPlatformVersion = 4
-        minimumPlatformVersion = 4
-    }
-}
-
 dependencies {
     implementation("org.clojure", "clojure", "1.10.0")
-    implementation("pro.juxt.crux", "crux-core", "1.17.1-rc1")
+    implementation("pro.juxt.crux", "crux-core", "1.18.0-rc1")
     implementation("pro.juxt.clojars-mirrors.com.github.seancorfield", "next.jdbc", "1.2.674")
     implementation(project(":crux-corda-state"))
 

--- a/labs/crux-corda/examples/iou-contract/build.gradle.kts
+++ b/labs/crux-corda/examples/iou-contract/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 val cordaGroup = "net.corda"
-val cordaVersion = "4.5"
+val cordaVersion = "4.8"
 
 cordapp {
     contract {

--- a/labs/crux-corda/examples/iou-workflow/build.gradle.kts
+++ b/labs/crux-corda/examples/iou-workflow/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val cordaGroup = "net.corda"
-val cordaVersion = "4.5"
+val cordaVersion = "4.8"
 
 cordapp {
     workflow {

--- a/labs/crux-corda/examples/iou-workflow/build.gradle.kts
+++ b/labs/crux-corda/examples/iou-workflow/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     cordapp(project(":examples:iou-contract"))
     cordapp(project(":crux-corda-state"))
     cordapp(project(":crux-corda"))
-    implementation("pro.juxt.crux", "crux-core", "1.17.1-rc1")
+    implementation("pro.juxt.crux", "crux-core", "1.18.0-rc1")
 
     testImplementation("junit", "junit", "4.12")
     testImplementation(cordaGroup, "corda-node-driver", cordaVersion)


### PR DESCRIPTION
* Corda needed updating to 1.18.0 - particularly, the implementation of `TxLog.subscribe`. This does make things a little cleaner, on balance (we don't have to implement our own `sync-txs` fn any more because the main Crux ingester takes care of it) but, because it runs on a different thread, it means we can't use the per-thread Corda database connection - we have to create our own. (We probably should have been doing this anyway...)
* Bumped Corda to 4.8
* Fixed IOU tests - now that we're indexing Crux on a different thread we need to ensure we're awaiting the transactions.
* Checked that it releases to Central without issue