### PR TITLE
Xtdb 1881

### DIFF
--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -277,7 +277,7 @@
                                       :default false
                                       :spec ::sys/boolean}
                               :db-options {:doc "RocksDB Options"
-                                           :spec #(instance? Options %)}
+                                           :spec #(instance? DBOptions %)}
                               :disable-wal? {:doc "Disable Write Ahead Log"
                                              :default false
                                              :spec ::sys/boolean}

--- a/modules/rocksdb/src/xtdb/rocksdb.clj
+++ b/modules/rocksdb/src/xtdb/rocksdb.clj
@@ -393,3 +393,10 @@
                                 :->column-family-handle ->column-family-handle})]
     (cond-> kv-store
       checkpointer (assoc :cp-job (cp/start checkpointer kv-store {::cp/cp-format cp-format})))))
+
+
+(comment
+
+  (cond-> 1 (.setStatistics stats))
+
+  :ok)


### PR DESCRIPTION
fixes #1881 

RocksDB `:db-options` bust be an instance of `org.rocksdb.DBOptions`.