### PR TITLE
Dropped usage of `:as-alias` to support for 1.10.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
           at: ~/
       - run:
           command: |
+            lein version
             ./lein-sub check
             ./lein-sub test
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/clojure:1.10.3-openjdk-8.0
+      - image: wotbrew/xtdb-ci-lein-fix:latest
 
     working_directory: ~/xtdb
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/clojure:1.10.3-openjdk-8.0
+      - image: wotbrew/xtdb-ci-lein-fix:latest
 
     working_directory: ~/xtdb
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/clojure:openjdk-8-lein
+      - image: cimg/clojure:1.10.3-openjdk-8.0
 
     working_directory: ~/xtdb
 
@@ -94,7 +94,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/clojure:openjdk-8-lein
+      - image: cimg/clojure:1.10.3-openjdk-8.0
 
     working_directory: ~/xtdb
     steps:

--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -5,8 +5,7 @@
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
-            [cognitect.anomalies :as-alias anomalies])
+            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy])
   (:import (clojure.lang Box MapEntry)
            [java.io DataInputStream DataOutputStream File IOException Reader]
            (java.lang AutoCloseable)
@@ -403,10 +402,10 @@
        :or {retryable (fn default-retryable [t]
                         (let [data (ex-data t)
                               not-found (Object.)
-                              category (::anomalies/category data not-found)]
+                              category (:cognitect.anomalies/category data not-found)]
                           (if (identical? not-found category)
                             (instance? Exception t)
-                            (contains? #{::anomalies/unavailable, ::anomalies/busy} category))))
+                            (contains? #{:cognitect.anomalies/unavailable, :cognitect.anomalies/busy} category))))
             start-wait-ms 50
             on-retry #(log/error % "Retryable exception caught during exp-backoff loop")
             wait-mul 2

--- a/dev/xtdb/dev/consistency_check.clj
+++ b/dev/xtdb/dev/consistency_check.clj
@@ -243,16 +243,19 @@
 
 (defn state-at [model index] (nth (state-seq model) index))
 
+(defn- update-vals-backport [m f] (persistent! (reduce-kv #(assoc! %1 %2 (f %3)) (transient {}) m)))
+
 (defn- present-state
   "Sorts maps in docs for easier visual consumption."
   [x]
   (cond
     (map? x)
-    (update-vals (into (sorted-map-by
-                         (let [sort-key (juxt #(.getName (class %)) identity)]
-                           (fn [a b] (compare (sort-key a) (sort-key b)))))
-                       x)
-                 present-state)
+    (update-vals-backport
+      (into (sorted-map-by
+              (let [sort-key (juxt #(.getName (class %)) identity)]
+                (fn [a b] (compare (sort-key a) (sort-key b)))))
+            x)
+      present-state)
     (coll? x) (into (empty x) (map present-state) x)
     :else x))
 

--- a/modules/replicator/src/xtdb/replicator.clj
+++ b/modules/replicator/src/xtdb/replicator.clj
@@ -15,6 +15,8 @@
 (defprotocol TestReplicator
   (force-close-file! [test-replicator]))
 
+(defn- update-vals-backport [m f] (persistent! (reduce-kv #(assoc! %1 %2 (f %3)) (transient {}) m)))
+
 (def tj-write-handlers
   (merge {Id (t/write-handler "xtdb/oid" str)
           EDNId (t/write-handler "xtdb/oid" str)
@@ -35,7 +37,7 @@
               Year "time/year"
               YearMonth "time/year-month"
               MonthDay "time/month-day"}
-             (update-vals #(t/write-handler % str)))))
+             (update-vals-backport #(t/write-handler % str)))))
 
 (def ^"[Ljava.nio.file.attribute.FileAttribute;" empty-file-attrs
   (make-array FileAttribute 0))

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://opensource.org/licenses/MIT"}
 
   :managed-dependencies
-  [[org.clojure/clojure "1.11.1"]
+  [[org.clojure/clojure "1.10.3"]
    [org.clojure/data.csv "1.0.1"]
    [org.clojure/data.json "2.4.0"]
    [org.clojure/java.data "1.0.86"]

--- a/test/test/xtdb/document_store_test.clj
+++ b/test/test/xtdb/document_store_test.clj
@@ -9,7 +9,8 @@
             [xtdb.kv.document-store :as kv-doc-store]
             [xtdb.mem-kv :as mem-kv])
   (:import (clojure.lang IFn)
-           (java.io Closeable)))
+           (java.io Closeable)
+           (java.util UUID)))
 
 (defn dodgy-doc-store
   ([] (dodgy-doc-store (kv-doc-store/->document-store {:kv-store (mem-kv/->kv-store)
@@ -53,7 +54,7 @@
                         on-ret (constantly nil)
                         on-ex (constantly nil)
                         on-done (constantly nil)}}]
-  (let [fid (str (random-uuid))
+  (let [fid (str (UUID/randomUUID))
         f (eval f)
         f' '(fn [ctx fid & args] ((requiring-resolve 'xtdb.document-store-test/run-test-tx-fn) fid (cons ctx args)))
         ret-ref (atom nil)
@@ -107,7 +108,7 @@
 
 (t/deftest reads-during-tx-processing-recovery-test
   (doseq [example recoverable-exceptions
-          :let [unique-msg (str (random-uuid))
+          :let [unique-msg (str (UUID/randomUUID))
                 ex (construct-ex example unique-msg)
                 retried (promise)]]
     (with-open [node (dodgy-node)]
@@ -123,7 +124,7 @@
 
 (t/deftest reads-during-tx-processing-panic-test
   (doseq [example unrecoverable-exceptions
-          :let [unique-msg (str (random-uuid))
+          :let [unique-msg (str (UUID/randomUUID))
                 ex (construct-ex example "test panic")]]
     (with-open [node (dodgy-node)]
       (misbehave node ex)
@@ -136,7 +137,7 @@
           call ['(xtdb.api/entity (xtdb.api/db ctx) 0)
                 '(xtdb.api/pull (xtdb.api/db ctx) [:foo] 0)
                 '(xtdb.api/q (xtdb.api/db ctx) (quote {:find [(pull ?e [:foo])] :where [[?e :xt/id 0]]}))]]
-    (let [unique-msg (str (random-uuid))
+    (let [unique-msg (str (UUID/randomUUID))
           ex (construct-ex example unique-msg)
           retried (promise)]
       (with-open [node (dodgy-node)]
@@ -194,7 +195,7 @@
         start-node #(xt/start-node node-opts)]
 
     (let [node (start-node)
-          unique-msg (str (random-uuid))
+          unique-msg (str (UUID/randomUUID))
           ex (Exception. unique-msg)
           retried (promise)]
       (with-redefs [xio/sleep (constantly nil)

--- a/test/test/xtdb/jdbc_test.clj
+++ b/test/test/xtdb/jdbc_test.clj
@@ -8,7 +8,8 @@
             [xtdb.fixtures.lubm :as fl]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.result-set :as jdbcr]
-            [xtdb.jdbc :as j]))
+            [xtdb.jdbc :as j])
+  (:import (java.util UUID)))
 
 (comment
   ;; NOTE: CI does not run the tests for all dialects, to do so, run the setup code below.
@@ -180,8 +181,8 @@
                        (with-redefs [jdbc/execute! jdbc-execute]
                          (dotimes [_ n]
                            (#'j/insert-event! pool
-                             (str (random-uuid))
-                             (str (random-uuid))
+                             (str (UUID/randomUUID))
+                             (str (UUID/randomUUID))
                              "not-a-topic"))))
         captured-queries (atom [])]
 


### PR DESCRIPTION
Resolves #1936.

Build and test steps run on a new docker image that tests 1.10.x. The new image is based on the circle clojure convenience image. I use a version of leiningen 2.9.9 that includes a fix for top level exceptions during tests being swallowed. This may also help with investigation #1929. Tests seem more stable on this image for some reason, so may actually fix it!

