### PR TITLE
Lucene fixes for 1.18 users

### DIFF
--- a/crux-lucene/src/crux/lucene.clj
+++ b/crux-lucene/src/crux/lucene.clj
@@ -323,11 +323,12 @@
                         :spec ::sys/path}
                :fsync-frequency {:required? true
                                  :spec ::sys/duration
-                                 :default "PT5M"}
+                                 :default "PT5M"
+                                 :doc "Approx. time between IO-intensive Lucene `.commit` operations."}
                :disable-refresh? {:required? true
+                                  :spec ::sys/boolean
                                   :default false
-                                  :doc "Disable synchronous maybeRefreshBlocking calls during ingestion at the cost of full consistency with the main KV index-store. These calls can have a dramatic, negative ingestion performance impact when replaying small transactions."
-                                  :spec ::sys/boolean}}
+                                  :doc "Disable synchronous maybeRefreshBlocking calls during ingestion at the cost of full consistency with the main KV index-store. These calls can have a dramatic, negative ingestion performance impact when replaying small transactions."}}
    ::sys/deps {:document-store :crux/document-store
                :query-engine :crux/query-engine
                :indexer `->indexer

--- a/docs/reference/modules/ROOT/pages/lucene.adoc
+++ b/docs/reference/modules/ROOT/pages/lucene.adoc
@@ -67,6 +67,12 @@ EDN::
 ----
 ====
 
+== Parameters
+
+* `db-dir` (string/`File`/`Path`): Path to Lucene data directory
+* `fsync-frequency` (string/`Integer`/`Duration`): Approx. time between IO-intensive Lucene `.commit` operations
+* `disable-refresh?` (boolean, default false): Disable synchronous maybeRefreshBlocking calls during ingestion at the cost of full consistency with the main KV index-store. These calls can have a dramatic, negative ingestion performance impact when replaying small transactions
+
 == Indexing
 
 All top-level text fields in a document are automatically indexed.


### PR DESCRIPTION
## During query

1. fix cardinality of AV resolver results

## During ingest

1. move maybeRefresh work into the fsync-loop thread
2. set `applyAllDeletes` to true