### PR TITLE
Tidy up Lucene 1.18 EAV changes

### DIFF
--- a/crux-lucene/test/crux/lucene/extension_test.clj
+++ b/crux-lucene/test/crux/lucene/extension_test.clj
@@ -88,7 +88,7 @@
                                          (for [v (cc/vectorize-value v)
                                                :when (string? v)]
                                            [a v]))))
-            :let [id-str (l/->hash-str (l/->DocumentId e a v))
+            :let [id-str (l/->hash-str {:e e :a a :v v})
                   doc (doto (Document.)
                         ;; To search for triples by e-a-v for deduping
                         (.add (StringField. l/field-crux-id, id-str, Field$Store/NO))
@@ -208,7 +208,7 @@
                                        :when (string? v)]
                                    [a v]))))
             :when (contains? #{:product/title :product/description} a) ;; example - don't index all attributes
-            :let [id-str (l/->hash-str (l/->DocumentId e a v))
+            :let [id-str (l/->hash-str {:e e :a a :v v})
                   doc (doto (Document.)
                         ;; To search for triples by e-a-v for deduping
                         (.add (StringField. l/field-crux-id, id-str, Field$Store/NO))


### PR DESCRIPTION
## Querying

In 1.18 we moved from AV storage to EAV storage for Lucene, so now adding a `distinct` step in the resolver fns is essential to avoiding a cartesian product of lookups.

This is essentially the same as what was discussed previously for the userspace limit fn https://github.com/juxt/crux/blob/master/crux-lucene/test/crux/lucene/extension_test.clj#L38-L54

Unfortunately we can't introduce the `distinct` within `l/pred-constraint` generically, since it won't work across the equality of the Lucene documents.

~~Alternatively we could revert the move to EAVs (and the removal of `exclusive-avs`).~~

## Indexing

I have attempted to re-use as many of the Lucene objects (Documents and Fields) where possible to avoid GC churn, although this seems to only offer very marginal to benefit performance, if any. Motivated by a suggestion in https://cwiki.apache.org/confluence/display/lucene/ImproveIndexingSpeed

~~I have stripped out field-crux-id and change updateDocument to addDocument since there is no longer any structural sharing.~~

~~I also moved `maybeRefreshBlocking` to the start of `search*`. This might slow down searches slightly but in the grand scheme of things is probably the better tradeoff.~~

~~These two changes alone saves 70% of indexing time on my local testing (approx. 120s -> 35s).~~

I also observed that use of pmap within `index!` shaves off a further few seconds, which suggests it _might_ be worth having a threadpool (but I've not added anything in this PR).
```clojure
(doall (pmap
            (fn add-doc [{e :crux.db/id, :as crux-doc}]
              (doseq  [[a v] (->> (dissoc crux-doc :crux.db/id)
                                  (mapcat (fn [[a v]]
                                            (for [v (cc/vectorize-value v)
                                                  :when (string? v)]
                                              [a v]))))
                       :let [doc (doto (Document.)
                                   ;; The actual term, which will be tokenized
                                   (.add (TextField. (keyword->k a), v, Field$Store/YES))
                                   ;; Used for wildcard searches
                                   (.add (TextField. field-crux-val, v, Field$Store/YES))
                                   ;; Used for eviction
                                   (.add (StringField. field-crux-eid, (->hash-str e), Field$Store/NO))
                                   ;; Used for wildcard searches
                                   (.add (StringField. field-crux-attr, (keyword->k a), Field$Store/YES)))]]
                (.addDocument ^IndexWriter index-writer doc)))
            (vals docs)))
```