### PR TITLE
Add Azure Blob Storage object store #2298

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
     projectDep(":modules:jdbc")
     projectDep(":modules:kafka")
     projectDep(":modules:s3")
+    projectDep(":modules:azure")
 
     projectDep(":modules:bench")
     projectDep(":modules:c1-import")
@@ -174,6 +175,7 @@ dependencies {
     testImplementation("org.clojure", "tools.cli", "1.0.206")
 
     devImplementation("integrant", "repl", "0.3.2")
+    devImplementation("com.azure","azure-identity","1.9.0")
     testImplementation("org.slf4j", "slf4j-api", "2.0.6")
     testImplementation("com.clojure-goes-fast", "clj-async-profiler", "1.0.0")
     testImplementation("org.postgresql", "postgresql", "42.5.0")

--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,7 @@
 
         com.xtdb.labs/xtdb-kafka {:local/root "modules/kafka"}
         com.xtdb.labs/xtdb-s3 {:local/root "modules/s3"}
+        com.xtdb.labs/xtdb-azure {:local/root "modules/azure"}
         com.xtdb.labs/xtdb-jdbc {:local/root "modules/jdbc"}
         com.xtdb.labs/xtdb-bench {:local/root "modules/bench"}
         com.xtdb.labs/xtdb-c1-import {:local/root "modules/c1-import"}

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":http-server"))
     implementation(project(":modules:jdbc"))
     implementation(project(":modules:kafka"))
+    implementation(project(":modules:azure"))
     implementation(project(":modules:flight-sql"))
     implementation("ch.qos.logback", "logback-classic", "1.4.5")
 }

--- a/modules/azure/.gitignore
+++ b/modules/azure/.gitignore
@@ -1,0 +1,16 @@
+/target
+/classes
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -28,7 +28,7 @@ Authentication for the components in the module is done via the https://learn.mi
 
 ## Azure Blob Storage Object Store
 
-We can swap out the implementation of the objedct store with one based on Azure Blob Storage. To do so, we add the `xtdb.azure/blob-object-store` key within the integrant config for our node, alongside any config:
+We can swap out the implementation of the object store with one based on Azure Blob Storage. To do so, we add the `xtdb.azure/blob-object-store` key within the integrant config for our node, alongside any config:
 ```clojure
 {
   ...

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -1,0 +1,61 @@
+# Azure Module
+
+Within our XTDB node, we can make use of Azure Services for certain purposes. Currently, we can:
+
+* Use *Azure Blob Storage* as the XTDB Object Store.
+
+### Project Dependency 
+
+In order to use any of the azure services, you will need to include a dependency on the xtdb.azure module.
+
+_deps.edn_
+```
+com.xtdb.labs/xtdb-azure {:mvn/version "2.0.0-SNAPSHOT"}
+```
+
+_pom.xml_
+```
+<dependency>
+    <groupId>com.xtdb.labs</groupId>
+    <artifactId>xtdb-azure</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+### Authentication
+
+Authentication for the components in the module is done via the https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable[*DefaultAzureCredential*] class - you will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules.
+
+## Azure Blob Storage Object Store
+
+We can swap out the implementation of the objedct store with one based on Azure Blob Storage. To do so, we add the `xtdb.azure/blob-object-store` key within the integrant config for our node, alongside any config:
+```clojure
+{
+  ...
+  {:xtdb.azure/blob-object-store {:storage-account "storage-account"
+                                  :container "container"}}
+  ...
+}
+```
+
+### Parameters
+
+These are the following parameters that can be passed within the config for our `xtdb.azure/blob-object-store`:
+[cols="1,1,2,1"]
+|===
+| *Name* | *Type* | *Description* | *Required?*
+| `storage-account`
+| String
+| The https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview[storage account] that has the container to use as an object store
+| Yes
+
+| `container`
+| String 
+| The name of the https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[container] to use an an object store
+| Yes
+
+|`prefix`
+| String 
+| A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
+| No
+|=== 

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `java-library`
+    id("dev.clojurephant.clojure")
+    `maven-publish`
+    signing
+}
+
+publishing {
+    publications.create("maven", MavenPublication::class) {
+        pom {
+            name.set("XTDB Azure")
+            description.set("XTDB Azure")
+        }
+    }
+}
+
+dependencies {
+    api(project(":api"))
+    api(project(":core"))
+
+    api("com.azure", "azure-storage-blob", "12.22.0")
+    api("com.azure", "azure-identity", "1.9.0")
+}

--- a/modules/azure/deps.edn
+++ b/modules/azure/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src/main/clojure" "target/classes"]
+ 
+ :deps {com.xtdb.labs/xtdb-api {:local/root "../../api"}
+        com.xtdb.labs/xtdb-core {:local/root "../../core"}
+
+        com.azure/azure-storage-blob {:mvn/version "12.22.0"}
+        com.azure/azure-identity {:mvn/version "1.9.0"}}}

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -1,0 +1,101 @@
+(ns xtdb.azure
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [xtdb.object-store :as os]
+            [xtdb.util :as util]
+            [juxt.clojars-mirrors.integrant.core :as ig])
+  (:import xtdb.object_store.ObjectStore
+           java.util.concurrent.CompletableFuture
+           java.util.function.Supplier
+           com.azure.core.util.BinaryData
+           [com.azure.storage.blob.models BlobStorageException ListBlobsOptions BlobItem]
+           [com.azure.storage.blob BlobServiceClientBuilder BlobContainerClient BlobClient]
+           [com.azure.identity DefaultAzureCredentialBuilder]))
+
+(defn- get-blob [^BlobContainerClient blob-container-client blob-name]
+  (try
+    (-> (.getBlobClient blob-container-client blob-name)
+        (.downloadContent)
+        (.toByteBuffer))
+    (catch BlobStorageException e
+      (if (= 404 (.getStatusCode e))
+        (throw (os/obj-missing-exception blob-name))
+        (throw e)))))
+
+(defn- put-blob [^BlobContainerClient blob-container-client blob-name blob-buffer]
+  (try
+    (-> (.getBlobClient blob-container-client blob-name)
+        (.upload (BinaryData/fromByteBuffer blob-buffer)))
+    (catch BlobStorageException e
+      (if (= 409 (.getStatusCode e))
+        nil
+        (throw e)))))
+
+(defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
+  (-> (.getBlobClient blob-container-client blob-name)
+      (.deleteIfExists)))
+
+(defn- list-blobs [^BlobContainerClient blob-container-client prefix obj-prefix]
+  (let [list-blob-opts (cond-> (ListBlobsOptions.)
+                         obj-prefix (.setPrefix obj-prefix))]
+    (->> (.listBlobs blob-container-client list-blob-opts nil)
+         (.iterator)
+         (iterator-seq)
+         (mapv (fn [^BlobItem blob-item]
+                 (subs (.getName blob-item) (count prefix)))))))
+(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix]
+  ObjectStore
+  (getObject [_ k]
+    (CompletableFuture/completedFuture
+     (get-blob blob-container-client (str prefix k))))
+
+  (getObject [_ k out-path]
+    (CompletableFuture/supplyAsync
+     (reify Supplier
+       (get [_]
+         (let [blob-buffer (get-blob blob-container-client (str prefix k))]
+           (util/write-buffer-to-path blob-buffer out-path)
+
+           out-path)))))
+
+  (putObject [_ k buf]
+    (put-blob blob-container-client (str prefix k) buf)
+    (CompletableFuture/completedFuture nil))
+
+  (listObjects [this]
+    (.listObjects this nil))
+
+  (listObjects [_ obj-prefix]
+    (list-blobs blob-container-client prefix (str prefix obj-prefix)))
+
+  (deleteObject [_ k]
+    (delete-blob blob-container-client (str prefix k))
+    (CompletableFuture/completedFuture nil)))
+
+(derive ::blob-object-store :xtdb/object-store)
+
+(defn- parse-prefix [prefix]
+  (cond
+    (string/blank? prefix) ""
+    (string/ends-with? prefix "/") prefix
+    :else (str prefix "/")))
+
+(s/def ::storage-account string?)
+(s/def ::container string?)
+(s/def ::prefix string?)
+
+(defmethod ig/prep-key ::blob-object-store [_ opts]
+  (-> opts
+      (util/maybe-update :prefix parse-prefix)))
+
+(defmethod ig/pre-init-spec ::blob-object-store [_]
+  (s/keys :req-un [::storage-account ::container]
+          :opt-un [::prefix]))
+
+(defmethod ig/init-key ::blob-object-store [_ {:keys [storage-account container prefix]}]
+  (let [blob-service-client (cond-> (-> (BlobServiceClientBuilder.)
+                                        (.endpoint (str "https://" storage-account ".blob.core.windows.net"))
+                                        (.credential (.build (DefaultAzureCredentialBuilder.)))
+                                        (.buildClient)))
+        blob-client (.getBlobContainerClient blob-service-client container)]
+    (->AzureBlobObjectStore blob-client prefix)))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,6 @@ include("api", "core", "wire-formats")
 include("http-server", "http-client-clj", "pgwire-server")
 include("docker")
 
-include("modules:jdbc", "modules:kafka", "modules:s3")
+include("modules:jdbc", "modules:kafka", "modules:s3", "modules:azure")
 include("modules:c1-import", "modules:flight-sql")
 include("modules:bench", "modules:datasets")

--- a/src/dev/clojure/azure_testing.clj
+++ b/src/dev/clojure/azure_testing.clj
@@ -1,0 +1,45 @@
+(ns azure-testing
+  (:require [clojure.java.io :as io]
+            [xtdb.node :as xtdb]
+            [xtdb.util :as util]
+            [xtdb.azure :as azure]
+            [integrant.core :as i]
+            [integrant.repl :as ir])
+  (:import java.time.Duration
+           [com.azure.storage.common StorageSharedKeyCredential]
+           [com.azure.identity DefaultAzureCredentialBuilder]))
+
+(def dev-node-dir
+  (io/file "dev/azure-node"))
+
+(def node)
+(def storage-account "xtdb")
+(def container "xtdb-azure-test")
+
+(defmethod i/init-key ::xtdb [_ {:keys [node-opts]}]
+  (alter-var-root #'node (constantly (xtdb/start-node node-opts)))
+  node)
+
+(defmethod i/halt-key! ::xtdb [_ node]
+  (util/try-close node)
+  (alter-var-root #'node (constantly nil)))
+
+(def azure-default-auth
+  {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
+                       :xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                       ::azure/blob-object-store {:storage-account storage-account
+                                                  :container container}}}})
+
+(ir/set-prep! (fn [] azure-default-auth))
+
+(comment
+  (ir/go)
+  (node)
+  (.putObject (:xtdb.azure/blob-object-store (:system node)) "bar" (java.nio.ByteBuffer/wrap (.getBytes "helloworld")))
+  (ir/halt)
+  (ir/reset)
+  )
+
+(System/getenv "AZURE_TENANT_ID")
+(System/getenv "AZURE_CLIENT_ID")
+(System/getenv "AZURE_CLIENT_SECRET")

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -1,0 +1,29 @@
+(ns xtdb.azure-test
+  (:require [clojure.test :as t]
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.object-store-test :as os-test]
+            [xtdb.azure :as azure]
+            [clojure.tools.logging :as log])
+  (:import java.util.UUID))
+
+(def storage-account "xtdbazureobjectstoretest")
+(def container "xtdb-test")
+
+(def ^:dynamic *obj-store*)
+
+(t/use-fixtures :each
+  (fn [f]
+    (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
+                                              :container container
+                                              :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
+                  ig/prep
+                  ig/init)]
+      (try
+        (binding [*obj-store* (::azure/blob-object-store sys)]
+          (f))
+        (finally
+          (ig/halt! sys))))))
+
+;; TODO: Throws an error when trying to return an IllegalStateException - classcast issue?
+(os-test/def-obj-store-tests ^:azure azure [f]
+  (f *obj-store*))

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -29,6 +29,5 @@
           (finally
             (ig/halt! sys)))))))
 
-;; TODO: Throws an error when trying to return an IllegalStateException - classcast issue?
 (os-test/def-obj-store-tests ^:azure azure [f]
   (f *obj-store*))

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -8,21 +8,26 @@
 
 (def storage-account "xtdbazureobjectstoretest")
 (def container "xtdb-test")
+(def config-present? (some? (and (System/getenv "AZURE_CLIENT_ID")
+                                 (System/getenv "AZURE_CLIENT_SECRET")
+                                 (System/getenv "AZURE_TENANT_ID"))))
 
 (def ^:dynamic *obj-store*)
 
 (t/use-fixtures :each
   (fn [f]
-    (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
-                                              :container container
-                                              :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
-                  ig/prep
-                  ig/init)]
-      (try
-        (binding [*obj-store* (::azure/blob-object-store sys)]
-          (f))
-        (finally
-          (ig/halt! sys))))))
+    (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID set)? - " config-present?)
+    (when config-present?
+      (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
+                                                :container container
+                                                :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
+                    ig/prep
+                    ig/init)]
+        (try
+          (binding [*obj-store* (::azure/blob-object-store sys)]
+            (f))
+          (finally
+            (ig/halt! sys)))))))
 
 ;; TODO: Throws an error when trying to return an IllegalStateException - classcast issue?
 (os-test/def-obj-store-tests ^:azure azure [f]


### PR DESCRIPTION
Resolves #2298

Implements a new object store using Azure Blob Storage, alongside:
- All of the related integrant config to add it to a node.
- Including the module within various places - namely the xtdb standalone deps and dev dependencies. 
- Documentation in the form of a README in the module.
- A test file making use of the object-store tests.
   - Expects ENV vars to be present - these have been added to the CI.  
- A dev file for locally playing around with it under `dev/azure-testing`

## TODO

- At a later point - want to benchmark this/containerize this for Azure, when the current benchmarking story has been better fleshed out.

## Local Benchmarking Results
Ran a benchmark against TPCH with a 0.05 scale-factor. This was done by (temporarily) adding a new node type to the "bench.clj" (local-azure) that used local-directory-log and azure/blob-object-store. Can see some of the files/folders/chunks appear on the Azure blob storage container, and got back some timings (keeping in mind it's being ran locally on an xps15 with 64GB RAM):

```
'submit-docs', 35137.653094ms
'sync', 278904.935517ms
'finish-chunk', 27307.571926ms
('ingest', 341356.655297ms)

'cold-queries', 51346.988333ms
'hot-queries', 8876.262816ms
```