### PR TITLE
remote_api_client pull-many implementation should use its eids parameter

### DIFF
--- a/modules/http-client/src/xtdb/remote_api_client.clj
+++ b/modules/http-client/src/xtdb/remote_api_client.clj
@@ -168,7 +168,7 @@
       (->> (xt/q this
                   {:find [(list 'pull ?eid projection)]
                    :in [[?eid '...]]}
-                  this)
+                  eids)
            (mapv first))))
 
   ;; TODO should we make the Clojure history opts the same format (`:start-valid-time`, `:start-tx`)


### PR DESCRIPTION
https://github.com/xtdb/xtdb/blob/e2f51ed99fc2716faa8ad254c0b18166c937b134/modules/http-client/src/xtdb/remote_api_client.clj#L165-L172

I was putting together https://github.com/tekacs/xtdb-ts and was curious how the remote API client in XTDB itself implements `pull-many` (I tried `{:find [(pull ?e expr)] :in [[?e ...]]}` but a bug in my implementation was causing it to fail).

When I went to look at the implementation, I noticed that the implementation doesn't use its `eids` parameter, instead repeating `this`.

Upon testing, it looks like `pull` works, but the `pull-many` implementation is broken?

![CleanShot 2021-12-19 at 03 37 29](https://user-images.githubusercontent.com/63247/146668741-c8b0b395-5e55-4c67-acb5-7b5814aa9967.png)

I'm guessing the implementation should be what I've proposed in this PR?