### PR TITLE
Resource utilities

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,6 +2,7 @@
            xtdb.rewrite/zmatch clojure.core.match/match
            xtdb.rewrite/zcase clojure.core/case
            xtdb.sql.logic-test.runner/def-slt-test clojure.test/deftest
+           xtdb.util/with-open clojure.core/with-open
            clojure.test.check.clojure-test/defspec clojure.test/deftest
            clojure.test.check.properties/for-all clojure.core/for
            juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc/with-transaction next.jdbc/with-transaction}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,6 +2,7 @@
            xtdb.rewrite/zmatch clojure.core.match/match
            xtdb.rewrite/zcase clojure.core/case
            xtdb.sql.logic-test.runner/def-slt-test clojure.test/deftest
+           xtdb.util/with-close-on-catch clojure.core/with-open
            xtdb.util/with-open clojure.core/with-open
            clojure.test.check.clojure-test/defspec clojure.test/deftest
            clojure.test.check.properties/for-all clojure.core/for

--- a/core/src/main/clojure/xtdb/datalog.clj
+++ b/core/src/main/clojure/xtdb/datalog.clj
@@ -1235,13 +1235,8 @@
                                                        :expected (count in-bindings)
                                                        :actual args})))
 
-        (let [^AutoCloseable
-              params (vw/open-params allocator (args->params args in-bindings))]
-          (try
-            (-> (.bind pq wm-src {:params params, :table-args (args->tables args in-bindings),
-                                  :basis basis, :default-tz default-tz :default-all-valid-time? default-all-valid-time?})
-                (.openCursor)
-                (op/cursor->result-set params))
-            (catch Throwable t
-              (.close params)
-              (throw t))))))))
+        (util/with-close-on-catch [^AutoCloseable params (vw/open-params allocator (args->params args in-bindings))]
+          (-> (.bind pq wm-src {:params params, :table-args (args->tables args in-bindings),
+                                :basis basis, :default-tz default-tz :default-all-valid-time? default-all-valid-time?})
+              (.openCursor)
+              (op/cursor->result-set params)))))))

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -266,15 +266,10 @@
 
             ;; if the user returns `nil` or `true`, we just continue with the rest of the transaction
             (when-not (or (nil? res) (true? res))
-              (let [tx-ops-vec (txp/open-tx-ops-vec allocator)]
-                (try
-                  (txp/write-tx-ops! allocator (vw/->writer tx-ops-vec) res)
-                  (.setValueCount tx-ops-vec (count res))
-                  tx-ops-vec
-
-                  (catch Throwable t
-                    (.close tx-ops-vec)
-                    (throw t))))))
+              (util/with-close-on-catch [tx-ops-vec (txp/open-tx-ops-vec allocator)]
+                (txp/write-tx-ops! allocator (vw/->writer tx-ops-vec) res)
+                (.setValueCount tx-ops-vec (count res))
+                tx-ops-vec)))
 
           (catch Throwable t
             (reset! !last-tx-fn-error t)

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -117,12 +117,8 @@
         {:keys [col-types ->cursor stats]} (f inner-col-types)]
     {:col-types col-types
      :->cursor (fn [opts]
-                 (let [inner (->inner-cursor opts)]
-                   (try
-                     (->cursor opts inner)
-                     (catch Throwable e
-                       (util/try-close inner)
-                       (throw e)))))
+                 (util/with-close-on-catch [inner (->inner-cursor opts)]
+                   (->cursor opts inner)))
      :stats stats}))
 
 (defn binary-expr {:style/indent 3} [left right f]
@@ -132,17 +128,9 @@
 
     {:col-types col-types
      :->cursor (fn [opts]
-                 (let [left (->left-cursor opts)]
-                   (try
-                     (let [right (->right-cursor opts)]
-                       (try
-                         (->cursor opts left right)
-                         (catch Throwable e
-                           (util/try-close right)
-                           (throw e))))
-                     (catch Throwable e
-                       (util/try-close left)
-                       (throw e)))))
+                 (util/with-close-on-catch [left (->left-cursor opts)
+                                            right (->right-cursor opts)]
+                   (->cursor opts left right)))
      :stats stats}))
 
 ;;;; Rewriting of logical plan.

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -54,18 +54,14 @@
       (getColumnName [_] col-name)
       (getColumnType [_] :i64)
       (project [_ allocator in-rel _params]
-        (let [out-vec (BigIntVector. (str col-name) allocator)
-              start-row-num (aget row-num 0)
-              row-count (.rowCount in-rel)]
-          (try
+        (util/with-close-on-catch [out-vec (BigIntVector. (str col-name) allocator)]
+          (let [start-row-num (aget row-num 0)
+                row-count (.rowCount in-rel)]
             (.setValueCount out-vec row-count)
             (dotimes [idx row-count]
               (.set out-vec idx (+ idx start-row-num)))
             (aset row-num 0 (+ start-row-num row-count))
-            (iv/->direct-vec out-vec)
-            (catch Throwable e
-              (.close out-vec)
-              (throw e))))))))
+            (iv/->direct-vec out-vec)))))))
 
 (defrecord RenameProjectionSpec [to-name from-name col-type]
   IProjectionSpec

--- a/core/src/main/clojure/xtdb/temporal.clj
+++ b/core/src/main/clojure/xtdb/temporal.clj
@@ -301,10 +301,8 @@
                                                              (applyAsLong [_ x]
                                                                (aget ^longs x row-id-idx)))))
                         (.toArray))
-        value-count (alength coordinates)
-
-        cols (ArrayList. (count columns))]
-    (try
+        value-count (alength coordinates)]
+    (util/with-close-on-catch [cols (ArrayList. (count columns))]
       (doseq [col-name columns]
         (let [col-idx (->temporal-column-idx col-name)
               col-type (types/col-type->field col-name (get temporal-col-types col-name)) ;TODO rename to field
@@ -317,11 +315,7 @@
           (.setValueCount temporal-vec value-count)
           (.add cols (iv/->direct-vec temporal-vec))))
 
-      (iv/->indirect-rel cols value-count)
-
-      (catch Throwable e
-        (run! util/try-close cols)
-        (throw e)))))
+      (iv/->indirect-rel cols value-count))))
 
 (defn row-ids-to-add [kd-tree ^long latest-completed-tx-time ^long current-time]
   (let [min-range (doto (->min-range)

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -875,13 +875,9 @@
              vs))
 
   (^org.apache.arrow.vector.ValueVector [allocator col-name col-type vs]
-   (let [res (-> (types/col-type->field col-name col-type)
-                 (.createVector allocator))]
-     (try
-       (doto res (write-vec! vs))
-       (catch Throwable e
-         (.close res)
-         (throw e))))))
+   (util/with-close-on-catch [res (-> (types/col-type->field col-name col-type)
+                                      (.createVector allocator))]
+     (doto res (write-vec! vs)))))
 
 (defn open-rel ^xtdb.vector.IIndirectRelation [vecs]
   (iv/->indirect-rel (map iv/->direct-vec vecs)))

--- a/src/test/clojure/xtdb/datalog_test.clj
+++ b/src/test/clojure/xtdb/datalog_test.clj
@@ -19,19 +19,20 @@
     [:put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
 
 (deftest test-scan
-  (let [tx (xt/submit-tx tu/*node* ivan+petr)]
-    (t/is (= [{:name "Ivan"}
-              {:name "Petr"}]
-             (xt/q tu/*node*
-                   '{:find [name]
-                     :where [(match :xt_docs {:first-name name})]})))
+  (xt/submit-tx tu/*node* ivan+petr)
 
-    (t/is (= [{:e :ivan, :name "Ivan"}
-              {:e :petr, :name "Petr"}]
-             (xt/q tu/*node*
-                   '{:find [e name]
-                     :where [(match :xt_docs {:xt/id e, :first-name name})]}))
-          "returning eid")))
+  (t/is (= [{:name "Ivan"}
+            {:name "Petr"}]
+           (xt/q tu/*node*
+                 '{:find [name]
+                   :where [(match :xt_docs {:first-name name})]})))
+
+  (t/is (= [{:e :ivan, :name "Ivan"}
+            {:e :petr, :name "Petr"}]
+           (xt/q tu/*node*
+                 '{:find [e name]
+                   :where [(match :xt_docs {:xt/id e, :first-name name})]}))
+        "returning eid"))
 
 (deftest test-basic-query
   (let [tx (xt/submit-tx tu/*node* ivan+petr)]


### PR DESCRIPTION
Four relatively small changes in this PR that should make correct resource management easier:

1. `util/with-open` - like `clojure.core/with-open` but throws the original error rather than the close error if both fail (e.g. Arrow memory leaks).
2. `util/try-close` no longer silently ignores non-Closeable things. also now handles seqs and maps of closeable things.
3. add `util/close` that doesn't hide the close error (likely more useful after 1)
4. add `util/with-close-on-catch` to sugar the common 'open thing in let, try, return thing, catch Throwable, close thing, rethrow t' pattern - like `with-open` but doesn't close the resource when the body returns successfully, only if it fails. was especially annoying when you're opening more than one resource:

   ```clojure
   (let [left (->left-cursor opts)]
     (try
       (let [right (->right-cursor opts)]
         (try
           (->cursor opts left right)
           (catch Throwable e
             (util/try-close right)
             (throw e))))
       (catch Throwable e
         (util/try-close left)
         (throw e))))
   
   ;; becomes
   
   (util/with-close-on-catch [left (->left-cursor opts)
                              right (->right-cursor opts)]
     (->cursor opts left right))
   ```