### PR TITLE
`:for-valid-time [:from ...]` and `[:to ...]` options

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -54,6 +54,14 @@
 (defmethod temporal-filter-spec :in [_]
   (s/tuple #{:in} (s/nilable ::temporal-filter-value) (s/nilable ::temporal-filter-value)))
 
+(defmethod temporal-filter-spec :from [_]
+  (s/and (s/tuple #{:from} (s/nilable ::temporal-filter-value))
+         (s/conformer (fn [x] [:in (second x) nil]) identity)))
+
+(defmethod temporal-filter-spec :to [_]
+  (s/and (s/tuple #{:to} (s/nilable ::temporal-filter-value))
+         (s/conformer (fn [x] [:in nil (second x)]) identity)))
+
 (defmethod temporal-filter-spec :between [_]
   (s/tuple #{:between} (s/nilable ::temporal-filter-value) (s/nilable ::temporal-filter-value)))
 

--- a/core/src/main/clojure/xtdb/tx_producer.clj
+++ b/core/src/main/clojure/xtdb/tx_producer.clj
@@ -31,9 +31,15 @@
 (s/def ::valid-time-start (s/nilable ::util/datetime-value))
 (s/def ::valid-time-end (s/nilable ::util/datetime-value))
 
-(s/def ::for-valid-time (s/cat :in #{:in}
-                               :valid-time-start ::valid-time-start
-                               :valid-time-end (s/? ::valid-time-end)))
+(s/def ::for-valid-time (s/and
+                         (s/or :in (s/cat :in #{:in}
+                                          :valid-time-start ::valid-time-start
+                                          :valid-time-end (s/? ::valid-time-end))
+                               :from (s/cat :from #{:from}
+                                            :valid-time-start ::valid-time-start)
+                               :to (s/cat :to #{:to}
+                                          :valid-time-end ::valid-time-end))
+                         (s/conformer val (fn [x] [(some #{:in :from :to} (vals x)) x]))))
 
 (s/def ::temporal-opts (s/and (s/keys :opt-un [::for-valid-time])
                               (s/conformer #(:for-valid-time %) #(hash-map :for-valid-time %))))


### PR DESCRIPTION
Closes #2487.
`{:for-valid-time [:from #inst "2020]}` ->  `{:for-valid-time [:in #inst "2020" nil]}`
`{:for-valid-time [:to #inst "2020]}`-> `{:for-valid-time [:in nil #inst "2020"]}`

The added test
```clj
(t/deftest test-temporal-opts-from-and-to
  (letfn [(q [query tx current-time]
            (xt/q tu/*node*
                  (-> query
                      (assoc :basis {:tx tx, :current-time (util/->instant current-time)}))))]

    ;; tx0
    ;; 2015 - eof : Matthew
    ;; now - 2050 : Mark

    ;; tx1
    ;; now - 2040 : Matthew

    (let [tx0 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:from #inst "2015"]}]
                                        [:put :xt_docs {:xt/id :mark} {:for-valid-time [:to #inst "2050"]}]])
          tx1 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:to #inst "2040"]}]])]
      (t/is (= [{:id :matthew,
                 :vt-start #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
                 :vt-end #time/zoned-date-time "9999-12-31T23:59:59.999999Z[UTC]"}
                {:id :mark,
                 :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
                 :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
               (q '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
                                                                         :xt/valid-from vt-start
                                                                         :xt/valid-to vt-end})]},
                  tx0, #inst "2023")))

      (t/is (= [{:id :matthew,
                 :vt-start #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
                 :vt-end #time/zoned-date-time "9999-12-31T23:59:59.999999Z[UTC]"}]
               (q '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
                                                                         :xt/valid-from vt-start
                                                                         :xt/valid-to vt-end}
                                                               {:for-valid-time [:from #inst "2051"]})]},
                  tx0, #inst "2023")))

      (t/is (= [{:id :mark,
                 :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
                 :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}
                {:id :matthew,
                 :vt-start #time/zoned-date-time "2020-01-02T00:00Z[UTC]",
                 :vt-end #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}]
               (q '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
                                                                         :xt/valid-from vt-start
                                                                         :xt/valid-to vt-end}
                                                               {:for-valid-time [:to #inst "2040"]})]},
                  tx1, #inst "2023"))))))
```