### PR TITLE
Return `nil` instead of an empty map for missing pull joins.

### DIFF
--- a/core/src/xtdb/pull.clj
+++ b/core/src/xtdb/pull.clj
@@ -58,7 +58,9 @@
                              (f v db recurse-state))
                            (.child-fns recurse-state))
                      (raise-doc-lookup-out-of-coll)
-                     (after-doc-lookup (fn [res] (not-empty (into {} (mapcat identity) res))))))))]
+                     (after-doc-lookup (fn [res]
+                                         (when-let [res (seq (remove nil? res))]
+                                           (into {} (mapcat identity) res))))))))]
     (cond
       (= '... query) pull-child
       (int? query) (fn [v db ^RecurseState recurse-state]
@@ -120,7 +122,7 @@
         (when-let [content-hash (some-> (entity-resolver-fn (c/->id-buffer value))
                                         c/new-id)]
           (let-docs [docs #{content-hash}]
-            (let [doc (get docs content-hash)]
+            (when-let [doc (get docs content-hash)]
               (->> (concat (->> forward-join-child-fns (map (fn [f] (f doc db recurse-state))))
                            (->> union-child-fns (mapcat (fn [f] (f value doc db recurse-state)))))
                    (raise-doc-lookup-out-of-coll)

--- a/core/src/xtdb/pull.clj
+++ b/core/src/xtdb/pull.clj
@@ -58,8 +58,7 @@
                              (f v db recurse-state))
                            (.child-fns recurse-state))
                      (raise-doc-lookup-out-of-coll)
-                     (after-doc-lookup (fn [res]
-                                         (into {} (mapcat identity) res)))))))]
+                     (after-doc-lookup (fn [res] (not-empty (into {} (mapcat identity) res))))))))]
     (cond
       (= '... query) pull-child
       (int? query) (fn [v db ^RecurseState recurse-state]

--- a/core/test/xtdb/pull_test.clj
+++ b/core/test/xtdb/pull_test.clj
@@ -21,8 +21,11 @@
 
 (t/deftest test-pull
   (let [db (submit-bond)]
+    (t/is (= #{}
+             (xt/q db '{:find [(pull ?v [])]
+                        :where [[?v :not/here "N/A"]]})))
 
-    (t/is (= #{[{}]}
+    (t/is (= #{[nil]}
              (xt/q db '{:find [(pull ?v [])]
                         :where [[?v :vehicle/brand "Aston Martin"]]})))
 
@@ -240,7 +243,7 @@
                              :where [[?root :xt/id :root]]}))))))
 
 (t/deftest test-doesnt-hang-on-unknown-eid
-  (t/is (= #{[{}]}
+  (t/is (= #{[nil]}
            (xt/q (xt/db *api*)
                  '{:find [(pull ?e [*])]
                    :in [?e]
@@ -257,8 +260,7 @@
 (t/deftest test-missing-forward-join
   (fix/submit+await-tx [[::xt/put {:xt/id :foo :ref [:bar :baz]}]
                         [::xt/put {:xt/id :bar}]])
-
-  (t/is (= #{[{:ref [{:xt/id :bar} {}]}]}
+  (t/is (= #{[{:ref [{:xt/id :bar} nil]}]}
            (xt/q (xt/db *api*)
                  '{:find [(pull ?it [{:ref [:xt/id]}])]
                    :where [[?it :xt/id :foo]]}))))

--- a/core/test/xtdb/pull_test.clj
+++ b/core/test/xtdb/pull_test.clj
@@ -21,13 +21,18 @@
 
 (t/deftest test-pull
   (let [db (submit-bond)]
-    (t/is (= #{}
-             (xt/q db '{:find [(pull ?v [])]
-                        :where [[?v :not/here "N/A"]]})))
+    (t/testing "empty cases"
+      (t/is (= #{}
+               (xt/q db '{:find [(pull ?v [])]
+                          :where [[?v :not/here "N/A"]]})))
 
-    (t/is (= #{[nil]}
-             (xt/q db '{:find [(pull ?v [])]
-                        :where [[?v :vehicle/brand "Aston Martin"]]})))
+      (t/is (= #{[nil]}
+               (xt/q db '{:find [(pull ?v [])]
+                          :where [[?v :vehicle/brand "Aston Martin"]]})))
+
+      (t/is (= #{[{}]}
+               (xt/q db '{:find [(pull ?v [:doesntexist])]
+                          :where [[?v :vehicle/brand "Aston Martin"]]}))))
 
     (t/testing "simple props"
       (let [expected #{[{:vehicle/brand "Aston Martin", :vehicle/model "DB5"}]
@@ -248,7 +253,9 @@
                  '{:find [(pull ?e [*])]
                    :in [?e]
                    :timeout 500}
-                 "doesntexist"))))
+                 "doesntexist")))
+
+  (t/is (nil? (xt/pull (xt/db *api*) '[*] "doesntexist"))))
 
 (t/deftest test-with-speculative-doc-store
   (let [db (xt/with-tx (xt/db *api*) [[::xt/put {:xt/id :foo}]])]


### PR DESCRIPTION
(from @danmason in #1610)

> Attempt at a fix #1549 - realize I may have misunderstood the expectation here/might be too quick a jump into it, though.