### PR TITLE
Round-tripping and operations on decimals

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -160,7 +160,8 @@
          :f32 'float
          :f64 'double
          :timestamp-tz 'long
-         :duration 'long}
+         :duration 'long
+         :decimal 'bigdec}
         types/col-type-head))
 
 (def idx-sym (gensym 'idx))
@@ -227,7 +228,7 @@
   :hierarchy #'types/col-type-hierarchy)
 
 (def ^:private col-type->rw-fn
-  '{:bool Boolean, :i8 Byte, :i16 Short, :i32 Int, :i64 Long, :f32 Float, :f64 Double
+  '{:bool Boolean, :i8 Byte, :i16 Short, :i32 Int, :i64 Long, :f32 Float, :f64 Double,
     :date Long, :time-local Long, :timestamp-tz Long, :timestamp-local Long, :duration Long
     :utf8 Bytes, :varbinary Bytes, :keyword Bytes, :uuid Bytes, :uri Bytes
 
@@ -243,7 +244,7 @@
   (defmethod read-value-code k [_ & args] `(~(symbol (str ".read" rw-fn)) ~@args))
   (defmethod write-value-code k [_ & args] `(~(symbol (str ".write" rw-fn)) ~@args)))
 
-(doseq [[k tag] {:interval PeriodDuration}]
+(doseq [[k tag] {:interval PeriodDuration :decimal BigDecimal}]
   (defmethod read-value-code k [_ & args]
     (-> `(.readObject ~@args) (with-tag tag)))
 


### PR DESCRIPTION
Short circuiting #2044. Handling of decimals generally in a dynamic engine seems to be quite a rabbit hole. 
This PR essentially allows operation on decimals for precision 38 and scale 19. Anything outside of this range will currently throw an exception. Anything coming out of the engine will also have that precision and scale set.

Some useful information:
- https://github.com/apache/arrow-rs/issues/2387 - only useful link I could find of why arrow actually stores precision
- [IEEE-754 2008](http://www.dsc.ufcg.edu.br/~cnum/modulos/Modulo2/IEEE754_2008.pdf#%5B%7B%22num%22%3A281%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C110.2%2C720%2C0%5D) - expression evaluation between different types (doesn't actually say much)
- SQL standard 6.27 <numeric value expression> - if both operands are exact numeric (decimal, ints)  -> (implementation dependent) exact numeric, if one type is approximate numeric (float, double) -> (implementation dependent) approximate numeric  
- Postgres (http://sqlfiddle.com/#!17/8756f8/2) and Clojure (`(type (+' (double 1.0) (bigdec 1.0)))`) seem to favor Double over Decimal    

Stuff still todo/decide:
- ~correctly support operations between other types and decimal~ this currently follows the same behavior as Clojure (fewest changes). One could think about promoting an operation on `:f32` and `:decimal` to `:f64`, but the SQL spec does not require it. 
- How should we deal with decimals that still fit into an Arrow Decimal (128bit) but fall outside the above range (`1E+35M` , `1E-35M`)
- How to deal with things that don't fit into an Arrow Decimal ? Over- and Underflow? 

