### PR TITLE
Fix order-by for external sort

### DIFF
--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -147,7 +147,7 @@
    (->> (new-merge-sort-priority-queue comp sorted-seqs)
         (merge-sort-priority-queue->seq))))
 
-(def ^:const default-external-sort-part-size (* 1024 1024))
+(def default-external-sort-part-size (* 1024 1024))
 
 (defn with-nippy-thaw-all* [f]
   (binding [nippy/*thaw-serializable-allowlist* #{"*"}]

--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -123,11 +123,11 @@
 
 ;; External Merge Sort
 
-(defn- new-merge-sort-priority-queue ^PriorityQueue [comp sorted-seqs]
+(defn- new-merge-sort-priority-queue ^PriorityQueue [^Comparator comp sorted-seqs]
   (let [sorted-seqs (remove empty? sorted-seqs)
         pq-comp (reify Comparator
                   (compare [_ [a] [b]]
-                    (comp a b)))]
+                    (.compare comp a b)))]
     (doto (PriorityQueue. (max 1 (count sorted-seqs)) pq-comp)
       (.addAll sorted-seqs))))
 

--- a/test/test/xtdb/query_test.clj
+++ b/test/test/xtdb/query_test.clj
@@ -9,7 +9,8 @@
             [xtdb.fixtures.kv :as fkv]
             [xtdb.fixtures.tpch :as tpch]
             [xtdb.index :as idx]
-            [xtdb.query :as q])
+            [xtdb.query :as q]
+            [xtdb.io :as xio])
   (:import (java.util Arrays Date UUID)
            (java.util.concurrent TimeoutException)))
 
@@ -4155,3 +4156,13 @@
                                      {:with-docs? true, :with-corrections? true
                                       :start-tx {::xt/tx-time (Date. (dec (.getTime tx-time)))}})
                   (map #(select-keys % [::xt/tx-id ::xt/doc])))))))
+
+(t/deftest external-sort-test
+  (with-redefs [xio/default-external-sort-part-size 1024]
+    (fix/submit+await-tx (for [i (range 1025)]
+                           [::xt/put {:xt/id i, :some/data i}]))
+    (t/is (= (mapv vector (range 1025))
+             (xt/q (xt/db *api*)
+                   '{:find [i]
+                     :where [[?e :some/data i]]
+                     :order-by [[i :asc]]})))))


### PR DESCRIPTION
Currently the invocation of the `order-by` comparator  for external sorting is broken https://github.com/xtdb/xtdb/blob/ae34fd5b27aa33ea914df6bc4ab52c3e3d853c19/core/src/xtdb/io.clj#L130 as Comparators don't implement `IFn`.

I also made `default-external-sort-part-size` in `xtdb.io` dynamic which made testing easier and would allow dynamic adjustment of memory usage for certain `order-by` queries. This doesn't need to go in like this. We could also make this configurable on start up as the current default seems to be an issue on my current project. 