### PR TITLE
Remove cross transaction doc deduplication for statistics counts

### DIFF
--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -574,16 +574,9 @@
             stats-buffer-doc-count 32
             stats-buffer-flush-ms 500
 
-            stats-agent (agent {} :error-handler (fn [_ag ex] (handle-ex ex)))
+            stats-agent (agent [] :error-handler (fn [_ag ex] (handle-ex ex)))
 
-            flush-stats (fn [buf] (db/index-stats index-store buf) {})
-
-            buffer-docs
-            (fn [buf docs]
-              (cond
-                (not (map? docs)) (into buf docs)
-                (= 0 (count buf)) docs
-                :else (into buf docs)))
+            flush-stats (fn [buf] (db/index-stats index-store buf) [])
 
             flush-stats-if-enough-docs
             (fn [buf]
@@ -619,8 +612,7 @@
                                               (do
                                                 (db/commit in-flight-tx tx)
                                                 (doto stats-agent
-                                                  (send buffer-docs docs)
-                                                  (send buffer-docs indexed-docs)
+                                                  (send into (into docs indexed-docs))
                                                   (send flush-stats-if-enough-docs)))
                                               (db/abort in-flight-tx tx))))
 

--- a/test/src/xtdb/fixtures.clj
+++ b/test/src/xtdb/fixtures.clj
@@ -130,3 +130,17 @@
       (doc-value-count [_ attr] (get-in stats [attr :doc-value-count]))
       (eid-cardinality [_ attr] (get-in stats [attr :eids]))
       (value-cardinality [_ attr] (get-in stats [attr :vals])))))
+
+(defn spin-until-true
+  "Spin calling (f) until it returns truthy or the timeout (ms) elapses.
+
+  If (f) never returns truthy, returns the last value of (f) (i.e false or nil).
+
+  Always calls (f) at least once, does not short circuit on false/nil."
+  [ms f]
+  (let [end-ms (+ (System/currentTimeMillis) ms)]
+    (loop [ret (f)]
+      (cond
+        ret ret
+        (< (System/currentTimeMillis) end-ms) (recur (f))
+        :else ret))))

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -1553,4 +1553,4 @@
                               :xt/fn '(fn [_ n] [[::xt/put {:xt/id :foo, :answer n}]])}]
                    [::xt/fn :put-foo 42]])
     (xt/sync node)
-    (t/is (try-until-true 1000 #(= 1 (:answer (xt/attribute-stats node)))))))
+    (t/is (fix/spin-until-true 1000 #(= 1 (:answer (xt/attribute-stats node)))))))


### PR DESCRIPTION
1.22.2-rc1 contains an accidental statistics behaviour change related to buffering. 

Multiple transactions could share the same buffer map if they were not flushed due to size or timing. This leads to a non-deterministic count if your log contains duplicates close enough together in time. 

In this PR, transactions can share a buffer, but deduplication only happens within a single transaction, this should therefore ensure the counts match 1.22.1, and removes non-determinism on replay (though it remains the case failure can cause non-deterministic results, which was also true of 1.22.1)

Fixes #1852 
