### PR TITLE
fix(http-server): missing tx-time & valid-time in history diff ui

### DIFF
--- a/modules/http-server/src-cljs/xtdb/ui/views.cljs
+++ b/modules/http-server/src-cljs/xtdb/ui/views.cljs
@@ -379,7 +379,7 @@
                           (:xtdb.api/valid-time up-to-date-doc)
                           (:xtdb.api/tx-time up-to-date-doc)]]
                         (for [{:keys [additions deletions
-                                      xt/tx-time xt/valid-time]
+                                      xtdb.api/tx-time xtdb.api/valid-time]
                                :as history-elem} history-diffs]
                           ^{:key history-elem}
                           [:div.entity-history__container


### PR DESCRIPTION
This fixes the missing transaction time and valid time on UI when comparing the diff in the entity history