### PR TITLE
Reduce likelyhood of use-after-free segfault (LMDB/RocksDB)

### DIFF
--- a/test/test/xtdb/api_test.clj
+++ b/test/test/xtdb/api_test.clj
@@ -640,3 +640,9 @@
           (xt/submit-tx *api* tx))
         (xt/sync *api*)
         (t/is (fix/spin-until-true 600 #(= 5850 (:xt/id (xt/attribute-stats *api*)))))))))
+
+(t/deftest db-throw-closing-1803-test
+  (.close *api*)
+  ;; will segfault on early versions, exception here is ok, :remote config does not throw.
+  (when-not (= :remote every-api/*node-type*)
+    (t/is (thrown-with-msg? IllegalStateException #"closing" (xt/db *api*)))))

--- a/test/test/xtdb/user_after_free_segfault_test.clj
+++ b/test/test/xtdb/user_after_free_segfault_test.clj
@@ -1,0 +1,42 @@
+(ns xtdb.user-after-free-segfault-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.io :as xio]))
+
+(defn- kv-node-opts [kv-module]
+  {:xtdb/index-store
+   {:kv-store {:xtdb/module kv-module,
+               :db-dir (xio/create-tmpdir "idx")}},
+   :xtdb/document-store
+   {:kv-store {:xtdb/module kv-module,
+               :db-dir (xio/create-tmpdir "doc")}},
+   :xtdb/tx-log
+   {:kv-store {:xtdb/module kv-module,
+               :db-dir (xio/create-tmpdir "log")}}})
+
+(t/deftest use-after-free-segfault-on-close-1803-rocks-test
+  (let [node (xt/start-node (kv-node-opts 'xtdb.rocksdb/->kv-store))
+        spy identity
+        ;; use println version if having segfaults, test reporter will not help you!
+        #_#_ spy println]
+    (.close node)
+    ;; will segfault on early versions
+    (spy "db")
+    (t/is (thrown-with-msg? IllegalStateException #"closing" (xt/db node)))
+    (spy "stats")
+    (try (xt/attribute-stats node) (catch Throwable _))
+    (spy "completed-tx")
+    (try (xt/latest-completed-tx node) (catch Throwable _))
+    (spy "submitted-tx")
+    (try (xt/latest-submitted-tx node) (catch Throwable _))))
+
+(t/deftest use-after-free-segfault-on-close-1803-lmdb-test
+  (let [node-opts (kv-node-opts 'xtdb.lmdb/->kv-store)
+        node1 (xt/start-node node-opts)]
+    (.close node1)
+    ;; will segfault on early versions, requires another thread for lmdb for some reason
+    ;; bit sporadic, hence the 1000 attempts
+    (with-open [node2 (xt/start-node node-opts)]
+      (let [exceptions (doall (repeatedly 1000 #(deref (future (try (xt/db node1) nil (catch IllegalStateException e e))))))
+            msg-freqs (frequencies (map #(some-> ^Throwable % .getMessage) exceptions))]
+        (t/is (= {"closing" 1000} msg-freqs))))))


### PR DESCRIPTION
Currently, RocksDB and LMDB kv implementations will segfault if accessed after `.close`.

Resolves #1803.

In practice it is very hard for us to protect against racing with `.close` without locking when kv pointers are in use - so instead this PR offers a pragmatic solution for the immediate concern of trivial user-after-free.

This PR extends the index-store ThreadManager to track open snapshots in more methods that currently cause segfaults.

Additionally, the KvTxLog checks if-closed in a few more places to avoid trivial segfaults (such as on `last-submitted-tx`).
