### PR TITLE
Add `:ingester-failed?` key to node status

### DIFF
--- a/core/src/xtdb/tx.clj
+++ b/core/src/xtdb/tx.clj
@@ -9,6 +9,7 @@
             [xtdb.error :as err]
             [xtdb.fork :as fork]
             [xtdb.io :as xio]
+            [xtdb.status :as status]
             [xtdb.system :as sys]
             [xtdb.tx.conform :as txc]
             [xtdb.tx.event :as txe])
@@ -456,6 +457,10 @@
 
   db/LatestCompletedTx
   (latest-completed-tx [_] (db/latest-completed-tx index-store))
+
+  status/Status
+  (status-map [_]
+    {:ingester-failed? (some? @!error)})
 
   Closeable
   (close [_]

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -1554,3 +1554,12 @@
                    [::xt/fn :put-foo 42]])
     (xt/sync node)
     (t/is (fix/spin-until-true 1000 #(= 1 (:answer (xt/attribute-stats node)))))))
+
+(t/deftest ingester-failed-returned-by-status-test
+  (t/is (false? (:ingester-failed? (xt/status *api*))))
+
+  (with-redefs [tx/strict-fetch-docs (fn [& _] (throw (Exception. "boom")))]
+    (xt/submit-tx *api* [[::xt/put {:xt/id "boom"}]])
+    (try (xt/sync *api*) (catch Throwable _)))
+
+  (t/is (true? (:ingester-failed? (xt/status *api*)))))


### PR DESCRIPTION
True if the ingester encountered a fatal exception.

Relates to #1831