### PR TITLE
Feature/add java type safety

### DIFF
--- a/core/src/xtdb/api/XtdbDocument.java
+++ b/core/src/xtdb/api/XtdbDocument.java
@@ -5,10 +5,12 @@ import clojure.lang.IPersistentMap;
 import clojure.lang.Keyword;
 import clojure.lang.PersistentArrayMap;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.net.URI;
+import java.net.URL;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class XtdbDocument {
     private static final Keyword DB_ID = Keyword.intern("xt/id");
@@ -18,6 +20,7 @@ public final class XtdbDocument {
     private final IPersistentMap data;
 
     private XtdbDocument(Object id, IPersistentMap data) {
+        assertValidIdType(id);
         this.id = id;
         this.data = data;
     }
@@ -169,6 +172,22 @@ public final class XtdbDocument {
     private static void assertNotReserved(Keyword key) {
         if (DB_ID.equals(key)) throw new IllegalArgumentException(":xt/id is a reserved key");
         if (FN_ID.equals(key)) throw new IllegalArgumentException(":xt/fn is a reserved key");
+    }
+
+    private static void assertValidIdType(Object id) {
+        final Stream<Class<?>> allowedIdTypes = Stream.of(
+                Keyword.class,
+                String.class,
+                Long.class,
+                UUID.class,
+                URI.class,
+                URL.class,
+                Map.class
+        );
+
+        if (allowedIdTypes.noneMatch(c -> c.isInstance(id))) {
+            throw new IllegalArgumentException("ID " + id.toString() + " is not a valid type.");
+        }
     }
 
     private Builder toBuilder() {

--- a/test/test/xtdb/api/DocumentTest.java
+++ b/test/test/xtdb/api/DocumentTest.java
@@ -183,6 +183,11 @@ public class DocumentTest {
         document.plus("baz", 7);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void idsMustObeyTypeRules() {
+        XtdbDocument.create(1.1);
+    }
+
     private void assertSameAfterPut(XtdbDocument document) {
         try (IXtdb node = IXtdb.startNode()) {
             TransactionInstant transaction = node.submitTx(Transaction.buildTx(tx -> {

--- a/test/test/xtdb/api/DocumentTest.java
+++ b/test/test/xtdb/api/DocumentTest.java
@@ -4,9 +4,12 @@ import clojure.lang.IPersistentMap;
 import clojure.lang.Keyword;
 
 import clojure.lang.PersistentArrayMap;
+import clojure.lang.PersistentVector;
 import xtdb.api.tx.*;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import org.junit.Test;
 
@@ -64,6 +67,49 @@ public class DocumentTest {
 
         data.put("bar", 0);
         compare.put(bar, 0);
+
+        XtdbDocument document = XtdbDocument.create(documentId, data);
+
+        assertEquals(compare, document.toMap());
+        assertSameAfterPut(document);
+    }
+
+    @Test
+    public void collectionsAreConvertedToPersistentVec() {
+        HashMap<Keyword, Object> compare = new HashMap<>();
+        HashMap<String, Object> data = new HashMap<>();
+
+        compare.put(DB_ID, documentId);
+
+        HashMap<Keyword, Object> innerDataMap = new HashMap<>();
+        innerDataMap.put(bar, listOf(1, 2, 3));
+
+        data.put("foo", innerDataMap);
+        compare.put(foo, PersistentArrayMap.EMPTY.assoc(bar, PersistentVector.create(1, 2, 3)));
+
+        XtdbDocument document = XtdbDocument.create(documentId, data);
+
+        assertEquals(compare, document.toMap());
+        assertSameAfterPut(document);
+    }
+
+    @Test
+    public void nestedCollectionsAreConvertedToNestedPersistentVec() {
+        HashMap<Keyword, Object> compare = new HashMap<>();
+        HashMap<String, Object> data = new HashMap<>();
+
+        compare.put(DB_ID, documentId);
+
+        data.put("foo", listOf(
+                listOf(1, 2, 3),
+                new HashSet<>(listOf(4, 5, 6)),
+                listOf(7, 8, 9)
+        ));
+        compare.put(foo, PersistentVector.create(
+                PersistentVector.create(1, 2, 3),
+                PersistentVector.create(4, 5, 6),
+                PersistentVector.create(7, 8, 9)
+        ));
 
         XtdbDocument document = XtdbDocument.create(documentId, data);
 


### PR DESCRIPTION
This change came out of an issue I was experiencing detailed here: https://juxt-oss.zulipchat.com/#narrow/stream/194466-xtdb-users/topic/.E2.9C.94.20SQL.20Where.20clause.20errors/near/264782867

@refset helped me solve the problem, and he also submitted a PR here to verify the types are correct: #1667 .
That PR is helpful because it would've pointed out the problem to me sooner, but I prefer to have the types be coerced for easier use in Java/Kotlin. It's kind of a pain to create `PersistentVector`s every time you need one.

Thanks for taking a look at this PR. I'm not sure if this is up to the XTDB standards, so all comments are welcome :)