### PR TITLE
Fix non nil end-valid-time when start-valid-time is nil

### DIFF
--- a/core/src/xtdb/tx/conform.clj
+++ b/core/src/xtdb/tx/conform.clj
@@ -145,12 +145,12 @@
 
 (defmethod ->tx-event ::xt/put [{:keys [eid doc-id start-valid-time end-valid-time]}]
   (cond-> [:crux.tx/put (c/new-id eid) doc-id]
-    start-valid-time (conj start-valid-time)
+    (or start-valid-time end-valid-time) (conj start-valid-time)
     end-valid-time (conj end-valid-time)))
 
 (defmethod ->tx-event ::xt/delete [{:keys [eid start-valid-time end-valid-time]}]
   (cond-> [:crux.tx/delete (c/new-id eid)]
-    start-valid-time (conj start-valid-time)
+    (or start-valid-time end-valid-time) (conj start-valid-time)
     end-valid-time (conj end-valid-time)))
 
 (defmethod ->tx-event ::xt/match [{:keys [eid doc-id at-valid-time]}]

--- a/core/src/xtdb/tx/event.clj
+++ b/core/src/xtdb/tx/event.clj
@@ -12,13 +12,13 @@
   (s/cat :op #{:crux.tx/put}
          :id id?
          :doc id?
-         :start-valid-time (s/? date?)
+         :start-valid-time (s/? (s/nilable date?))
          :end-valid-time (s/? date?)))
 
 (defmethod tx-event :crux.tx/delete [_]
   (s/cat :op #{:crux.tx/delete}
          :id id?
-         :start-valid-time (s/? date?)
+         :start-valid-time (s/? (s/nilable date?))
          :end-valid-time (s/? date?)))
 
 (defmethod tx-event :crux.tx/cas [_]
@@ -40,7 +40,7 @@
 (defmethod tx-event :crux.tx/evict [_]
   (s/cat :op #{:crux.tx/evict}
          :id id?
-         :start-valid-time (s/? date?)
+         :start-valid-time (s/? (s/nilable date?))
          :end-valid-time (s/? date?)
          :keep-latest? (s/? boolean?)
          :keep-earliest? (s/? boolean?)))

--- a/test/test/xtdb/query_test.clj
+++ b/test/test/xtdb/query_test.clj
@@ -4294,3 +4294,55 @@
                    '{:find [i]
                      :where [[?e :some/data i]]
                      :order-by [[i :asc]]})))))
+
+(t/deftest nil-valid-times
+  (t/testing "nil valid-time and end-valid-time"
+    (fix/submit+await-tx [[::xt/put {:xt/id :foo, :v 0} nil nil]])
+    (t/is (= #{[:foo]}
+             (xt/q (xt/db *api*)
+                   '{:find [?e]
+                     :where [[?e :xt/id :foo]]})))
+
+    (fix/submit+await-tx [[::xt/delete :foo nil nil]])
+    (t/is (= #{}
+             (xt/q (xt/db *api*)
+                   '{:find [?e]
+                     :where [[?e :xt/id :foo]]}))))
+
+  (t/testing "nil end-valid-time"
+    (fix/submit+await-tx [[::xt/put {:xt/id :bar, :v 0} #inst "2500" nil]])
+    (t/is (= #{}
+             (xt/q (xt/db *api*)
+                   '{:find [?e]
+                     :where [[?e :xt/id :bar]]})))
+    (t/is (= #{[:bar]}
+             (xt/q (xt/db *api* #inst "2500")
+                   '{:find [?e]
+                     :where [[?e :xt/id :bar]]})))
+
+    (fix/submit+await-tx [[::xt/delete :bar #inst "2400" nil]])
+    (t/is (= #{}
+             (xt/q (xt/db *api* #inst "2400")
+                   '{:find [?e]
+                     :where [[?e :xt/id :bar]]}))))
+
+  (t/testing "nil end-valid-time"
+    (fix/submit+await-tx [[::xt/put {:xt/id :baz, :v 0} nil #inst "2500"]])
+    (t/is (= #{[:baz]}
+             (xt/q (xt/db *api*)
+                   '{:find [?e]
+                     :where [[?e :xt/id :baz]]})))
+    (t/is (= #{}
+             (xt/q (xt/db *api* #inst "2500")
+                   '{:find [?e]
+                     :where [[?e :xt/id :baz]]})))
+
+    (fix/submit+await-tx [[::xt/delete :baz nil #inst "2400"]])
+    (t/is (= #{}
+             (xt/q (xt/db *api* #inst "2300")
+                   '{:find [?e]
+                     :where [[?e :xt/id :baz]]})))
+    (t/is (= #{[:baz]}
+             (xt/q (xt/db *api* #inst "2400")
+                   '{:find [?e]
+                     :where [[?e :xt/id :baz]]})))))


### PR DESCRIPTION
This is a potential fix for #1835. Mainly fixes the operation `[::xt/put doc nil #inst "2500"]`.

Things to consider: This now writes `nil` values for certain `start-valid-time`'s in the tx-log. Could this have any unintended consequences? Backwards compatibility issues?