### PR TITLE
Reduce allocations in free-memory-loop.

### DIFF
--- a/core/src/xtdb/cache/second_chance.clj
+++ b/core/src/xtdb/cache/second_chance.clj
@@ -113,15 +113,16 @@
 (def ^:private ^:const free-memory-check-interval-ms 1000)
 
 (defn- free-memory-loop []
-  (try
-    (while true
-      (let [max-memory (.maxMemory (Runtime/getRuntime))
-            used-memory (- (.totalMemory (Runtime/getRuntime))
-                           (.freeMemory (Runtime/getRuntime)))
-            free-memory (- max-memory used-memory)]
-        (.set free-memory-ratio (double (/ free-memory max-memory))))
-      (Thread/sleep free-memory-check-interval-ms))
-    (catch InterruptedException _)))
+  (let [runtime (Runtime/getRuntime)]
+    (try
+      (while true
+        (let [max-memory (.maxMemory runtime)
+              used-memory (-  (.totalMemory runtime)
+                              (.freeMemory runtime))
+              free-memory (- max-memory used-memory)]
+          (.set free-memory-ratio  (/ (double free-memory) (double max-memory))))
+        (Thread/sleep free-memory-check-interval-ms))
+      (catch InterruptedException _))))
 
 (def ^:private ^Thread free-memory-thread
   (do (when (and (bound? #'free-memory-thread) free-memory-thread)


### PR DESCRIPTION
Whilst investigating performance issues with Second Chance cache I noticed that the free-memory-loop was allocating ~1k bytes/sec. 

This is excessive.

Two possible causes are noted
* multiple calls to `(Runtime/getRuntime)`
* (unnecessary) boxing of primitives and the creation of a clojure.lang.Ratio which is then cast immediately to a double. This is another occurrence of the issue fixed elsewhere in 9a36cad2e7316e4c8aa093af7a698292fe398033

This PR rearranges `free-memory-loop` to reduce allocations. With this change the allocation rate falls to ~24B/sec

 