### PR TITLE
Use a smaller heap during CI tests to save container memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,11 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum ".circleci-cache-key" }}
-
   test:
     docker:
       - image: wotbrew/xtdb-ci-lein-fix:latest
-
+    environment:
+      JVM_OPTS: -Xmx2500m
     working_directory: ~/xtdb
     steps:
       - checkout


### PR DESCRIPTION
Resolves #1929