### PR TITLE
Fix codec/hex->id-buffer `to` arity

### DIFF
--- a/core/src/xtdb/codec.clj
+++ b/core/src/xtdb/codec.clj
@@ -695,7 +695,7 @@
   ([hex to]
    (.putByte ^MutableDirectBuffer to 0 id-value-type-id)
    (mem/hex->buffer hex (mem/slice-buffer to value-type-id-size hash/id-hash-size))
-   to))
+   (mem/limit-buffer to id-size)))
 
 (deftype EDNId [hex original-id]
   IdToBuffer

--- a/core/test/xtdb/codec_test.clj
+++ b/core/test/xtdb/codec_test.clj
@@ -210,3 +210,14 @@
                :uuid (java.util.UUID/randomUUID)}]
       (fix/submit+await-tx node [[::xt/put doc]])
       (t/is (= doc (xt/entity (xt/db node) :foo))))))
+
+(t/deftest test-id-reader-with-existing-buffer-1778
+  (t/testing "can read and convert to real id using existing buffer"
+    (t/is (= (-> #xtdb/id "http://google.com"
+                 c/->id-buffer
+                 mem/buffer->hex
+                 count)
+             (-> #xtdb/id "http://google.com"
+                 (c/id->buffer (mem/allocate-buffer 100))
+                 mem/buffer->hex
+                 count)))))


### PR DESCRIPTION
This fix is in support of #1762 where we would like to use a `ExpandableDirectByteBuffer` ThreadLocal but can't currently because it breaks `:local-kafka-transit` tests (which rely on `hex->id-buffer` to hydrate `#xtdb/id` reader IDs). This fix ensures that the correct thing is returned - i.e. a limited view buffer and not simply the supplied destination buffer.

I had a quick look to see whether any other `*->buffer` functions had a similar issue where the non-limited/sliced thing was being returned, but couldn't see any.

I also couldn't find any existing callers of `hex->id-buffer` that relied on the 2-arg `to` arity, so there should be no impact of the current behaviour (or indeed the fix) to existing users.