### PR TITLE
Schedule query timeout interrupt job before calling `open-q*`

### DIFF
--- a/test/test/xtdb/query_test.clj
+++ b/test/test/xtdb/query_test.clj
@@ -3428,6 +3428,14 @@
                                          :where [[e :xt/id _]]
                                          :timeout 100})))))
 
+(defn long-running-pred [] (Thread/sleep 100) :ivan)
+
+(t/deftest test-query-with-predicate-with-timeout-1654
+  (t/is (thrown? TimeoutException
+                 (xt/q (xt/db *api*) '{:find [e]
+                                       :where [[(xtdb.query-test/long-running-pred) e]]
+                                       :timeout 10}))))
+
 (t/deftest test-nil-query-attribute-453
   (fix/transact! *api* [{:xt/id :id :this :that :these :those}])
   (t/is (thrown-with-msg? IllegalArgumentException


### PR DESCRIPTION
* allows eager evaluation of long-running predicates (such as Lucene searches)
to be interrupted - closes #1654

Previously, the interrupt-job was only being scheduled _after_ the long-running predicate (e.g. `text-search`) had finished running (which happens eagerly when `open-q*` is called in the `with-open` bindings).