### PR TITLE
Ingest pipelining

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -10,16 +10,18 @@
   (max-depth [this]))
 
 (defprotocol IndexStoreTx
-  (index-docs [this docs])
+  (index-docs [this docs encoded-docs])
   (unindex-eids [this eids])
   (index-entity-txs [this entity-txs])
   (commit-index-tx [this])
   (abort-index-tx [this]))
 
 (defprotocol IndexStore
+  (encode-docs [_ docs])
   (store-index-meta [this k v])
   (tx-failed? [this tx-id])
-  (begin-index-tx [index-store tx fork-at]))
+  (begin-index-tx [index-store tx fork-at])
+  (index-stats [this docs]))
 
 (defprotocol LatestCompletedTx
   (latest-completed-tx [this]))
@@ -66,7 +68,7 @@
     or, outside of f, complete the future returned from this function to stop the subscription."))
 
 (defprotocol InFlightTx
-  (index-tx-events [in-flight-tx tx-events prefetched-docs]
+  (index-tx-events [in-flight-tx tx-events prefetched-docs encoded-docs]
     "prefetched-docs :: docs from the batch of transactions")
   (commit [in-flight-tx])
   (abort [in-flight-tx]))

--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -10,7 +10,7 @@
   (max-depth [this]))
 
 (defprotocol IndexStoreTx
-  (index-docs [this docs encoded-docs])
+  (index-docs [this encoded-docs])
   (unindex-eids [this eids])
   (index-entity-txs [this entity-txs])
   (commit-index-tx [this])

--- a/core/src/xtdb/kv/index_store.clj
+++ b/core/src/xtdb/kv/index_store.clj
@@ -1006,12 +1006,11 @@
 
 (defrecord KvIndexStoreTx [persistent-kv-store transient-kv-store tx fork-at !evicted-eids thread-mgr cav-cache canonical-buffer-cache stats-kvs-cache]
   db/IndexStoreTx
-  (index-docs [_ docs content-idx-kvs]
+  (index-docs [_ content-idx-kvs]
     (with-open [transient-kv-snapshot (kv/new-snapshot transient-kv-store)]
       ;; we can write to the transient-kv-store here within an open read snapshot
       ;; on the assumption that the transient-kv-store is always in-memory
-      (some->> (seq content-idx-kvs) (kv/store transient-kv-store))
-      {:indexed-docs docs}))
+      (some->> (seq content-idx-kvs) (kv/store transient-kv-store))))
 
   (unindex-eids [_ eids]
     (when (seq eids)

--- a/core/src/xtdb/kv/index_store.clj
+++ b/core/src/xtdb/kv/index_store.clj
@@ -1104,7 +1104,9 @@
 (defrecord KvIndexStore [kv-store thread-mgr cav-cache canonical-buffer-cache stats-kvs-cache]
   db/IndexStore
   (encode-docs [_ docs]
-    (->content-idx-kvs docs))
+    (let [kvs (->content-idx-kvs docs)
+          bytes-indexed (->> kvs (transduce (comp cat (map mem/capacity)) +))]
+      (with-meta kvs {:bytes-indexed bytes-indexed})))
 
   (begin-index-tx [_ tx fork-at]
     (let [{::xt/keys [tx-id tx-time]} tx

--- a/core/src/xtdb/query.clj
+++ b/core/src/xtdb/query.clj
@@ -2121,8 +2121,9 @@
 
       (db/submit-docs in-flight-tx docs)
 
-      (let [tx-events (map txc/->tx-event conformed-tx-ops)]
-        (when (db/index-tx-events in-flight-tx tx-events docs)
+      (let [tx-events (map txc/->tx-event conformed-tx-ops)
+            encoded-docs (db/encode-docs index-store docs)]
+        (when (db/index-tx-events in-flight-tx tx-events docs encoded-docs)
           (xt/db in-flight-tx valid-time))))))
 
 (defmethod print-method QueryDatasource [{:keys [valid-time tx-id]} ^Writer w]

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -70,12 +70,14 @@
                                      {:crux.db/id (:crux.db/id arg-doc)
                                       :crux.db.fn/failed? true}))))))
 
+;; TODO The mix of docs & encoded-docs is hard to grapple with. It can also lead to inconsistency between the two.
+
 (defn- index-docs [{:keys [index-store-tx !tx]} docs encoded-docs]
   (when (seq docs)
     (when-let [missing-ids (seq (remove :crux.db/id (vals docs)))]
       (throw (err/illegal-arg :missing-eid {::err/message "Missing required attribute :crux.db/id"
                                             :docs missing-ids})))
-    (let [{:keys [indexed-docs]} (db/index-docs index-store-tx docs encoded-docs)
+    (let [indexed-docs (db/index-docs index-store-tx encoded-docs)
           av-count (->> (vals indexed-docs) (apply concat) (count))]
       (swap! !tx
              (fn [tx]

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -70,8 +70,6 @@
                                      {:crux.db/id (:crux.db/id arg-doc)
                                       :crux.db.fn/failed? true}))))))
 
-;; TODO The mix of docs & encoded-docs is hard to grapple with. It can also lead to inconsistency between the two.
-
 (defn- index-docs [{:keys [index-store-tx !tx]} docs encoded-docs]
   (when (seq docs)
     (when-let [missing-ids (seq (remove :crux.db/id (vals docs)))]

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -525,13 +525,10 @@
                                                               without-tx-fn-docs)}))]
                                  (.put txs-docs-encoder-queue txs)))
 
-
             txs-doc-encoder-fn (fn [txs]
                                  (let [txs (doall
                                             (for [{:keys [docs] :as m} txs]
-                                              (let [encoded-docs (db/encode-docs index-store docs)
-                                                    bytes-indexed (->> encoded-docs (transduce (comp cat (map mem/capacity)) +))]
-                                                (assoc m :encoded-docs (with-meta encoded-docs {:bytes-indexed bytes-indexed})))))]
+                                              (assoc m :encoded-docs (db/encode-docs index-store docs))))]
                                    (.put txs-process-queue txs)))
 
             txs-process-fn (fn [txs]

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -307,9 +307,7 @@
 
       (swap! !tx update :tx-events into tx-events)
 
-      (index-docs this (-> (select-keys prefetched-docs (txc/tx-events->doc-hashes tx-events))
-                           without-tx-fn-docs)
-                  encoded-docs)
+      (index-docs this prefetched-docs encoded-docs)
 
       (with-open [index-snapshot (db/open-index-snapshot index-store-tx)]
         (let [deps (assoc this :index-snapshot index-snapshot)

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -77,14 +77,14 @@
     (when-let [missing-ids (seq (remove :crux.db/id (vals docs)))]
       (throw (err/illegal-arg :missing-eid {::err/message "Missing required attribute :crux.db/id"
                                             :docs missing-ids})))
-    (let [indexed-docs (db/index-docs index-store-tx encoded-docs)
-          av-count (->> (vals indexed-docs) (apply concat) (count))]
+    (db/index-docs index-store-tx encoded-docs)
+    (let [av-count (->> (vals docs) (apply concat) (count))]
       (swap! !tx
              (fn [tx]
                (-> tx
                    (update :av-count + av-count)
                    (update :bytes-indexed + (:bytes-indexed (meta encoded-docs)))
-                   (update :doc-ids into (map c/new-id) (keys indexed-docs))))))))
+                   (update :doc-ids into (map c/new-id) (keys docs))))))))
 
 (defn- etx->vt [^EntityTx etx]
   (.vt etx))

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -357,11 +357,11 @@
     (log/debug "Transaction committed:" (pr-str tx))
 
     (let [{:keys [tx-events]} @!tx]
-      (bus/send bus (into {::xt/event-type ::indexed-tx,
+      (bus/send bus (merge {::xt/event-type ::indexed-tx,
                            :submitted-tx tx,
                            :committed? true
                            ::txe/tx-events tx-events}
-                          (select-keys @!tx [:doc-ids :av-count :bytes-indexed])))))
+                           (select-keys @!tx [:doc-ids :av-count :bytes-indexed])))))
 
   (abort [_]
     (swap! !tx-state (fn [tx-state]

--- a/test/test/xtdb/api/JXtdbNodeTest.java
+++ b/test/test/xtdb/api/JXtdbNodeTest.java
@@ -216,6 +216,7 @@ public class JXtdbNodeTest {
     public void attributeStatsTest() {
         put();
         sync();
+        sleep(100);
         Map<Keyword, ?> stats = node.attributeStats();
         assertEquals(1L, stats.get(DB_ID));
         assertEquals(1L, stats.get(versionId));

--- a/test/test/xtdb/query_test.clj
+++ b/test/test/xtdb/query_test.clj
@@ -1,14 +1,14 @@
 (ns xtdb.query-test
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]
             [clojure.test :as t]
             [clojure.walk :as w]
             [xtdb.api :as xt]
             [xtdb.fixtures :as fix :refer [*api*]]
             [xtdb.fixtures.tpch :as tpch]
             [xtdb.index :as idx]
-            [xtdb.query :as q]
-            [clojure.java.io :as io]
-            [clojure.string :as str])
+            [xtdb.query :as q])
   (:import (java.util Arrays Date UUID)
            (java.util.concurrent TimeoutException)))
 

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -259,9 +259,9 @@
           (t/is (empty? history)))))))
 
 (defn index-tx [tx tx-events docs]
-  (let [{:keys [xtdb/tx-indexer]} @(:!system *api*)
+  (let [{:keys [xtdb/tx-indexer xtdb/index-store]} @(:!system *api*)
         in-flight-tx (db/begin-tx tx-indexer tx nil)]
-    (db/index-tx-events in-flight-tx tx-events docs)
+    (db/index-tx-events in-flight-tx tx-events docs (db/encode-docs index-store docs))
     (db/commit in-flight-tx)))
 
 (t/deftest test-handles-legacy-evict-events


### PR DESCRIPTION
Closes https://github.com/xtdb/xtdb/issues/1692

Pipelines ingest operations:

- 15% - Fetching docs from doc-store for ingestion
- 15% - Encoding of doc KVs
- 65% - Processing of tx-ops and indexing to Rocks
- 5% - Stats

We have observed ~25% savings on ingestion times by parallelising the above operations. 

Potential issues:

- Code is made a little harder, for example `xtdb.tx/index-docs` knowing about docs and `encoded-docs`. I suggest we live with this for now, and a subsequent clean up / refactor - i.e. formalising and specifying what a _batch_ is - could be introduced later.
- The one inconsistency this code introduces currently, is stats recorded aborted KVs in attribute/value counts. We may want to tackle this as part of this PR.

TODOs:

- [x] Error handling (ensure Throwables aren't swallowed)
- [x] Make batch-size configurable (will not do in this PR)
- [x] Consider making stats consistent with previous approach
- [x] Use consistent ThreadPoolExecutor approach
- [x] Run Kondo (ns declaraton tidy up)
- [x] move common threadpool code to io
- [x] Test on ingest weather
