### PR TITLE
fix JDBC auto-increment/identity race condition, #1603

### DIFF
--- a/modules/jdbc/src/xtdb/jdbc/mssql.clj
+++ b/modules/jdbc/src/xtdb/jdbc/mssql.clj
@@ -39,7 +39,11 @@ DROP INDEX tx_events.tx_events_event_key_idx"])
 IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id('dbo.tx_events') AND NAME ='tx_events_event_key_idx_2')
 CREATE INDEX tx_events_event_key_idx_2 ON tx_events(event_key)"])
 
-        (check-tx-time-col)))))
+        (check-tx-time-col)))
+
+    (ensure-serializable-identity-seq! [_ _tx _table-name]
+      ;; not required
+      )))
 
 (defmethod j/->date :mssql [^DateTimeOffset d _]
   (Date/from (.toInstant (.getOffsetDateTime d))))

--- a/modules/jdbc/src/xtdb/jdbc/mysql.clj
+++ b/modules/jdbc/src/xtdb/jdbc/mysql.clj
@@ -43,4 +43,10 @@ CREATE TABLE IF NOT EXISTS tx_events (
       (when-not (idx-exists? ds "tx_events_event_key_idx_2")
         (jdbc/execute! ds ["CREATE INDEX tx_events_event_key_idx_2 ON tx_events(event_key)"]))
 
-      (check-tx-time-col ds))))
+      (check-tx-time-col ds))
+
+    (ensure-serializable-identity-seq! [_ tx table-name]
+      ;; `table-name` is trusted
+      ;; HACK: this fails if the table happens to be empty, but this isn't likely,
+      ;; even if there's no transactions yet - the docs are submitted first
+      (jdbc/execute! tx [(format "SELECT * FROM %s ORDER BY event_offset LIMIT 1 FOR UPDATE" table-name)]))))

--- a/modules/jdbc/src/xtdb/jdbc/psql.clj
+++ b/modules/jdbc/src/xtdb/jdbc/psql.clj
@@ -35,4 +35,9 @@ CREATE TABLE IF NOT EXISTS tx_events (
 
         (jdbc/execute! ["DROP INDEX IF EXISTS tx_events_event_key_idx"])
         (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])
-        (check-tx-time-col)))))
+        (check-tx-time-col)))
+
+    (ensure-serializable-identity-seq! [_ tx table-name]
+      ;; we have to take a table write lock in Postgres, because auto-increments aren't guaranteed to be increasing, even between transactions with 'serializable' isolation level
+      ;; `table-name` is trusted
+      (jdbc/execute! tx [(format "LOCK TABLE %s IN SHARE ROW EXCLUSIVE MODE" table-name)]))))

--- a/modules/jdbc/src/xtdb/jdbc/sqlite.clj
+++ b/modules/jdbc/src/xtdb/jdbc/sqlite.clj
@@ -35,7 +35,11 @@ CREATE TABLE IF NOT EXISTS tx_events (
   compacted INTEGER NOT NULL)"])
 
         (jdbc/execute! ["DROP INDEX IF EXISTS tx_events_event_key_idx"])
-        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])))))
+        (jdbc/execute! ["CREATE INDEX IF NOT EXISTS tx_events_event_key_idx_2 ON tx_events(event_key)"])))
+
+    (ensure-serializable-identity-seq! [_ _tx _table-name]
+      ;; writes are serialized between connections in SQLite
+      )))
 
 (defmethod j/doc-exists-sql :sqlite [_ doc-id]
   ["SELECT EVENT_OFFSET from tx_events WHERE EVENT_KEY = ? AND COMPACTED = 0" doc-id])

--- a/test/src/xtdb/fixtures/jdbc.clj
+++ b/test/src/xtdb/fixtures/jdbc.clj
@@ -7,9 +7,15 @@
   (:import com.opentable.db.postgres.embedded.EmbeddedPostgres))
 
 (def ^:dynamic *jdbc-opts*)
+(def ^:dynamic *db-type*)
 
 (defn with-opts [opts f]
   (binding [*jdbc-opts* opts]
+    (f)))
+
+(defn with-db-type [f]
+  (binding [*db-type* (j/db-type (-> @(:!system fix/*api*)
+                                     (get-in [::j/connection-pool :dialect])))]
     (f)))
 
 (defn with-h2-opts [f]


### PR DESCRIPTION
resolves #1603.

* MSSQL not vulnerable, SQLite doesn't support writing from multiple connections.
* Postgres seems reasonable - an in-transaction explicit lock
* MySQL and H2 don't have any such functionality, so we lock a row in the table as a proxy. This would be an issue if there are no rows in the table, although this isn't likely because even for the first transaction in a new node, we submit the documents first.
* Adding 'serializable' transaction isolation didn't seem to make a difference - the ones that weren't vulnerable didn't require it; the ones that were didn't include 'consecutive id generation in serializable transactions' as a guarantee (bit stronger than what's usually required from ids, fair enough).