### PR TITLE
Return `nil` instead of an empty map for missing pull joins.

### DIFF
--- a/crux-core/src/crux/pull.clj
+++ b/crux-core/src/crux/pull.clj
@@ -56,8 +56,7 @@
                              (f v db recurse-state))
                            (.child-fns recurse-state))
                      (raise-doc-lookup-out-of-coll)
-                     (after-doc-lookup (fn [res]
-                                         (into {} (mapcat identity) res)))))))]
+                     (after-doc-lookup (fn [res] (not-empty (into {} (mapcat identity) res))))))))]
     (cond
       (= '... query) pull-child
       (int? query) (fn [v db ^RecurseState recurse-state]

--- a/crux-core/test/crux/datascript_pull_test.clj
+++ b/crux-core/test/crux/datascript_pull_test.clj
@@ -116,7 +116,7 @@
 (t/deftest test-pull-default
   (let [db (submit-test-docs people-docs)]
     ;; Datascript returns nil here, because there's no matching datom
-    (t/is (= #{[{}]}
+    (t/is (= #{[nil]}
              (crux/q db '{:find [(pull ?e [:foo])]
                           :where [[?e :crux.db/id :petr]]}))
           "Missing attrs return empty map")
@@ -160,7 +160,7 @@
 
     ;; Datascript returns `{:name "Petr", :children []}` for this, but we've matched documents,
     ;; so we can say 'there are two children, but they don't have `:foo`'
-    (t/is (= #{[{:name "Petr" :children [{} {}]}]}
+    (t/is (= #{[{:name "Petr"}]}
              (crux/q db '{:find [(pull ?e [:name {(:_parent {:as :children}) [:foo]}])]
                           :where [[?e :crux.db/id :petr]]}))
           "Non matching results are removed from collections")

--- a/crux-core/test/crux/pull_test.clj
+++ b/crux-core/test/crux/pull_test.clj
@@ -22,7 +22,11 @@
 (t/deftest test-pull
   (let [db (submit-bond)]
 
-    (t/is (= #{[{}]}
+    (t/is (= #{}
+             (crux/q db '{:find [(pull ?v [])]
+                          :where [[?v :not/here "N/A"]]})))
+
+    (t/is (= #{[nil]}
              (crux/q db '{:find [(pull ?v [])]
                           :where [[?v :vehicle/brand "Aston Martin"]]})))
 
@@ -240,7 +244,7 @@
                                :where [[?root :crux.db/id :root]]}))))))
 
 (t/deftest test-doesnt-hang-on-unknown-eid
-  (t/is (= #{[{}]}
+  (t/is (= #{[nil]}
            (crux/q (crux/db *api*)
                    '{:find [(pull ?e [*])]
                      :in [?e]
@@ -258,7 +262,7 @@
   (fix/submit+await-tx [[:crux.tx/put {:crux.db/id :foo :ref [:bar :baz]}]
                         [:crux.tx/put {:crux.db/id :bar}]])
 
-  (t/is (= #{[{:ref [#:crux.db{:id :bar} {}]}]}
+  (t/is (= #{[{:ref [#:crux.db{:id :bar} nil]}]}
            (crux/q (crux/db *api*)
                    '{:find [(pull ?it [{:ref [:crux.db/id]}])]
                      :where [[?it :crux.db/id :foo]]}))))


### PR DESCRIPTION
Attempt at a fix #1549 - realize I may have misunderstood the expectation here/might be too quick a jump into it, though.