### PR TITLE
Use :xtdb.query/query spec to validate :xtdb.sql/table-query prior to transformations

### DIFF
--- a/modules/sql/src/xtdb/calcite.clj
+++ b/modules/sql/src/xtdb/calcite.clj
@@ -8,6 +8,7 @@
             [xtdb.api :as xt]
             [xtdb.calcite.types]
             [xtdb.error :as err]
+            [xtdb.query :as query]
             [xtdb.system :as sys]
             [juxt.clojars-mirrors.cheshire.v5v10v0.cheshire.core :as json])
   (:import clojure.lang.Symbol
@@ -459,7 +460,8 @@
 
 (s/def :xtdb.sql/table-name string?)
 (s/def :xtdb.sql/table-columns (s/map-of symbol? java-sql-types->calcite-sql-type))
-(s/def ::table (s/keys :req [:xt/id :xtdb.sql/table-name :xtdb.sql/table-columns]))
+(s/def :xtdb.sql/table-query ::query/query)
+(s/def ::table (s/keys :req [:xt/id :xtdb.sql/table-name :xtdb.sql/table-columns :xtdb.sql/table-query]))
 
 (defn- lookup-schema [node]
   (let [db (xt/db node)]


### PR DESCRIPTION
This resolves an issue encountered by a user constructing schema documents with Kotlin's `listOf`: https://juxt-oss.zulipchat.com/#narrow/stream/194466-xtdb-users/topic/SQL.20Where.20clause.20errors

Alternative approaches I can think of:
1. the query spec could be more liberal about accepting/coercing other list-like objects
2. the xtdb.sql code could coerce what it needs to for this specific case or otherwise avoid depending on the where list-like object implementing `IPersistentCollection` for its transformations