### PR TITLE
Add support for select *, see ADR: 0041

### DIFF
--- a/core/src/main/clojure/xtdb/live_chunk.clj
+++ b/core/src/main/clojure/xtdb/live_chunk.clj
@@ -101,12 +101,12 @@
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface ILiveChunkWatermark
   (^xtdb.live_chunk.ILiveTableWatermark liveTable [^String table])
+  (^java.util.Map allColumnTypes [])
   (^void close []))
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface ILiveChunkTx
   (^xtdb.live_chunk.ILiveTableTx liveTable [^String table])
-
   (^xtdb.live_chunk.ILiveChunkWatermark openWatermark [])
 
   (^long nextRowId [])
@@ -117,7 +117,6 @@
 (definterface ILiveChunk
   (^xtdb.live_chunk.ILiveTable liveTable [^String table])
   (^xtdb.live_chunk.ILiveChunkWatermark openWatermark [])
-
   (^xtdb.live_chunk.ILiveChunkTx startTx [])
 
   (^long chunkIdx [])
@@ -364,7 +363,7 @@
                   (.startTx)))]
 
       (.computeIfAbsent live-table-txs table-name
-                        (util/->jfn ->live-table-tx))))
+        (util/->jfn ->live-table-tx))))
 
   (openWatermark [_]
     (let [wms (HashMap.)]
@@ -378,6 +377,8 @@
 
         (reify ILiveChunkWatermark
           (liveTable [_ table-name] (.get wms table-name))
+
+          (allColumnTypes [_] (update-vals wms #(.columnTypes ^ILiveTableWatermark %)))
 
           AutoCloseable
           (close [_] (run! util/try-close (.values wms))))
@@ -425,6 +426,8 @@
 
         (reify ILiveChunkWatermark
           (liveTable [_ table-name] (.get wms table-name))
+
+          (allColumnTypes [_] (update-vals wms #(.columnTypes ^ILiveTableWatermark %)))
 
           AutoCloseable
           (close [_] (run! util/try-close (.values wms))))

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -58,7 +58,8 @@
   (^java.util.NavigableMap chunksMetadata [])
   (^java.util.concurrent.CompletableFuture withMetadata [^long chunkIdx, ^String tableName, ^java.util.function.Function #_<ITableMetadata> f])
   (columnTypes [^String tableName])
-  (columnType [^String tableName, ^String colName]))
+  (columnType [^String tableName, ^String colName])
+  (allColumnTypes []))
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface IMetadataPredicate
@@ -431,6 +432,7 @@
 
   (columnType [_ table-name col-name] (get-in col-types [table-name col-name]))
   (columnTypes [_ table-name] (get col-types table-name))
+  (allColumnTypes [_] col-types)
 
   AutoCloseable
   (close [_]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -11,12 +11,18 @@
            java.util.HashMap
            org.apache.arrow.memory.BufferAllocator))
 
+(defn parse-query
+  [query]
+  (binding [r/*memo* (HashMap.)]
+    (-> (parser/parse query) parser/or-throw)))
+
 (defn compile-query
   ([query] (compile-query query {}))
 
   ([query query-opts]
    (binding [r/*memo* (HashMap.)
-             plan/*opts* query-opts]
+             plan/*opts* query-opts
+             sem/*table-info* (:table-info query-opts)]
      (let [ast (-> (parser/parse query) parser/or-throw
                    (sem/analyze-query) sem/or-throw)]
        (-> ast

--- a/notes/adr/0041-select-star-dup-cols.adoc
+++ b/notes/adr/0041-select-star-dup-cols.adoc
@@ -1,0 +1,102 @@
+= 41. SQL SELECT * / Duplicate Columns
+
+Date: 2023-05-16
+
+== Status
+
+Accepted
+
+== Context
+
+=== SQL Spec
+
+SELECT * in SQL is an often used feature for discovery and retrevial of whole documents.
+We would like to support this in some form, however it presents a number of questions, such as in what order are the columns of tables returned and what do to about duplicate columns names when they arrise (this is a more general problem, but the use of SELECT * is a likely instance).
+
+Consulting the SQL spec, I would say there are a number of (condensed) requirements/intentions:
+
+* SELECT * should return columns in the their order they appear in the table being 'selected' from
+
+[quote, SQL:2011 §7.12 Query Specification - Syntax Rules 4b]
+
+Otherwise, the <select list> “*” is equivalent to a <value expression> sequence in which each <value expression> is a column reference that references a column of T and each column of T is referenced exactly once.
+The columns are referenced in the ascending sequence of their ordinal position within T.
+
+* Joined Tables are defined in terms of SELECT * FROM t1, t2
+
+[quote, SQL:2011 §7.7 <joined table> - Syntax Rules 2]
+____
+Let TRA be the <table reference> or <table factor> that is the first operand of the <joined table>, and let TRB be the <table reference> or <table factor> that is the second operand of the <joined table>.
+Let RTA and RTB be the row types of TRA and TRB, respectively.
+
+Let CP be: SELECT * FROM TRA, TRB
+____
+Section goes on to define various join types e.g.
+
+[quote, SQL:2011 §7.7 <joined table> - General Rules 1a]
+
+If a <cross join> is specified, then let T be CP
+
+* Result of FROM with multiple table references contains columns in the order in which the tables appear in the and in the order in which the columns are defined within each table.
+
+[quote, SQL:2011 §7.5 <from clause> - Syntax Rules 2b]
+
+If the <table reference list> immediately contains more than one <table reference>, then the descriptors of the columns of the result of the <table reference list> are the descriptors of the columns of the tables identified by the <table reference>s, in the order in which the <table reference>s appear in the <table reference list> and in the order in which the columns are defined within each table.
+
+* Column references (via identifier chains) should unambiguously refer to a column from a single table from the innermost (local) scope.
+
+[quote, SQL:2011 §6.6 <identifier chain> - Syntax Rules 8c]
+There shall be exactly one candidate basis CB with innermost scope
+
+* There is no specific mention of how to deal with common columns between joined tables (across all join types), nor the duplicate columns that may result from projecting out all possible columns contained within the new relation.
+We infer from this that the most correct thing is to therefore support those duplicate columns as long as references are not ambiguous.
+
+[source,SQL]
+----
+--Assuming tab0 and tab1 both contain col1
+
+--Okay
+
+SELECT new_tab.* FROM (SELECT tab0.*, tab1.* FROM tab0, tab1) AS new_tab
+
+--Error ambiguous which column (tab0.col1 or tab1.col1) new_tab.col1 refers to
+
+SELECT new_tab.col1 FROM (SELECT tab0.*, tab1.* FROM tab0, tab1) AS new_tab
+----
+
+=== State of 2.x
+
+*The spec assumes columns within an table have a fixed order as defined by the schema.
+Currently 2.x has an undefined but deterministic ordering to columns within a table.
+
+*We know the current set of columns for a given table (atemporally)
+
+== Options:
+
+Given the above we should be able to support unambiguous qualified and unqualified use of SELECT *, the decision left is how to deal with the naming collisions that may result from its use.
+
+Where possible special cases should be avoided to preserve query composability (such as * working differently in a subquery vs outer query).
+
+== A: Support Duplicate Columns
+
+* Duplicate column names present challenges when trying to treat rows as maps/structs as typically these structures require unique keys.
+One such instance is when returning result says as clojure maps, here we may take inspiration from java.sql.ResultSet which opts to return the first matching column for any given name.
+
+* Postgres takes this approach
+
+== B: Remove Duplicate Columns
+
+=== 1: Error in the case that duplicate column names are introduced
+
+* MySQL takes this approach for subqueries
+
+=== 2: Merge/Rename duplicate columns at the point they are introduced
+
+* SQLite takes this approach for subqueries
+
+== Decision: Option B2 -> Revisit Option A later
+
+Where possible we try to adhere to the SQL spec, and as a fallback take inspiration from postgres.
+However as outlined above, duplicate columns present issues when thinking of rows as maps, as keys must be unique.
+For now we have chosen to rename duplicate columns when they are introduced as currently we return maps from SQL queries, with a view to revisit option A when tuple results are better supported.
+Additionally, while there may be an order to the columns within a table, the backend currently stores column info in an unordered form leaving the order of columns returned by * non deterministic, however we see this as acceptable (for now) as relying on said ordering should be avoided.

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -403,25 +403,6 @@
              (util/rethrowing-cause)))
         "parse error - date with double quotes")
 
-  (t/testing "semantic errors"
-    (t/is (thrown-with-msg?
-           xtdb.IllegalArgumentException
-           #"XTDB requires fully-qualified columns"
-           (-> (xt/submit-tx tu/*node* [[:sql "UPDATE foo SET bar = 'bar' WHERE id = 'foo'"]])
-               (util/rethrowing-cause))))
-
-    (t/is (thrown-with-msg?
-           xtdb.IllegalArgumentException
-           #"INSERT does not contain mandatory xt\$id column"
-           (-> (xt/submit-tx tu/*node* [[:sql "INSERT INTO users (foo, bar) VALUES ('foo', 'bar')"]])
-               (util/rethrowing-cause))))
-
-    (t/is (thrown-with-msg?
-           xtdb.IllegalArgumentException
-           #"Column name duplicated"
-           (-> (xt/submit-tx tu/*node* [[:sql "INSERT INTO users (xt$id, foo, foo) VALUES ('foo', 'foo', 'foo')"]])
-               (util/rethrowing-cause)))))
-
   (t/testing "still an active node"
     (xt/submit-tx tu/*node* [[:sql "INSERT INTO users (xt$id, name) VALUES ('dave', 'Dave')"]])
 

--- a/src/test/clojure/xtdb/sql/logic_test/runner.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/runner.clj
@@ -467,7 +467,7 @@
 
   (time (-main "--verify" "--db" "sqlite" "src/test/resources/xtdb/sql/logic_test/sqlite_test/select4.test"))
 
-  (time (-main "--verify" "--direct-sql" "--db" "xtdb" "src/test/resources/xtdb/sql/logic_test/direct-sql/no-projected-cols.test"))
+  (time (-main "--verify" "--direct-sql" "--db" "xtdb" "src/test/resources/xtdb/sql/logic_test/direct-sql/dml.test"))
 
  (= (time
       (with-out-str

--- a/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
@@ -153,10 +153,10 @@
     :create-view (create-view node record)))
 
 (defn outer-projection [tree]
+  ;;TODO no support for select * in SLT, outer-projection would require access to table-info
   (->> (sem/projected-columns (r/$ (r/vector-zip tree) 1))
        (first)
-       (mapv plan/unqualified-projection-symbol)
-       (plan/generate-unique-column-names)))
+       (mapv #(or (:outer-name %) (plan/unqualified-projection-symbol %)))))
 
 (defn execute-query-expression [node from-subquery]
   (binding [r/*memo* (HashMap.)]
@@ -214,6 +214,7 @@
                        (-> opts
                            (assoc :default-all-valid-time? (not= (get variables "VALID_TIME_DEFAULTS") "AS_OF_NOW"))
                            (cond-> (get variables "CURRENT_TIMESTAMP") (assoc-in [:basis :current-time] (Instant/parse (get variables "CURRENT_TIMESTAMP"))))))]
+
          (mapv #(-> % name keyword row) projection))))))
 
 (defn parse-create-table [^String x]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1,15 +1,17 @@
 (ns xtdb.sql-test
   (:require [clojure.java.io :as io]
             [clojure.test :as t :refer [deftest]]
+            [xtdb.sql.analyze :as sem]
             [xtdb.logical-plan :as lp]
             [xtdb.sql :as sql])
 
   (:import (java.time LocalDateTime)))
+
 (defn plan-sql
   ([sql opts] (sql/compile-query sql (into {:default-all-valid-time? true} opts)))
   ([sql] (plan-sql sql {:decorrelate? true, :validate-plan? true, :instrument-rules? true})))
 
-(def regen-expected-files? true)
+(def regen-expected-files? false)
 
 (defmethod t/assert-expr '=plan-file [msg form]
   `(let [exp-plan-file-name# ~(nth form 1)

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 name, x5 name_1}
+ {x1 name, x5 name:1}
  [:project
   [x1 x5]
   [:mega-join

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-with-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-with-clause.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 id, x3 id_1}
+ {x1 id, x3 id:1}
  [:mega-join
   []
   [[:rename {id x1} [:scan {:table bar} [{id (= id 5)}]]]


### PR DESCRIPTION
Adds support for qualified and unqualified `*`

```
SELECT * FROM TRA, TRB

SELECT *.TRB FROM TRA, TRB
```

Change pushes the generation of unique column names where duplicates exist down to the projected-columns attribute of query specification, any `outer-name`s generated this way are then forwarded by table-primary projected cols as an `inner-name` in the case of subqueries etc. enabling `build-query-specification` to use the correct column names during the plan step. If we wanted to return the original column names this information could be forwarded with the outer projection and then used in combination with remove-names (probably dropping the outer-projection) to do a single clojure rename to a duplicate name supporting format.