### PR TITLE
Override tx time for import, #1517

### DIFF
--- a/core/src/xtdb/api.clj
+++ b/core/src/xtdb/api.clj
@@ -16,6 +16,8 @@
 (s/def ::tx-time date?)
 (s/def ::tx (s/keys :opt [::tx-id ::tx-time]))
 
+(s/def ::submit-tx-opts (s/keys :opt [::tx-time]))
+
 (s/def :crux.db/id c/valid-id?)
 (s/def :xt/id c/valid-id?)
 (s/def ::evicted? boolean?)
@@ -97,17 +99,31 @@
 
 (defprotocol PXtdbSubmitClient
   "Provides API access to XTDB transaction submission."
-  (submit-tx-async [node tx-ops]
+  (submit-tx-async
+    [node tx-ops]
+    [node tx-ops opts]
     "Writes transactions to the log for processing tx-ops datalog
   style transactions. Non-blocking.  Returns a deref with map with
   details about the submitted transaction, including tx-time and
-  tx-id.")
+  tx-id.
 
-  (submit-tx [node tx-ops]
+  opts (map):
+  - ::tx-time
+    overrides tx-time for the transaction.
+    mustn't be earlier than any previous tx-time, and mustn't be later than the tx-log's clock.")
+
+  (submit-tx
+    [node tx-ops]
+    [node tx-ops opts]
     "Writes transactions to the log for processing
   tx-ops datalog style transactions.
   Returns a map with details about the submitted transaction,
-  including tx-time and tx-id.")
+  including tx-time and tx-id.
+
+  opts (map):
+   - ::tx-time
+     overrides tx-time for the transaction.
+     mustn't be earlier than any previous tx-time, and mustn't be later than the tx-log's clock.")
 
   (open-tx-log ^java.io.Closeable [this after-tx-id with-ops?]
     "Reads the transaction log. Optionally includes

--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -58,7 +58,7 @@
   (open-nested-index-snapshot ^java.io.Closeable [this]))
 
 (defprotocol TxLog
-  (submit-tx [this tx-events])
+  (submit-tx [this tx-events] [this tx-events opts])
   (open-tx-log ^xtdb.api.ICursor [this after-tx-id])
   (latest-submitted-tx [this])
   (^java.util.concurrent.CompletableFuture subscribe [_ after-tx-id f]

--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -5,22 +5,21 @@
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
-            [clojure.set :as set])
-  (:import clojure.lang.MapEntry
-           xtdb.api.ICursor
-           [java.io DataInputStream DataOutputStream File IOException Reader]
-           java.lang.AutoCloseable
-           [java.lang.management BufferPoolMXBean ManagementFactory]
-           [java.lang.ref PhantomReference ReferenceQueue]
-           java.net.ServerSocket
-           [java.nio.file Files FileVisitResult SimpleFileVisitor]
-           java.nio.file.attribute.FileAttribute
-           java.text.SimpleDateFormat
-           java.time.Duration
-           [java.util Collections Comparator Date IdentityHashMap Iterator Map PriorityQueue Properties]
-           java.util.concurrent.locks.StampedLock
-           java.util.concurrent.ThreadFactory))
+            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy])
+  (:import (clojure.lang MapEntry)
+           (java.io DataInputStream DataOutputStream File IOException Reader)
+           (java.lang AutoCloseable)
+           (java.lang.management BufferPoolMXBean ManagementFactory)
+           (java.lang.ref PhantomReference ReferenceQueue)
+           (java.net ServerSocket)
+           (java.nio.file Files FileVisitResult SimpleFileVisitor)
+           (java.nio.file.attribute FileAttribute)
+           (java.text SimpleDateFormat)
+           (java.time Duration)
+           (java.util Collections Comparator Date IdentityHashMap Iterator Map PriorityQueue Properties)
+           (java.util.concurrent ThreadFactory)
+           (java.util.concurrent.locks StampedLock)
+           (xtdb.api ICursor)))
 
 (s/def ::port (s/int-in 1 65536))
 
@@ -347,3 +346,10 @@
    (->> m
         (into {} (map (fn [v]
                         (MapEntry/create (key v) (f (val v)))))))))
+
+(defn conform-tx-log-entry [tx entry]
+  (into tx
+        (cond
+          (vector? entry) {:xtdb.tx.event/tx-events entry}
+          (map? entry) entry
+          :else (throw (IllegalStateException. (format "unexpected value on tx-log: '%s'" (pr-str entry)))))))

--- a/docs/language-reference/modules/ROOT/pages/datalog-transactions.adoc
+++ b/docs/language-reference/modules/ROOT/pages/datalog-transactions.adoc
@@ -414,6 +414,33 @@ XTDB automatically indexes the top-level fields across all documents as Entity-A
 
 When you submit a transaction, the current time will be the Transaction Time.
 
+You can override the transaction time for a transaction (e.g. for importing data into XTDB from another bitemporal database) so long as:
+
+* the transaction time provided is no earlier than any other transaction currently in the system - i.e. transaction times must be increasing.
+* the transaction time is no later than the clock on the transaction log (e.g. Kafka) - i.e. transactions cannot be inserted into the future.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+buildTx(tx -> {
+  tx.put(document);
+  tx.withTxTime(txTime);
+});
+----
+
+Clojure::
++
+[source,clojure]
+----
+(xt/submit-tx node
+              [[::xt/put {:xt/id :foo}]]
+              {::xt/tx-time #inst "2020"})
+----
+====
+
 [#valid-times]
 == Valid Times
 

--- a/labs/kotlin-dsl/build.gradle.kts
+++ b/labs/kotlin-dsl/build.gradle.kts
@@ -17,6 +17,7 @@ java {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 publishing {
@@ -76,7 +77,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    api("com.xtdb:xtdb-core:1.20.0") {
+    api("com.xtdb:xtdb-core:${version}") {
         isTransitive = true
     }
 
@@ -84,7 +85,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")
     testImplementation("com.natpryce:hamkrest:1.8.0.1")
-    testImplementation("com.xtdb:xtdb-rocksdb:1.20.0")
+    testImplementation("com.xtdb:xtdb-rocksdb:${version}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")
 }
 

--- a/labs/kotlin-dsl/src/main/kotlin/xtdb/api/tx/TransactionContext.kt
+++ b/labs/kotlin-dsl/src/main/kotlin/xtdb/api/tx/TransactionContext.kt
@@ -5,8 +5,8 @@ import xtdb.api.query.domain.XtdbDocumentSerde
 import xtdb.api.underware.BuilderContext
 import java.util.*
 
-class TransactionContext private constructor(): BuilderContext<Transaction> {
-    companion object: BuilderContext.Companion<Transaction, TransactionContext>(::TransactionContext)
+class TransactionContext private constructor() : BuilderContext<Transaction> {
+    companion object : BuilderContext.Companion<Transaction, TransactionContext>(::TransactionContext)
 
     private val builder = Transaction.builder()
 
@@ -38,18 +38,18 @@ class TransactionContext private constructor(): BuilderContext<Transaction> {
     infix fun <T> T.by(serde: XtdbDocumentSerde<T>) = serde.toDocument(this)
 
     fun put(document: XtdbDocument) = +PutOperation.create(document)
-    fun put(data: DocWithValidTime) = +data.run{PutOperation.create(document, validTime)}
-    fun put(data: DocWithValidTimes) = +data.run{PutOperation.create(document, validTime, endValidTime)}
+    fun put(data: DocWithValidTime) = +data.run { PutOperation.create(document, validTime) }
+    fun put(data: DocWithValidTimes) = +data.run { PutOperation.create(document, validTime, endValidTime) }
 
     fun delete(id: Any) = +DeleteOperation.create(id)
-    fun delete(data: IdWithValidTime) = +data.run{DeleteOperation.create(id, validTime)}
-    fun delete(data: IdWithValidTimes) = +data.run{DeleteOperation.create(id, validTime, endValidTime)}
+    fun delete(data: IdWithValidTime) = +data.run { DeleteOperation.create(id, validTime) }
+    fun delete(data: IdWithValidTimes) = +data.run { DeleteOperation.create(id, validTime, endValidTime) }
 
     fun match(document: XtdbDocument) = +MatchOperation.create(document)
-    fun match(data: DocAtValidTime) = +data.run{MatchOperation.create(document, validTime)}
+    fun match(data: DocAtValidTime) = +data.run { MatchOperation.create(document, validTime) }
 
     fun notExists(id: Any) = +MatchOperation.create(id)
-    fun notExists(data: IdAtValidTime) = +data.run{MatchOperation.create(id, validTime)}
+    fun notExists(data: IdAtValidTime) = +data.run { MatchOperation.create(id, validTime) }
 
     fun evict(id: Any) = +EvictOperation.create(id)
 
@@ -59,10 +59,10 @@ class TransactionContext private constructor(): BuilderContext<Transaction> {
         infix fun Any.until(endValidTime: Date) = IdWithEndValidTime(this, endValidTime)
 
         fun put(document: XtdbDocument) = +PutOperation.create(document, validTime)
-        fun put(data: DocWithEndValidTime) = +data.run{PutOperation.create(document, validTime, endValidTime)}
+        fun put(data: DocWithEndValidTime) = +data.run { PutOperation.create(document, validTime, endValidTime) }
 
         fun delete(id: Any) = +DeleteOperation.create(id, validTime)
-        fun delete(data: IdWithEndValidTime) = +data.run{DeleteOperation.create(id, validTime, endValidTime)}
+        fun delete(data: IdWithEndValidTime) = +data.run { DeleteOperation.create(id, validTime, endValidTime) }
     }
 
     fun from(validTime: Date, block: FromValidTimeContext.() -> Unit) = FromValidTimeContext(validTime).apply(block)
@@ -74,6 +74,10 @@ class TransactionContext private constructor(): BuilderContext<Transaction> {
 
     fun between(validTime: Date, endValidTime: Date, block: BetweenTimesContext.() -> Unit) =
         BetweenTimesContext(validTime, endValidTime).apply(block)
+
+    fun setTxTime(txTime: Date) {
+        builder.withTxTime(txTime)
+    }
 
     override fun build(): Transaction = builder.build()
 }

--- a/labs/kotlin-dsl/src/test/kotlin/xtdb/api/tx/TransactionTest.kt
+++ b/labs/kotlin-dsl/src/test/kotlin/xtdb/api/tx/TransactionTest.kt
@@ -1,6 +1,8 @@
 package xtdb.api.tx
 
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -15,6 +17,7 @@ import xtdb.api.tx.Transaction.buildTx
 import xtdb.api.tx.TransactionContext.Companion.build
 import java.time.Duration
 import java.time.Instant
+import java.time.ZonedDateTime
 import java.util.*
 import kotlin.test.assertEquals
 
@@ -275,6 +278,46 @@ class TransactionTest {
             assert {
                 +document
             }
+        }
+
+        val String.date get() = Date.from(ZonedDateTime.parse(this).toInstant())
+
+        @Test
+        internal fun `can override txTime`(): Unit = xtdb.run {
+            val doc1 = aDocument()
+            val doc2 = aDocument()
+            val doc3 = aDocument()
+            val doc4 = aDocument()
+
+
+            submitTx {
+                put(doc1)
+                setTxTime("2020-01-01T00:00:00Z".date)
+            }.await()
+
+            assert {
+                +doc1
+            }
+
+            val tx2 = submitTx {
+                put(doc2)
+                setTxTime("2019-01-01T00:00:00Z".date)
+            }.also { it.await() }
+
+            assertFalse(this.hasTxCommitted(tx2))
+
+            val tx3 = submitTx {
+                put(doc3)
+                setTxTime("3000-01-01T00:00:00Z".date)
+            }.also { it.await() }
+
+            assertFalse(this.hasTxCommitted(tx3))
+
+            val tx4 = submitTx {
+                put(doc4)
+            }.also { it.await() }
+
+            assertTrue(this.hasTxCommitted(tx4))
         }
     }
 

--- a/modules/http-server/src/xtdb/http_server.clj
+++ b/modules/http-server/src/xtdb/http_server.clj
@@ -98,12 +98,15 @@
              [->submit-json-decoder])))
 
 (s/def ::tx-ops vector?)
-(s/def ::submit-tx-spec (s/keys :req-un [::tx-ops]))
+
+(s/def ::submit-tx-spec
+  (s/keys :req-un [::tx-ops]
+          :opt [::xt/submit-tx-opts]))
 
 (defn- submit-tx [xtdb-node]
   (fn [req]
-    (let [tx-ops (get-in req [:parameters :body :tx-ops])
-          {::xt/keys [tx-time] :as submitted-tx} (xt/submit-tx xtdb-node tx-ops)]
+    (let [{:keys [tx-ops ::xt/submit-tx-opts]} (get-in req [:parameters :body])
+          {::xt/keys [tx-time] :as submitted-tx} (xt/submit-tx xtdb-node tx-ops submit-tx-opts)]
       (-> {:status 202
            :body submitted-tx}
           (add-last-modified tx-time)))))

--- a/test/test/xtdb/fixtures/every_api.clj
+++ b/test/test/xtdb/fixtures/every_api.clj
@@ -33,7 +33,8 @@
                                    (with-meta {::embedded-kafka? true}))}
       #_(select-keys [:local-standalone])
       #_(select-keys [:local-standalone :remote])
-      #_(select-keys [:local-standalone :h2 :sqlite :remote])))
+      #_(select-keys [:local-standalone :h2 :sqlite :remote])
+      #_(select-keys [:local-kafka])))
 
 (def ^:dynamic *node-type*)
 

--- a/test/test/xtdb/submit_client_test.clj
+++ b/test/test/xtdb/submit_client_test.clj
@@ -21,7 +21,8 @@
                 (let [result (iterator-seq tx-log-iterator)]
                   (t/is (not (realized? result)))
                   (t/is (= [(assoc submitted-tx
-                                   :xtdb.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc {:xt/id :ivan :name "Ivan"})]])]
+                                   :xtdb.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc {:xt/id :ivan :name "Ivan"})]]
+                                   ::xt/submit-tx-opts {})]
                            result))
                   (t/is (realized? result))))
               submitted-tx))]

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -542,11 +542,13 @@
         (t/is (not (realized? log)))
         (t/is (= [{::xt/tx-id tx1-id
                    ::xt/tx-time tx1-tx-time
-                   :xtdb.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc tx1-ivan) tx1-valid-time]]}
+                   :xtdb.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc tx1-ivan) tx1-valid-time]]
+                   ::xt/submit-tx-opts {}}
                   {::xt/tx-id tx2-id
                    ::xt/tx-time tx2-tx-time
                    :xtdb.tx.event/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc tx2-ivan) tx2-valid-time]
-                                             [:crux.tx/put (c/new-id :petr) (c/hash-doc tx2-petr) tx2-valid-time]]}]
+                                             [:crux.tx/put (c/new-id :petr) (c/hash-doc tx2-petr) tx2-valid-time]]
+                   ::xt/submit-tx-opts {}}]
                  log))))))
 
 (t/deftest migrates-unhashed-tx-log-eids


### PR DESCRIPTION
resolves #1517 

Adding the ability to overload transaction times for a transaction as an overload to `submit-tx`: `(xt/submit-tx node [tx-ops...] {::xt/tx-time #inst "..."})`. In Java and Kotlin, this is added as a `withTxTime` method on the `Transaction.Builder`.

The transaction time must be no earlier than any transaction already in the system, and no later than the clock on the TxLog. If these constraints aren't adhered to, the system will abort the transaction, log a warning, and continue ingesting (option 2 on #1517).

Impacts:
* The format on the XT-provided TxLogs has changed - these are now maps rather than just the vector of operations. We must still be able to read from old-style tx-logs - this is covered by the migration test. This does mean that older versions of XT won't be able to read newer tx-logs.
* This is a breaking change for TxLog implementors - they should implement the extra overload. We could also consider introducing a second TxLog protocol, so that the same version of the third-party TxLog artifact can run against older and newer XT versions - I don't know how many people this would affect?