### PR TITLE
Jan/checkpoint cleanup

### DIFF
--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -50,7 +50,6 @@
               (->> pr-str (log/info "Uploaded checkpoint:")))
             (swap! success inc)
             (finally
-              (prn [:DIR (type dir)])
               (xio/delete-dir dir)
               (when-not (pos? @success)
                 (cleanup-checkpoint store opts)

--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -77,7 +77,6 @@
           ses (Executors/newSingleThreadScheduledExecutor (xio/thread-factory "xtdb-checkpoint"))]
       (letfn [(run [[time & more-times]]
                 (try
-
                   (checkpoint {:approx-frequency approx-frequency,
                                :dir checkpoint-dir,
                                :src src,

--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -161,6 +161,7 @@
       (try
         (sync-path cp-path to-path)
         (catch Exception e
+          (xio/delete-dir to-path)
           (throw (ex-info "incomplete checkpoint restore"
                           {:cp-path cp-path
                            :local-dir to-path}

--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -15,7 +15,8 @@
 (defprotocol CheckpointStore
   (available-checkpoints [store opts])
   (download-checkpoint [store checkpoint dir])
-  (upload-checkpoint [store dir opts]))
+  (upload-checkpoint [store dir opts])
+  (cleanup-checkpoint [store dir]))
 
 (alter-meta! #'available-checkpoints assoc :arglists '([store {:keys [::cp-format]}]))
 (alter-meta! #'upload-checkpoint assoc :arglists '([store dir {:keys [::cp-format tx]}]))

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -135,8 +135,8 @@
 
 
 ;; swap for `embedded-kafka-config`  to use embedded-kafka
-(ir/set-prep! (fn [] checkpoint-fs-config))
-; (ir/set-prep! (fn [] standalone-config))
+; (ir/set-prep! (fn [] checkpoint-fs-config))
+(ir/set-prep! (fn [] standalone-config))
 ; (ir/set-prep! (fn [] local-kafka-config))
 ; (ir/set-prep! (fn [] embedded-kafka-config))
 

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -45,6 +45,34 @@
 (defmethod i/halt-key! ::xtdb [_ ^IXtdb node]
   (.close node))
 
+(def checkpoint-fs-config
+  {::xtdb
+   {:node-opts
+    {:xtdb/index-store
+     {:kv-store
+      {:xtdb/module `rocks/->kv-store,
+       :db-dir (io/file dev-node-dir "indexes"),
+       :checkpointer
+       {:xtdb/module 'xtdb.checkpoint/->checkpointer
+        :store {:xtdb/module 'xtdb.checkpoint/->filesystem-checkpoint-store
+                :path (io/file dev-node-dir "checkpoints")}
+        :approx-frequency (java.time.Duration/ofSeconds 30)}}}
+
+     :xtdb/document-store
+     {:kv-store {:xtdb/module `rocks/->kv-store,
+                 :db-dir (io/file dev-node-dir "documents")
+                 :block-cache :xtdb.rocksdb/block-cache}}
+
+     :xtdb/tx-log
+     {:kv-store {:xtdb/module `rocks/->kv-store,
+                 :db-dir (io/file dev-node-dir "tx-log")
+                 :block-cache :xtdb.rocksdb/block-cache}}
+
+     :xtdb.rocksdb/block-cache
+     {:xtdb/module `rocks/->lru-block-cache
+      :cache-size (* 128 1024 1024)}}}})
+
+
 (def standalone-config
   {::xtdb {:node-opts {:xtdb/index-store {:kv-store {:xtdb/module `rocks/->kv-store,
                                                      :db-dir (io/file dev-node-dir "indexes"),
@@ -106,8 +134,9 @@
                                   :kafka-config :kafka-config}}}})
 
 
-;; swap for `embedded-kafka-config` to use embedded-kafka
-(ir/set-prep! (fn [] standalone-config))
+;; swap for `embedded-kafka-config`  to use embedded-kafka
+(ir/set-prep! (fn [] checkpoint-fs-config))
+; (ir/set-prep! (fn [] standalone-config))
 ; (ir/set-prep! (fn [] local-kafka-config))
 ; (ir/set-prep! (fn [] embedded-kafka-config))
 

--- a/modules/s3/src/xtdb/s3.clj
+++ b/modules/s3/src/xtdb/s3.clj
@@ -76,8 +76,8 @@
                  (.build))
         res (-> (.deleteObjects client req)
                 (.join))]
-        (when (.hasError res)
-      (log/warnf "Failed to delete some objects on s3://%s/%s" bucket prefix))))
+        (when (.hasErrors res)
+          (log/warnf "Failed to delete some objects on s3://%s/%s" bucket prefix))))
 
 (defn ^:no-doc list-objects [{:keys [^S3Configurator _ ^S3AsyncClient client bucket prefix]}
                              {:keys [path recursive?]}]

--- a/modules/s3/src/xtdb/s3/checkpoint.clj
+++ b/modules/s3/src/xtdb/s3/checkpoint.clj
@@ -48,6 +48,7 @@
                                                              (AsyncResponseTransformer/toFile (doto file (io/make-parents)))))))]
 
       (when-not (= (set (keys get-objs-resp)) (set s3-paths))
+        (xio/delete-dir dir)
         (throw (ex-info "incomplete checkpoint restore" {:expected s3-paths
                                                          :actual (keys get-objs-resp)})))
 
@@ -62,9 +63,6 @@
                               (MapEntry/create (str s3-dir "/" (.relativize dir-path (.toPath file)))
                                                (AsyncRequestBody/fromFile file))))))
            (s3/put-objects this))
-
-      ;; TODO remove me.
-      (throw (ex-info "artificial failing" {}))
 
       (let [cp {::cp/cp-format cp-format,
                 :tx tx

--- a/modules/s3/src/xtdb/s3/checkpoint.clj
+++ b/modules/s3/src/xtdb/s3/checkpoint.clj
@@ -38,21 +38,25 @@
     (when-not (empty? (.listFiles ^File dir))
       (throw (IllegalArgumentException. "non-empty checkpoint restore dir: " dir)))
 
-    (let [s3-paths (->> (s3/list-objects this {:path s3-dir, :recursive? true})
-                        (map second))
-          get-objs-resp (s3/get-objects this
-                                        (for [s3-path s3-paths]
-                                          (let [file (io/file dir (str (.relativize (Paths/get s3-dir (make-array String 0))
-                                                                                    (Paths/get s3-path (make-array String 0)))))]
-                                            (MapEntry/create s3-path
-                                                             (AsyncResponseTransformer/toFile (doto file (io/make-parents)))))))]
+    (let [success (atom 0)]
+      (try
+        (let [s3-paths (->> (s3/list-objects this {:path s3-dir, :recursive? true})
+                            (map second))
+              get-objs-resp (s3/get-objects this
+                                            (for [s3-path s3-paths]
+                                              (let [file (io/file dir (str (.relativize (Paths/get s3-dir (make-array String 0))
+                                                                                        (Paths/get s3-path (make-array String 0)))))]
+                                                (MapEntry/create s3-path
+                                                                 (AsyncResponseTransformer/toFile (doto file (io/make-parents)))))))]
 
-      (when-not (= (set (keys get-objs-resp)) (set s3-paths))
-        (xio/delete-dir dir)
-        (throw (ex-info "incomplete checkpoint restore" {:expected s3-paths
-                                                         :actual (keys get-objs-resp)})))
-
-      checkpoint))
+          (when-not (= (set (keys get-objs-resp)) (set s3-paths))
+            (throw (ex-info "incomplete checkpoint restore" {:expected s3-paths
+                                                             :actual (keys get-objs-resp)})))
+          (swap! success inc)
+          checkpoint)
+        (finally
+          (when-not (pos? @success)
+            (xio/delete-dir dir))))))
 
   (upload-checkpoint [this dir {:keys [tx cp-at ::cp/cp-format]}]
     (let [dir-path (.toPath ^File dir)
@@ -79,11 +83,11 @@
   (cleanup-checkpoint [this  {:keys [tx cp-at]}]
     (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))
           files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
-                    (keep (fn [[type arg]]
-                             (when (= type :object)
-                               arg)) $)
-                     (vec $)
-                     (conj $ s3-dir))]
+                  (keep (fn [[type arg]]
+                          (when (= type :object)
+                            arg)) $)
+                  (vec $)
+                  (conj $ s3-dir))]
       (s3/delete-objects this files)))
 
   Closeable

--- a/test/src/xtdb/fixtures/checkpoint_store.clj
+++ b/test/src/xtdb/fixtures/checkpoint_store.clj
@@ -81,7 +81,7 @@
       (Files/copy from-path to-path ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0))))
   (throw (Exception. "broken!")))
 
-(defn test-checkpoint-broken-store
+(defn test-checkpoint-broken-store-failed-download
   [cp-store]
   (fix/with-tmp-dirs #{local-dir}
     (let [src-dir (doto (io/file local-dir "src")

--- a/test/src/xtdb/fixtures/checkpoint_store.clj
+++ b/test/src/xtdb/fixtures/checkpoint_store.clj
@@ -7,19 +7,6 @@
   (:import  [java.nio.file NoSuchFileException CopyOption Files FileVisitOption LinkOption Path]
             java.nio.file.attribute.FileAttribute))
 
-(defn- sync-path-throw
-  [^Path from-root-path ^Path to-root-path]
-  (doseq [^Path from-path (-> (Files/walk from-root-path Integer/MAX_VALUE (make-array FileVisitOption 0))
-                              .iterator
-                              iterator-seq)
-          :let [to-path (.resolve to-root-path (str (.relativize from-root-path from-path)))]]
-    (cond
-      (Files/isDirectory from-path (make-array LinkOption 0))
-      (Files/createDirectories to-path (make-array FileAttribute 0))
-      (Files/isRegularFile from-path (make-array LinkOption 0))
-      (Files/copy from-path to-path ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0))))
-  (throw :bang))
-
 (defn test-checkpoint-store [cp-store]
   (fix/with-tmp-dirs #{local-dir}
     (let [src-dir (doto (io/file local-dir "src")

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -91,3 +91,7 @@
 (t/deftest test-fs-checkpoint-store
   (fix/with-tmp-dirs #{cp-store-dir}
     (fix.cp-store/test-checkpoint-store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)}))))
+
+(t/deftest test-fs-checkpoint-broken-store
+  (fix/with-tmp-dirs #{cp-store-dir}
+    (fix.cp-store/test-checkpoint-broken-store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)}))))


### PR DESCRIPTION
fixes #1873 

* will cleanup any leftover on the CP storage (S3 FileSystem) after a failed checkpoint upload.

* will cleanup `[:index-store :kv-store :db-dir]`  when the download of a checkpoint fails (S3 & Filesystem).