### PR TITLE
Correct handling of Files/list in download-checkpoint error path.

### DIFF
--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -159,8 +159,8 @@
   (download-checkpoint [_ {::keys [cp-path]} dir]
     (let [to-path (.toPath ^File dir)]
       (when-not (or (not (Files/exists to-path (make-array LinkOption 0)))
-                    (empty? (Files/list to-path)))
-        (throw (IllegalArgumentException. "non-empty checkpoint restore dir: " to-path)))
+                    (empty? (.toArray (Files/list to-path))))
+        (throw (IllegalArgumentException. (str "non-empty checkpoint restore dir: " to-path))))
 
       (try
         (sync-path cp-path to-path)

--- a/test/src/xtdb/fixtures/checkpoint_store.clj
+++ b/test/src/xtdb/fixtures/checkpoint_store.clj
@@ -16,6 +16,17 @@
           cp-2 {::cp/cp-format ::foo-cp-format
                 :tx {::xt/tx-id 2}}]
 
+      (t/testing "destination dir exists and contains a file"
+        (let [dest-dir (io/file local-dir "dest")
+              rogue-file (io/file dest-dir "hello.txt")
+              cps (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format})]
+          (try
+            (.mkdirs dest-dir)
+            (spit rogue-file "I should not be present")
+            (t/is (thrown? IllegalArgumentException  (cp/download-checkpoint cp-store (first cps) dest-dir)))
+            (finally
+                  (io/delete-file rogue-file)))))
+
       (t/testing "first checkpoint"
         (spit (io/file src-dir "hello.txt") "Hello world")
 


### PR DESCRIPTION
This ensures that when a checkpoint destination exists that the check for whether the destination has files can proceed
correctly. `java.nio.files.Files/list` returns a `java.util.Stream<Path>` which cannot be coerced into a seq. By converting to an array the call to `(empty? ...)` will succeed. In the case where there are a lot of files, this might realise a large array into memory, but this seems unlikely and the system is already in the process of crashing at this point anyway, so doesn't seem too worrisome.