### PR TITLE
Fix lazy asserts for `or` branches

### DIFF
--- a/core/src/xtdb/query.clj
+++ b/core/src/xtdb/query.clj
@@ -810,7 +810,7 @@
                                                             :free-vars free-args}))))]
 
                            [(conj or-clauses (-> {:args [:explicit-bound-args {:bound-args bound-args, :free-args free-args}]
-                                                  :branches branches}
+                                                  :branches (vec branches)}
                                                  (with-meta (meta clause))))
                             (into known-vars free-args)])))
 

--- a/test/test/xtdb/query_test.clj
+++ b/test/test/xtdb/query_test.clj
@@ -4375,3 +4375,14 @@
                             [a :x x]
                             [c :z x]]]}
                  1 2))))
+
+(t/deftest test-query-cache-pollution-1937
+  (letfn [(bad-q [node]
+            (xt/q (xt/db node)
+                  '{:find [foo],
+                    :where [[foo :bar baz]
+                            (or [(clojure.string/includes? x ?z)]
+                                [(clojure.string/includes? y ?z)])]}))]
+    (with-open [node (xt/start-node {})]
+      (t/is (thrown? IllegalArgumentException (bad-q node)))
+      (t/is (thrown? IllegalArgumentException (bad-q node))))))


### PR DESCRIPTION
Lazy `for` here causes cache pollution as plans are cached before evaluation triggers the error

Resolves #1937