### PR TITLE
Better hashCodes for the Second Chance cache

### DIFF
--- a/core/src/xtdb/cache/second_chance.clj
+++ b/core/src/xtdb/cache/second_chance.clj
@@ -22,15 +22,17 @@
     (when-let [table (ConcurrentHashMapTableAccess/getConcurrentHashMapTable m)]
       (let [len (alength table)
             start (.nextInt (ThreadLocalRandom/current) len)]
-        (loop [i start]
+        (loop [i start
+               wrapped-around false]
           (if-let [^Map$Entry e (aget table i)]
             e
             (let [next (inc i)
-                  next (if (= next len)
+                  last (= next len)
+                  next (if last
                          0
                          next)]
-              (when-not (= next start)
-                (recur next)))))))))
+              (when-not (and (= next start) wrapped-around)
+                (recur next (if last true wrapped-around))))))))))
 
 (declare resize-cache)
 

--- a/core/src/xtdb/query.clj
+++ b/core/src/xtdb/query.clj
@@ -11,7 +11,6 @@
             [xtdb.api :as xt]
             [xtdb.bus :as bus]
             [xtdb.cache :as cache]
-            [xtdb.cache.lru :as lru]
             [xtdb.codec :as c]
             [xtdb.db :as db]
             [xtdb.error :as err]
@@ -1635,7 +1634,7 @@
     (db/open-index-snapshot index-store)))
 
 (defn- with-entity-resolver-cache [entity-resolver-fn {:keys [entity-cache-size]}]
-  (let [entity-cache (lru/->lru-cache {:cache-size entity-cache-size})]
+  (let [entity-cache (cache/->cache {:cache-size entity-cache-size})]
     (fn [k]
       (cache/compute-if-absent entity-cache k mem/copy-to-unpooled-buffer entity-resolver-fn))))
 


### PR DESCRIPTION
The Second Chance cache relies on randomly sampling the table that underlies a ConcurrentHashMap, however various objects that XT passes in as keys don't calculate hashCodes that are sufficient for even distribution in this table - this leads to the degenerative behaviours as seen in #1702 where, given Integer-like keys (i.e. including things like via `(xtdb.codec/->value-buffer 123)`), substantial time is spent scanning through empty regions of the table, whilst many entries end up in the same slots.

A `KeyWrapper` class has been implemented to enable overriding of the hashCode. The new hashCode calculation involves:

1. an `Integer/rotateLeft` operation directly inspired by a forked CHM implementation - see https://github.com/ehcache/ehcache3/blob/5cfa96b868423f0fbb19bf27ead647823b14a165/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java#L714-L724
2. multiplication by `31`, which is a wide-applied technique - see https://stackoverflow.com/questions/299304/why-does-javas-hashcode-in-string-use-31-as-a-multiplier

The `KeyWrapper` is implemented using deftype, but I understand it might be preferable to add it as another small Java class. In any case, all feedback is welcome!

This PR also adds a check for infinite loops in `random-entry`, in case the `.isEmpty` is insufficient (as alluded to #1702)

To-do:

1. [x] Benchmark runs (see internal Slack discussion: https://juxt.slack.com/archives/G018EA25K71/p1644421234114349?thread_ts=1644365778.321879&cid=G018EA25K71)

We could also consider discussing/reviewing/fixing (not done so far):

1. the cache-size configuration parameter is essentially ignored because the cache automatically resizes
2. it's not clear to me whether the hot-target-size should be using `(.size cache)` (as-is currently) or what I suspect it's supposed to be: `(.size (getHot cache))`

Closes #1702 