### PR TITLE
Document query timeout default

### DIFF
--- a/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
+++ b/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
@@ -706,7 +706,7 @@ include::example$test/xtdb/docs/examples/query_test.clj[tags=rules-4,indent=0]
 [#timeout]
 == Timeout
 
-`:timeout` sets the maximum run time of the query (in milliseconds). If specified, it overrides the `:query-timeout` Query Engine configuration option, which defaults to `30000` (30 seconds). If the query has not completed after this amount of time, a `java.util.concurrent.TimeoutException` is thrown.
+`:timeout` sets the maximum run time of the query (in milliseconds). If specified, it overrides the `:query-timeout` xref:{page-component-version}@administration::configuring.adoc#_query_engine[Query Engine configuration] option, which defaults to `30000` (30 seconds). If the query has not completed after this amount of time, a `java.util.concurrent.TimeoutException` is thrown.
 
 
 [#valid-time-travel]

--- a/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
+++ b/docs/language-reference/modules/ROOT/pages/datalog-queries.adoc
@@ -706,9 +706,8 @@ include::example$test/xtdb/docs/examples/query_test.clj[tags=rules-4,indent=0]
 [#timeout]
 == Timeout
 
-`:timeout` sets the maximum run time of the query (in milliseconds).
+`:timeout` sets the maximum run time of the query (in milliseconds). If specified, it overrides the `:query-timeout` Query Engine configuration option, which defaults to `30000` (30 seconds). If the query has not completed after this amount of time, a `java.util.concurrent.TimeoutException` is thrown.
 
-If the query has not completed by this time, a `java.util.concurrent.TimeoutException` is thrown.
 
 [#valid-time-travel]
 == Valid Time travel


### PR DESCRIPTION
It's nice for the query docs to mention the default, and how the default can be configured.