### PR TITLE
Reduce lock contention for MySQL during submit-docs!

### DIFF
--- a/modules/jdbc/src/xtdb/jdbc.clj
+++ b/modules/jdbc/src/xtdb/jdbc.clj
@@ -115,7 +115,7 @@
 (defrecord JdbcDocumentStore [pool dialect]
   db/DocumentStore
   (submit-docs [_ id-and-docs]
-    (jdbc/with-transaction [tx pool]
+    (jdbc/with-transaction [tx pool {:isolation :read-committed}]
       (doseq [[id doc] (->> (for [[id doc] id-and-docs]
                               (MapEntry/create (str id) doc))
                             (sort-by key))]


### PR DESCRIPTION
The proposed change is to use `:read-committed` rather than `:repeatable-read` (the jdbc default) for submit-docs! 

For MySQL this avoids the deadlocks described in #2546.

`consistency-check` finds no problem with this after several runs, performance does not seem affected.