### PR TITLE
Closing issue with rocks tx-log

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -62,9 +62,12 @@
   (submit-tx [this tx-events] [this tx-events opts])
   (open-tx-log ^xtdb.api.ICursor [this after-tx-id])
   (latest-submitted-tx [this])
-  (^java.util.concurrent.CompletableFuture subscribe [_ after-tx-id f]
-   "f takes Future + txs - complete the future to stop the subscription.
-    or, outside of f, complete the future returned from this function to stop the subscription."))
+  (^java.util.concurrent.CompletableFuture subscribe
+   [_ after-tx-id f]
+   [_ after-tx-id f completed-promise]
+   "f takes Future + tx - complete the future to stop the subscription.
+    or, outside of f, complete the future returned from this function to stop the subscription.
+    Optionally pass a completed-promise which returns true once the work in f is finished."))
 
 (defprotocol InFlightTx
   (index-tx-docs [in-flight-tx docs])

--- a/core/src/xtdb/kv/tx_log.clj
+++ b/core/src/xtdb/kv/tx_log.clj
@@ -104,8 +104,8 @@
                              (tx-log (::xt/tx-id (last txs))))))))]
         (xio/->cursor (fn []) (tx-log after-tx-id)))))
 
-  (subscribe [this after-tx-id f]
-    (tx-sub/handle-notifying-subscriber subscriber-handler this after-tx-id f))
+  (subscribe [this after-tx-id f completed-promise]
+    (tx-sub/handle-notifying-subscriber subscriber-handler this after-tx-id f completed-promise))
 
   Closeable
   (close [_]


### PR DESCRIPTION
Doing something of the following with a rocksdb tx-log
```clj
(xt/submit-tx xtdb-node data) ;; with data more than 10000 put transaction
(.close xtdb-node)
```
can potentially crash. See the test of the first commit. 

The problem seems to be the `tx-ingester` close [call](https://github.com/xtdb/xtdb/blob/0405e2d04c5f7c85ddd978f67cb525e55656ff26/core/src/xtdb/tx.clj#L430). 
The scenario when this happens is as follows:
1.) The tx-ingester gets closed thereby canceling the thread responsible for catching up with the tx-log.
2.) The tx log gets closed.
3.) The thread responsible for catching up with the tx-log still tries to iterate over a the rocksdb tx-log somewhere around [here](https://github.com/xtdb/xtdb/blob/0405e2d04c5f7c85ddd978f67cb525e55656ff26/core/src/xtdb/tx/subscribe.clj#L93-L113). 

The solution is to wait for the completion / termination of the tx-log catch up thread when closing the `tx-ingester`. I did not see an easy way to do this. I added a ad-hoc solution via a promise (that is definitely not bullet proof) but makes the test pass. I just wanted to get some feedback before moving on.

I don't know if this could potentially also effect other tx-log storage solutions around [here](https://github.com/xtdb/xtdb/blob/0405e2d04c5f7c85ddd978f67cb525e55656ff26/core/src/xtdb/tx/subscribe.clj#L54-L56)
