### PR TITLE
Implement Azure EventHubs as a TX Log

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -51,6 +51,7 @@
                                                    (try
                                                      (.readRecords log after-tx-id 100)
                                                      (catch ClosedChannelException e (throw e))
+                                                     (catch InterruptedException e (throw e))
                                                      (catch Exception e
                                                        (log/warn e "Error polling for txs, will retry"))))]
                             (when (Thread/interrupted)

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -97,6 +97,11 @@ These are the following parameters that can be passed within the config for our 
 | A duration representing the max amount of time to wait when reading data from the log - can be provided as a Java Duration or passed as a https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-[duration string] or int representing a time in milliseconds. 
 | No - defaults to "PT1S"
 
+| `poll-sleep-duration`
+| Duration
+| A duration representing the time to sleep between reads of the log - can be provided as a Java Duration or passed as a https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-[duration string] or int representing a time in milliseconds. 
+| No - defaults to "PT1S"
+
 | `create-event-hub?`
 | Boolean
 | Whether or not XTDB should create an eventhub for you within the specified namespace. See "<<Creating the Event Hub Automatically>>" for more info.

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -7,7 +7,7 @@ Within our XTDB node, we can make use of Azure Services for certain purposes. Cu
 
 ### Project Dependency 
 
-In order to use any of the azure services, you will need to include a dependency on the xtdb.azure module.
+In order to use any of the Azure services, you will need to include a dependency on the xtdb.azure module.
 
 _deps.edn_
 ```
@@ -109,16 +109,16 @@ These are the following parameters that can be passed within the config for our 
 
 | `retention-period-in-days`
 | Long
-| The retention period of the event hub for the Log - the maximum period determined by the tier of eventhub namespace you are using, see the https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#event-retention[Azure Docs].
-| No - only needed if creating event hub automatically, and defaults to "7".
+| The retention period of the Event Hub for the Log - the maximum period determined by the tier of eventhub namespace you are using, see the https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#event-retention[Azure Docs].
+| No - only needed if creating Event Hub automatically, and defaults to "7".
 
 |=== 
 
 ### Using Event Hubs 
 
-Some things to note when setting up event hubs for XTDB:
+Some things to note when setting up Event Hubs for XTDB:
 
-* When using EventHubs as a log - you will require a pre-existing Event Hubs namespace, see 
+* When using EventHubs as a log - you will require a pre-existing Event Hubs namespace, see the https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create#create-an-event-hubs-namespace[Azure docs].
 * As a bare minimum, whichever credentials you use to authenticate to Azure for the app will require two roles on the namespace - *Azure Event Hubs Data sender* and *Azure Event Hubs Data receiver*. 
 
 #### Creating the Event Hub Manually
@@ -126,15 +126,15 @@ Some things to note when setting up event hubs for XTDB:
 When creating an eventhub manually to use as an XTDB log, there are a few properties to consider:
 
 * Partition count should be set to *1* - XTDB will only ever use a single partition within it's implementations of Log as they are required to be *totally ordered*.
-* The retention period is configurable - you will likely wish to set this to as high as you reasonably can given the priving tier of your Event Hubs namespace. 
+* The retention period is configurable - you will likely wish to set this to as high as you reasonably can given the pricing tier of your Event Hubs namespace. 
 
 #### Creating the Event Hub Automatically
 
 If `create-event-hub?` is set to `true`, XTDB will attempt to create an Event Hub on your behalf - some notes on this:
 
-* In `create-event-hub?` is set, a number of other pieces of configuration must be done to allow your application to manage event hubs on your behalf:
+* If `create-event-hub?` is set, a number of other pieces of configuration must be done to allow your application to manage Event Hubs on your behalf:
 ** Whichever credentials you use to authenticate to Azure for the app will require one extra roles for the namespace - *Azure Event Hubs Data Owner*.
-** Within your XTDB integrant config, you will need to directly specify the resource group the event hub namespace belongs to within the `resource-group-name` parameter.
-** The application will require two azure related environment variables to be set - `AZURE_SUBCRIPTION_ID` & `AZURE_TENANT_ID`. See the https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id[Azure docs] for more info.
-* The event hub will only be created if the `event-hub-name` in the configuartion doesn't already exist in the given namespace - it will not start a new event hub every time the node restarts.
-* The created event hub will have a single partition, and the retention period will be set based on the `retention-period-in-days` parameter (this defaults to 7 days - the maximum retention period of the 'basic' namespace pricing tier)
+** Within your XTDB integrant config, you will need to directly specify the resource group the Event Hub namespace belongs to within the `resource-group-name` parameter.
+** The application will require two Azure related environment variables to be set - `AZURE_SUBSCRIPTION_ID` & `AZURE_TENANT_ID`. See the https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id[Azure docs] for more info.
+* The Event Hub will only be created if the `event-hub-name` in the configuartion doesn't already exist in the given namespace - it will not start a new Event Hub every time the node restarts.
+* The created Event Hub will have a single partition, and the retention period will be set based on the `retention-period-in-days` parameter (this defaults to 7 days - the maximum retention period of the 'basic' namespace pricing tier)

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -3,6 +3,7 @@
 Within our XTDB node, we can make use of Azure Services for certain purposes. Currently, we can:
 
 * Use *Azure Blob Storage* as the XTDB Object Store.
+* Use *Azure Eventhubs* as the Log.
 
 ### Project Dependency 
 
@@ -59,3 +60,81 @@ These are the following parameters that can be passed within the config for our 
 | A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
 | No
 |=== 
+
+## Azure EventHub Log
+
+We can swap out the implementation of the log with one based on Azure Eventhubs. To do so, we add the `xtdb.azure/event-hub-log` key within the integrant config for our node, alongside any config:
+```clojure
+{
+  ...
+  {::azure/event-hub-log {:namespace "eventhub-namespace"
+                          :resource-group-name "resource-group-name"
+                          :event-hub-name "example-event-hub"
+                          :create-event-hub? true
+                          :retention-period-in-days 60}}
+  ...
+}
+```
+
+### Parameters
+
+These are the following parameters that can be passed within the config for our `xtdb.azure/event-hub-log`:
+[cols="1,1,2,1"]
+|===
+| *Name* | *Type* | *Description* | *Required?*
+| `namespace`
+| String
+| The Event Hubs namespace of the EventHub. 
+| Yes
+
+| `event-hub-name`
+| String
+| The name of the EventHub that you wish to use a log.
+| Yes
+
+| `max-wait-time`
+| Duration
+| A duration representing the max amount of time to wait when reading data from the log - can be provided as a Java Duration or passed as a https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-[duration string] or int representing a time in milliseconds. 
+| No - defaults to "PT1S"
+
+| `create-event-hub?`
+| Boolean
+| Whether or not XTDB should create an eventhub for you within the specified namespace. See "<<Creating the Event Hub Automatically>>" for more info.
+| No - defaults to false. 
+
+| `resource-group-name`
+| String
+| The name of the resource group that the eventhub namespace belongs to.
+| Only if `create-event-hub?` is true
+
+| `retention-period-in-days`
+| Long
+| The retention period of the event hub for the Log - the maximum period determined by the tier of eventhub namespace you are using, see the https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#event-retention[Azure Docs].
+| No - only needed if creating event hub automatically, and defaults to "7".
+
+|=== 
+
+### Using Event Hubs 
+
+Some things to note when setting up event hubs for XTDB:
+
+* When using EventHubs as a log - you will require a pre-existing Event Hubs namespace, see 
+* As a bare minimum, whichever credentials you use to authenticate to Azure for the app will require two roles on the namespace - *Azure Event Hubs Data sender* and *Azure Event Hubs Data receiver*. 
+
+#### Creating the Event Hub Manually
+
+When creating an eventhub manually to use as an XTDB log, there are a few properties to consider:
+
+* Partition count should be set to *1* - XTDB will only ever use a single partition within it's implementations of Log as they are required to be *totally ordered*.
+* The retention period is configurable - you will likely wish to set this to as high as you reasonably can given the priving tier of your Event Hubs namespace. 
+
+#### Creating the Event Hub Automatically
+
+If `create-event-hub?` is set to `true`, XTDB will attempt to create an Event Hub on your behalf - some notes on this:
+
+* In `create-event-hub?` is set, a number of other pieces of configuration must be done to allow your application to manage event hubs on your behalf:
+** Whichever credentials you use to authenticate to Azure for the app will require one extra roles for the namespace - *Azure Event Hubs Data Owner*.
+** Within your XTDB integrant config, you will need to directly specify the resource group the event hub namespace belongs to within the `resource-group-name` parameter.
+** The application will require two azure related environment variables to be set - `AZURE_SUBCRIPTION_ID` & `AZURE_TENANT_ID`. See the https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id[Azure docs] for more info.
+* The event hub will only be created if the `event-hub-name` in the configuartion doesn't already exist in the given namespace - it will not start a new event hub every time the node restarts.
+* The created event hub will have a single partition, and the retention period will be set based on the `retention-period-in-days` parameter (this defaults to 7 days - the maximum retention period of the 'basic' namespace pricing tier)

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -19,5 +19,6 @@ dependencies {
     api(project(":core"))
 
     api("com.azure", "azure-storage-blob", "12.22.0")
+    api("com.azure", "azure-messaging-eventhubs", "5.15.0")
     api("com.azure", "azure-identity", "1.9.0")
 }

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -21,4 +21,6 @@ dependencies {
     api("com.azure", "azure-storage-blob", "12.22.0")
     api("com.azure", "azure-messaging-eventhubs", "5.15.0")
     api("com.azure", "azure-identity", "1.9.0")
+    api("com.azure", "azure-core-management", "1.11.1")
+    api("com.azure.resourcemanager", "azure-resourcemanager-eventhubs", "2.26.0")
 }

--- a/modules/azure/deps.edn
+++ b/modules/azure/deps.edn
@@ -4,4 +4,5 @@
         com.xtdb.labs/xtdb-core {:local/root "../../core"}
 
         com.azure/azure-storage-blob {:mvn/version "12.22.0"}
+        com.azure/azure-messaging-eventhubs {:mvn/version "5.15.0"}
         com.azure/azure-identity {:mvn/version "1.9.0"}}}

--- a/modules/azure/deps.edn
+++ b/modules/azure/deps.edn
@@ -5,4 +5,6 @@
 
         com.azure/azure-storage-blob {:mvn/version "12.22.0"}
         com.azure/azure-messaging-eventhubs {:mvn/version "5.15.0"}
-        com.azure/azure-identity {:mvn/version "1.9.0"}}}
+        com.azure/azure-identity {:mvn/version "1.9.0"}
+        com.azure/azure-core-management {:mvn/version "1.11.1"}
+        com.azure.resourcemanager/azure-resourcemanager-eventhubs {:mvn/version "2.26.0"}}}

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -1,76 +1,12 @@
 (ns xtdb.azure
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
-            [xtdb.object-store :as os]
             [xtdb.util :as util]
-            [juxt.clojars-mirrors.integrant.core :as ig])
-  (:import xtdb.object_store.ObjectStore
-           java.util.concurrent.CompletableFuture
-           java.util.function.Supplier
-           com.azure.core.util.BinaryData
-           [com.azure.storage.blob.models BlobStorageException ListBlobsOptions BlobItem]
-           [com.azure.storage.blob BlobServiceClientBuilder BlobContainerClient BlobClient]
-           [com.azure.identity DefaultAzureCredentialBuilder]))
-
-(defn- get-blob [^BlobContainerClient blob-container-client blob-name]
-  (try
-    (-> (.getBlobClient blob-container-client blob-name)
-        (.downloadContent)
-        (.toByteBuffer))
-    (catch BlobStorageException e
-      (if (= 404 (.getStatusCode e))
-        (throw (os/obj-missing-exception blob-name))
-        (throw e)))))
-
-(defn- put-blob [^BlobContainerClient blob-container-client blob-name blob-buffer]
-  (try
-    (-> (.getBlobClient blob-container-client blob-name)
-        (.upload (BinaryData/fromByteBuffer blob-buffer)))
-    (catch BlobStorageException e
-      (if (= 409 (.getStatusCode e))
-        nil
-        (throw e)))))
-
-(defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
-  (-> (.getBlobClient blob-container-client blob-name)
-      (.deleteIfExists)))
-
-(defn- list-blobs [^BlobContainerClient blob-container-client prefix obj-prefix]
-  (let [list-blob-opts (cond-> (ListBlobsOptions.)
-                         obj-prefix (.setPrefix obj-prefix))]
-    (->> (.listBlobs blob-container-client list-blob-opts nil)
-         (.iterator)
-         (iterator-seq)
-         (mapv (fn [^BlobItem blob-item]
-                 (subs (.getName blob-item) (count prefix)))))))
-(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix]
-  ObjectStore
-  (getObject [_ k]
-    (CompletableFuture/completedFuture
-     (get-blob blob-container-client (str prefix k))))
-
-  (getObject [_ k out-path]
-    (CompletableFuture/supplyAsync
-     (reify Supplier
-       (get [_]
-         (let [blob-buffer (get-blob blob-container-client (str prefix k))]
-           (util/write-buffer-to-path blob-buffer out-path)
-
-           out-path)))))
-
-  (putObject [_ k buf]
-    (put-blob blob-container-client (str prefix k) buf)
-    (CompletableFuture/completedFuture nil))
-
-  (listObjects [this]
-    (.listObjects this nil))
-
-  (listObjects [_ obj-prefix]
-    (list-blobs blob-container-client prefix (str prefix obj-prefix)))
-
-  (deleteObject [_ k]
-    (delete-blob blob-container-client (str prefix k))
-    (CompletableFuture/completedFuture nil)))
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.azure
+             [object-store :as os]])
+  (:import  [com.azure.storage.blob BlobServiceClientBuilder]
+            [com.azure.identity DefaultAzureCredentialBuilder]))
 
 (derive ::blob-object-store :xtdb/object-store)
 
@@ -98,4 +34,4 @@
                                         (.credential (.build (DefaultAzureCredentialBuilder.)))
                                         (.buildClient)))
         blob-client (.getBlobContainerClient blob-service-client container)]
-    (->AzureBlobObjectStore blob-client prefix)))
+    (os/->AzureBlobObjectStore blob-client prefix)))

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -3,10 +3,13 @@
             [clojure.string :as string]
             [xtdb.util :as util]
             [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.log :as xtdb-log]
             [xtdb.azure
-             [object-store :as os]])
-  (:import  [com.azure.storage.blob BlobServiceClientBuilder]
-            [com.azure.identity DefaultAzureCredentialBuilder]))
+             [object-store :as os]
+             [log :as tx-log]])
+  (:import [com.azure.storage.blob BlobServiceClientBuilder]
+           [com.azure.identity DefaultAzureCredentialBuilder]
+           [com.azure.messaging.eventhubs EventHubClientBuilder EventProcessorClientBuilder]))
 
 (derive ::blob-object-store :xtdb/object-store)
 
@@ -35,3 +38,31 @@
                                         (.buildClient)))
         blob-client (.getBlobContainerClient blob-service-client container)]
     (os/->AzureBlobObjectStore blob-client prefix)))
+
+(s/def ::fully-qualified-namespace string?)
+(s/def ::event-hub-name string?)
+(s/def ::max-wait-time ::util/duration)
+
+(derive ::event-hub-log :xtdb/log)
+
+(defmethod ig/prep-key ::event-hub-log [_ opts]
+  (-> (merge {:max-wait-time "PT1S"} opts)
+      (util/maybe-update :max-wait-time util/->duration)))
+
+(defmethod ig/pre-init-spec ::event-hub-log [_]
+  (s/keys :req-un [::fully-qualified-namespace ::event-hub-name ::max-wait-time]))
+
+(defmethod ig/init-key ::event-hub-log [_ {:keys [fully-qualified-namespace event-hub-name max-wait-time]}]
+  (let [event-hub-client-builder (-> (EventHubClientBuilder.)
+                                     (.consumerGroup "$DEFAULT")
+                                     (.credential fully-qualified-namespace
+                                                  event-hub-name
+                                                  (.build (DefaultAzureCredentialBuilder.))))
+        subscriber-handler (xtdb-log/->notifying-subscriber-handler nil)]
+    (tx-log/->EventHubLog subscriber-handler
+                          (.buildAsyncProducerClient event-hub-client-builder)
+                          (.buildConsumerClient event-hub-client-builder)
+                          max-wait-time)))
+
+(defmethod ig/halt-key! ::event-hub-log [_ log]
+  (util/try-close log))

--- a/modules/azure/src/main/clojure/xtdb/azure/log.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/log.clj
@@ -35,7 +35,8 @@
 (defrecord EventHubLog [^INotifyingSubscriberHandler subscriber-handler
                         ^EventHubProducerAsyncClient async-producer
                         ^EventHubConsumerClient consumer
-                        ^Duration max-wait-time]
+                        ^Duration max-wait-time
+                        ^Duration poll-sleep-duration]
   Log
   (appendRecord [_ record]
     (let [fut (CompletableFuture.)
@@ -61,7 +62,7 @@
             (throw e))))))
 
   (subscribe [this after-tx-id subscriber]
-    (log/handle-polling-subscription this after-tx-id {:poll-sleep-duration (Duration/ofSeconds 1)} subscriber))
+    (log/handle-polling-subscription this after-tx-id {:poll-sleep-duration poll-sleep-duration} subscriber))
 
   Closeable
   (close [_]

--- a/modules/azure/src/main/clojure/xtdb/azure/log.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/log.clj
@@ -1,0 +1,69 @@
+(ns xtdb.azure.log
+  (:require [xtdb.api.protocols :as xtp]
+            [xtdb.log :as log]
+            [xtdb.util :as util])
+  (:import java.util.concurrent.CompletableFuture
+           java.nio.ByteBuffer
+           java.time.Duration
+           java.io.Closeable
+           [xtdb.log INotifyingSubscriberHandler Log LogRecord]
+           [com.azure.messaging.eventhubs EventData EventHubProducerAsyncClient EventHubConsumerClient]
+           [com.azure.messaging.eventhubs.models SendOptions EventPosition PartitionEvent]))
+
+(defn ->consumer [f]
+  (reify java.util.function.Consumer
+    (accept
+     [_ val]
+     (f val))))
+
+(defn event-data->tx-instant [data]
+  (xtp/->TransactionInstant (.getOffset data) (.getEnqueuedTime data)))
+
+(def producer-send-options
+  (.setPartitionId (SendOptions.) "0"))
+
+(defn get-partition-properties [consumer]
+  (let [partition-properties (.getPartitionProperties consumer "0")]
+    {:offset (Long/parseLong (.getLastEnqueuedOffset partition-properties))
+     :timestamp (.getLastEnqueuedTime partition-properties)}))
+
+(defn- ->log-record [^PartitionEvent event]
+  (let [data ^EventData (.getData event)]
+    (log/->LogRecord (event-data->tx-instant data) (ByteBuffer/wrap (.getBody data)))))
+
+;; consumer class: https://learn.microsoft.com/en-us/java/api/com.azure.messaging.eventhubs.eventhubconsumerclient?view=azure-java-stable
+(defrecord EventHubLog [^INotifyingSubscriberHandler subscriber-handler
+                        ^EventHubProducerAsyncClient async-producer
+                        ^EventHubConsumerClient consumer
+                        ^Duration max-wait-time]
+  Log
+  (appendRecord [_ record]
+    (let [fut (CompletableFuture.)
+          event-data (EventData. record)]
+      (-> (.send async-producer [event-data] producer-send-options)
+          (.subscribe nil
+                      (->consumer (fn [e]
+                                    (.completeExceptionally fut e)))
+                      (fn [] (let [{:keys [offset timestamp]} (get-partition-properties consumer)]
+                               (.complete fut (log/->LogRecord (xtp/->TransactionInstant offset timestamp) record))))))
+      fut))
+
+  (readRecords [_ after-tx-id limit]
+    (let [event-position (if after-tx-id
+                           (EventPosition/fromOffset after-tx-id)
+                           (EventPosition/earliest))]
+      (try
+        (->> (.receiveFromPartition consumer "0" limit event-position max-wait-time)
+             (mapv ->log-record))
+        (catch RuntimeException e
+          (if-let [cause (.getCause e)]
+            (throw cause)
+            (throw e))))))
+
+  (subscribe [this after-tx-id subscriber]
+    (log/handle-polling-subscription this after-tx-id {:poll-sleep-duration (Duration/ofSeconds 1)} subscriber))
+
+  Closeable
+  (close [_]
+    (util/try-close consumer)
+    (util/try-close async-producer)))

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -1,0 +1,71 @@
+
+(ns xtdb.azure.object-store
+  (:require [xtdb.object-store :as os]
+            [xtdb.util :as util])
+  (:import xtdb.object_store.ObjectStore
+           java.util.concurrent.CompletableFuture
+           java.util.function.Supplier
+           com.azure.core.util.BinaryData
+           [com.azure.storage.blob.models BlobStorageException ListBlobsOptions BlobItem]
+           [com.azure.storage.blob BlobContainerClient]))
+
+(defn- get-blob [^BlobContainerClient blob-container-client blob-name]
+  (try
+    (-> (.getBlobClient blob-container-client blob-name)
+        (.downloadContent)
+        (.toByteBuffer))
+    (catch BlobStorageException e
+      (if (= 404 (.getStatusCode e))
+        (throw (os/obj-missing-exception blob-name))
+        (throw e)))))
+
+(defn- put-blob [^BlobContainerClient blob-container-client blob-name blob-buffer]
+  (try
+    (-> (.getBlobClient blob-container-client blob-name)
+        (.upload (BinaryData/fromByteBuffer blob-buffer)))
+    (catch BlobStorageException e
+      (if (= 409 (.getStatusCode e))
+        nil
+        (throw e)))))
+
+(defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
+  (-> (.getBlobClient blob-container-client blob-name)
+      (.deleteIfExists)))
+
+(defn- list-blobs [^BlobContainerClient blob-container-client prefix obj-prefix]
+  (let [list-blob-opts (cond-> (ListBlobsOptions.)
+                         obj-prefix (.setPrefix obj-prefix))]
+    (->> (.listBlobs blob-container-client list-blob-opts nil)
+         (.iterator)
+         (iterator-seq)
+         (mapv (fn [^BlobItem blob-item]
+                 (subs (.getName blob-item) (count prefix)))))))
+(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix]
+  ObjectStore
+  (getObject [_ k]
+    (CompletableFuture/completedFuture
+     (get-blob blob-container-client (str prefix k))))
+
+  (getObject [_ k out-path]
+    (CompletableFuture/supplyAsync
+     (reify Supplier
+       (get [_]
+         (let [blob-buffer (get-blob blob-container-client (str prefix k))]
+           (util/write-buffer-to-path blob-buffer out-path)
+
+           out-path)))))
+
+  (putObject [_ k buf]
+    (put-blob blob-container-client (str prefix k) buf)
+    (CompletableFuture/completedFuture nil))
+
+  (listObjects [this]
+    (.listObjects this nil))
+
+  (listObjects [_ obj-prefix]
+    (list-blobs blob-container-client prefix (str prefix obj-prefix)))
+
+  (deleteObject [_ k]
+    (delete-blob blob-container-client (str prefix k))
+    (CompletableFuture/completedFuture nil)))
+

--- a/src/dev/clojure/azure_testing.clj
+++ b/src/dev/clojure/azure_testing.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [xtdb.node :as xtdb]
             [xtdb.util :as util]
+            [xtdb.api :as xt]
             [xtdb.azure :as azure]
             [integrant.core :as i]
             [integrant.repl :as ir])
@@ -15,6 +16,8 @@
 (def node)
 (def storage-account "xtdb")
 (def container "xtdb-azure-test")
+(def fully-qualified-namespace "xtdbeventhublogtest.servicebus.windows.net")
+(def eventhub "xtdb-azure-module-test")
 
 (defmethod i/init-key ::xtdb [_ {:keys [node-opts]}]
   (alter-var-root #'node (constantly (xtdb/start-node node-opts)))
@@ -24,16 +27,36 @@
   (util/try-close node)
   (alter-var-root #'node (constantly nil)))
 
-(def azure-default-auth
+(def azure-object-store
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
                        :xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
                        ::azure/blob-object-store {:storage-account storage-account
                                                   :container container}}}})
 
-(ir/set-prep! (fn [] azure-default-auth))
+(def azure-log
+  {::xtdb {:node-opts {:xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                       ::azure/event-hub-log {:fully-qualified-namespace fully-qualified-namespace
+                                              :event-hub-name eventhub
+                                              :max-wait-time "PT1S"}}}})
+
+(ir/set-prep! (fn [] azure-log))
 
 (comment
   (ir/go)
+  (xt/status node)
+  (def submit (xt/submit-tx node [[:put :posts {:xt/id 1234
+                                                :user-id 5678
+                                                :text "hello world!"}]]))
+  
+  (def a
+    (.appendRecord (:xtdb.azure/event-hub-log (:system node))
+                   (java.nio.ByteBuffer/wrap (.getBytes "Hello3"))))
+
+  
+  (.readRecords (:xtdb.azure/event-hub-log (:system node)) 0 100)
+  
+  (xt/q node '{:find [text]
+               :where [($ :posts [text])]})
   (node)
   (.putObject (:xtdb.azure/blob-object-store (:system node)) "bar" (java.nio.ByteBuffer/wrap (.getBytes "helloworld")))
   (ir/halt)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -1,33 +1,44 @@
 (ns xtdb.azure-test
   (:require [clojure.test :as t]
             [juxt.clojars-mirrors.integrant.core :as ig]
-            [xtdb.object-store-test :as os-test]
+            [xtdb.api :as xt]
             [xtdb.azure :as azure]
+            [xtdb.object-store-test :as os-test]
+            [xtdb.node :as node]
+            [xtdb.test-util :as tu]
             [clojure.tools.logging :as log])
   (:import java.util.UUID))
 
 (def storage-account "xtdbazureobjectstoretest")
 (def container "xtdb-test")
+(def fully-qualified-namespace "xtdbeventhublogtest.servicebus.windows.net")
+(def eventhub "xtdb-azure-module-test")
 (def config-present? (some? (and (System/getenv "AZURE_CLIENT_ID")
                                  (System/getenv "AZURE_CLIENT_SECRET")
                                  (System/getenv "AZURE_TENANT_ID"))))
 
 (def ^:dynamic *obj-store*)
 
-(t/use-fixtures :each
-  (fn [f]
-    (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID set)? - " config-present?)
-    (when config-present?
-      (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
-                                                :container container
-                                                :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
-                    ig/prep
-                    ig/init)]
-        (try
-          (binding [*obj-store* (::azure/blob-object-store sys)]
-            (f))
-          (finally
-            (ig/halt! sys)))))))
-
 (os-test/def-obj-store-tests ^:azure azure [f]
-  (f *obj-store*))
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
+    (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
+                                              :container container
+                                              :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
+                  ig/prep
+                  ig/init)]
+      (try
+        (binding [*obj-store* (::azure/blob-object-store sys)]
+          (f *obj-store*))
+        (finally
+          (ig/halt! sys))))))
+
+(t/deftest ^:azure test-eventhub-log
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
+    (with-open [node (node/start-node {::azure/event-hub-log {:fully-qualified-namespace fully-qualified-namespace
+                                                              :event-hub-name eventhub}})]
+      (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
+      (t/is (= [{:id :foo}]
+               (xt/q node '{:find [id]
+                            :where [($ :xt_docs [{:xt/id id}])]}))))))

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -21,7 +21,7 @@
 (def ^:dynamic *obj-store*)
 
 (os-test/def-obj-store-tests ^:azure azure [f]
-  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
   (when config-present?
     (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
                                               :container container
@@ -35,7 +35,7 @@
           (ig/halt! sys))))))
 
 (t/deftest ^:azure test-eventhub-log
-  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
   (when config-present?
     (with-open [node (node/start-node {::azure/event-hub-log {:namespace eventhub-namespace
                                                               :resource-group-name resource-group-name


### PR DESCRIPTION
Within this PR, I make some changes to the structure azure module, and introduce an eventhubs based txlog:
- Split out all of the azure blob object store code, and eventhubs log code, to separate files, keeping the main file for integrant config.
- Added a new dependency to the azure module for the eventhubs client library.
- Integrant "derive key" setup for the new tx log implementation (allows it to replace the `:xtdb/log`)
- Setup an eventhub namespace/eventhub for CI/testing/dev.
- Added it to the azure_testing dev file to play around with.
- Implementing the interface, using `xtdb.log/handle-polling-subscription` to handle the susbcribe behaviour - also implements closable to close consumer/producer.
- Testing the new log implementation with a very basic submit test.
- Adding options to allow the module to manage/create it's own eventhub.
- Documentation on how to use/configure the event hubs log.

## Potential follow up work

The following would likely be the preferable way to handle the subscription, and could likely be done as a piece of followup work:
- Looking into handling subscription using a `notifying-subscriber-handler` and the [azure event processor class? ](https://learn.microsoft.com/en-us/java/api/com.azure.messaging.eventhubs.eventprocessorclientbuilder?view=azure-java-stable#com-azure-messaging-eventhubs-eventprocessorclientbuilder-processevent(java-util-function-consumer(com-azure-messaging-eventhubs-models-eventcontext)))

We could also likely do with some generic TxLog based tests (similar to the Object Store tests) that we can run against our TxLog implementations