### PR TITLE
Bump Kafka client minor version due to jackson-databind regression

### DIFF
--- a/modules/kafka/project.clj
+++ b/modules/kafka/project.clj
@@ -15,7 +15,7 @@
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/tools.logging "1.1.0"]
                  [com.xtdb/xtdb-core]
-                 [org.apache.kafka/kafka-clients "2.6.0" :exclusions [org.lz4/lz4-java]]
+                 [org.apache.kafka/kafka-clients "2.6.1" :exclusions [org.lz4/lz4-java]]
                  [pro.juxt.clojars-mirrors.cheshire/cheshire "5.10.0"]
                  [com.cognitect/transit-clj "1.0.324" :exclusions [org.msgpack/msgpack]]]
 


### PR DESCRIPTION
* see https://issues.apache.org/jira/browse/KAFKA-10378

Reported via https://juxt-oss.zulipchat.com/#narrow/stream/194466-xtdb-users/topic/.E2.9C.94.20Kafka.20ClassNotFoundException (thank you Felipe!)