### PR TITLE
Fix temporal index memory leak on tx abort

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -592,10 +592,14 @@
                     (catch xtdb.RuntimeException e e)
                     (catch xtdb.IllegalArgumentException e e)
                     (catch ClosedByInterruptException e
+                      (.abort temporal-idxer)
                       (throw (InterruptedException. (.toString e))))
-                    (catch InterruptedException e (throw e))
+                    (catch InterruptedException e
+                      (.abort temporal-idxer)
+                      (throw e))
                     (catch Throwable t
                       (log/error t "error in indexer")
+                      (.abort temporal-idxer)
                       (throw t)))
                 wm-lock-stamp (.writeLock wm-lock)]
             (try

--- a/core/src/main/clojure/xtdb/temporal/grid.clj
+++ b/core/src/main/clojure/xtdb/temporal/grid.clj
@@ -303,6 +303,7 @@
       (.set ref-cnt 0)
       (throw (IllegalStateException. "grid closed")))
     this)
+  (with-point-vec [this _pv] this)
   (kd-tree-point-access [this]
     (->grid-point-access this))
   (kd-tree-size [_] size)

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -390,3 +390,17 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
                               3)
                       first
                       :err :form))))))
+
+(t/deftest test-indexer-cleans-up-aborted-transactions-2489
+  (t/testing "INSERT"
+    (xt.sql/submit-tx tu/*node*
+                      [[:sql "INSERT INTO xt_docs (xt$id, xt$valid_from, xt$valid_to)
+                              VALUES (1, DATE '2010-01-01', DATE '2020-01-01'),
+                                     (1, DATE '2030-01-01', DATE '2020-01-01')"]])
+
+    (t/is (= [{:committed? false}]
+             (xt.d/q tu/*node*
+                     '{:find [committed?]
+                       :in [tx-id]
+                       :where [($ :xt/txs {:xt/id tx-id, :xt/committed? committed?})]}
+                     0)))))


### PR DESCRIPTION
resolves #2489

When a transaction had an operation that succeeded and then an operation that caused a rollback (e.g. a tx-fn fail), we were getting a memory leak.

* Caused by losing the reference to the transient kd-tree during the temporal manager tx - as soon as there was any `indexPut` etc, this created resources that weren't being closed on abort.
* We initially solved this by 'retaining' the kd-tree within the tx, and either passing ownership on commit, or closing on abort, but this threw use-after-free errors - we'd missed the point about how the point-vec is expected to work in the temporal index:
  * The temporal manager creates a single `point-vec`; leaves use various idxs within this large vector (which we manually re-use/garbage collect using the leaf-pool/leaf-token/leaf-cleaner mechanism)
  * When the root node is 'retained', it retains the point-vec, but doesn't update the references to the point-vec within the child nodes - so releasing the original point-vec caused any further accesses to child nodes to throw the use-after-free errors.
  * So this PR adds a `with-point-vec` fn on kd-tree nodes which recursively updates this reference, job done.