### PR TITLE
moving the SQL transaction and query param syntax to be closer to the Clojure SQL ecosystem

### DIFF
--- a/core/src/main/clojure/xtdb/core/sql.clj
+++ b/core/src/main/clojure/xtdb/core/sql.clj
@@ -28,7 +28,7 @@
                                        {:keys [basis default-tz default-all-app-time?] :as query-opts}]
   (let [^AutoCloseable
         params (vw/open-params allocator
-                               (->> (:? query-opts)
+                               (->> (:args query-opts)
                                     (into {} (map-indexed (fn [idx v]
                                                             (MapEntry/create (symbol (str "?_" idx)) v))))))]
     (try

--- a/doc/sql.adoc
+++ b/doc/sql.adoc
@@ -13,9 +13,9 @@ First, follow the link:./getting-started.adoc[Getting Started] guide.
 (with-open [node ...]
   ;; submit some data
   (xt/submit-tx node
-                [[:sql "INSERT INTO users (xt$id, first_name) VALUES (?, ?)"
-                  [["jms", "James"]
-                   ["jdt", "Jeremy"]]]])
+                [[:sql-batch ["INSERT INTO users (xt$id, first_name) VALUES (?, ?)"
+                              ["jms", "James"]
+                              ["jdt", "Jeremy"]]]])
 
   ;; run a SQL query
 

--- a/http-server/src/main/clojure/xtdb/server.clj
+++ b/http-server/src/main/clojure/xtdb/server.clj
@@ -121,11 +121,11 @@
 
 (s/def :xtdb.server.sql/query string?)
 
-(s/def ::? (s/nilable (s/coll-of any? :kind vector?)))
+(s/def ::args (s/nilable (s/coll-of any? :kind vector?)))
 
 (s/def :xtdb.server.sql/query-body
   (s/keys :req-un [:xtdb.server.sql/query],
-          :opt-un [::basis ::basis-timeout ::? ::default-all-app-time? ::default-tz]))
+          :opt-un [::basis ::basis-timeout ::args ::default-all-app-time? ::default-tz]))
 
 (defmethod route-handler :sql-query [_]
   {:muuntaja (m/create (-> muuntaja-opts
@@ -135,8 +135,8 @@
                                      [->tj-resultset-encoder {:handlers xt.transit/tj-write-handlers}])))
 
    :post {:handler (fn [{:keys [node parameters]}]
-                     (let [{{:keys [query] :as query-opts} :body} parameters]
-                       (-> (xt.impl/open-sql& node query (dissoc query-opts :query))
+                     (let [{{:keys [query args] :as query-opts} :body} parameters]
+                       (-> (xt.impl/open-sql& node (into [query] args) (dissoc query-opts :query :args))
                            (util/then-apply (fn [res]
                                               {:status 200, :body res})))))
 

--- a/modules/datasets/src/main/clojure/xtdb/datasets/tpch.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/tpch.clj
@@ -83,7 +83,7 @@
                                                  (partition-all 1000)
                                                  (reduce (fn [[_!last-tx last-doc-count] param-batch]
                                                            [(xt.sql/submit-tx& tx-producer
-                                                                               [[:sql dml param-batch]])
+                                                                               [[:sql-batch (into [dml] param-batch)]])
                                                             (+ last-doc-count (count param-batch))])
                                                          [nil 0]))]
                    (log/debug "Transacted" doc-count (.getTableName table))

--- a/pgwire-server/src/main/clojure/xtdb/pgwire.clj
+++ b/pgwire-server/src/main/clojure/xtdb/pgwire.clj
@@ -1404,7 +1404,7 @@
 
 (defn- submit-tx [{:keys [server conn-state]} dml-buf {:keys [default-all-app-time?]}]
   (let [tx-ops (mapv (fn [{:keys [transformed-query params]}]
-                       [:sql transformed-query [params]])
+                       [:sql-batch [transformed-query params]])
                      dml-buf)]
     ;; TODO review err log policy
     (try
@@ -1478,7 +1478,7 @@
         query-opts {:basis (or basis {:current-time (.instant clock), :after-tx latest-submitted-tx})
                     :basis-timeout (Duration/ofSeconds 1)
                     :default-tz (.getZone clock)
-                    :? xt-params
+                    :args xt-params
                     :default-all-app-time? default-all-app-time?}
 
         ;; execute the query asynchronously (to enable later enable cancellation mid query)

--- a/src/test/clojure/xtdb/default_tz_test.clj
+++ b/src/test/clojure/xtdb/default_tz_test.clj
@@ -24,8 +24,8 @@
 
 (t/deftest can-specify-default-tz-in-dml-396
   (let [q "INSERT INTO foo (xt$id, dt, tstz) VALUES (?, DATE '2020-08-01', CAST(DATE '2020-08-01' AS TIMESTAMP WITH TIME ZONE))"]
-    (xt/submit-tx tu/*node* [[:sql q [["foo"]]]])
-    (let [tx (xt/submit-tx tu/*node* [[:sql q [["bar"]]]]
+    (xt/submit-tx tu/*node* [[:sql [q "foo"]]])
+    (let [tx (xt/submit-tx tu/*node* [[:sql [q "bar"]]]
                            {:default-tz #time/zone "America/Los_Angeles"})
           q "SELECT foo.xt$id, foo.dt, CAST(foo.dt AS TIMESTAMP WITH TIME ZONE) cast_tstz, foo.tstz FROM foo"]
 

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -635,9 +635,9 @@
 
         (let [last-tx-key (xt.api/map->TransactionInstant {:tx-id 0, :sys-time (util/->instant #inst "2020-01-01")})]
           (t/is (= last-tx-key
-                   (xt.sql/submit-tx node [[:sql "INSERT INTO table (xt$id, foo, bar, baz) VALUES (?, ?, ?, ?)"
-                                            '[[0, 2, "hello", 12]
-                                              [1, 1, "world", 3.3]]]])))
+                   (xt.sql/submit-tx node [[:sql-batch ["INSERT INTO table (xt$id, foo, bar, baz) VALUES (?, ?, ?, ?)"
+                                                        [0, 2, "hello", 12]
+                                                        [1, 1, "world", 3.3]]]])))
 
           (t/is (= last-tx-key
                    (tu/then-await-tx* last-tx-key node (Duration/ofSeconds 1)))))

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -45,14 +45,13 @@
 
 (t/deftest test-param-metadata-error-310
   (let [tx1 (xt/submit-tx tu/*node*
-                           [[:sql "INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)"
-                             [["dave", "Dave", #inst "2018"]
-                              ["claire", "Claire", #inst "2019"]]]])]
+                          [[:sql-batch ["INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)"
+                                        ["dave", "Dave", #inst "2018"]
+                                        ["claire", "Claire", #inst "2019"]]]])]
 
     (t/is (= [{:name "Dave"}]
-             (xt/q tu/*node* "SELECT users.name FROM users WHERE users.xt$id = ?"
-                   {:basis {:tx tx1}
-                    :? ["dave"]}))
+             (xt/q tu/*node* ["SELECT users.name FROM users WHERE users.xt$id = ?" "dave"]
+                   {:basis {:tx tx1}}))
           "#310")))
 
 (deftest test-bloom-filter-for-num-types-2133

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -85,11 +85,11 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
     (t/is (= [] (q)))))
 
 (t/deftest test-update-set-field-from-param-328
-  (xt.sql/submit-tx tu/*node* [[:sql "INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)"
-                                [["susan", "Susan", "Smith"]]]])
+  (xt.sql/submit-tx tu/*node* [[:sql ["INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)"
+                                      "susan", "Susan", "Smith"]]])
 
-  (xt.sql/submit-tx tu/*node* [[:sql "UPDATE users FOR PORTION OF VALID_TIME FROM ? TO ? AS u SET first_name = ? WHERE u.xt$id = ?"
-                                [[#inst "2021", util/end-of-time, "sue", "susan"]]]])
+  (xt.sql/submit-tx tu/*node* [[:sql ["UPDATE users FOR PORTION OF VALID_TIME FROM ? TO ? AS u SET first_name = ? WHERE u.xt$id = ?"
+                                      #inst "2021", util/end-of-time, "sue", "susan"]]])
 
   (t/is (= #{["Susan" "Smith", (util/->zdt #inst "2020") (util/->zdt #inst "2021")]
              ["sue" "Smith", (util/->zdt #inst "2021") (util/->zdt util/end-of-time)]}

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -197,8 +197,8 @@
                              :where [($ :xt/txs {:xt/id tx-id,
                                                  :xt/committed? committed?})]})))
   (xt.sql/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (2)"]])
-  (xt.sql/submit-tx tu/*node* [[:sql "DELETE FROM xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? WHERE xt_docs.xt$id = 2"
-                                [[#inst "2011"]]]])
+  (xt.sql/submit-tx tu/*node* [[:sql ["DELETE FROM xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? WHERE xt_docs.xt$id = 2"
+                                      #inst "2011"]]])
   (is (= [{:tx-id 0, :committed? false}
           {:tx-id 1, :committed? true}
           {:tx-id 2, :committed? false}]
@@ -206,8 +206,8 @@
                              :where [($ :xt/txs {:xt/id tx-id,
                                                  :xt/committed? committed?})]})))
   (xt.sql/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (3)"]])
-  (xt.sql/submit-tx tu/*node* [[:sql "UPDATE xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? SET foo = 'bar' WHERE xt_docs.xt$id = 3"
-                                [[#inst "2011"]]]])
+  (xt.sql/submit-tx tu/*node* [[:sql ["UPDATE xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? SET foo = 'bar' WHERE xt_docs.xt$id = 3"
+                                      #inst "2011"]]])
   (is (= [{:committed? false}]
          (xt.d/q tu/*node* '{:find [committed?]
                              :where [($ :xt/txs {:xt/id 4,

--- a/src/test/clojure/xtdb/tx_producer_test.clj
+++ b/src/test/clojure/xtdb/tx_producer_test.clj
@@ -90,15 +90,15 @@
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-sql.json")
                          [[:sql "INSERT INTO foo (xt$id) VALUES (0)"]
 
-                          [:sql "INSERT INTO foo (xt$id, foo, bar) VALUES (?, ?, ?)"
-                           [[1 nil 3.3]
-                            [2 "hello" 12]]]
+                          [:sql-batch ["INSERT INTO foo (xt$id, foo, bar) VALUES (?, ?, ?)"
+                                       [1 nil 3.3]
+                                       [2 "hello" 12]]]
 
-                          [:sql "UPDATE foo FOR PORTION OF VALID_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.xt$id = ?"
-                           [[1]]]
+                          [:sql ["UPDATE foo FOR PORTION OF VALID_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.xt$id = ?"
+                                 1]]
 
-                          [:sql "DELETE FROM foo FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01' WHERE foo.xt$id = ?"
-                           [[1]]]]))
+                          [:sql ["DELETE FROM foo FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01' WHERE foo.xt$id = ?"
+                                 1]]]))
 
 (t/deftest can-write-opts
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-opts.json")


### PR DESCRIPTION
Transacting and querying SQL now looks much more like the idioms in [next.jdbc](https://github.com/seancorfield/next-jdbc)

e.g.

```clojure
(xt/submit-tx node
              [[:sql ["INSERT INTO users (xt$id, first_name) VALUES (?, ?)" "jms" "James"]]

               ;; batch - submit a vec of vecs
               [:sql-batch ["INSERT INTO users (xt$id, first_name) VALUES (?, ?)"
                            ["jms" "James"]
                            ["jdt" "Jeremy"]]]])

(xt/q *node*
      ["SELECT u.first_name FROM users u WHERE xt$id = ?" "jms"]
      {:default-all-app-time? false})
```

cc @seancorfield - thanks for the feedback!