### PR TITLE
First cut of `get-valid-end-time`

### DIFF
--- a/docs/language-reference/modules/ROOT/examples/test/xtdb/docs/examples_test.clj
+++ b/docs/language-reference/modules/ROOT/examples/test/xtdb/docs/examples_test.clj
@@ -102,3 +102,24 @@
 
 ;; end::history-range[]
 )
+
+(defn example-history-predicates [node]
+;; tag::history-predicates[]
+(xt/submit-tx node [[::xt/put
+                     {:xt/id 1 :hello :world}
+                     #inst "1900-08-29T15:05:31.530-00:00"
+                     #inst "2100-08-29T15:05:31.530-00:00"]])
+
+(xt/q (xt/db node)
+      '{:find [e start-time end-time]
+        :where [[e :hello :world]
+                [(get-start-valid-time e) start-time]
+                [(get-end-valid-time e) end-time]]})
+
+;yields
+#{[1
+   #inst "1900-08-29T15:05:31.530-00:00"
+   #inst "2100-08-29T15:05:31.530-00:00"]}
+
+;; end::history-predicates[]
+)

--- a/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
+++ b/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
@@ -857,6 +857,16 @@ include::example$test/xtdb/docs/examples_test.clj[tags=history-range,indent=0]
 === Lazy Iteration
 See the `open-entity-history` (Clojure) and `openEntityHistory` (Java) APIs.
 
+=== History predicates
+There also exists the predicates `get-start-valid-time` and `get-end-valid-time` to access
+the history of an entity inside a query. These allow to get the start `valid-time` and
+`end-valid` time of an entity with respect to the snapshot view of the given db.
+
+[source,clj]
+----
+include::example$test/xtdb/docs/examples_test.clj[tags=history-predicates,indent=0]
+----
+
 [#clojure-tips]
 == Clojure Tips
 


### PR DESCRIPTION
This would allow to get valid-end-time in queries without resorting to creating future db instances
```clj
'{:find [?e ?end-time]
  :where [[?e :type :some-value2]
               [(get-valid-end-time ?e) ?end-time]]}
```
the predicate constraint also takes an optional second argument as default value if no `end-time` can be found. `nil` is returned if no end-time can be found an no default was specified. The `end-time` is currently defined as the next time the entity changes or is removed. 

Possible improvements:
- allow literals, currently only logic vars work
- currently another roundtrip (buffer -> value) is needed for accessing the `entity-history`. Another option is to seek with the `eid` buffer into the bitemp indices directly. This would possibly be faster and avoid iterating through the whole history of the entity. It would probably a bit less clean as there is no function/protocol to do so on the index snapshot.

Possible impact:
- The db `valid-time` had to be added the query-cache for this to work correctly.   