### PR TITLE
Switch default cache to LRU

### DIFF
--- a/core/src/xtdb/cache.clj
+++ b/core/src/xtdb/cache.clj
@@ -2,6 +2,7 @@
   (:require [xtdb.cache.second-chance :as sc]
             [xtdb.system :as sys]
             [xtdb.cache.lru :as lru]
+            [xtdb.error :as err]
             [clojure.tools.logging :as log])
   (:import xtdb.cache.ICache
            xtdb.cache.second_chance.ConcurrentHashMapTableAccess))
@@ -13,14 +14,20 @@
   (.evict cache k))
 
 (defn ->cache
-  {::sys/args {:cache-size {:doc "Cache size"
+  {::sys/args {:cache-alg {:doc "Vary the default cache algorithm"
+                           :default :lru
+                           :spec #{:lru :second-chance}}
+               :cache-size {:doc "Cache size"
                             :default (* 128 1024)
                             :spec ::sys/nat-int}}}
   ^xtdb.cache.ICache [opts]
-  (if (ConcurrentHashMapTableAccess/canAccessTable)
-    (sc/->second-chance-cache opts)
-    (do
-      (defonce scc-warning
-        (log/warn "Could not open ConcurrentHashMap.table field - falling back to LRU caching. Use `--add-opens java.base/java.util.concurrent=ALL-UNNAMED` to use the second-chance cache.")) ;
-
-      (lru/->lru-cache opts))))
+  (case (:cache-alg opts (-> #'->cache meta ::sys/args :cache-alg :default))
+    :lru (lru/->lru-cache opts)
+    :second-chance
+    (if (ConcurrentHashMapTableAccess/canAccessTable)
+      (sc/->second-chance-cache opts)
+      (do
+        (defonce scc-warning
+          (log/warn "Could not open ConcurrentHashMap.table field - falling back to LRU caching. Use `--add-opens java.base/java.util.concurrent=ALL-UNNAMED` to use the second-chance cache."))
+        (lru/->lru-cache opts)))
+    (throw (err/illegal-arg :cache-alg))))


### PR DESCRIPTION
Due to bugs discovered with the second-chance cache (#1818, #1821, #1822), it is recommended we disable it by default, until such a time we have more confidence in its correctness and performance.

This PR adds a new config option to specify the caching algorithm for a particular module `:cache-alg` whose value can be `:lru` by default or `:second-chance`.

Would expect this to cause a performance regression, bench results incoming.