### PR TITLE
RocksDB ingest performance pass

### DIFF
--- a/core/src/xtdb/hyper_log_log.clj
+++ b/core/src/xtdb/hyper_log_log.clj
@@ -9,9 +9,9 @@
 (def ^{:tag 'int} default-buffer-size (* Integer/BYTES 1024))
 
 (defn add ^org.agrona.MutableDirectBuffer [^MutableDirectBuffer hll v]
-  (let [m (/ (.capacity hll) Integer/BYTES)
+  (let [m (quot (.capacity hll) Integer/BYTES)
         b (Integer/numberOfTrailingZeros m)
-        x (mix-collection-hash (hash v) 0)
+        x (mix-collection-hash (clojure.lang.Util/hasheq v) 0)
         j (bit-and (bit-shift-right x (- Integer/SIZE b)) (dec m))
         w (bit-and x (dec (bit-shift-left 1 (- Integer/SIZE b))))]
     (doto hll
@@ -21,7 +21,7 @@
                ByteOrder/BIG_ENDIAN))))
 
 (defn estimate ^double [^DirectBuffer hll]
-  (let [m (/ (.capacity hll) Integer/BYTES)
+  (let [m (quot (.capacity hll) Integer/BYTES)
         z (/ 1.0 (double (loop [n 0
                                 acc 0.0]
                            (if (< n (.capacity hll))

--- a/core/src/xtdb/kv.clj
+++ b/core/src/xtdb/kv.clj
@@ -15,6 +15,21 @@
   (new-iterator ^java.io.Closeable [this])
   (get-value [this k]))
 
+;; interface rather than protocol because made optional via fast instance? checks.
+(definterface KvSnapshotPrefixSupport
+  (newPrefixSeekOptimisedIterator []))
+
+(defn new-prefix-seek-optimised-iterator
+  "Opens a new iterator, allowing for prefix-only search optimisations (if they are possible).
+
+  Callers must be ok for your iterator to only see keys sharing the prefix supplied as the `k` arg to `(seek iterator k)`.
+
+  WARNING: Depending on the capabilities of the KV store implementation you may or may not see keys outside the prefix, do not depend on either."
+  [kv-snapshot]
+  (if (instance? KvSnapshotPrefixSupport kv-snapshot)
+    (.newPrefixSeekOptimisedIterator ^KvSnapshotPrefixSupport kv-snapshot)
+    (new-iterator kv-snapshot)))
+
 (defprotocol KvStoreTx
   (new-tx-snapshot ^java.io.Closeable [this])
   (abort-kv-tx [this])

--- a/core/src/xtdb/kv/index_store.clj
+++ b/core/src/xtdb/kv/index_store.clj
@@ -711,6 +711,7 @@
                             level-1-iterator-delay
                             level-2-iterator-delay
                             entity-as-of-iterator-delay
+                            entity-as-of-prefix-optimised-iterator-delay
                             decode-value-iterator-delay
                             cache-iterator-delay
                             nested-index-snapshot-state
@@ -723,7 +724,7 @@
     (when (.compareAndSet closed? false true)
       (doseq [nested-index-snapshot @nested-index-snapshot-state]
         (xio/try-close nested-index-snapshot))
-      (doseq [i [level-1-iterator-delay level-2-iterator-delay entity-as-of-iterator-delay decode-value-iterator-delay cache-iterator-delay]
+      (doseq [i [level-1-iterator-delay level-2-iterator-delay entity-as-of-iterator-delay entity-as-of-prefix-optimised-iterator-delay decode-value-iterator-delay cache-iterator-delay]
               :when (realized? i)]
         (xio/try-close @i))
       (when close-snapshot?
@@ -806,7 +807,7 @@
 
   (entity-as-of-resolver [this eid valid-time tx-id]
     (assert tx-id)
-    (let [i @entity-as-of-iterator-delay
+    (let [i @entity-as-of-prefix-optimised-iterator-delay
           prefix-size (+ c/index-id-size c/id-size)
           eid (if (instance? DirectBuffer eid)
                 (if (c/id-buffer? eid)
@@ -834,7 +835,7 @@
 
   (entity-as-of [_ eid valid-time tx-id]
     (assert tx-id)
-    (let [i @entity-as-of-iterator-delay
+    (let [i @entity-as-of-prefix-optimised-iterator-delay
           prefix-size (+ c/index-id-size c/id-size)
           eid-buffer (c/->id-buffer eid)
           seek-k (encode-bitemp-key-to (.get seek-buffer-tl)
@@ -959,6 +960,7 @@
                      (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
+                     (delay (kv/new-prefix-seek-optimised-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
                      (delay (kv/new-iterator snapshot))
                      (atom [])

--- a/core/src/xtdb/memory.clj
+++ b/core/src/xtdb/memory.clj
@@ -182,7 +182,7 @@
     (UnsafeBuffer. (->off-heap b tmp) 0 (capacity b))))
 
 (defn direct-byte-buffer ^java.nio.ByteBuffer [b]
-  (let [b (->off-heap b)
+  (let [^DirectBuffer b (if (and (instance? DirectBuffer b) (some? (.byteBuffer ^DirectBuffer b))) b (->off-heap b))
         offset (.wrapAdjustment b)]
     (-> (.byteBuffer b)
         (.duplicate)

--- a/core/src/xtdb/memory.clj
+++ b/core/src/xtdb/memory.clj
@@ -188,8 +188,7 @@
         (.duplicate)
         (.clear)
         (.position offset)
-        ^ByteBuffer (.limit (+ offset (.capacity b)))
-        (.slice))))
+        ^ByteBuffer (.limit (+ offset (.capacity b))))))
 
 (defn on-heap-buffer ^org.agrona.DirectBuffer [^bytes b]
   (UnsafeBuffer. b))

--- a/modules/rocksdb/project.clj
+++ b/modules/rocksdb/project.clj
@@ -14,4 +14,4 @@
   :dependencies [[org.clojure/clojure]
                  [com.xtdb/xtdb-core]
                  [com.xtdb/xtdb-metrics :scope "provided"]
-                 [org.rocksdb/rocksdbjni "7.3.1"]])
+                 [org.rocksdb/rocksdbjni "7.7.3"]])

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -289,7 +289,8 @@
         opts (doto (or ^DBOptions db-options (DBOptions.))
                (cond-> metrics (.setStatistics stats))
                (.setCreateIfMissing true)
-               (.setCreateMissingColumnFamilies true))
+               (.setCreateMissingColumnFamilies true)
+               (.setMaxBackgroundJobs (max 2 (dec (-> (Runtime/getRuntime) .availableProcessors)))))
 
         db (try
              (RocksDB/open opts (-> (Files/createDirectories db-dir (make-array FileAttribute 0))

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -120,10 +120,11 @@
                            wb)))
 
   (put-kv [_ k v]
-    (let [cfh ^ColumnFamilyHandle (->column-family-handle (->cf-id k))]
+    (let [kb (mem/direct-byte-buffer k)
+          cfh ^ColumnFamilyHandle (->column-family-handle (.get kb 0))]
       (if v
-        (.put wb cfh (mem/direct-byte-buffer k) (mem/direct-byte-buffer v))
-        (.delete wb cfh (mem/direct-byte-buffer k)))))
+        (.put wb cfh kb (mem/direct-byte-buffer v))
+        (.delete wb cfh kb))))
 
   (commit-kv-tx [this]
     (.write db write-options wb)

--- a/test/test/xtdb/api/JXtdbNodeTest.java
+++ b/test/test/xtdb/api/JXtdbNodeTest.java
@@ -214,7 +214,7 @@ public class JXtdbNodeTest {
     public void attributeStatsTest() {
         put();
         sync();
-        sleep(100);
+        sleep(1000);
         Map<Keyword, ?> stats = node.attributeStats();
         assertEquals(1L, stats.get(DB_ID));
         assertEquals(1L, stats.get(versionId));


### PR DESCRIPTION
# Rocks indexing performance pass 

This PR includes changes to improve maximum RocksDB indexing performance on varied workloads. The goal for users will be to improve re-indexing performance from a checkpoint or scratch when restarting an XTDB node, as well as increase the effective write throughput of an XTDB node.

The improvement measured during both auction mark and tpc-h traces can be quite significant at around 40-60% reduction in the time taken to index a tx-log when enough CPU resources are available.

The overall improvement in the wild will depend heavily on the database contents, hardware, configuration, etc. New deployments will likely benefit more than existing ones as some of the changes will require new SST files to be written. 

![auctionmark](https://user-images.githubusercontent.com/4095999/207031723-c0d32d31-0428-40aa-9951-fefa86c88acc.png)

> Auctionmark result on an `m5.2xlarge` node, 30GB RAM, Xmx 8G, 8 vCPU

![tpch](https://user-images.githubusercontent.com/4095999/207031925-608bd75f-fa45-427c-88e9-f9775b246294.png)

> TPC-H SF 1.0 load, batch size 1000 on an `m5.2xlarge` node, 30GB RAM, Xmx 8G, 8 vCPU

For limited hardware any improvement will be modest.

![image](https://user-images.githubusercontent.com/4095999/207068252-2cd2c683-4259-4ad7-a483-52c59d87d076.png)

> TPC-H SF 1.0 load, batch size 1000 on an `m5.large` node, 8GB RAM, Xmx 2G, 2 vCPU

The changes were developed focusing on the indexer with pure rocks (log, docs and tx), changes may indirectly influence log, doc store and query performance, but it was not a goal.
To summarize the changes (explained in more detail further into the PR)

- statistics writes are buffered, as small transactions would spend more time maintaining statistics than indexing the transactions themselves due to relatively high constant factor overhead.
- the default configuration for rocks includes a prefix length for the bitemporal index, which is used to provide a bloom filter on entity-as-of seeks, removing a large source of overhead when inserting new entities
- the default rocks configuration will use n-CPUs-1 max background jobs (for compaction & flushing) rather than a fixed 2, reducing write stalls. This does increase the overall CPU load on the system if indexing is at capacity.
- index and filter blocks are now cached in the block cache, with high priority. This does increase the min cache size requirements somewhat.
- certain very hot functions such as `kv/put-kv`, and `hll/add` have been tuned, removing indirection, improving cache locality, and removing allocations.

Furthermore, the improvements should improve overall system throughput on busy nodes as the indexer now produces less GC and memory pressure, and frees CPU resources to do other work.

---
## Prefix seek support on the bitemporal index

As the database grows, more and more time is spent searching for existing entity history keys. In many cases, entities have no history, and so they could be filtered out pre-emptively with a bloom filter. Luckily Rocks provides filtering on key prefixes, so by default, we configure the bitemporal index column family to build prefix bloom filters, and conditionally use them during seek for history. This puts more pressure on the block cache.

Prefix filtering is enabled using the new option `:enable-filters? true` on the rocks kv-store. 

## Increased number of Rocks background jobs by default

By default, rocks permits 2 background jobs for compaction and flushing, with the other changes in play, write stalls could be observed due to high numbers of 'L0' SST files. To reduce write stalling more potential CPU resources are allocated to compaction (and flushing to disk) by increasing the maximum number of rocks background jobs to `n-CPUs - 1`. This change will increase the CPU load on systems whose write throughput requirements are very high. Most of the time this will be when preparing a node from a checkpoint, but we may want to allow reconfiguring this parameter to free the CPU for query and re-apply write stalls.

## Faster Rocks CF handle lookup

The RocksDB kv-store makes many calls to a function `->column-family-handle` that returns a RocksDB column family object for a given `cf-id` byte. The object you return is a member of a list of ColumnFamilyHandle instances, created when the database was opened.

This call is made for each individual put on a WriteBatch.

The change introduces a fixed array for lookup as the cf-id is represented as a single byte. This array lookup replaces the `PersistentArrayMap` lookup and slow default column handle lookup via Clojure `first` on a `j.u.Vector`.

## Fast path for Rocks ByteBuffer conversion

Each RocksDB `put-kv` operation requires two ByteBuffer instances, for the key and value.

The interface for put specifies implicitly two `xtdb.memory` 'buffers' of some kind, so the rocks implementation must tolerate polymorphism on this path.

However, in practice the current production (e.g non test) indexer only ever supplies instances of `org.agrona.DirectBuffer` to put.

Because of the possibility of polymorphism, a `mem/->off-heap` call ensured we had an `org.agrona.DirectBuffer` instance. Unfortunately, this introduces a method lookup as the protocol is extended to existing java types.

The new fast path makes a quick type check, if we have an `org.agrona.DirectByteBuffer`, the protocol method is skipped and rocks receives the underlying buffer. The old polymorphic call still happens if we receive any other type of buffer for either the key or value.

## Fast path for Rocks column family byte lookup

The Rocks KV implementation determines on every put a column family of a key by inspecting the first byte in the key. Because `put-kv` specifies abstract 'buffers' rather than any concrete type this byte lookup is performed indirectly by calling the `->cf-id` function, incurring a protocol cache lookup to determine the implementation. 

The change here is to lean on the fact we arrive at a `j.nio.DirectByteBuffer` as required by Rocks itself, and so we can re-order the calls to lookup the first byte using a regular java `.get` call on the buffer.

## Do not create `Seq` wrappers over `j.u.Map` instances in `index-docs`

The index-docs implementation in `index_store.clj` must loop over every document and each entry of those maps. An observation was made that visiting every entry in this way with doseq could cost significant CPU time.

It was observed that we will often receive both the `docs` arg and each `doc` as a `java.util.Map`, so we can use `.forEach` instead to walk these maps without the `Seq` indirection.

The slow path is preserved for tests that produce seq's of kv and Clojure maps as well as `java.util.Map`.

## Stats buffering

Currently, stat entries are calculated and written for each transaction, for large enough transactions, this imposes little overhead, but with very small transactions the cost of computing and writing back the statistics to the kv-store can start to cost significant CPU time. 

The PR buffers documents whose stats are computed and written only after we have many documents, or a time elapses. (32 and 500ms for now).

The stats buffering change impact varies depending on batch size, the difference is most significant when transactions contain few documents:

![image](https://user-images.githubusercontent.com/4095999/207092176-db24c8b5-0e17-492d-a735-39a35beed463.png)

> tpch 0.05 indexing trace, batch size 1 (m5.large)

![image](https://user-images.githubusercontent.com/4095999/207092825-9dce1077-c068-4d5b-b02c-0c8a556005c1.png)

> tpch 0.05 indexing trace, batch size 8 (m5.large)

Once the transaction size increases beyond our buffer limit, the statistics buffering no longer provides a significant improvement:

![image](https://user-images.githubusercontent.com/4095999/207092562-6ca31d33-de3b-488e-a179-c4ac6e2e9d28.png)

> tpch 0.05 indexing trace, batch size 512 (m5.large)
