### PR TITLE
Parked: improve performance in entity resolution by reducing buffer conversions

### DIFF
--- a/core/src/xtdb/codec.clj
+++ b/core/src/xtdb/codec.clj
@@ -26,7 +26,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def index-version 19)
+(def index-version 20)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/test/test/xtdb/api_test.clj
+++ b/test/test/xtdb/api_test.clj
@@ -61,7 +61,7 @@
       (t/is (empty? (xt/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:xtdb.index/index-version 19}
+  (t/is (= (merge {:xtdb.index/index-version 20}
                   (when (instance? xtdb.kafka.KafkaTxLog (:tx-log *api*))
                     {:xtdb.zk/zk-active? true}))
            (select-keys (xt/status *api*) [:xtdb.index/index-version :xtdb.zk/zk-active?])))


### PR DESCRIPTION
parked, but written up here for posterity.

About 25% of TPC-H Q5 is now in bitemporal resolution (fair enough, we're a bitemporal DB). 30% of that, though, (7% overall),  is converting eids from value-buffers to id-buffers (mainly nippy encoding + SHA1ing). we need to do this because the eids are stored as reversible values in the content indices and hashes in the bitemp indices.
* reason we store eids as value-bufs in the content indices is because we need to compare eids in the E position to eids in the V position (e.g. `e2` in `[[e1 :child e2], [e2 :property ?v]]` - `e2` in the former is encoded as a value, so `e2` in the latter has to be too, so that we can join them)
* reason we store eids as id-bufs (hashed) in the bitemp indices is because we need to be able replay the creation of the bitemp indices even after the values have been evicted, so that matches (for example) have the same result before and after eviction

This spike tried to use the hash cache, but it turned out that this wasn't significantly quicker, and (for reasons I didn't look in to) caused a performance regression in the rest of the query equivalent to the gains in entity resolution.

* Updated the hash cache to use entity id-buffers rather than value-buffers - the entity part here is only used to determine whether to remove the value from the hash cache when the entity is evicted, and we have the id-buf to hand when we're evicting anyway
* Looking up the id-buf in this cache isn't free - it itself requires some buffer mangling, and RocksDB seeking.

Written up here as potential discussion fodder, but otherwise I'll park it for now.

Other potential solutions:
* could we store them as both id-bufs and value-bufs in the bitemp index? maybe. maybe as another bitemp index. would need to keep both in sync, might be a pain.
* if we stored the result of matches on the permanent log (like we do for tx-fns), we wouldn't need to be able to replay the matches - we'd look up the result instead - and that might mean we could move the bitemp indices to have eids as value-bufs. we've talked about doing this a few times - it has other benefits, like reducing our exposure to hash-related bugs, but it's a significant change.

Before:

![before.png](https://user-images.githubusercontent.com/336964/152778901-d410492c-a743-414b-b691-9a808075c6c4.png)

After: 

![after.png](https://user-images.githubusercontent.com/336964/152778908-821c236c-0c82-4a46-8a3e-66545202df04.png)
