### PR TITLE
Fix LMDB MAP_FULL resizing race during store

### DIFF
--- a/modules/lmdb/project.clj
+++ b/modules/lmdb/project.clj
@@ -14,9 +14,11 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
-                 [org.lmdbjava/lmdbjava "0.7.0"]
-                 [org.lwjgl/lwjgl "3.2.3" :classifier "natives-linux" :native-prefix ""]
-                 [org.lwjgl/lwjgl-lmdb "3.2.3" :classifier "natives-linux" :native-prefix ""]
-                 [org.lwjgl/lwjgl "3.2.3" :classifier "natives-macos" :native-prefix ""]
-                 [org.lwjgl/lwjgl-lmdb "3.2.3" :classifier "natives-macos" :native-prefix ""]
-                 [org.lwjgl/lwjgl-lmdb "3.2.3"]])
+                 [org.lmdbjava/lmdbjava "0.8.2"]
+                 [org.lwjgl/lwjgl "3.3.1" :classifier "natives-linux" :native-prefix ""]
+                 [org.lwjgl/lwjgl-lmdb "3.3.1" :classifier "natives-linux" :native-prefix ""]
+                 [org.lwjgl/lwjgl "3.3.1" :classifier "natives-macos" :native-prefix ""]
+                 [org.lwjgl/lwjgl-lmdb "3.3.1" :classifier "natives-macos" :native-prefix ""]
+                 [org.lwjgl/lwjgl "3.3.1" :classifier "natives-macos-arm64" :native-prefix ""]
+                 [org.lwjgl/lwjgl-lmdb "3.3.1" :classifier "natives-macos-arm64" :native-prefix ""]
+                 [org.lwjgl/lwjgl-lmdb "3.3.1"]])

--- a/modules/lmdb/src/xtdb/lmdb.clj
+++ b/modules/lmdb/src/xtdb/lmdb.clj
@@ -46,7 +46,7 @@
   (let [stamp (acquire-write-lock mapsize-lock)]
     (try
       (with-open [stack (MemoryStack/stackPush)]
-        (let [info (MDBEnvInfo/mallocStack stack)]
+        (let [info (MDBEnvInfo/malloc stack)]
           (success? (LMDB/mdb_env_info env info))
           (let [new-mapsize (* factor (.me_mapsize info))]
             (log/debug "Increasing mapsize to:" new-mapsize)
@@ -137,8 +137,8 @@
               tx (new-transaction mapsize-lock env 0)
               cursor (new-cursor dbi (:txn tx))]
     (let [{:keys [cursor]} cursor
-          kv (MDBVal/mallocStack stack)
-          dv (MDBVal/mallocStack stack)
+          kv (MDBVal/malloc stack)
+          dv (MDBVal/malloc stack)
           kb (ExpandableDirectByteBuffer.)
           vb (ExpandableDirectByteBuffer.)]
       (doseq [[k v] kvs]
@@ -158,10 +158,10 @@
 (defn- tx-get [dbi ^LMDBTransaction tx k]
   (with-open [stack (MemoryStack/stackPush)]
     (let [k (mem/->off-heap k)
-          kv (-> (MDBVal/mallocStack stack)
+          kv (-> (MDBVal/malloc stack)
                  (.mv_data (MemoryUtil/memByteBuffer (.addressOffset k) (.capacity k)))
                  (.mv_size (.capacity k)))
-          dv (MDBVal/mallocStack stack)
+          dv (MDBVal/malloc stack)
           rc (LMDB/mdb_get (.txn tx) dbi kv dv)]
       (when-not (= LMDB/MDB_NOTFOUND rc)
         (success? rc)
@@ -242,7 +242,7 @@
   (count-keys [_]
     (with-open [stack (MemoryStack/stackPush)
                 tx (new-transaction mapsize-lock env LMDB/MDB_RDONLY)]
-      (let [stat (MDBStat/mallocStack stack)]
+      (let [stat (MDBStat/malloc stack)]
         (LMDB/mdb_stat (.txn tx) dbi stat)
         (.ms_entries stat))))
 

--- a/test/test/xtdb/kv_test.clj
+++ b/test/test/xtdb/kv_test.clj
@@ -291,6 +291,8 @@
       (let [r-fs (for [_ (range 128)]
                    (future
                      (String. ^bytes (value kv-store (long->bytes 1)))))]
+        (doall w-fs)
+        (doall r-fs)
         (mapv deref w-fs)
         (doseq [r-f r-fs]
           (t/is (= "XTDB" @r-f)))))))


### PR DESCRIPTION
This PR the LMDB module has had some dependency bumps, including new natives for arm64 macs - which caused the tests to be runnable, but flaky.

TLDR; Flake seems to be due to a race condition in the `kv/store` implementation which allowed queued concurrent writes to all see a MAP_FULL error, and then go on each to increase the mapsize by a factor of two, very quickly resulting in segfault. 

## Notes on the `MAP_FULL` race

The pattern we use in the code is to double the size of the lmdb database when we receive a `MAP_FULL` on a kv/store call [here](https://github.com/xtdb/xtdb/blob/master/modules/lmdb/src/xtdb/lmdb.clj#L223). 

The (apparent) issue with the implementation is that multiple concurrent requests can race to resize the map at the same time (applying a factor), causing multiple doublings in a short amount of time, rather than an OOM error, this seems to result in a segfault. At least when running concurrent tests on my M1 mac.

This is made worse because of the exclusive lock on `increase-mapsize`, it means all pending transactions seeing `MAP_FULL` will queue up to increase the map size (and do so), regardless of whether it has already been increased by another thread. I observed a low <= 32 number of concurrent `store` operations could trigger this segfault.

It might be better to ensure at most one resize happens, and that pending operations (seeing the same `MAP_FULL`) are then retried. 

This PR attempts this by ensuring map resizes happen under an exclusive lock, so that only one of them gets to do so before pending writes are retried.