### PR TITLE
Apply back pressure to second chance writers when resizing

### DIFF
--- a/core/src/xtdb/cache/second_chance.clj
+++ b/core/src/xtdb/cache/second_chance.clj
@@ -144,26 +144,6 @@
                      (.offer cooling vp))
             (.unswizzle vp (.getKey e))))))))
 
-(def ^:private ^AtomicReference free-memory-ratio (AtomicReference. 1.0))
-(def ^:private ^:const free-memory-check-interval-ms 1000)
-
-(defn- free-memory-loop []
-  (try
-    (while true
-      (let [max-memory (.maxMemory (Runtime/getRuntime))
-            used-memory (- (.totalMemory (Runtime/getRuntime))
-                           (.freeMemory (Runtime/getRuntime)))
-            free-memory (- max-memory used-memory)]
-        (.set free-memory-ratio (double (/ free-memory max-memory))))
-      (Thread/sleep free-memory-check-interval-ms))
-    (catch InterruptedException _)))
-
-(def ^:private ^Thread free-memory-thread
-  (do (when (and (bound? #'free-memory-thread) free-memory-thread)
-        (.interrupt ^Thread free-memory-thread))
-      (doto (Thread. ^Runnable free-memory-loop "xtdb.cache.second-chance.free-memory-thread")
-        (.setDaemon true))))
-
 (defn- move-to-cold-state [^SecondChanceCache cache]
   (let [cooling ^Queue (.cooling cache)
         cold ^ICache (.cold cache)

--- a/test/test/xtdb/cache/second_chance_test.clj
+++ b/test/test/xtdb/cache/second_chance_test.clj
@@ -1,0 +1,40 @@
+(ns xtdb.cache.second-chance-test
+  (:require [clojure.test :as t]
+            [xtdb.cache.second-chance :as scc])
+  (:import (java.time Duration)))
+
+(set! *warn-on-reflection* false)
+
+;; https://github.com/xtdb/xtdb/pull/1821
+(t/deftest cache-size-back-pressure-test
+  (let [stop (atom false)]
+    (try
+      (let [sample-for (Duration/ofSeconds 1)
+            sample-frequency (Duration/ofMillis 10)
+            cache-size 1024
+            n-elements (* 1024 1024)
+            n-threads 42
+
+            elements (vec (repeatedly n-elements #(rand-int Integer/MAX_VALUE)))
+            scc (scc/->second-chance-cache
+                  {:cache-size cache-size
+                   :adaptive-sizing? false
+                   :cooling-factor 0.1
+                   :adaptive-break-even-level 0.8
+                   :downsize-load-factor 0.01})
+            mutate (fn [] (let [k (rand-nth elements)] (.computeIfAbsent scc k identity (constantly k))))
+            sizes-ref (atom [])]
+
+        (dorun (repeatedly n-threads #(future (while (not @stop) (mutate)))))
+
+        (loop [sample-until (+ (System/currentTimeMillis) (.toMillis sample-for))]
+          (swap! sizes-ref conj (.size (.getHot scc)))
+          (Thread/sleep (max 1 (.toMillis sample-frequency)))
+          (when (< (System/currentTimeMillis) sample-until)
+            (recur sample-until)))
+
+        (let [sizes @sizes-ref
+              max-size (reduce max 0 sizes)]
+          (t/is (<= max-size (+ cache-size 2048)))))
+
+      (finally (reset! stop true)))))


### PR DESCRIPTION
It has been observed that the second chance cache may be using too much memory here #1818 

After reviewing the code I noticed that a cache can be full (and resizing) but no back pressure is applied to producers who may continue creating new cache entries.

I ran some experiments and observed that even with 2 threads, you could cause the cache to grow far beyond the `:cache-size` limit. (See examples below).

## Examples

I set up a quick test that filled the cache with integers over 10 seconds, and sampled the size of the hot cache every 10 milliseconds.

- `:cache-size` is `1024`
- `:adaptive-sizing?` is `false`

### 1 Thread
![image](https://user-images.githubusercontent.com/4095999/189940200-769648d4-7b77-4e1a-a4a9-28ee99044a34.png)

### 2 Threads
![image](https://user-images.githubusercontent.com/4095999/189940256-a82f3f30-50b2-4770-926b-29ca7fd75b85.png)

### 42 Threads
![image](https://user-images.githubusercontent.com/4095999/189940330-42fbffb1-832c-4642-9fdf-c7596971665d.png)

## Semaphore solution (initial choice) 

Force cache misses to await any pending resize when the cache is bigger than the max size, applying back pressure. A small buffer of `1024` allows a small number of misses to not block, if contention is not high. We reuse the resize semaphore to cause the blocking behaviour.

##  Counter solution

An alternative solution that was considered is to use an atomic counter initialised to max size, each put decrements the counter - if negative, the put must spin (and increment) until the counter is not negative. Evictions increment the counter.

This should bring about desired back pressure without risking the `.size` problem (see @sw1nn comment) and as far as co-ordination is concerned _should_ be very cheap - measurement pending.