### PR TITLE
Try restoring Lucene from checkpoint

### DIFF
--- a/modules/lucene/deps.edn
+++ b/modules/lucene/deps.edn
@@ -1,8 +1,0 @@
-{:paths ["src"]
- :deps {org.apache.lucene/lucene-core {:mvn/version "8.9.0"}
-        org.apache.lucene/lucene-queryparser {:mvn/version "8.9.0"}}
- :aliases {:dev {:extra-deps
-                 {org.apache.lucene/lucene-analyzers-common
-                  {:mvn/version  "8.9.0"}}}}
- :jvm-opts ["-Dclojure.spec.compile-asserts=true"
-            "-Dclojure.spec.check-asserts=true"]}

--- a/modules/lucene/deps.edn
+++ b/modules/lucene/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.apache.lucene/lucene-core {:mvn/version "8.9.0"}
+        org.apache.lucene/lucene-queryparser {:mvn/version "8.9.0"}}
+ :aliases {:dev {:extra-deps
+                 {org.apache.lucene/lucene-analyzers-common
+                  {:mvn/version  "8.9.0"}}}}
+ :jvm-opts ["-Dclojure.spec.compile-asserts=true"
+            "-Dclojure.spec.check-asserts=true"]}

--- a/modules/lucene/src/xtdb/lucene.clj
+++ b/modules/lucene/src/xtdb/lucene.clj
@@ -352,6 +352,7 @@
   [{:keys [^Path db-dir analyzer indexer query-engine secondary-indices checkpointer
            fsync-frequency ^Duration refresh-frequency]
     :as opts}]
+  (some-> checkpointer (cp/try-restore (.toFile db-dir) "lucene-8"))
   (let [directory (if db-dir
                     (FSDirectory/open db-dir)
                     (ByteBuffersDirectory.))


### PR DESCRIPTION

Lucene currently does not actually try to restore from a checkpoint. Add the restore call.

Noticed this while investigating very slow startup in ECS. We have lots of transactions and this greatly speeds up startup time.