### PR TITLE
tx-logs containing `clojure.lang.PersistentVector$ChunkedSeq` should still be readable

### DIFF
--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -362,4 +362,5 @@
         (cond
           (vector? entry) {:xtdb.tx.event/tx-events entry}
           (map? entry) entry
-          :else (throw (IllegalStateException. (format "unexpected value on tx-log: '%s'" (pr-str entry)))))))
+          (instance? clojure.lang.PersistentVector$ChunkedSeq entry) {:xtdb.tx.event/tx-events entry}
+          :else (throw (IllegalStateException. (format "unexpected value on tx-log: '%s' of type '%s'" (pr-str entry) (pr-str (type entry))))))))


### PR DESCRIPTION
Adds backwards compatibility for tx-logs that inadvertently contain serializations of `clojure.lang.PersistentVector$ChunkedSeq` instead of plain vectors.

How these serializations might have ended up on the tx-log is unclear to me for the moment, and resolving this alone isn't fully resolving the broader replay issue yet (so a related fix is probably needed also).

The proposed fix is necessary for backwards compatibility since at least the change in https://github.com/xtdb/xtdb/pull/1720

The H2 tx-log where this was observed was written by `20.06-1.8.5-alpha` (or possibly even earlier) but I haven't done a full analysis of all possible changes since then, and this is what was shown prior to fixing:
```clojure
Execution error (IllegalStateException) at xtdb.io/conform-tx-log-entry (io.clj:367).
unexpected value on tx-log: '([:crux.tx/put "0ea5661d363f521f8133b664048b8feb3ad0aeba" "99266546a2219eda420f92d3f0b10d49ec859115"])' of type 'class clojure.lang.PersistentVector$ChunkedSeq'
```