### PR TITLE
Include documents indexed as part of tx-fn expansion in attribute stats

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -77,7 +77,7 @@
 
 (defprotocol InFlightTx
   (index-tx-docs [in-flight-tx docs])
-  (index-tx-events [in-flight-tx tx])
+  (index-tx-events [in-flight-tx tx] "Returns a map of :committing? (true/false) representing whether the transactions were indexed, :indexed-docs (any new docs indexed during the expansion of tx fns)")
   (commit [in-flight-tx tx])
   (abort [in-flight-tx tx]))
 

--- a/core/src/xtdb/with_tx.clj
+++ b/core/src/xtdb/with_tx.clj
@@ -144,5 +144,5 @@
 
     (db/submit-docs in-flight-tx docs)
     (db/index-tx-docs in-flight-tx docs)
-    (when (db/index-tx-events in-flight-tx tx)
+    (when (:committing? (db/index-tx-events in-flight-tx tx))
       (xt/db in-flight-tx valid-time))))


### PR DESCRIPTION
Fixes #1825

# Problem

Attribute stats are not calculated for documents introduced by transaction function expansion. Possibly a regression as part of the pipelined ingester work.

## Solution

This PR changes `db/index-tx-events` to return docs indexed during tx-event indexing (incl evaluation of transaction functions).

If the transaction is to be committed, these extra docs are sent (with the top-level ones) to the stats pipeline.