### PR TITLE
Column families for temporal indexes

### DIFF
--- a/core/src/xtdb/codec.clj
+++ b/core/src/xtdb/codec.clj
@@ -26,7 +26,7 @@
 ;; Indexes
 
 ;; NOTE: Must be updated when existing indexes change structure.
-(def index-version 21)
+(def index-version 22)
 (def ^:const index-version-size Long/BYTES)
 
 (def ^:const index-id-size Byte/BYTES)

--- a/core/src/xtdb/system.clj
+++ b/core/src/xtdb/system.clj
@@ -260,8 +260,6 @@
 (s/def ::nat-int (s/and ::int nat-int?))
 (s/def ::pos-int (s/and ::int pos-int?))
 
-(s/def ::pos-int-list (s/coll-of ::pos-int))
-
 (s/def ::double
   (s/and (s/conformer (fn [x] (cond (float? x) x, (string? x) (Double/parseDouble x), :else x)))
          float?))

--- a/core/src/xtdb/system.clj
+++ b/core/src/xtdb/system.clj
@@ -260,6 +260,8 @@
 (s/def ::nat-int (s/and ::int nat-int?))
 (s/def ::pos-int (s/and ::int pos-int?))
 
+(s/def ::pos-int-list (s/coll-of ::pos-int))
+
 (s/def ::double
   (s/and (s/conformer (fn [x] (cond (float? x) x, (string? x) (Double/parseDouble x), :else x)))
          float?))

--- a/core/test/xtdb/fork_test.clj
+++ b/core/test/xtdb/fork_test.clj
@@ -92,6 +92,12 @@
     (t/testing "returns nil on failed match"
       (t/is (nil? (xt/with-tx db [[::xt/match :nope {:xt/id :nope}]]))))))
 
+(t/deftest test-history-ascending-sanity-check
+  (let [tx1 (fix/submit+await-tx [[::xt/put {:xt/id :ivan, :name "Ivna"}]])]
+    (t/is (not-empty (xt/entity-history (xt/db *api* tx1) :ivan :asc
+                                        {:with-docs? true
+                                         :with-corrections? true})))))
+
 (t/deftest test-history
   (fix/submit+await-tx [[::xt/put {:xt/id :ivan, :name "Ivna"}]])
 

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -41,9 +41,6 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(def ^:const column-family-defs [c/entity+vt+tt+tx-id->content-hash-index-id
-                                 c/entity+z+tx-id->content-hash-index-id])
-
 (defn- iterator->key [^RocksIterator i]
   (when (.isValid i)
     (mem/as-buffer (.key i))))
@@ -217,8 +214,11 @@
                                            :spec #(instance? Options %)}
                               :disable-wal? {:doc "Disable Write Ahead Log"
                                              :default false
-                                             :spec ::sys/boolean}}}
-  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer ^Options db-options block-cache] :as options}]
+                                             :spec ::sys/boolean}
+                              :column-family-defs {:doc "Rocks Column Family Key Prefixes"
+                                                   :default [7, 9]
+                                                   :spec ::sys/pos-int-list}}}
+  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer ^Options db-options block-cache column-family-defs] :as options}]
 
   (RocksDB/loadLibrary)
 

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -41,6 +41,9 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
+(def ^:const column-family-defs [c/entity+vt+tt+tx-id->content-hash-index-id
+                                 c/entity+z+tx-id->content-hash-index-id])
+
 (defn- iterator->key [^RocksIterator i]
   (when (.isValid i)
     (mem/as-buffer (.key i))))
@@ -214,11 +217,8 @@
                                            :spec #(instance? Options %)}
                               :disable-wal? {:doc "Disable Write Ahead Log"
                                              :default false
-                                             :spec ::sys/boolean}
-                              :column-family-defs {:doc "Rocks Column Family Key Prefixes"
-                                                   :default [7, 9]
-                                                   :spec ::sys/pos-int-list}}}
-  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer ^Options db-options block-cache column-family-defs] :as options}]
+                                             :spec ::sys/boolean}}}
+  [{:keys [^Path db-dir sync? disable-wal? metrics checkpointer ^Options db-options block-cache] :as options}]
 
   (RocksDB/loadLibrary)
 

--- a/test/test/xtdb/api_test.clj
+++ b/test/test/xtdb/api_test.clj
@@ -61,7 +61,7 @@
       (t/is (empty? (xt/entity-history empty-db :foo :asc))))))
 
 (t/deftest test-status
-  (t/is (= (merge {:xtdb.index/index-version 21}
+  (t/is (= (merge {:xtdb.index/index-version 22}
                   (when (instance? xtdb.kafka.KafkaTxLog (:tx-log *api*))
                     {:xtdb.zk/zk-active? true}))
            (select-keys (xt/status *api*) [:xtdb.index/index-version :xtdb.zk/zk-active?])))


### PR DESCRIPTION
Sets up column families for temporal indexes. Minimizes temporal seek time during ingest.

This could be seen as a part 1 of column families. We could bring in more CFs and measure the respective performance gains. Note that each CF brings in a 64 mb by default mem-table.

Rebased on #1762 