### PR TITLE
Add `nvd-check` to run in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,19 @@ jobs:
       - store_test_results:
           path: "crux-test/target/test-results"
 
+  nvd-check:
+    docker:
+      - image: circleci/clojure:openjdk-8-lein
+    working_directory: ~/crux
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - run: lein nvd check
+      - store_artifacts:
+          path: "~/crux/target/nvd/dependency-check-report.html"
+          destination: "nvd-report.html"
+
   deploy-bench:
     docker:
       - image: circleci/clojure:openjdk-8-lein
@@ -224,6 +237,9 @@ workflows:
     jobs:
       - build
       - test:
+          requires:
+            - build
+      - nvd-check:
           requires:
             - build
       - deploy-api-docs:

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,9 @@
              "-Dclojure.spec.compile-asserts=true"
              "-Dclojure.spec.check-asserts=true"]
 
-  :profiles {:attach-yourkit {:jvm-opts ["-agentpath:/opt/yourkit/bin/linux-x86-64/libyjpagent.so"]}
+  :profiles {:dev {:dependencies [[lein-nvd "1.5.0"]]
+                   :plugins [[lein-nvd "1.5.0"]]}
+             :attach-yourkit {:jvm-opts ["-agentpath:/opt/yourkit/bin/linux-x86-64/libyjpagent.so"]}
              :with-s3-tests {:jvm-opts ["-Dcrux.s3.test-bucket=crux-s3-test"]}
              :with-azure-blobs-tests {:jvm-opts ["-Dcrux.azure.blobs.test-storage-account=crux-azure-blobs-test-storage-account"
                                                  "-Dcrux.azure.blobs.test-container=crux-azure-blobs-test-container"]}


### PR DESCRIPTION
(See [lein-nvd](https://github.com/rm-hull/lein-nvd))

Runs `lein nvd check` for every commit onto CI - uploads the html version of the report as an artifact.

Currently will fail the build every time currently due to the nvd-check. As per the lein-nvd options you can configure what level of severity causes a build to fail (or just make it never fail builds if you set that high enough).

Closes #1606