### PR TITLE
Fix 1719 - rocksdb - warn about MALLOC_ARENA_MAX only when starting module

### DIFF
--- a/core/src/xtdb/api.clj
+++ b/core/src/xtdb/api.clj
@@ -2,9 +2,7 @@
   "Public API of XTDB."
   (:refer-clojure :exclude [sync])
   (:require [clojure.spec.alpha :as s]
-            [clojure.tools.logging :as log]
             [xtdb.codec :as c]
-            [xtdb.io :as xio]
             [xtdb.system :as sys])
   (:import [xtdb.api IXtdb IXtdbSubmitClient RemoteClientOptions]
            java.lang.AutoCloseable
@@ -244,10 +242,6 @@
                                             :xtdb/secondary-indices 'xtdb.tx/->secondary-indices}]
                                           (cond-> options (not (vector? options)) vector)))
                    (sys/start-system))]
-    (when (and (nil? @xio/malloc-arena-max)
-               (xio/glibc?))
-      (defonce warn-on-malloc-arena-max
-        (log/warn "MALLOC_ARENA_MAX not set, memory usage might be high, recommended setting for XTDB is 2")))
     (reset! (get-in system [:xtdb/node :!system]) system)
     (-> (:xtdb/node system)
         (assoc :close-fn #(.close ^AutoCloseable system)))))

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -138,6 +138,12 @@
 
   (RocksDB/loadLibrary)
 
+  (when (and (nil? @xio/malloc-arena-max)
+             (xio/glibc?))
+    ;; defonce allows us to see the warning once only
+    (defonce warn-on-malloc-arena-max
+      (log/warn "MALLOC_ARENA_MAX not set, memory usage might be high, recommended setting for XTDB is 2")))
+
   (when checkpointer
     (cp/try-restore checkpointer (.toFile db-dir) cp-format))
 

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -1,7 +1,6 @@
 (ns ^:no-doc xtdb.rocksdb
   "RocksDB KV backend for XTDB."
-  (:require [clojure.java.io :as io]
-            [clojure.spec.alpha :as s]
+  (:require [clojure.tools.logging :as log]
             [xtdb.kv :as kv]
             [xtdb.rocksdb.loader]
             [xtdb.memory :as mem]
@@ -11,7 +10,6 @@
             [xtdb.kv.index-store :as kvi]
             [xtdb.codec :as c])
   (:import (java.io Closeable File)
-           java.nio.ByteBuffer
            (java.nio.file Files Path)
            java.nio.file.attribute.FileAttribute
            (org.rocksdb BlockBasedTableConfig Checkpoint CompressionType FlushOptions LRUCache


### PR DESCRIPTION
Here is my patch, again, haven't tested it yet, still trying to figure that out (I left a message on Zulip :smile:).
