### PR TITLE
M1 early pass

### DIFF
--- a/modules/jdbc/project.clj
+++ b/modules/jdbc/project.clj
@@ -23,7 +23,7 @@
                  [org.postgresql/postgresql "42.2.18" :scope "provided"]
                  [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]
                  [com.h2database/h2 "1.4.200" :scope "provided"]
-                 [org.xerial/sqlite-jdbc "3.28.0" :scope "provided"]
+                 [org.xerial/sqlite-jdbc "3.36.0.3" :scope "provided"]
                  [mysql/mysql-connector-java "8.0.23" :scope "provided"]
                  [com.microsoft.sqlserver/mssql-jdbc "8.2.2.jre8" :scope "provided"]]
 

--- a/modules/kafka/project.clj
+++ b/modules/kafka/project.clj
@@ -15,7 +15,9 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
-                 [org.apache.kafka/kafka-clients "2.6.1" :exclusions [org.lz4/lz4-java]]
+                 [org.apache.kafka/kafka-clients "2.6.1" :exclusions [org.lz4/lz4-java
+                                                                      org.xerial.snappy/snappy-java]]
+                 [org.xerial.snappy/snappy-java "1.1.8.4"]
                  [pro.juxt.clojars-mirrors.cheshire/cheshire]
                  [com.cognitect/transit-clj nil :exclusions [org.msgpack/msgpack]]]
 

--- a/test/project.clj
+++ b/test/project.clj
@@ -22,7 +22,7 @@
                  ;; JDBC
                  [com.h2database/h2 "1.4.200"]
                  [com.opentable.components/otj-pg-embedded "0.13.3"]
-                 [org.xerial/sqlite-jdbc "3.28.0"]
+                 [org.xerial/sqlite-jdbc "3.36.0.3"]
                  [mysql/mysql-connector-java "8.0.23"]
                  [com.microsoft.sqlserver/mssql-jdbc "8.2.2.jre8"]
 

--- a/test/src/xtdb/fixtures/jdbc.clj
+++ b/test/src/xtdb/fixtures/jdbc.clj
@@ -54,8 +54,13 @@
     f))
 
 (def ^:private jdbc-dialects
-  #{:h2 :sqlite :embedded-postgres
-    #_:postgres #_:mysql #_:mssql})
+  (cond->
+    #{:h2 :sqlite #_:postgres #_:mysql #_:mssql}
+
+    ;; current :embedded-postgres dep does not support m1 (amd64)
+    ;; we can upgrade to get support via docker, but it changes the lib significantly (native tarball vs docker)
+    ;; so skipping tests for now
+    (not= "aarch64" (System/getProperty "os.arch")) (conj :embedded-postgres)))
 
 ;; Optional:
 ;; in `xtdb-jdbc`: `docker-compose up` (`docker-compose up -d` for background)


### PR DESCRIPTION
Included in this PR are some commits to improve M1 support, mostly for tests - but snappy will affect users as well.

I opted to update snappy (#1806) without bumping the kafka client itself to limit the chance of accidental breakage for now. I think it'd be worth reviewing our kafka-client dep soon - 2.6.1 is over a year old, upstream is at 3.2.1 (July 22) .