### PR TITLE
Create bloom hashes for each param for every type in col via EE

### DIFF
--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -88,7 +88,7 @@
                             :where [(match :xt_docs [{:xt/id id}])
                                     [id :struct struct]]}))))))
 
-(t/deftest round-trips-temporal
+(deftest round-trips-temporal
   (let [vs {:dt #time/date "2022-08-01"
             :ts #time/date-time "2022-08-01T14:34"
             :tstz #time/zoned-date-time "2022-08-01T14:34+01:00"
@@ -101,8 +101,7 @@
 
     (t/is (= [(assoc vs :xt$id "foo")]
              (xt.sql/q *node* "SELECT f.xt$id, f.dt, f.ts, f.tstz, f.tm FROM foo f"
-                       {:basis-timeout (Duration/ofMillis 100)
-                        :default-tz (ZoneId/of "Europe/London")})))
+                       {:default-tz (ZoneId/of "Europe/London")})))
 
     (let [lits [[:dt "DATE '2022-08-01'"]
                 [:ts "TIMESTAMP '2022-08-01 14:34:00'"]
@@ -118,8 +117,7 @@
       (t/is (= (set (for [[t _lit] lits]
                       {:xt$id (name t), :v (get vs t)}))
                (set (xt.sql/q *node* "SELECT b.xt$id, b.v FROM bar b"
-                              {:basis-timeout (Duration/ofMillis 100)
-                               :default-tz (ZoneId/of "Europe/London")})))))))
+                              {:default-tz (ZoneId/of "Europe/London")})))))))
 
 (t/deftest can-manually-specify-sys-time-47
   (let [tx1 (xt.d/submit-tx *node* '[[:put :xt_docs {:xt/id :foo}]]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.test :as t]
+            [clojure.test :as t :refer [deftest]]
             [clojure.tools.logging :as log]
             [xtdb.api :as xt.api]
             [xtdb.buffer-pool :as bp]
@@ -647,7 +647,7 @@
         (tj/check-json (.toPath (io/as-file (io/resource "xtdb/indexer-test/can-index-sql-insert")))
                        (.resolve node-dir "objects"))))))
 
-(t/deftest test-skips-irrelevant-live-blocks-632
+(deftest test-skips-irrelevant-live-blocks-632
   (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 2, :rows-per-chunk 10}})]
     (-> (xt.d/submit-tx node [[:put :xt_docs {:name "Håkan", :xt/id :hak}]])
         (tu/then-await-tx* node))
@@ -664,8 +664,8 @@
     (let [^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)
           ^IWatermarkSource wm-src (tu/component node :xtdb/indexer)]
       (with-open [params (tu/open-params {'?name "Ivan"})]
-        (let [gt-literal-selector (expr.meta/->metadata-selector '(> name "Ivan") '#{name} {})
-              gt-param-selector (expr.meta/->metadata-selector '(> name ?name) '#{name} params)]
+        (let [gt-literal-selector (expr.meta/->metadata-selector '(> name "Ivan") '{name :utf8} {})
+              gt-param-selector (expr.meta/->metadata-selector '(> name ?name) '{name :utf8} params)]
 
           (t/is (= #{0} (set (keys (.chunksMetadata metadata-mgr)))))
 

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -43,12 +43,12 @@
                                  {:chunk-idx 2, :block-idxs (doto (RoaringBitmap.) (.add 1)), :col-names #{"_row_id" "xt$id" "name"}})]]
             (t/is (= expected-match
                      (meta/matching-chunks metadata-mgr "xt_docs"
-                                           (expr.meta/->metadata-selector '(> name "Ivan") '#{name} {})))
+                                           (expr.meta/->metadata-selector '(> name "Ivan") '{name :utf8} {})))
                   "only needs to scan chunk 1, block 1")
             (t/is (= expected-match
                      (with-open [params (tu/open-params {'?name "Ivan"})]
                        (meta/matching-chunks metadata-mgr "xt_docs"
-                                             (expr.meta/->metadata-selector '(> name ?name) '#{name} params))))
+                                             (expr.meta/->metadata-selector '(> name ?name) '{name :utf8} params))))
                   "only needs to scan chunk 1, block 1"))
 
           (let [tx2 (xt/submit-tx node [[:put :xt_docs {:name "Jeremy", :xt/id :jdt}]])]
@@ -82,13 +82,13 @@
                              {:chunk-idx 0, :block-idxs (doto (RoaringBitmap.) (.add 0)), :col-names #{"_row_id" "xt$id" "name"}})]]
         (t/is (= expected-match
                  (meta/matching-chunks metadata-mgr "xt_docs"
-                                       (expr.meta/->metadata-selector '(= name "Ivan") '#{name} {})))
+                                       (expr.meta/->metadata-selector '(= name "Ivan") '{name :utf8} {})))
               "only needs to scan chunk 0, block 0")
 
         (t/is (= expected-match
                  (with-open [params (tu/open-params {'?name "Ivan"})]
                    (meta/matching-chunks metadata-mgr "xt_docs"
-                                         (expr.meta/->metadata-selector '(= name ?name) '#{name} params))))
+                                         (expr.meta/->metadata-selector '(= name ?name) '{name :utf8} params))))
               "only needs to scan chunk 0, block 0"))
 
       (t/is (= #{{:name "Ivan"}}


### PR DESCRIPTION
Creates new entry-point to EE via within bloom.clj which allows us to leverage the expression engine to correctly cast various comparable values such as the different number and temporal types.

Changes metadata expressions so they are only generated if param and col types are comparable.

Also contains a fix to macro-expand metadata expressions so that n-arity `or` expressions are generated correctly.

fixes: #2133 