### PR TITLE
Add poll-wait-duration option for xtdb.api/open-tx-log #1834

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -61,7 +61,7 @@
 
 (defprotocol TxLog
   (submit-tx [this tx-events] [this tx-events opts])
-  (open-tx-log ^xtdb.api.ICursor [this after-tx-id]
+  (open-tx-log ^xtdb.api.ICursor [this after-tx-id opts]
    "Returns a serialized iterator (cursor) over transactions (see spec ::xtdb.api/tx) in the log after the given tx id.
 
    The cursor:

--- a/core/src/xtdb/kv/tx_log.clj
+++ b/core/src/xtdb/kv/tx_log.clj
@@ -94,7 +94,7 @@
   (latest-submitted-tx [_]
     (latest-submitted-tx kv-store))
 
-  (open-tx-log [this after-tx-id]
+  (open-tx-log [this after-tx-id _]
     (let [batch-size 100]
       (letfn [(tx-log [after-tx-id]
                 (lazy-seq

--- a/core/src/xtdb/node.clj
+++ b/core/src/xtdb/node.clj
@@ -224,7 +224,8 @@
   (submit-tx [this tx-ops opts] @(xt/submit-tx-async this tx-ops opts))
 
   (open-tx-log ^xtdb.api.ICursor [this after-tx-id with-ops?]
-    (let [with-ops? (if (map? with-ops?) (boolean (:with-ops? with-ops?)) (boolean with-ops?))]
+    (let [opts with-ops?
+          with-ops? (if (map? opts) (boolean (:with-ops? opts)) (boolean opts))]
       (xio/with-read-lock lock
         (ensure-node-open this)
         (if (let [latest-submitted-tx-id (::xt/tx-id (xt/latest-submitted-tx this))]
@@ -233,7 +234,7 @@
           xio/empty-cursor
 
           (let [latest-completed-tx-id (::xt/tx-id (xt/latest-completed-tx this))
-                tx-log-iterator (db/open-tx-log tx-log after-tx-id with-ops?)
+                tx-log-iterator (db/open-tx-log tx-log after-tx-id opts)
                 tx-log (->> (iterator-seq tx-log-iterator)
                             (remove #(db/tx-failed? index-store (::xt/tx-id %)))
                             (take-while (comp #(<= % latest-completed-tx-id) ::xt/tx-id))

--- a/core/src/xtdb/node.clj
+++ b/core/src/xtdb/node.clj
@@ -224,7 +224,7 @@
   (submit-tx [this tx-ops opts] @(xt/submit-tx-async this tx-ops opts))
 
   (open-tx-log ^xtdb.api.ICursor [this after-tx-id with-ops?]
-    (let [with-ops? (boolean with-ops?)]
+    (let [with-ops? (if (map? with-ops?) (boolean (:with-ops? with-ops?)) (boolean with-ops?))]
       (xio/with-read-lock lock
         (ensure-node-open this)
         (if (let [latest-submitted-tx-id (::xt/tx-id (xt/latest-submitted-tx this))]
@@ -233,7 +233,7 @@
           xio/empty-cursor
 
           (let [latest-completed-tx-id (::xt/tx-id (xt/latest-completed-tx this))
-                tx-log-iterator (db/open-tx-log tx-log after-tx-id)
+                tx-log-iterator (db/open-tx-log tx-log after-tx-id with-ops?)
                 tx-log (->> (iterator-seq tx-log-iterator)
                             (remove #(db/tx-failed? index-store (::xt/tx-id %)))
                             (take-while (comp #(<= % latest-completed-tx-id) ::xt/tx-id))

--- a/core/src/xtdb/submit_client.clj
+++ b/core/src/xtdb/submit_client.clj
@@ -26,7 +26,7 @@
     (when with-ops?
       (throw (err/illegal-arg :with-opts-not-supported
                               {::err/message "with-ops? not supported"})))
-    (db/open-tx-log (:tx-log this) after-tx-id))
+    (db/open-tx-log (:tx-log this) after-tx-id {}))
 
   Closeable
   (close [_]

--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -525,7 +525,7 @@
           (try
             (when (or (nil? after-tx-id)
                       (< ^long after-tx-id ^long latest-xtdb-tx-id))
-              (with-open [log (db/open-tx-log tx-log after-tx-id)]
+              (with-open [log (db/open-tx-log tx-log after-tx-id {})]
                 (doseq [{::keys [tx-id] :as tx} (->> (iterator-seq log)
                                                      (take-while (comp #(<= ^long % ^long latest-xtdb-tx-id) ::xt/tx-id)))]
                   (process-tx-f document-store (assoc tx :committing? (not (db/tx-failed? index-store tx-id)))))))

--- a/core/src/xtdb/tx/subscribe.clj
+++ b/core/src/xtdb/tx/subscribe.clj
@@ -49,7 +49,7 @@
    (fn [^CompletableFuture fut]
      (loop [after-tx-id after-tx-id]
        (let [last-tx-id (if-let [^ICursor log (try
-                                                (db/open-tx-log tx-log after-tx-id)
+                                                (db/open-tx-log tx-log after-tx-id {})
                                                 (catch InterruptedException e (throw e))
                                                 (catch Exception e
                                                   (log/warn e "Error polling for txs, will retry")))]
@@ -94,7 +94,7 @@
                                              (< after-tx-id latest-submitted-tx-id)))
 
                                   ;; catching up
-                                  (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                  (with-open [log (db/open-tx-log tx-log after-tx-id {})]
                                     (reduce handle-txs
                                             after-tx-id
                                             (->> (iterator-seq log)
@@ -110,7 +110,7 @@
                                                   (.release semaphore (- permits tx-batch-size))
                                                   tx-batch-size)
                                                 permits)]
-                                    (with-open [log (db/open-tx-log tx-log after-tx-id)]
+                                    (with-open [log (db/open-tx-log tx-log after-tx-id {})]
                                       (handle-txs after-tx-id
                                                   (->> (iterator-seq log)
                                                        (into [] (take limit)))))))]

--- a/docs/storage/modules/ROOT/pages/kafka.adoc
+++ b/docs/storage/modules/ROOT/pages/kafka.adoc
@@ -302,19 +302,17 @@ EDN::
 * `tx-topic-opts` (topic options)
 * `poll-wait-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to wait on each Kafka poll.
 
-[NOTE]
+==== Note
 
 `poll-wait-duration` specifies the duration for which xref:client::clojure.adoc[open-tx-doc] will wait for a record to show
-up on the transaction topic. If for any reason (e.g., latency to the Kafka broker) no record was received, the call
-will return an empty cursor (i.e., on which `.hasNext` is false). For the Kafka implementation of `open-tx-doc` accepts
+up on the transaction topic. If for any reason (e.g., latency to the Kafka broker) no record was received during that time,
+the call would return an empty cursor (i.e., on which `.hasNext` is false). For the Kafka implementation of `open-tx-doc` accepts
 also a map (instead of the `with-ops?` Boolean) with the following optional keys:
 
 [source,clojure]
- ----
  {:with-ops? true
    :kafka/poll-wait-duration (Duration/ofMillis 2000)
  }
- ----
 
 
 === Document store (`+xtdb.kafka/->document-store+`)

--- a/docs/storage/modules/ROOT/pages/kafka.adoc
+++ b/docs/storage/modules/ROOT/pages/kafka.adoc
@@ -311,7 +311,7 @@ also a map (instead of the `with-ops?` Boolean) with the following optional keys
 
 [source,clojure]
  {:with-ops? true
-   :kafka/poll-wait-duration (Duration/ofMillis 2000)
+  :kafka/poll-wait-duration (Duration/ofMillis 2000)
  }
 
 

--- a/docs/storage/modules/ROOT/pages/kafka.adoc
+++ b/docs/storage/modules/ROOT/pages/kafka.adoc
@@ -304,7 +304,7 @@ EDN::
 
 ==== Note
 
-`poll-wait-duration` specifies the duration for which xref:client::clojure.adoc[open-tx-log] will wait for a record to show
+`poll-wait-duration` specifies the duration for which xref:clients::clojure.adoc[open-tx-log] will wait for a record to show
 up on the transaction topic. If for any reason (e.g., latency to the Kafka broker) no record was received during that time,
 the call would return an empty cursor (i.e., on which `.hasNext` is false). For this reason,  the Kafka implementation
 of `open-tx-log` accepts also a map (instead of the `with-ops?` Boolean) with the following optional keys:

--- a/docs/storage/modules/ROOT/pages/kafka.adoc
+++ b/docs/storage/modules/ROOT/pages/kafka.adoc
@@ -304,10 +304,10 @@ EDN::
 
 ==== Note
 
-`poll-wait-duration` specifies the duration for which xref:client::clojure.adoc[open-tx-doc] will wait for a record to show
+`poll-wait-duration` specifies the duration for which xref:client::clojure.adoc[open-tx-log] will wait for a record to show
 up on the transaction topic. If for any reason (e.g., latency to the Kafka broker) no record was received during that time,
-the call would return an empty cursor (i.e., on which `.hasNext` is false). For the Kafka implementation of `open-tx-doc` accepts
-also a map (instead of the `with-ops?` Boolean) with the following optional keys:
+the call would return an empty cursor (i.e., on which `.hasNext` is false). For this reason,  the Kafka implementation
+of `open-tx-log` accepts also a map (instead of the `with-ops?` Boolean) with the following optional keys:
 
 [source,clojure]
  {:with-ops? true

--- a/docs/storage/modules/ROOT/pages/kafka.adoc
+++ b/docs/storage/modules/ROOT/pages/kafka.adoc
@@ -302,6 +302,21 @@ EDN::
 * `tx-topic-opts` (topic options)
 * `poll-wait-duration` (string/`Duration`, default 1 second, `"PT1S"`): time to wait on each Kafka poll.
 
+[NOTE]
+
+`poll-wait-duration` specifies the duration for which xref:client::clojure.adoc[open-tx-doc] will wait for a record to show
+up on the transaction topic. If for any reason (e.g., latency to the Kafka broker) no record was received, the call
+will return an empty cursor (i.e., on which `.hasNext` is false). For the Kafka implementation of `open-tx-doc` accepts
+also a map (instead of the `with-ops?` Boolean) with the following optional keys:
+
+[source,clojure]
+ ----
+ {:with-ops? true
+   :kafka/poll-wait-duration (Duration/ofMillis 2000)
+ }
+ ----
+
+
 === Document store (`+xtdb.kafka/->document-store+`)
 
 * `kafka-config` (connection config)

--- a/labs/corda/xtdb-corda/src/main/clojure/xtdb/corda.clj
+++ b/labs/corda/xtdb-corda/src/main/clojure/xtdb/corda.clj
@@ -149,7 +149,7 @@
     (throw (UnsupportedOperationException.
             "CordaTxLog does not support submit-tx - submit transactions directly to Corda")))
 
-  (open-tx-log ^xtdb.api.ICursor [this after-tx-id]
+  (open-tx-log ^xtdb.api.ICursor [this after-tx-id _]
     (let [txs (open-tx-log this after-tx-id)]
       (xio/->cursor #(xio/try-close txs) (iterator-seq txs))))
 

--- a/modules/jdbc/src/xtdb/jdbc.clj
+++ b/modules/jdbc/src/xtdb/jdbc.clj
@@ -160,7 +160,7 @@
            ::xt/tx-time (or (::xt/tx-time opts)
                             (::xt/tx-time tx-data))}))))
 
-  (open-tx-log [_ after-tx-id]
+  (open-tx-log [_ after-tx-id _]
     ;; see https://github.com/xtdb/xtdb/pull/1815 for detail on fetch policy
     (let [conn (jdbc/get-connection pool)
           require-rollback (when (= :postgresql (db-type dialect)) (.setAutoCommit conn false) true)

--- a/modules/kafka/src/xtdb/kafka.clj
+++ b/modules/kafka/src/xtdb/kafka.clj
@@ -182,8 +182,10 @@
            ::xt/tx-time (or (::xt/tx-time opts)
                             (Date. (.timestamp record-meta)))}))))
 
-  (open-tx-log [this after-tx-id]
-    (let [consumer (open-consumer this after-tx-id)]
+  (open-tx-log [this after-tx-id opts]
+    (let [consumer (open-consumer this after-tx-id)
+          duration (get opts :kafka/poll-wait-duration)
+          poll-wait-duration (if (instance? Duration duration) duration poll-wait-duration)]
       (xio/->cursor #(.close consumer)
                     (->> (consumer-seqs consumer poll-wait-duration true)
                          (mapcat identity)

--- a/modules/kafka/src/xtdb/kafka.clj
+++ b/modules/kafka/src/xtdb/kafka.clj
@@ -120,20 +120,12 @@
         (Thread/interrupted)
         (throw (.getCause e))))))
 
-(defn- consumer-seqs
-  ([consumer poll-duration]
-   (consumer-seqs consumer poll-duration false))
-  ([consumer poll-duration throw?]
-   (lazy-seq
-    (log/trace "polling")
-    (if-let [records (seq (poll-consumer consumer poll-duration))]
-      (do
-        (log/tracef "got %d records" (count records))
-        (cons records (consumer-seqs consumer poll-duration)))
-      (when throw?
-        (throw (ex-info "Poll timeout on Kafka consumer!"
-                        {:cause #{:poll-wait-duration :xtdb.kafka/tx-log}
-                         :current-value poll-duration})))))))
+(defn- consumer-seqs [consumer poll-duration]
+  (lazy-seq
+   (log/trace "polling")
+   (when-let [records (seq (poll-consumer consumer poll-duration))]
+     (log/tracef "got %d records" (count records))
+     (cons records (consumer-seqs consumer poll-duration)))))
 
 ;;;; TxLog
 
@@ -187,7 +179,7 @@
           duration (get opts :kafka/poll-wait-duration)
           poll-wait-duration (if (instance? Duration duration) duration poll-wait-duration)]
       (xio/->cursor #(.close consumer)
-                    (->> (consumer-seqs consumer poll-wait-duration true)
+                    (->> (consumer-seqs consumer poll-wait-duration)
                          (mapcat identity)
                          (map tx-record->tx-log-entry)))))
 

--- a/modules/kafka/src/xtdb/kafka.clj
+++ b/modules/kafka/src/xtdb/kafka.clj
@@ -132,8 +132,8 @@
         (cons records (consumer-seqs consumer poll-duration)))
       (when throw?
         (throw (ex-info "Poll timeout on Kafka consumer!"
-                        {:cause #{:poll-wait-duration}
-                         :value poll-duration})))))))
+                        {:cause #{:poll-wait-duration :xtdb.kafka/tx-log}
+                         :current-value poll-duration})))))))
 
 ;;;; TxLog
 

--- a/test/test/xtdb/api_test.clj
+++ b/test/test/xtdb/api_test.clj
@@ -429,7 +429,7 @@
                (xt/entity (xt/db *api*) :ivan)))
 
       (let [*server-api* (or *http-server-api* *api*)
-            arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *server-api*) nil)]
+            arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *server-api*) nil {})]
                          (-> (iterator-seq tx-log) last ::txe/tx-events first last))]
 
         (t/is (= {:crux.db.fn/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc {:xt/id :ivan, :name "Ivan"})]]}

--- a/test/test/xtdb/fixtures/kafka.clj
+++ b/test/test/xtdb/fixtures/kafka.clj
@@ -39,9 +39,11 @@
 (def ^:dynamic *consumer-options* {})
 
 (defn ^KafkaConsumer open-consumer []
-  (k/->consumer {:kafka-config (k/->kafka-config {:bootstrap-servers *kafka-bootstrap-servers*
-                                                  :properties-map (merge {"group.id" (str (UUID/randomUUID))}
-                                                                         *consumer-options*)})}))
+  (k/->consumer {:kafka-config
+                 (k/->kafka-config
+                   {:bootstrap-servers *kafka-bootstrap-servers*
+                    :properties-map (merge {"group.id" (str (UUID/randomUUID))}
+                                           *consumer-options*)})}))
 
 (def ^:dynamic *kafka-config* {})
 
@@ -57,8 +59,11 @@
       (fix/with-opts {::k/kafka-config (merge
                                         {:bootstrap-servers *kafka-bootstrap-servers*}
                                         *kafka-config*)
-                      ::tx-topic-opts {:xtdb/module `k/->topic-opts, :topic-name *tx-topic*}
-                      :xtdb/tx-log {:xtdb/module `k/->tx-log, :kafka-config ::k/kafka-config, :tx-topic-opts ::tx-topic-opts}}
+                      ::tx-topic-opts {:xtdb/module `k/->topic-opts,
+                                       :topic-name *tx-topic*}
+                      :xtdb/tx-log {:xtdb/module `k/->tx-log,
+                                    :kafka-config ::k/kafka-config,
+                                    :tx-topic-opts ::tx-topic-opts}}
         f))))
 
 (defn with-cluster-doc-store-opts [f]
@@ -68,6 +73,9 @@
       (fix/with-opts {::k/kafka-config (merge
                                         {:bootstrap-servers *kafka-bootstrap-servers*}
                                         *kafka-config*)
-                      ::doc-topic-opts {:xtdb/module `k/->topic-opts, :topic-name *doc-topic*}
-                      :xtdb/document-store {:xtdb/module `k/->document-store, :kafka-config ::k/kafka-config, :doc-topic-opts ::doc-topic-opts}}
+                      ::doc-topic-opts {:xtdb/module `k/->topic-opts,
+                                        :topic-name *doc-topic*}
+                      :xtdb/document-store {:xtdb/module `k/->document-store,
+                                            :kafka-config ::k/kafka-config,
+                                            :doc-topic-opts ::doc-topic-opts}}
         f))))

--- a/test/test/xtdb/kafka_test.clj
+++ b/test/test/xtdb/kafka_test.clj
@@ -27,7 +27,7 @@
     (fn []
       (t/testing "transacting and indexing"
         (let [submitted-tx (xt/submit-tx *api* [[::xt/put evicted-doc]
-                                                 [::xt/put non-evicted-doc]])
+                                                [::xt/put non-evicted-doc]])
               _ (xt/await-tx *api* submitted-tx)
               _ (xt/submit-tx *api* [[::xt/evict (:xt/id evicted-doc)]])
               submitted-tx (xt/submit-tx *api* [[::xt/put after-evict-doc]])
@@ -52,8 +52,12 @@
 
 (defn with-compacted-node [{:keys [compacted-docs submitted-tx]} f]
   (t/testing "compaction"
-    (let [with-fixtures (t/join-fixtures [(fix/with-opts {::fk/doc-topic-opts {:topic-name (str "compacted-" fk/*doc-topic*)}})
-                                          fix/with-node])]
+    (let [with-fixtures
+          (t/join-fixtures
+            [(fix/with-opts
+               {::fk/doc-topic-opts
+                {:topic-name (str "compacted-" fk/*doc-topic*)}})
+             fix/with-node])]
       (with-fixtures
         (fn []
           (t/testing "new node can pick-up"
@@ -66,7 +70,9 @@
   ;; replace the original document. The original document will be then
   ;; removed once kafka compacts it away.
 
-  (let [with-fixtures (t/join-fixtures [fk/with-cluster-tx-log-opts fk/with-cluster-doc-store-opts])]
+  (let [with-fixtures (t/join-fixtures
+                        [fk/with-cluster-tx-log-opts
+                         fk/with-cluster-doc-store-opts])]
     (with-fixtures
       (fn []
         (with-compacted-node (submit-txs-to-compact)
@@ -78,10 +84,18 @@
 
 (t/deftest test-consumer-seeks-after-restart
   (fix/with-tmp-dirs #{tmp-indices tmp-docs}
-    (let [with-fixtures (t/join-fixtures [fk/with-cluster-tx-log-opts
-                                          fk/with-cluster-doc-store-opts
-                                          (fix/with-opts {:xtdb/index-store {:kv-store {:xtdb/module `xtdb.rocksdb/->kv-store, :db-dir tmp-indices}}
-                                                          :xtdb/document-store {:local-document-store {:kv-store {:xtdb/module `xtdb.rocksdb/->kv-store, :db-dir tmp-docs}}}})])]
+    (let [with-fixtures (t/join-fixtures
+                         [fk/with-cluster-tx-log-opts
+                          fk/with-cluster-doc-store-opts
+                          (fix/with-opts
+                            {:xtdb/index-store
+                             {:kv-store
+                              {:xtdb/module `xtdb.rocksdb/->kv-store,
+                               :db-dir tmp-indices}}
+                             :xtdb/document-store
+                             {:local-document-store
+                              {:kv-store {:xtdb/module `xtdb.rocksdb/->kv-store,
+                                          :db-dir tmp-docs}}}})])]
       (with-fixtures
         (fn []
           (fix/with-node
@@ -95,13 +109,14 @@
               (t/is (xt/entity (xt/db *api*) :bar)))))))))
 
 (t/deftest submit-oversized-doc
-  (let [with-fixtures (t/join-fixtures [(partial
-                                         fk/with-kafka-config
-                                         {:properties-map {"max.partition.fetch.bytes" "1024"
-                                                           "max.request.size" "1024"}})
-                                        fk/with-cluster-tx-log-opts
-                                        fk/with-cluster-doc-store-opts
-                                        fix/with-node])]
+  (let [with-fixtures (t/join-fixtures
+                       [(partial
+                         fk/with-kafka-config
+                         {:properties-map {"max.partition.fetch.bytes" "1024"
+                                           "max.request.size" "1024"}})
+                        fk/with-cluster-tx-log-opts
+                        fk/with-cluster-doc-store-opts
+                        fix/with-node])]
     (with-fixtures
       (fn []
         (t/testing "submitting an oversized document returns proper exception"

--- a/test/test/xtdb/kafka_test.clj
+++ b/test/test/xtdb/kafka_test.clj
@@ -159,6 +159,6 @@
         (t/testing "open-tx-log throws when poll timeouts (poll-wait-duration)"
           (t/is
             (thrown-with-msg?
-              Exception
+              clojure.lang.ExceptionInfo
               #"Poll timeout on Kafka consumer!"
               (xt/open-tx-log *api* 0 false))))))))

--- a/test/test/xtdb/submit_client_test.clj
+++ b/test/test/xtdb/submit_client_test.clj
@@ -17,7 +17,7 @@
           submitted-tx
           (with-open [submit-client (xt/new-submit-client submit-opts)]
             (let [submitted-tx (xt/submit-tx submit-client [[::xt/put {:xt/id :ivan :name "Ivan"}]])]
-              (with-open [tx-log-iterator (db/open-tx-log (:tx-log submit-client) nil)]
+              (with-open [tx-log-iterator (db/open-tx-log (:tx-log submit-client) nil {})]
                 (let [result (iterator-seq tx-log-iterator)]
                   (t/is (not (realized? result)))
                   (t/is (= [(assoc submitted-tx

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -547,7 +547,7 @@
         (fix/submit+await-tx [[::xt/put tx2-ivan tx2-valid-time]
                               [::xt/put tx2-petr tx2-valid-time]])]
 
-    (with-open [log-iterator (db/open-tx-log (:tx-log *api*) nil)]
+    (with-open [log-iterator (db/open-tx-log (:tx-log *api*) nil {})]
       (let [log (iterator-seq log-iterator)]
         (t/is (not (realized? log)))
         (t/is (= [{::xt/tx-id tx1-id
@@ -1070,7 +1070,7 @@
     (t/is (= {:xt/id :ivan, :name "Ivan"}
              (xt/entity (xt/db *api*) :ivan)))
 
-    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil)]
+    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil {})]
                        (-> (iterator-seq tx-log) last ::txe/tx-events first last))]
 
       (t/is (= {:crux.db.fn/tx-events [[:crux.tx/put (c/new-id :ivan) (c/hash-doc {:xt/id :ivan, :name "Ivan"})]]}
@@ -1088,7 +1088,7 @@
     (t/is (= {:xt/id :no-fn-args-doc}
              (xt/entity (xt/db *api*) :no-fn-args-doc)))
 
-    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil)]
+    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil {})]
                        (-> (iterator-seq tx-log) last ::txe/tx-events first last))]
 
       (t/is (= {:crux.db.fn/tx-events [[:crux.tx/put (c/new-id :no-fn-args-doc) (c/hash-doc {:xt/id :no-fn-args-doc})]]}
@@ -1111,7 +1111,7 @@
     (t/is (= {:xt/id :bob, :name "Bob"}
              (xt/entity (xt/db *api*) :bob)))
 
-    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) 1)]
+    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) 1 {})]
                        (-> (iterator-seq tx-log) last ::txe/tx-events first last))
           arg-doc (-> (db/fetch-docs (:document-store *api*) #{arg-doc-id})
                       (get arg-doc-id)
@@ -1149,7 +1149,7 @@
 
     (t/is (nil? (xt/entity (xt/db *api*) :petr)))
 
-    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil)]
+    (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil {})]
                        (-> (iterator-seq tx-log) last ::txe/tx-events first last))]
 
       (t/is (true? (-> (db/fetch-docs (:document-store *api*) #{arg-doc-id})
@@ -1209,7 +1209,7 @@
                         [::xt/match :foo {:xt/id :foo}]
                         [::xt/fn :foo :foo-arg]])
 
-  (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil)]
+  (let [arg-doc-id (with-open [tx-log (db/open-tx-log (:tx-log *api*) nil {})]
                      (-> (iterator-seq tx-log)
                          first
                          :xtdb.tx.event/tx-events


### PR DESCRIPTION
This PR addresses issue #1834.

* the third parameter of `xtdb.api/open-tx-log` can now be a map, which will be checked for the following keys:
  `[:with-ops? :kafka/poll-wait-duration]`

When `:kafka/poll-wait-duration` is not specified `:xtdb.api/open-tx-log` uses `poll-wait-duration` specified in `[:node-opts :xtdb/tx-log]` (defaulting to 1 second).


Please note that this addition is specific only to the Kafka module. All other storages can keep using a boolean as 3rd argument for `xtdb.api/open-tx-log`.
 