### PR TITLE
typo(http-server): small correction on route description

### DIFF
--- a/modules/http-server/src/xtdb/http_server.clj
+++ b/modules/http-server/src/xtdb/http_server.clj
@@ -333,7 +333,7 @@
                  ["/db" (-> {:get (db-handler xtdb-node)
                              :parameters {:query ::db-spec}
                              :summary "DB"
-                             :description "Get the resolved db-basis for the given valid-time/transactoin"}
+                             :description "Get the resolved db-basis for the given valid-time/transaction"}
                             (with-example "db-response"))]
                  ["/status" (-> {:muuntaja (status/->status-muuntaja opts)
                                  :summary "Status"


### PR DESCRIPTION
Page is generated here: https://docs.xtdb.com/clients/http/openapi/1.23.1/#/paths/~1_xtdb~1db/get