### PR TITLE
Fix jdbc `open-tx-log` unbounded tx query result set

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -61,7 +61,15 @@
 
 (defprotocol TxLog
   (submit-tx [this tx-events] [this tx-events opts])
-  (open-tx-log ^xtdb.api.ICursor [this after-tx-id])
+  (open-tx-log ^xtdb.api.ICursor [this after-tx-id]
+   "Returns a serialized iterator (cursor) over transactions (see spec ::xtdb.api/tx) in the log after the given tx id.
+
+   The cursor:
+
+   - is free to return log entries introduced after the creation of the cursor.
+   - does not necessarily block when it runs out of entries, the sequence can just end. Do not expect it to be infinite or blocking.
+   - it can appear infinite regardless of any blocking or polling behaviour, given frequent enough writes to the log.
+   - should be closed with .close to free any resources such as threads or connections held by the cursor.")
   (latest-submitted-tx [this])
   (^java.util.concurrent.CompletableFuture subscribe [_ after-tx-id f]
    "f takes Future + txs - complete the future to stop the subscription.

--- a/modules/jdbc/docker-compose.yml
+++ b/modules/jdbc/docker-compose.yml
@@ -1,24 +1,25 @@
 version: '2'
 services:
   postgres:
-    image: postgres:13.2
+    image: postgres:14.5
     ports:
       - "5432:5432"
     environment:
       POSTGRES_PASSWORD: postgres
 
   mysql:
-    image: mysql:8.0.21
+    image: mysql:8.0.30
     ports:
       - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: my-secret-pw
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+    # using edge image for now due to issue with M1 https://github.com/microsoft/mssql-docker/issues/668
+    # go back to sql server when we can, but as we do not use any advanced sql server features, edge should be enough
+    image: mcr.microsoft.com/azure-sql-edge
     ports:
       - "1433:1433"
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: "yourStrong(!)Password"
-      MSSQL_PID: Express


### PR DESCRIPTION
# Problem

The current jdbc open-tx-log requires materialization of an unbounded number of records, if your log is very large and your watermark is low (perhaps you are re-indexing) then it is somewhat likely XTDB will run out of available memory and crash. See #1682 and #1163.

# Solutions considered

## Pagination via limit query

My initial thought was to use `LIMIT` in addition to the existing range query on `EVENT_OFFSET` to fetch some number of rows, continuing the seek at the next offset. The problem with doing this is syntax for fetching becomes vendor specific. It remains a solid option but may be somewhat more expensive to test and maintain than a solution that is compatible with all supported dialects (range query below would do this).

## Streaming ResultSet

Certain drivers allow one to configure statements or connections to stream row data via the ResultSet interface in batches or a row at a time. Such configuration would be vendor specific. This solution would allow us to lean on hopefully optimised and well tested solutions for each vendors jdbc driver. However it would require specific set up and tests to get confidence that we have solved our problem.

For all dialects AFAICT we need to ensure forward only, read only result set flags are used `(.prepareStatement conn sql ResultSet/TYPE_FORWARD_ONLY ResultSet/CONCUR_READ_ONLY)`.

### MySQL 

I have found two ways to configure the driver for streaming (see resultset section [here](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-implementation-notes.html))

 - connection property: [useCursorFetch](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_useCursorFetch). Enables the use of server side cursors for result sets, meaning that clients need not materialize entire result set in memory. I haven't looked at details for long enough, but it seems to imply a temporary table used for the results server side.
 
 - using `Integer/MIN_VALUE` as the jdbc `fetchSize`, this switches the result set into a row-by-row streaming mode, it is unclear what buffering policy (if any is applied) so we should keep an eye on performance impact. There is potential caveat about potentially having to read all rows before the result set can be closed (unverified).

### Postgres

Postgres will use a server side cursor and stream results up to `fetchSize` rows _if_ the autocommit flag is off. See `cursor` [here](https://jdbc.postgresql.org/documentation/head/query.html)

### SQL Server 

It seems you can use a server cursor to use `fetchSize` [here](https://docs.microsoft.com/en-us/sql/connect/jdbc/working-with-statements-and-result-sets?view=sql-server-ver16#use-the-appropriate-fetch-size)

Or you can rely on the (by default in 2.0+ drivers) [adaptive buffering](https://docs.microsoft.com/en-us/sql/connect/jdbc/using-adaptive-buffering?view=sql-server-ver16) 

### Oracle

Oracle fetches from cursors by default with a `fetchSize` of 10 rows ([see fetch size](https://docs.oracle.com/database/121/JJDBC/resltset.htm#JJDBC28620)), it should respect whichever fetch size we choose.

### SQLite 

The JDBC driver for SQLite is unbuffered and it seems each row pulled on `.next` [by default](https://github.com/xerial/sqlite-jdbc/blob/master/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java#L54)

### H2

(still investigating, not tested)

## Pagination via range query

I played with the idea having the open-tx-log cursor seq through the log with multiple discrete fetches (using `BETWEEN` or a `>` `<=` combo on the offset sequence. 

However, as transactions share the same table (and offset sequence) with docs (and potentially other topics) it is not as straightforward as `SELECT EVENT_OFFSET, TX_TIME, V, TOPIC FROM tx_events WHERE TOPIC = 'txs' AND EVENT_OFFSET > ? AND EVENT_OFFSET <= ? ORDER BY EVENT_OFFSET`

you could

- load all offsets per fetch (to find the next watermark)
- treat fetch-size as a max hint, introduce an extra speculative query on empty result set in case the offset range did not contain any transactions (say every offset for that batch was consumed by a doc, or some other topic).

Both of these may end up with batch sizing being dependent on the ratio of transactions to documents, this may vary by deployment and log so that makes it challenging to discover an appropriate initial policy.

## 1st solution attempt

See [this branch](https://github.com/wotbrew/xtdb/tree/jdbc-fetch-limit-range-query). It involves repeatedly issuing range queries to seq through unbounded `tx_events` tables. To simplify the initial implementation this is done by loading all offset sequences to avoid the problem of offset ids being shared between 'topics'. The main cost of this approach will be the redundant loading of non-transaction events, such as docs - so it may slow down ingest for smaller jdbc transaction logs, or those where the ratio of docs to transactions is heavily weighted toward docs.

## 2nd solution attempt

In this PR then is a set of tweaks to the PreparedStatement in `open-tx-log` to enable result set streaming. Testing this behaviour actually solves the problem is a little more difficult, I have been working on a stress test that should be able to trigger OOM without the fetch buffering, but it is still WIP.

