### PR TITLE
LMDB fairer lock synchronisation

### DIFF
--- a/modules/lmdb/project.clj
+++ b/modules/lmdb/project.clj
@@ -11,6 +11,13 @@
 
   :scm {:dir "../.."}
 
+  :java-source-paths ["src"]
+  :javac-options ["-source" "8" "-target" "8"
+                  "-XDignore.symbol.file"
+                  "-Xlint:all,-options,-path"
+                  "-Werror"
+                  "-proc:none"]
+
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]

--- a/modules/lmdb/project.clj
+++ b/modules/lmdb/project.clj
@@ -1,23 +1,6 @@
 (defproject com.xtdb/xtdb-lmdb "<inherited>"
   :description "XTDB LMDB"
 
-  :plugins [[lein-parent "0.3.8"]]
-
-  :parent-project {:path "../../project.clj"
-                   :inherit [:version :repositories :deploy-repositories
-                             :managed-dependencies
-                             :pedantic? :global-vars
-                             :license :url :pom-addition]}
-
-  :scm {:dir "../.."}
-
-  :java-source-paths ["src"]
-  :javac-options ["-source" "8" "-target" "8"
-                  "-XDignore.symbol.file"
-                  "-Xlint:all,-options,-path"
-                  "-Werror"
-                  "-proc:none"]
-
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
@@ -28,4 +11,36 @@
                  [org.lwjgl/lwjgl-lmdb "3.3.1" :classifier "natives-macos" :native-prefix ""]
                  [org.lwjgl/lwjgl "3.3.1" :classifier "natives-macos-arm64" :native-prefix ""]
                  [org.lwjgl/lwjgl-lmdb "3.3.1" :classifier "natives-macos-arm64" :native-prefix ""]
-                 [org.lwjgl/lwjgl-lmdb "3.3.1"]])
+                 [org.lwjgl/lwjgl-lmdb "3.3.1"]]
+
+  :plugins [[lein-javadoc "0.3.0"]
+            [lein-parent "0.3.8"]]
+
+  :parent-project {:path "../../project.clj"
+                   :inherit [:version :repositories :deploy-repositories
+                             :managed-dependencies
+                             :pedantic? :global-vars
+                             :license :url :pom-addition]}
+
+  :scm {:dir "../.."}
+
+  :java-source-paths ["src"]
+
+  :javac-options ["-source" "8" "-target" "8"
+                  "-XDignore.symbol.file"
+                  "-Xlint:all,-options,-path"
+                  "-Werror"
+                  "-proc:none"]
+
+  :javadoc-opts {:package-names ["xtdb"]
+                 :output-dir "target/javadoc/out"
+                 :additional-args ["-windowtitle" "XTDB LMDB Javadoc"
+                                   "-quiet"
+                                   "-Xdoclint:none"
+                                   "-link" "https://docs.oracle.com/javase/8/docs/api/"
+                                   "-link" "https://www.javadoc.io/static/org.clojure/clojure/1.10.3"]}
+
+  :classifiers {:sources {:prep-tasks ^:replace []}
+                :javadoc {:prep-tasks ^:replace ["javadoc"]
+                          :omit-source true
+                          :filespecs ^:replace [{:type :path, :path "target/javadoc/out"}]}})

--- a/modules/lmdb/src/xtdb/MapResizeSync.java
+++ b/modules/lmdb/src/xtdb/MapResizeSync.java
@@ -1,0 +1,85 @@
+package xtdb;
+
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+/**
+ * Provides synchronization for LMDB map resizes, see lmdb.clj (new-mapsize-sync).
+ * This class is an implementation detail of the lmdb module and may change without notice.
+ *
+ *
+ * Magic numbers:
+ *
+ * Lock state (atomic int):
+ * -1 write lock held for resize
+ * 0 no open transactions, no resize lock (default)
+ * 1+ number of open transactions
+ *
+ * Signal arg to acquire/release methods is 1 for 'open transaction' or -1 for 'map resize lock'.
+ */
+public class MapResizeSync extends AbstractQueuedSynchronizer {
+
+    private static final long serialVersionUID = -1672790154983593262L;
+
+    // Notes:
+    // I wanted to avoid the .java, but couldn't easily use (proxy) in clj because protected methods cannot be called.
+
+    // Reason for queued synchronizer to get fairness policy and platform blocking for LMDB locks without implementing our own spin.
+    // originally the stamped lock that was in use did not enforce fairness / write priority which could cause ingestion to wait too long
+    // to get lock.
+    public MapResizeSync() {
+        super();
+    }
+
+    @Override
+    protected boolean tryAcquire(int signal) {
+        // note: not re-entrant, not yet necessary
+        assert signal == -1;
+        if (compareAndSetState(0, -1)) {
+            setExclusiveOwnerThread(Thread.currentThread());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean tryRelease(int signal) {
+        assert signal == -1;
+        if (!isHeldExclusively()) {
+            throw new IllegalMonitorStateException("Map lock released on-non owner thread");
+        }
+        setState(0);
+        setExclusiveOwnerThread(null);
+        return true;
+    }
+
+    @Override
+    protected boolean isHeldExclusively() {
+        return getExclusiveOwnerThread() == Thread.currentThread();
+    }
+    @Override
+    protected int tryAcquireShared(int signal) {
+        assert signal == 1;
+        if (hasQueuedPredecessors()) {
+            return -1;
+        }
+        int st = getState();
+        if (st >= 0 && compareAndSetState(st, st+1)) {
+            return st+1;
+        }
+        return -1;
+    }
+
+    @Override
+    protected boolean tryReleaseShared(int signal) {
+        assert signal == 1;
+        for(;;) {
+            int st = getState();
+            if (st < 1) {
+                throw new IllegalMonitorStateException("Release of map resize read lock did not correspond to an acquire.");
+            }
+            if (compareAndSetState(st, st-1)) {
+                return true;
+            }
+        }
+    }
+}

--- a/modules/lmdb/src/xtdb/lmdb.clj
+++ b/modules/lmdb/src/xtdb/lmdb.clj
@@ -305,8 +305,7 @@
         env (env-create)
         mapsize-lock (StampedLock.)]
     (try
-      (when env-set-maxreaders
-        (env-set-maxreaders env env-maxreaders))
+      (env-set-maxreaders env env-maxreaders)
       (env-open env db-dir env-flags)
       (when env-mapsize
         (env-set-mapsize env env-mapsize))

--- a/modules/lmdb/src/xtdb/lmdb.clj
+++ b/modules/lmdb/src/xtdb/lmdb.clj
@@ -44,7 +44,9 @@
   When a resize is needed the (kv/store) call will acquire an exclusive (resize) lock, ensuring no concurrent transactions,
   new transactions must wait (block) for the resize to finish. See calls of (acquire-map-resize-permit sync), (release-map-resize-permit sync)
 
-  The reason over StampedLock (the original control mechanism) is to provide a fairness/barging policy so that writers are prioritised over readers, and that older readers get a chance to run if under high contention.
+  The reason over StampedLock (the original control mechanism) is to provide a fairness/barging policy for readers if under high contention, writes are probabilistically
+  preferred to readers, but there is no fairness between writers. This approach avoids deadlocks when reads nest while a resize acquire is spinning.
+
   We cannot use a ReentrantReadWriteLock as open transactions lifetimes are not tied to any particular thread.
 
   NOTE: resize permits must be released on acquiring thread, transaction permits can be released on any thread."


### PR DESCRIPTION
This PR _should_ fix #1826

## Problem

Release 1.22.0 introduced an additional write lock to avoid segfault when handling `MDB_MAP_FULL` errors (#1816). The write lock was used around all writes, as exclusivity of write transaction is necessary anyway for LMDB. This had an unintended consequence where the `acquire-write-lock` timeout was now used for ingester writes, where it would previously only be used for resizes.

Now, the timeout itself is fairly generous for writes, however due to the lack of fairness/write priority with the StampedLock mechanism, @tatut described running into ingester timeouts when ingesting nodes were also under high concurrent read load.

## Fix

This PR introduces a new locking mechanism in the java class `xtdb.lmdb.MapResizeSync`. It provides shared locks for open transactions, and exclusive 'resize' lock to deal with `MDB_MAP_FULL`.  It uses the base `AbstractQueueSynchronizer` to provide fairness and write priority to avoid in more situations reads blocking the ingester.

## Write lock timeouts

The PR as it stands _removes the write lock timeout_.  

I do not think there is a single good policy here, it depends ultimately on your write workload, but also how long at the limit your queries take, which is presumably open for many deployments.

I would welcome comments, not sure if a chesterton's fence situation. I understand that the timeout was introduced with #945 to provide observability of deadlock or otherwise blocking for too long. I think there may be better ways to achieve this without failing the ingester during resize.

I propose instead of timing out, we implement an ingester heartbeat (if it does not already exist) which will `WARN` if the ingester is blocked (for any reason, not just on lock acquisition). Perhaps as part of #1831. There is also deadlock/contention detection `ThreadMXBean` we can leverage to provide telemetry more holistically.