### PR TITLE
Add replicator module that'll export the processed tx-log out to a file #1862

### DIFF
--- a/core/src/xtdb/db.clj
+++ b/core/src/xtdb/db.clj
@@ -23,6 +23,16 @@
   (begin-index-tx [this])
   (index-stats [this docs]))
 
+(defprotocol ReplicatorTx
+  (index-replicator-tx [replicator-tx tx])
+  (index-replicator-docs [replicator-tx docs])
+  (index-coords [replicator-tx coords])
+  (commit-replicator-tx [replictor-tx])
+  (abort-replicator-tx [replicator-tx]))
+
+(defprotocol Replicator
+  (begin-replicator-tx [replicator]))
+
 (defprotocol LatestCompletedTx
   (latest-completed-tx [this]))
 

--- a/lein-sub
+++ b/lein-sub
@@ -26,6 +26,7 @@ test
 modules/s3
 modules/azure-blobs
 modules/google-cloud-storage
+modules/replicator
 bench"
   fi
 

--- a/modules/replicator/project.clj
+++ b/modules/replicator/project.clj
@@ -1,0 +1,22 @@
+(defproject com.xtdb/xtdb-replicator "<inherited>"
+  :description "XTDB Replication Log Exporter"
+
+  :plugins [[lein-parent "0.3.8"]]
+
+  :parent-project {:path "../../project.clj"
+                   :inherit [:version :repositories :deploy-repositories
+                             :managed-dependencies
+                             :pedantic? :global-vars
+                             :license :url :pom-addition]}
+
+  :scm {:dir "../.."}
+
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+
+                 [com.xtdb/xtdb-core]
+                 [com.cognitect/transit-clj]]
+
+  :profiles {:test {:dependencies [[com.xtdb/xtdb-test]]}}
+
+  :jvm-opts ["-Dlogback.configurationFile=../../resources/logback-test.xml"])

--- a/modules/replicator/src/xtdb/replicator.clj
+++ b/modules/replicator/src/xtdb/replicator.clj
@@ -1,0 +1,123 @@
+(ns xtdb.replicator
+  (:require [cognitect.transit :as t]
+            [xtdb.api :as xt]
+            [xtdb.codec :as c]
+            [xtdb.db :as db]
+            [xtdb.system :as sys])
+  (:import clojure.lang.MapEntry
+           java.io.OutputStream
+           java.lang.AutoCloseable
+           (java.nio.file CopyOption Files OpenOption Path StandardCopyOption StandardOpenOption)
+           java.nio.file.attribute.FileAttribute
+           [java.time DayOfWeek Duration Instant LocalDate LocalDateTime LocalTime Month MonthDay OffsetDateTime OffsetTime Period Year YearMonth ZoneId ZonedDateTime]
+           (xtdb.codec Id EDNId)))
+
+(defprotocol TestReplicator
+  (force-close-file! [test-replicator]))
+
+(def tj-write-handlers
+  (merge {Id (t/write-handler "xtdb/oid" str)
+          EDNId (t/write-handler "xtdb/oid" str)
+          (Class/forName "[B") (t/write-handler "xtdb/base64" c/base64-writer)}
+
+         (-> {Period "time/period"
+              LocalDate "time/date"
+              LocalDateTime  "time/date-time"
+              ZonedDateTime "time/zoned-date-time"
+              OffsetTime "time/offset-time"
+              Instant "time/instant"
+              OffsetDateTime "time/offset-date-time"
+              ZoneId "time/zone"
+              DayOfWeek "time/day-of-week"
+              LocalTime "time/time"
+              Month "time/month"
+              Duration "time/duration"
+              Year "time/year"
+              YearMonth "time/year-month"
+              MonthDay "time/month-day"}
+             (update-vals #(t/write-handler % str)))))
+
+(def ^"[Ljava.nio.file.attribute.FileAttribute;" empty-file-attrs
+  (make-array FileAttribute 0))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn ->local-dir-replicator {::sys/args {:path {:spec ::sys/path, :required? true}
+                                          :tx-events-per-file {:spec ::sys/pos-int, :required? true, :default 10000}}}
+  [{:keys [^Path path, ^long tx-events-per-file]}]
+
+  (Files/createDirectories path empty-file-attrs)
+
+  (with-open [dir-stream (Files/newDirectoryStream path)]
+    (assert (empty? dir-stream)
+            (format "already exists: '%s'" path)))
+
+  (let [!next-file-idx (atom 0)
+        !out-file (atom nil)
+        !ev-count (atom 0)
+
+        ;; could write these to the local KV store if we think they'll grow beyond memory
+        !eids (atom {})]
+
+    (letfn [(open-new-file! []
+              (let [tmp-path (Files/createTempFile "tmp-xtdb-log" ".transit.json" empty-file-attrs)
+                    os (Files/newOutputStream tmp-path
+                                              (into-array OpenOption #{StandardOpenOption/CREATE
+                                                                       StandardOpenOption/WRITE
+                                                                       StandardOpenOption/TRUNCATE_EXISTING}))
+                    w (t/writer os :json {:handlers tj-write-handlers})]
+                {:tmp-path tmp-path, :os os, :w w}))
+
+            (close-file! []
+              (when-let [{:keys [tmp-path ^OutputStream os]} (first (reset-vals! !out-file nil))]
+                (reset! !ev-count 0)
+                (let [next-idx (first (swap-vals! !next-file-idx inc))]
+                  (.close os)
+                  (Files/move tmp-path (.resolve path (format "log.%d.transit.json" next-idx))
+                              (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE])))))
+
+            (write-obj! [obj ev-count]
+              (let [{:keys [^OutputStream os w]} (or @!out-file
+                                                     (reset! !out-file (open-new-file!)))
+                    total-ev-count (swap! !ev-count + ev-count)]
+                (t/write w obj)
+                (.write os (int \newline))
+                (.flush os)
+                (when (>= total-ev-count tx-events-per-file)
+                  (close-file!))))]
+
+      (reify
+        db/Replicator
+        (begin-replicator-tx [_]
+          (let [!tx (atom nil)
+                !docs (atom {})
+                !coords (atom [])]
+            (reify db/ReplicatorTx
+              (index-replicator-tx [_ tx] (reset! !tx (select-keys tx [::xt/tx-id ::xt/tx-time])))
+
+              (index-replicator-docs [_ docs]
+                (swap! !docs into docs)
+                (swap! !eids into
+                       (comp (keep (fn [[_ doc]]
+                                     (when-let [id (:crux.db/id doc)]
+                                       (MapEntry/create (c/new-id id) id)))))
+                       docs))
+
+              (index-coords [_ coords] (swap! !coords into coords))
+
+              (commit-replicator-tx [_]
+                (let [docs @!docs, eids @!eids, coords @!coords]
+                  (write-obj! [:commit @!tx
+                               (vec (for [[tx-op {:keys [content-hash] :as coord}] coords]
+                                      [tx-op (-> (dissoc coord :content-hash)
+                                                 (assoc :doc (get docs content-hash))
+                                                 (update :eid (some-fn eids identity)))]))]
+                              (count coords))))
+
+              (abort-replicator-tx [_]
+                (write-obj! [:abort @!tx] 1)))))
+
+        TestReplicator
+        (force-close-file! [_] (close-file!))
+
+        AutoCloseable
+        (close [_] (close-file!))))))

--- a/modules/replicator/test/xtdb/replicator_test.clj
+++ b/modules/replicator/test/xtdb/replicator_test.clj
@@ -1,0 +1,96 @@
+(ns xtdb.replicator-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t]
+            [cognitect.transit :as transit]
+            [xtdb.api :as xt]
+            [xtdb.fixtures :as fix]
+            [xtdb.replicator :as replicator])
+  (:import java.io.File))
+
+(def ^:dynamic ^File *log-dir*)
+
+(t/use-fixtures :each
+  (fn [f]
+    (fix/with-tmp-dirs #{log-dir}
+      (binding [*log-dir* log-dir]
+        (fix/with-opts {:xtdb/tx-indexer {:replicator {:xtdb/module `replicator/->local-dir-replicator
+                                                       :path log-dir
+                                                       :tx-events-per-file 10}}}
+          f))))
+
+  fix/with-node)
+
+(defn- force-close-file! []
+  (replicator/force-close-file! (-> @(:!system fix/*api*)
+                                    (get-in [:xtdb/tx-indexer :replicator]))))
+
+(defn- read-log-files []
+  (force-close-file!)
+
+  (for [^File log-file (->> (seq (.listFiles *log-dir*))
+                            (sort-by #(.getName ^File %)))]
+    [(.getName log-file)
+     (with-open [is (io/input-stream log-file)]
+       (let [rdr (transit/reader is :json)]
+         (loop [evts []]
+           (if-let [evt (try
+                          (transit/read rdr)
+                          (catch Throwable _))]
+             (recur (conj evts evt))
+             evts))))]))
+
+(t/deftest test-replicator
+  (let [{tt0 ::xt/tx-time} (fix/submit+await-tx [[::xt/put {:xt/id :foo}]
+                                                 [::xt/put {:xt/id :bar}]])
+
+        {tt1 ::xt/tx-time} (fix/submit+await-tx [[::xt/delete :bar #inst "2021"]
+                                                 [::xt/put {:xt/id :baz}]])]
+
+    (t/is (= [["log.0.transit.json"
+               [[:commit #::xt{:tx-id 0, :tx-time tt0}
+                 [[:put {:eid :foo, :doc {:crux.db/id :foo}
+                         :start-valid-time tt0, :end-valid-time nil}]
+                  [:put {:eid :bar, :doc {:crux.db/id :bar}
+                         :start-valid-time tt0, :end-valid-time nil}]]]
+                [:commit #::xt{:tx-id 1, :tx-time tt1}
+                 [[:delete {:eid :bar, :doc nil
+                            :start-valid-time #inst "2021", :end-valid-time tt0}]
+                  [:put {:eid :baz, :doc {:crux.db/id :baz}
+                         :start-valid-time tt1, :end-valid-time nil,}]]]]]]
+
+             (read-log-files)))))
+
+(t/deftest splits-files
+  (let [{tt0 ::xt/tx-time} (fix/submit+await-tx (for [n (range 6)]
+                                                  [::xt/put {:xt/id n}]))
+
+        {tt1 ::xt/tx-time} (fix/submit+await-tx (for [n (range 6 12)]
+                                                  [::xt/put {:xt/id n}]))
+
+        {tt2 ::xt/tx-time} (fix/submit+await-tx (for [n (range 12 18)]
+                                                  [::xt/put {:xt/id n}]))]
+
+    (t/is (= [["log.0.transit.json"
+               [[:commit #::xt{:tx-id 0, :tx-time tt0}
+                 (for [n (range 6)]
+                   [:put {:eid n, :doc {:crux.db/id n}
+                          :start-valid-time tt0, :end-valid-time nil}])]
+                [:commit #::xt{:tx-id 1, :tx-time tt1}
+                 (for [n (range 6 12)]
+                   [:put {:eid n, :doc {:crux.db/id n}
+                          :start-valid-time tt1, :end-valid-time nil}])]]]
+              ["log.1.transit.json"
+               [[:commit #::xt{:tx-id 2, :tx-time tt2}
+                 (for [n (range 12 18)]
+                   [:put {:eid n, :doc {:crux.db/id n}
+                          :start-valid-time tt2, :end-valid-time nil}])]]]]
+
+             (read-log-files)))))
+
+(comment
+  (require '[xtdb.fixtures.tpch :as tpch])
+
+  (with-open [node (xt/start-node {:xtdb/tx-indexer {:replicator {:xtdb/module `replicator/->local-dir-replicator
+                                                                  :path "/tmp/tpch"}}})]
+    (tpch/submit-docs! node 0.01)
+    (xt/sync node)))

--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
    [com.xtdb/xtdb-lucene ~xt-version]
    [com.xtdb/xtdb-test ~xt-version]
    [com.xtdb/xtdb-bench ~xt-version]
+   [com.xtdb/xtdb-replicator ~xt-version]
 
    [ch.qos.logback/logback-classic "1.2.11"]
    [ch.qos.logback/logback-core "1.2.11"]
@@ -106,6 +107,7 @@
    [com.xtdb/xtdb-lucene]
    [com.xtdb/xtdb-test]
    [com.xtdb/xtdb-bench]
+   [com.xtdb/xtdb-replicator]
 
    [org.apache.kafka/connect-api "2.6.0" :scope "provided"]
 


### PR DESCRIPTION
Two main parts to this:

* A change to `xtdb.tx` that means we can pass the resulting low-level put/delete ops out to a replicator
  * Main reason for this is that this is the place that essentially resolves the end-valid-time (when the user hasn't provided it) using the C1 bitemporal logic - C2 defaults end-valid-time using SQL semantics, so we want to preserve the behaviour for transactions that have already been indexed into C1.
  * There's one change in here that may well have a performance impact: previously, we only called `entity-history` in `put-delete-etxs` when there was a visible entity; now, we call it every time (to get the end-valid-time) - this may impact the case where we're putting a new entity.
* A replicator module that writes those low-level opts out to a log directory
  * This can be attached to a running XT node using the module system, so this can be an online process. We write files out on a regular (every 10k tx-events) basis, so we can effectively stream transactions to another process watching the log directory.
  * Idea is that users set this up as a separate ad-hoc XT node (just another reader of the tx-log) rather than adding the config to a production node.
  * If there are any objects in the tx-log that can't be represented as Transit (with the java.time writers), this process will currently fail in an ugly way. We could try to write them out using `Serializable`, but tbh I'd rather be made aware of how many users this might affect.
  * At the moment if this catches up to the head of the log, it won't write out the final segment file until the process is stopped - we could consider writing out a segment after not seeing transactions for a duration?

(probably goes without saying, but not blocking for 1.22.2)