### PR TITLE
Downgrade console cljs dep to previous known working version

### DIFF
--- a/modules/http-server/project.clj
+++ b/modules/http-server/project.clj
@@ -28,7 +28,7 @@
              {:jvm-opts ["-Dlogback.configurationFile=../../resources/logback-test.xml"]
               :dependencies [[metosin/reitit-dev "0.5.18"]
 
-                             [org.clojure/clojurescript "1.11.60"]
+                             [org.clojure/clojurescript "1.10.844"]
                              [ch.qos.logback/logback-classic "1.2.11"]
                              [cljsjs/codemirror "5.44.0-1"]
                              [com.bhauman/figwheel-main "0.2.18"


### PR DESCRIPTION
Later versions cause issues with tick transient deps, might further  work to resolve, for now it does not seem necessary to upgrade.

Resolves #1863