### PR TITLE
Remove tx-events of successful tx ops that are later rolled back

### DIFF
--- a/test/test/xtdb/tx_abort_test.clj
+++ b/test/test/xtdb/tx_abort_test.clj
@@ -1,0 +1,57 @@
+(ns xtdb.tx-abort-test
+  (:require [clojure.test :as t]
+            [clojure.tools.logging :as log]
+            [xtdb.api :as xt]
+            [xtdb.io :as xio]))
+
+(t/deftest aborted-transactions-remove-events-test
+  (let [inc-tx-fn
+        '(fn [ctx fail]
+           (if fail
+             false
+             [[::xt/put (-> (xtdb.api/entity (xtdb.api/db ctx) 0)
+                            (or {:xt/id 0, :n 0})
+                            (update :n inc))]]))
+        pre-reqs
+        [[::xt/put {:xt/id :inc, :xt/fn inc-tx-fn}]]
+
+        fail-tx1
+        [[::xt/fn :inc false]
+         [::xt/match 0 {:xt/id 0, :n 0}]
+         [::xt/fn :inc false]]
+
+        fail-tx2
+        [[::xt/fn :inc false]
+         [::xt/fn :inc true]
+         [::xt/fn :inc false]]
+
+        success-tx
+        [[::xt/fn :inc false]
+         [::xt/match 0 {:xt/id 0, :n 1}]
+         [::xt/fn :inc false]]
+
+        tx-log-dir (xio/create-tmpdir "log")
+        doc-dir (xio/create-tmpdir "doc")
+
+        node-opts
+        {:xtdb/tx-log {:kv-store {:xtdb/module 'xtdb.rocksdb/->kv-store, :db-dir tx-log-dir}}
+         :xtdb/document-store {:kv-store {:xtdb/module 'xtdb.rocksdb/->kv-store, :db-dir doc-dir}}}]
+
+    (try
+
+      (with-open [node (xt/start-node node-opts)]
+        (doto node
+          (xt/submit-tx pre-reqs)
+          (xt/submit-tx fail-tx1)
+          (xt/submit-tx fail-tx2)
+          (xt/submit-tx success-tx)
+          (xt/sync))
+        (t/is (= {:xt/id 0, :n 2} (xt/entity (xt/db node) 0))))
+
+      (with-open [node (xt/start-node node-opts)]
+        (xt/sync node)
+        (t/is (= {:xt/id 0, :n 2} (xt/entity (xt/db node) 0))))
+
+      (finally
+        (xio/delete-dir tx-log-dir)
+        (xio/delete-dir doc-dir)))))

--- a/test/test/xtdb/tx_test.clj
+++ b/test/test/xtdb/tx_test.clj
@@ -1620,9 +1620,9 @@
       (t/is (= 1 (count transactions)))
       (t/is (= 3 (count tx-events)))
 
-      (t/testing "e1 arg doc replaced with tx-events"
+      (t/testing "e1 arg doc replaced with abort"
         (let [[_ _fn-id arg-id] e1]
-          (t/is (:crux.db.fn/tx-events (get-doc arg-id)))))
+          (t/is (:crux.db.fn/aborted? (get-doc arg-id)))))
 
       (t/testing "e3 arg doc replaced with fail"
         (let [[_ _fn-id arg-id] e3]


### PR DESCRIPTION
Resolves #2485.

Adds a new `:crux.db.fn/aborted?` flag to arg docs that themselves did not fail, but were aborted anyway (due to rollback). These docs behave for all intents and purposes behave as if the operation failed, causing the transaction to immediately abort on replay.

aborted docs are also marked as `:crux.db.fn/failed?` for backwards compatibility if users need to rollback, or otherwise run earlier XTDB versions on these new arg docs.

I have changed the logging behaviour to only WARN for failed transactions with exception data, this makes tx-fn rollback logging consistent with match, which does not log.
