### PR TITLE
Indexing performance improvements

### DIFF
--- a/core/src/xtdb/memory.clj
+++ b/core/src/xtdb/memory.clj
@@ -182,7 +182,7 @@
     (UnsafeBuffer. (->off-heap b tmp) 0 (capacity b))))
 
 (defn direct-byte-buffer ^java.nio.ByteBuffer [b]
-  (let [b (->off-heap b)
+  (let [^DirectBuffer b (if (and (instance? DirectBuffer b) (some? (.byteBuffer ^DirectBuffer b))) b (->off-heap b))
         offset (.wrapAdjustment b)]
     (-> (.byteBuffer b)
         (.duplicate)

--- a/modules/rocksdb/project.clj
+++ b/modules/rocksdb/project.clj
@@ -14,4 +14,4 @@
   :dependencies [[org.clojure/clojure]
                  [com.xtdb/xtdb-core]
                  [com.xtdb/xtdb-metrics :scope "provided"]
-                 [org.rocksdb/rocksdbjni "7.3.1"]])
+                 [org.rocksdb/rocksdbjni "7.7.3"]])

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -120,10 +120,11 @@
                            wb)))
 
   (put-kv [_ k v]
-    (let [cfh ^ColumnFamilyHandle (->column-family-handle (->cf-id k))]
+    (let [kb (mem/direct-byte-buffer k)
+          cfh ^ColumnFamilyHandle (->column-family-handle (.get kb 0))]
       (if v
-        (.put wb cfh (mem/direct-byte-buffer k) (mem/direct-byte-buffer v))
-        (.delete wb cfh (mem/direct-byte-buffer k)))))
+        (.put wb cfh kb (mem/direct-byte-buffer v))
+        (.delete wb cfh kb))))
 
   (commit-kv-tx [this]
     (.write db write-options wb)

--- a/test/test/xtdb/api/JXtdbNodeTest.java
+++ b/test/test/xtdb/api/JXtdbNodeTest.java
@@ -214,7 +214,7 @@ public class JXtdbNodeTest {
     public void attributeStatsTest() {
         put();
         sync();
-        sleep(100);
+        sleep(1000);
         Map<Keyword, ?> stats = node.attributeStats();
         assertEquals(1L, stats.get(DB_ID));
         assertEquals(1L, stats.get(versionId));


### PR DESCRIPTION
# Rocks indexing performance pass 

This PR includes changes to improve indexing performance on varied workloads. The goal for users will be to improve re-indexing performance from a checkpoint or from scratch when restarting an XTDB node.

Many of the changes are targeted optimisations, removing certain indirections on hot paths. The biggest mechanical change is the buffering of stats to amortize the high constant overhead of stats indexing.

The improvement measured during an auctionmark tx trace is quite significant at around 40-50% reduction in the time taken in OLTP-like workloads where small numbers of documents are indexed per transaction. For large numbers of documents per transaction, the difference is smaller. I expect users may see anywhere from a 5% to 50% improvement depending on the granularity of their transactions.

![indexing over time](https://user-images.githubusercontent.com/4095999/203576981-01a780c7-e9ed-4a48-a8d6-1baed4b1e1ca.png)

> Auctionmark trace result on a AWS ec2 `m5.large` node, 8GB RAM, Xmx 2G, 2 cores

Furthermore, the improvements should improve overall system throughput on busy nodes as the indexer now produces less GC and memory pressure, and frees CPU resources to do other work.

---
## Faster Rocks CF handle lookup

The RocksDB kv-store makes many calls to a function `->column-family-handle` that returns a RocksDB column family object for a given `cf-id` byte. The object you return is a member of a list of ColumnFamilyHandle instances, created when the database was opened.

This call is made for each individual put on a WriteBatch.

The change introduces a fixed array for lookup as the cf-id is represented as a single byte. This array lookup replaces the `PersistentArrayMap` lookup and slow default column handle lookup via Clojure `first` on a `j.u.Vector`.

## Fast path for Rocks ByteBuffer conversion

Each RocksDB `put-kv` operation requires two ByteBuffer instances, for the key and value.

The interface for put specifies implicitly two `xtdb.memory` 'buffers' of some kind, so the rocks implementation must tolerate polymorphism on this path.

However, in practice the current production (e.g non test) indexer only ever supplies instances of `org.agrona.DirectBuffer` to put.

Because of the possibility of polymorphism, a `mem/->off-heap` call ensured we had a `org.agrona.DirectBuffer` instance. Unfortunately, this introduces a method lookup as the protocol is extended to existing java types.

The new fast path makes a quick type check, if we have a `org.agrona.DirectByteBuffer`, the protocol method is skipped, and the old polymorphic call still happens if we receive any other type of buffer for either the key or value.

## Fast path for Rocks column family byte lookup

The Rocks KV implementation determines on every put a column family of a key by inspecting the first byte in the key. Because `put-kv` specifies abstract 'buffers' rather than any concrete type this byte lookup is performed indirectly by calling the `->cf-id` function, incurring a protocol cache lookup to determine the implementation. 

The change here is to lean on the fact we arrive at a `j.nio.DirectByteBuffer` as required by Rocks itself, and so we can re-order the calls to lookup the first byte using a regular java `.get` call on the buffer.

## Do not create `Seq` wrappers over `j.u.Map` instances in `index-docs`

The index-docs implementation in `index_store.clj` must loop over every document and each entry of those maps. An observation was made that visiting every entry in this way with doseq could cost significant CPU time.

It was observed that we will often receive both the `docs` arg and each `doc` as a `java.util.Map`, and so we can use `.forEach` instead to walk these maps without the `Seq` indirection.

The slow path is preserved for tests that produce seq's of kv and Clojure maps as well as `java.util.Map`.

## Stats buffering

Currently, stat entries are calculated and written for each transaction, for large enough transactions, this imposes little overhead, but with very small transactions the cost of computing and writing back the statistics to the kv-store can start to cost significant CPU time. 

The PR buffers documents whose stats are computed and written only after we have a number of documents, or a time period elapses. (32 and 500ms for now).

The stats buffering change impact varies depending on batch size, the difference is most significant when transactions contain few attributes:

![tpch 005](https://user-images.githubusercontent.com/4095999/203609708-dc56d7cf-44b3-46b5-9d22-f4a38f109607.png)

> tpch 0.05 indexing trace, batch size 1 (m5.large)

![image](https://user-images.githubusercontent.com/4095999/203759568-fd28bc0f-792e-4a2e-9c25-2772f6bb27a7.png)

> tpch 0.05 indexing trace, batch size 8 (m5.large)

Once the transaction size increases beyond our buffer limit, the statistics buffering no longer provides a significant improvement:

![image](https://user-images.githubusercontent.com/4095999/203760098-54df2235-fc2d-4ecb-9673-e9a5374d7ff6.png)

> tpch 0.05 indexing trace, batch size 512 (m5.large)