### PR TITLE
Passing await QPs with query requests, fixes #527

### DIFF
--- a/modules/http-client/test/xtdb/remote_api_client_test.clj
+++ b/modules/http-client/test/xtdb/remote_api_client_test.clj
@@ -9,6 +9,7 @@
            [com.nimbusds.jose JWSAlgorithm JWSHeader$Builder]
            [com.nimbusds.jose.jwk Curve ECKey JWKSet]
            [com.nimbusds.jwt JWTClaimsSet$Builder SignedJWT]
+           [java.time Duration]
            [java.util Date]
            [java.util.function Supplier]))
 
@@ -40,8 +41,8 @@
 
 (defn with-api* [{:keys [jwks ->jwt-token]} f]
   (let [server-port (xio/free-port)]
-    (with-open [node (xt/start-node {:xtdb.http-server/server {:port server-port
-                                                               :jwks jwks}})
+    (with-open [_node (xt/start-node {:xtdb.http-server/server {:port server-port
+                                                                :jwks jwks}})
                 client (xt/new-api-client (str "http://localhost:" server-port) {:->jwt-token ->jwt-token})]
 
       (binding [*api* client]
@@ -53,7 +54,7 @@
 (t/deftest test-unauthenticated-client-and-unauthenticated-server
   (with-api {}
     (let [submitted-tx (xt/submit-tx *api* [[::xt/put {:xt/id :ivan :name "Ivan"}]])]
-      (t/is (= submitted-tx (xt/await-tx *api* submitted-tx)))
+      (t/is (= submitted-tx (xt/await-tx *api* submitted-tx (Duration/ofSeconds 2))))
       (t/is (true? (xt/tx-committed? *api* submitted-tx))))))
 
 (t/deftest test-authenticated-client-and-unauthenticated-server

--- a/modules/http-server/src/xtdb/http_server/entity.clj
+++ b/modules/http-server/src/xtdb/http_server/entity.clj
@@ -26,6 +26,7 @@
 (s/def ::history boolean?)
 (s/def ::with-corrections boolean?)
 (s/def ::with-docs boolean?)
+
 (s/def ::query-params
   (s/keys :opt-un [::util/eid
                    ::util/eid-edn

--- a/modules/http-server/src/xtdb/http_server/util.clj
+++ b/modules/http-server/src/xtdb/http_server/util.clj
@@ -48,9 +48,9 @@
 
 (s/def ::link-entities? boolean?)
 (s/def ::valid-time ::date)
+(s/def ::tx-id int?)
 (s/def ::tx-time ::date)
 (s/def ::timeout int?)
-(s/def ::tx-id int?)
 
 (defn ->edn-encoder [_]
   (reify

--- a/test/test/xtdb/api_test.clj
+++ b/test/test/xtdb/api_test.clj
@@ -192,7 +192,10 @@
 
 (t/deftest test-sparql
   (let [submitted-tx (xt/submit-tx *api* [[::xt/put {:xt/id :ivan :name "Ivan"}]])]
-    (xt/await-tx *api* submitted-tx))
+    (xt/await-tx *api* submitted-tx)
+
+    ;; now required on remote (after fix for #527) to actually await the tx
+    (xt/db *api*))
 
   (t/testing "SPARQL query"
     (when (bound? #'fh/*api-url*)


### PR DESCRIPTION
… so that when we await on one node and query on another (e.g. when XT is load balanced), the queried node awaits the transaction correctly. fixes #527 

We continue to call the old await-tx endpoints so that new clients still ~work with old servers - this issue may still be present in that case, but no worse than currently.

This is essentially a backport of the approach from 2.x (where we don't have await-tx at all) - we could consider backporting more of the approach to 1.x (i.e. essentially make await-tx optional in 1.x) to make the user migration for 1.x -> 2.x more incremental.