### PR TITLE
Symmetry docs

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -29,3 +29,4 @@ These are located by branch name convention - branches prefixed with `docs-v*` w
   b. Update `version: master` to `version: <new-version>`
 3. Commit, push branch to the main JUXT Crux repo
 4. Head over to `crux-site` to deploy the docs.
+

--- a/docs/reference/modules/ROOT/nav.adoc
+++ b/docs/reference/modules/ROOT/nav.adoc
@@ -21,7 +21,7 @@
 * Persistence Modules
 ** xref:s3.adoc[AWS S3]
 ** xref:azure-blobs.adoc[Azure Blobs]
-** xref:corda.adoc[DLT - Corda]
+** xref:corda.adoc[Corda]
 ** xref:google-cloud-storage.adoc[Google Cloud Storage]
 ** xref:kafka.adoc[Kafka]
 ** xref:jdbc.adoc[JDBC]

--- a/docs/reference/modules/ROOT/pages/azure-blobs.adoc
+++ b/docs/reference/modules/ROOT/pages/azure-blobs.adoc
@@ -1,4 +1,4 @@
-= Crux Azure Blobs
+= Azure Blobs
 
 You can use Azure's Blob Storage as Crux's 'document store'.
 

--- a/docs/reference/modules/ROOT/pages/corda.adoc
+++ b/docs/reference/modules/ROOT/pages/corda.adoc
@@ -1,4 +1,6 @@
-= Corda (Labs - Alpha)
+= Corda
+
+Development Status: Alpha
 
 A Crux module that allows you to pipe verified https://www.corda.net/[Corda] transactions into a Crux node, to then query using Crux's bitemporal Datalog query engine.
 

--- a/docs/reference/modules/ROOT/pages/events.adoc
+++ b/docs/reference/modules/ROOT/pages/events.adoc
@@ -1,4 +1,4 @@
-= Event Subscription
+= Events
 
 [#overview]
 == Overview

--- a/docs/reference/modules/ROOT/pages/google-cloud-storage.adoc
+++ b/docs/reference/modules/ROOT/pages/google-cloud-storage.adoc
@@ -1,4 +1,4 @@
-= Crux Google Cloud Storage
+= Google Cloud Storage
 
 You can use Google's Cloud Storage (GCS) as Crux's 'document store' or 'checkpoint store'.
 

--- a/docs/reference/modules/ROOT/pages/jdbc.adoc
+++ b/docs/reference/modules/ROOT/pages/jdbc.adoc
@@ -1,4 +1,4 @@
-= JDBC Nodes
+= JDBC
 
 Crux nodes can use JDBC databases to store their transaction logs and/or document stores.
 

--- a/docs/reference/modules/ROOT/pages/lucene.adoc
+++ b/docs/reference/modules/ROOT/pages/lucene.adoc
@@ -1,4 +1,4 @@
-= Full-text Lucene search
+= Full-Text Search
 
 Full-text search module for Crux making use of https://lucene.apache.org/[Apache
 Lucene].

--- a/docs/reference/modules/ROOT/pages/monitoring.adoc
+++ b/docs/reference/modules/ROOT/pages/monitoring.adoc
@@ -1,4 +1,4 @@
-= Monitoring Crux
+= Monitoring
 
 Crux can expose metrics about a node via https://metrics.dropwizard.io/4.1.2/[Dropwizard] to https://prometheus.io/[Prometheus], AWS's CloudWatch, and Java's JMX.
 

--- a/docs/reference/modules/ROOT/pages/queries.adoc
+++ b/docs/reference/modules/ROOT/pages/queries.adoc
@@ -3,27 +3,37 @@
 [#intro]
 == Introduction
 
-Crux is a document database that provides you with a comprehensive means of traversing and querying across all of your documents and data without any need to define a schema ahead of time.
-This is possible because Crux is "schemaless" and automatically indexes the top-level fields in all of your documents to support efficient ad-hoc joins and retrievals.
-With these capabilities you can quickly build queries that match directly against the relations in your data without worrying too much about the shape of your documents or how that shape might change in future.
+Crux is a schemaless document database that provides you with a comprehensive means of traversing and querying across all of your documents.
+Crux automatically indexes the top-level fields in all documents, supporting efficient ad-hoc joins and retrievals.
+Crux is both _immutable_ and _bitemporal_, which are both required characteristics for a safe schemaless database.
 
 Crux is also a graph database.
 The central characteristic of a graph database is that it can support arbitrary-depth graph queries (recursive traversals) very efficiently by default, without any need for schema-level optimisations.
-Crux gives you the ability to construct graph queries via a Datalog query language and uses graph-friendly indexes to provide a powerful set of querying capabilities.
-Additionally, when Crux's indexes are deployed directly alongside your application you are able to easily blend Datalog and code together to construct highly complex graph algorithms.
+Graph queries are possible through the Crux dialect of the Datalog query language.
 
 //This page walks through many of the more interesting queries that run as part of Crux's default test suite.
 //See the https://github.com/juxt/crux/blob/master/crux-test/test/crux/query_test.clj[`Crux query test file`] for the full suite of query tests and how each test listed below runs in the wider context.
 
-Extensible Data Notation (edn) is used as the data format for the public Crux APIs.
-To gain an understanding of edn see xref:tutorials::essential-edn.adoc[Essential EDN for Crux].
+=== SQL
 
-Note that all Crux Datalog queries run using a point-in-time view of the database which means the query capabilities and patterns presented in this section are not aware of valid times or transaction times.
+Crux 1.x supports both Datalog and SQL, but SQL support is provided through a module.
+To query Crux using SQL, read the xref:reference::sql.adoc[SQL module documentation].
 
-A Datalog query consists of a set of variables and a set of clauses. The result
-of running a query is a result set of the possible combinations of values that
-satisfy all of the clauses at the same time. These combinations of values are
-referred to as "tuples".
+=== Datalog
+
+Extensible Data Notation (edn) is used as the data format for the Crux Datalog query APIs.
+EDN is a simple format.
+To understand how edn works, read the brief description at http://edn-format.org/[http://edn-format.org].
+
+To understand how Datalog works, read the _Learn Crux Datalog Today_ tutorial from the https://www.opencrux.com/tutorials/[Tutorials page].
+
+////
+Can we remove these 3 paragraphs? -sd
+
+A Datalog query consists of a set of variables and a set of clauses.
+The result of running a query is a result set of the possible combinations of values that
+satisfy all of the clauses at the same time.
+These combinations of values are referred to as "tuples".
 
 The possible values within the result tuples are derived from your database of
 documents. The documents themselves are represented in the database indexes as
@@ -35,9 +45,10 @@ In the most basic case, a Datalog query works by searching for "subgraphs" in
 the database that match the pattern defined by the clauses. The values within
 these subgraphs are then returned according to the list of return variables
 requested in the `:find` vector within the query.
+////
 
 [#structure]
-== Basic Structure
+=== Basic Structure
 
 A query in Crux is performed by calling `crux/q` on a Crux database snapshot with a quoted map and, optionally, additional arguments.
 
@@ -45,8 +56,8 @@ A query in Crux is performed by calling `crux/q` on a Crux database snapshot wit
 ----
 include::example$test/crux/docs/examples/query_test.clj[tags=anatomy,indent=0]
 ----
-<1> Database value. Usually, the snapshot view comes from calling `crux/db` on a Crux node
-<2> Query map (vector style queries are also supported)
+<1> Database value. Usually the snapshot view comes from calling `crux/db` on a Crux node
+<2> Query map or vector (ex. `[:find ...etc... ]`, as found in other Datalog databases)
 <3> Argument(s) supplied to the `:in` relations
 
 The query map accepts the following Keywords
@@ -74,7 +85,8 @@ The find clause of a query specifies what values to be returned. These will be r
 [#find-logic-variable]
 === Logic Variable
 
-You can directly specify a logic variable from your query. The following will return all last names.
+You can directly specify a logic variable from your query.
+The following will return all last names bound to the logic variable `n`.
 
 [source,clj]
 ----
@@ -103,6 +115,8 @@ You can specify an aggregate function to apply to at most one logic variable.
 |`(distinct ?lvar)`| Return a set of distinct values
 |===
 
+==== Example:
+
 [source,clj]
 ----
 include::example$test/crux/docs/examples/query_test.clj[tags=query-aggregates,indent=0]
@@ -112,7 +126,11 @@ include::example$test/crux/docs/examples/query_test.clj[tags=query-aggregates-r,
 
 Note there is always implicit grouping across aggregates due to how Crux performs the aggregation lazily _before_ turning the result tuples into a set.
 
-User-defined aggregates are supported by adding a new method (via Clojure `defmethod`) for `crux.query/aggregate`. For example:
+=== Custom Aggregates
+
+Custom (user-defined) aggregates are supported by adding a new method (via Clojure `defmethod`) for `crux.query/aggregate`.
+This method takes a single (ignored) parameter and returns a multi-arity function which accepts zero parameters, an accumulator, or an accumulator and a single entity.
+For example:
 
 [source,clojure]
 ----
@@ -126,7 +144,7 @@ User-defined aggregates are supported by adding a new method (via Clojure `defme
 [#pull]
 === Pull
 
-Crux queries support a 'pull' syntax, allowing you to decouple specifying which entities you want from what data you'd like about those entities in your queries.
+Crux queries support a `pull` syntax, allowing you to decouple specifying which entities you want from what data you'd like about those entities in your queries.
 Crux's support is based on the excellent https://edn-query-language.org/eql/1.0.0/what-is-eql.html[EDN Query Language (EQL)^] library.
 
 To specify what data you'd like about each entity, include a `(pull ?logic-var projection-spec)` entry in the `:find` clause of your query:
@@ -144,21 +162,21 @@ You can quickly grab the whole document by specifying `*` in the projection spec
 
 [source,clojure]
 ----
-include::example$test/crux/docs/examples/query_test.clj[tags=pull-query-6]
-include::example$test/crux/docs/examples/query_test.clj[tags=pull-query-6-r]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-query-6,indent=0]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-query-6-r,indent=0]
 ----
 
-If you have the entity ID(s) in hand, you can call `pull` or `pull-many` directly:
+If you have the entity id(s) in hand, you can call `pull` or `pull-many` directly:
 
 [source,clojure]
 ----
-include::example$test/crux/docs/examples/query_test.clj[tags=pull]
-include::example$test/crux/docs/examples/query_test.clj[tags=pull-r]
-include::example$test/crux/docs/examples/query_test.clj[tags=pull-many]
-include::example$test/crux/docs/examples/query_test.clj[tags=pull-many-r]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-many-query-1]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-many-query-1-r]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-many-query-2]
+include::example$test/crux/docs/examples/query_test.clj[tags=pull-many-query-2-r]
 ----
 
-We can navigate to other entities (and hence build up nested results) using 'joins'.
+We can navigate to other entities (and hence build up nested results) using joins.
 Joins are specified in `{}` braces in the projection-spec - each one maps one join key to its nested spec:
 
 [source,clojure]
@@ -180,7 +198,7 @@ include::example$test/crux/docs/examples/query_test.clj[tags=pull-query-5-r,inde
 
 ==== Attribute parameters
 
-Crux supports a handful of custom https://edn-query-language.org/eql/1.0.0/specification.html#_parameters[EQL parameters], specified by wrapping the `:attribute` key in a pair: `(:attribute {:param :value, ...})`.
+Crux `pull` syntax supports a handful of custom https://edn-query-language.org/eql/1.0.0/specification.html#_parameters[EQL parameters], specified by wrapping the `:attribute` key in a pair: `(:attribute {:param :value, ...})`.
 
 * `:as` - to rename attributes in the result, wrap the attribute in `(:source-attribute {:as :output-name})`:
 +
@@ -218,7 +236,7 @@ Crux supports a handful of custom https://edn-query-language.org/eql/1.0.0/speci
 For full details on what's supported in the projection-spec, see the https://edn-query-language.org/eql/1.0.0/specification.html[EQL specification^]
 
 [#return-maps]
-== Returning maps
+=== Returning maps
 To return maps rather than tuples, supply the map keys under `:keys` for keywords, `:syms` for symbols, or `:strs` for strings:
 
 [source,clojure]
@@ -238,7 +256,7 @@ The `:where` section of a query limits the combinations of possible results by s
 |Name|Description
 |<<#clause-triple, triple clause>>| Restrict using EAV indexes
 |<<#clause-pred, predicate>>| Restrict with any predicate
-|<<#clause-range, range predicate>>| Restrict with any of `< <= >= > =`
+|<<#clause-range, range predicate>>| Restrict with any of `<` `+<=+` `>=` `>` `=`
 |<<#clause-unification, unification predicate>>| Unify two distinct logic variables with `!=` or `==`
 |<<#clause-not, not rule>>| Negate a list of clauses
 |<<#clause-not-join, not-join rule>>| Not rule with its own scope
@@ -341,7 +359,7 @@ Any fully qualified Clojure function can also be used to return relation binding
 
 A `range predicate` is a vector containing a list of a range operator and then two logic variables or literals.
 
-Allowed range operators are `<`, `<=`, `>=`, `>`, and `=`.
+Allowed range operators are `<`, `+<=+`, `>=`, `>`, and `=`.
 
 [source,clj]
 ----
@@ -353,7 +371,7 @@ include::example$test/crux/docs/examples/query_test.clj[tags=range-3,indent=0]
 ----
 <1> Finds any entity, `p`, with an `:age` which is greater than 18
 <2> Finds any entity, `p`, with an `:age` which is greater than the `:age` of any entity
-<3> Finds any entity, `p`, for which 18 is greater than `p`'s `:age`
+<3> Finds any entity, `p`, for which 18 is greater than `:age` of `p`
 
 [#clause-unification]
 === Unification Predicate

--- a/docs/reference/modules/ROOT/pages/query-configuration.adoc
+++ b/docs/reference/modules/ROOT/pages/query-configuration.adoc
@@ -1,4 +1,4 @@
-= Query Engine Configuration
+= Query Engine
 
 There are a number of different defaults that can be overridden within the Crux query engine.
 

--- a/docs/reference/modules/ROOT/pages/s3.adoc
+++ b/docs/reference/modules/ROOT/pages/s3.adoc
@@ -1,4 +1,4 @@
-= Crux S3
+= AWS S3
 
 You can use AWS's Simple Storage Service (S3) as Crux's 'document store'.
 

--- a/docs/reference/modules/ROOT/pages/xodus.adoc
+++ b/docs/reference/modules/ROOT/pages/xodus.adoc
@@ -1,6 +1,6 @@
-= JetBrains Xodus
+= Xodus
 
-Our friends over at https://www.avisi.nl/en/home[Avisi] have released support for https://github.com/JetBrains/xodus[Xodus] as a KV store for Crux's indices
+Our friends over at https://www.avisi.nl/en/home[Avisi] have released support for https://github.com/JetBrains/xodus[JetBrains Xodus] as a KV store for Crux's indices.
 
 For more details, see the https://github.com/avisi-apps/crux-xodus[crux-xodus] GitHub repo.
 


### PR DESCRIPTION
- renamed links / titles to maintain symmetry (where possible)
- haven't renamed any files yet
- passed over the `Query` doc to clean it up and fix bugs