### PR TITLE
Fix speculative transaction cav cache pollution

### DIFF
--- a/core/src/xtdb/kv/index_store.clj
+++ b/core/src/xtdb/kv/index_store.clj
@@ -651,7 +651,9 @@
                                          v (canonical-buffer-lookup canonical-buffer-cache v)]
                                      (.add vs v)
                                      (recur (kv/next i)))))
-                               vs))))
+                               ;; for speculative transactions the iterator will not contain the desired entries
+                               ;; to avoid polluting the cache for subsequent transactions, we do not save 'not found' results
+                               (not-empty vs)))))
 
 (defn- step-fn [i k-fn seek-k]
   ((fn step [^DirectBuffer k]


### PR DESCRIPTION
When queries are used in speculative transactions, the cav cache used for forked rocks kv stores may cache an empty set as the result for content-hash, attribute -> value cache entries. This is because the compute function uses a base store iterator, but the entries for speculative transactions are indexed under the delta store (mem-kv).

This PR includes _a_ fix, which is simply to not cache empty sets, this should solve the problem - but it is not very satisfying. (action at a distance, mixing of concerns).

Another solution would be to not cache for speculative transactions (may have perf impacts on tx-fn queries for rocks, but the other stores don't use these caches for tx-fns 🤷 ). I'd recommend a perf test before doing this.

Resolves #1851