### PR TITLE
RFC: :xt/fn validation

### DIFF
--- a/core/src/xtdb/api.clj
+++ b/core/src/xtdb/api.clj
@@ -23,9 +23,12 @@
 (s/def ::evicted? boolean?)
 (s/def :crux.db.fn/args (s/coll-of any? :kind vector?))
 
+(s/def ::fn-db-arg (s/or :sym symbol? :destructuring map?))
+(s/def ::fn-arg (s/or :sym symbol? :destructuring (s/or :map map? :vec vector?)))
+
 (s/def ::fn
   (s/cat :fn #{'fn}
-         :args (s/coll-of symbol? :kind vector? :min-count 1)
+         :args (s/and vector? (s/cat :db ::fn-db-arg :args (s/* ::fn-arg)))
          :body (s/* any?)))
 
 (defprotocol PXtdb


### PR DESCRIPTION
RFC (tests will fail until I confirm this has merit, they can be fixed but this is a breaking change)

At looking at solving #1831 I was surprised to find we do not validate `:xt/fn` so a user can supply any form, quoted function or not. The supplied form will be eval'd later as part of ingest where the user might discover an error.

i.e `[[::xt/put {:xt/id :boom, :xt/fn '(println "boom")}]]` is a valid transaction, and if you later `[[:xt/fn :boom]]` you will see the print on eval.

This PR then provides immediate feedback on submit in the following cases:

- invalid fn form, i.e a clojure function object, non-list and so on. I use the `:xtdb.api/fn` spec, which I've extended to support destructuring bindings.
- error on compilation such as symbol resolution (this is achieved by running a speculative eval and catching any exceptions).

Security wise the early eval opens a vector where you no longer need to collide with an `:xt/id` that will later be called for RCE. I would like to have that conversation, I think perhaps the early eval could be a dev-only flag. The spec _should_ ensure only fn forms of course.

Possible breaking change if users are doing funky stuff like using combinators (comp) (constantly) etc, or running code as part of definition (let over lambda).

One idea to avoid breakage and (some) security concerns would be to add a specialised op for definition so it does not overload put.