### PR TITLE
Issue 1884: lucene-text-search fails when :xt/id is an URI

### DIFF
--- a/core/src/xtdb/codec.clj
+++ b/core/src/xtdb/codec.clj
@@ -366,7 +366,8 @@
                                          (mem/->nippy-buffer this))
                                        (mem/->nippy-buffer this))]
       (if (or (< max-value-index-length (.capacity nippy-buffer))
-              (not (nippy/freezable? this)))
+              (not (or (nippy/freezable? this)
+                       (uri? this))))
         (doto (id-function to nippy-buffer)
           (.putByte 0 object-value-type-id))
         (-> (doto to

--- a/core/src/xtdb/kv/tx_log.clj
+++ b/core/src/xtdb/kv/tx_log.clj
@@ -73,7 +73,7 @@
              (take limit)
              vec)))))
 
-(defn- throw-if-closed [tx-submit-executor]
+(defn- throw-if-closed [^ExecutorService tx-submit-executor]
   (when (.isShutdown tx-submit-executor)
     (throw (IllegalStateException. "TxLog is closed."))))
 

--- a/core/test/xtdb/codec_test.clj
+++ b/core/test/xtdb/codec_test.clj
@@ -209,6 +209,14 @@
                :url (java.net.URL. "https://google.com")
                :uuid (java.util.UUID/randomUUID)}]
       (fix/submit+await-tx node [[::xt/put doc]])
+      (t/is (= doc (xt/entity (xt/db node) :foo)))))
+  (with-open [node (xt/start-node {})]
+    (let [doc {:xt/id (new java.net.URI "http://clojuredocs.org/")
+               :date (java.util.Date.)
+               :uri (java.net.URI. "https://google.com")
+               :url (java.net.URL. "https://google.com")
+               :uuid (java.util.UUID/randomUUID)}]
+      (fix/submit+await-tx node [[::xt/put doc]])
       (t/is (= doc (xt/entity (xt/db node) :foo))))))
 
 (t/deftest test-id-reader-with-existing-buffer-1778


### PR DESCRIPTION
Fixes an issue with Lucene `multi-field` indexer, allowing `java.net.URI` instances to be used as `:xt/id`.

The raison for this is that 

```
(nippy/freezable? (new java.net.URI "http:foo.bar))
```
is falsey.  We do *not* call [serializable? ](http://ptaoussanis.github.io/nippy/taoensso.nippy.html#var-freezable.3F) whith `allow-java-serializable?` for that would allow *all* serializable objects to be usable as `:xt/id`.
