### PR TITLE
fix(http-client): use *internal-http-request-fn* for api request

### DIFF
--- a/modules/http-client/src/xtdb/remote_api_client.clj
+++ b/modules/http-client/src/xtdb/remote_api_client.clj
@@ -70,23 +70,25 @@
                       (throw error)
                       result))))
               (catch IOException _e))
+            (fn [opts]
+              (http/request opts))
             (fn [_]
               (throw (IllegalStateException. "No supported HTTP client found.")))))))))
 
 (defn- api-request-sync
   ([url {:keys [body http-opts ->jwt-token]}]
    (let [{:keys [body status] :as result}
-         (http/request (merge {:url url
-                               :method :post
-                               :headers (merge (when body
-                                                 {"Content-Type" "application/edn"})
-                                               (when ->jwt-token
-                                                 {"Authorization" (str "Bearer " (->jwt-token))}))
-                               :body (some-> body xio/pr-edn-str)
-                               :accept :edn
-                               :as "UTF-8"
-                               :throw-exceptions false}
-                              (update http-opts :query-params #(into {} (remove (comp nil? val) %)))))]
+         (*internal-http-request-fn* (merge {:url url
+                                             :method :post
+                                             :headers (merge (when body
+                                                               {"Content-Type" "application/edn"})
+                                                             (when ->jwt-token
+                                                               {"Authorization" (str "Bearer " (->jwt-token))}))
+                                             :body (some-> body xio/pr-edn-str)
+                                             :accept :edn
+                                             :as "UTF-8"
+                                             :throw-exceptions false}
+                                            (update http-opts :query-params #(into {} (remove (comp nil? val) %)))))]
      (cond
        (= 404 status)
        nil


### PR DESCRIPTION
Not to sure if the previous change was intended but I noticed that re-binding the *internal-http-request-fn* no longer works when requests are made via the remote-api-client.

This PR gives back the ability of overriding the *internal-http-request-fn* when making api-requests via the remote-api-client and fallback to using required juxt clj-http module.