### PR TITLE
Fix #2493

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -351,14 +351,12 @@
 
                     ;; overlaps [time-from time-to]
                     :in (let [[from to] args]
-                          (when from
-                            (apply-bound :> end-col (->time-μs from)))
+                          (apply-bound :> end-col (->time-μs (or from [:now])))
                           (when to
                             (apply-bound :< start-col (->time-μs to))))
 
                     :between (let [[from to] args]
-                               (when from
-                                 (apply-bound :> end-col (->time-μs from)))
+                               (apply-bound :> end-col (->time-μs (or from [:now])))
                                (when to
                                  (apply-bound :<= start-col (->time-μs to))))
 

--- a/src/test/clojure/xtdb/core/datalog_test.clj
+++ b/src/test/clojure/xtdb/core/datalog_test.clj
@@ -1522,6 +1522,22 @@
 
             "for all sys time"))))
 
+(t/deftest test-for-valid-time-with-current-time-2493
+  (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in nil #inst "2040"]}]])
+  (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in #inst "2022" #inst "2030"]}]])
+  (t/is (= [{:id :matthew,
+             :vt-start #time/zoned-date-time "2030-01-01T00:00Z[UTC]",
+             :vt-end #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}
+            {:id :matthew,
+             :vt-start #time/zoned-date-time "2022-01-01T00:00Z[UTC]",
+             :vt-end #time/zoned-date-time "2030-01-01T00:00Z[UTC]"}]
+           (xt/q tu/*node*
+                 (-> '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
+                                                                            :xt/valid-from vt-start
+                                                                            :xt/valid-to vt-end}
+                                                                  {:for-valid-time [:in nil #inst "2040"]})]}
+                     (assoc :basis {:current-time (util/->instant #inst "2023")}))))))
+
 (t/deftest test-temporal-opts-from-and-to
   (letfn [(q [query tx current-time]
             (xt/q tu/*node*
@@ -1558,18 +1574,17 @@
                                                                {:for-valid-time [:from #inst "2051"]})]},
                   tx0, #inst "2023")))
 
-      ;; depends on #2493
-      #_(t/is (= [{:id :mark,
-                   :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
-                   :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}
-                  {:id :matthew,
-                   :vt-start #time/zoned-date-time "2020-01-02T00:00Z[UTC]",
-                   :vt-end #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}]
-                 (q '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
-                                                                           :xt/valid-from vt-start
-                                                                           :xt/valid-to vt-end}
-                                                                 {:for-valid-time [:to #inst "2040"]})]},
-                    tx1, #inst "2023"))))))
+      (t/is (= [{:id :mark,
+                 :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
+                 :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}
+                {:id :matthew,
+                 :vt-start #time/zoned-date-time "2020-01-02T00:00Z[UTC]",
+                 :vt-end #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}]
+               (q '{:find [id vt-start vt-end], :where [(match :xt_docs {:xt/id id
+                                                                         :xt/valid-from vt-start
+                                                                         :xt/valid-to vt-end}
+                                                               {:for-valid-time [:to #inst "2040"]})]},
+                  tx1, #inst "2023"))))))
 
 (deftest test-snodgrass-99-tutorial
   (letfn [(q [query tx current-time & in]


### PR DESCRIPTION
This honors `nil` - valid-time-start values in scan.