### PR TITLE
WIP: Add retention policy settings to checkpointer

### DIFF
--- a/docs/administration/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/administration/modules/ROOT/pages/checkpointing.adoc
@@ -17,9 +17,9 @@ The checkpoint store is a pluggable module - there are a number of officially su
 XTDB nodes in a cluster don't explicitly communicate regarding which one is responsible for creating a checkpoint - instead, they check at random intervals to see whether any other node has recently created a checkpoint, and create one if necessary.
 The desired frequency of checkpoints can be set using `approx-frequency`.
 
-The default lifecycle of checkpoints is unbounded - XTDB will not attempt to clean up old checkpoints. Users will typically want to define a retention policy that best fits their requirements and create means of implementing that policy that is external to XTDB.
+The default lifecycle of checkpoints is **unbounded** - XTDB will not attempt to clean up old checkpoints unless explicitly told to. See <<retention-policy,**setting up a retention policy**>> below for how to manage checkpoint lifecycles within the XTDB checkpointer module itself. 
 
-WARNING: Current behaviour of the checkpointer is such that we only make a checkpoint if we have processed new transactions since the previous checkpoint. As such - you will need to be careful with any lifecycle policies set on your checkpoints - if no new transactions are handled for a period, no new checkpoints will be made, and you may risk having no checkpoints and having to replay from the Transaction Log!
+WARNING: Current behaviour of the checkpointer is such that we only make a checkpoint if we have processed new transactions since the previous checkpoint. As such - you will need to be careful if you have any external lifecycle policies set on your checkpoints - if no new transactions are handled for a period, no new checkpoints will be made, and you may risk having no checkpoints and having to replay from the Transaction Log!
 
 == Setting up
 
@@ -84,6 +84,9 @@ EDN::
 * `checkpoint-dir` (string/`File`/`Path`): temporary directory to store checkpoints in before they're uploaded
 * `keep-dir-between-checkpoints?` (boolean, default true): whether to keep the temporary checkpoint directory between checkpoints
 * `keep-dir-on-close?` (boolean, default false): whether to keep the temporary checkpoint directory when the node shuts down
+* `retention-policy` (map, optional): the retention settings of checkpointers made by the checkpointer, must contain at _least_ one of the following (though we can use both, see the <<retention-policy,section below>> for more info):
+** `retain-newer-than` (`Duration`): retain all checkpoints that are "newer than" the given duration 
+** `retain-at-least` (integer): retain _at least_ this many checkpoints (ie, the most recent `retain-at-least` checkpoints are safe from deletion)
 
 == `FileSystem` Checkpoint Store parameters
 * `path` (required, string/`File`/`Path`/`URI`): path to store checkpoints.
@@ -96,3 +99,68 @@ Often the Cloud provider also offers tooling to quickly snapshot those volumes (
 
 * having `[:checkpointer :store :path]` pointing to a filesystem mounted on such a volume
 * having the joining XTDB node `[:checkpointer :store :path]` point to a filesystem mounted an a snapshot from the main node (above).
+
+[#retention-policy]
+== Using `retention-policy` on the checkpointers
+
+When configuring the checkpointer module, we can provide a parameter, `retention-policy`, to have XTDB handle the deletion & retention behaviour of old checkpoints. The config for this will look like the following:
+
+[tabs]
+====
+JSON::
++
+[source,json]
+----
+{
+  ...
+  "checkpointer": {
+    "xtdb/module": "xtdb.checkpoint/->checkpointer",
+    "store": { ... },
+    "approx-frequency": "PT6H",
+    "retention-policy": {
+      "retain-newer-than": "PT7D",
+      "retain-at-least": 5
+    }
+  }
+  ...
+}
+----
+
+Clojure::
++
+[source,clojure]
+----
+{
+  ...
+  :checkpointer {:xtdb/module 'xtdb.checkpoint/->checkpointer
+                 :store {...}
+                 :approx-frequency (Duration/ofHours 6)
+                 :retention-policy {:retain-newer-than (Duration/ofDays 7)
+                                    :retain-at-least 5}}
+  ...
+}
+----
+
+EDN::
++
+[source,clojure]
+----
+{
+  ...
+  :checkpointer {:xtdb/module xtdb.checkpoint/->checkpointer
+                 :store {...}
+                 :approx-frequency "PT6H"
+                 :retention-policy {:retain-newer-than "PT7D"
+                                    :retain-at-least 5}}
+  ...
+}
+----
+====
+
+When passing in `retention-policy`, we need at _least_ one of `retain-newer-than` and `retain-at-least` - though you can provide both. What follows is the behaviour of the checkpointer at the point after we've completed making a new checkpoint:
+
+* If _only_ `retain-at-least` is provided, we will take the list of available checkpoints, keep the latest `retain-at-least` checkpoints, and delete the rest.
+* If _only_ `retain-newer-than` is provided, we will keep all checkpoints _newer_ than the configured Duration and delete all checkpoints _older_ than the configured Duration.
+* If _both_ `retain-at-least` and `retain-newer-than` are provided:
+** We start by splitting the list of checkpoints into "safe (from deletion)" and "unsafe (from deletion)" checkpoints - the latest `retain-at-least` values will be considered "safe", and will always be kept.
+** The "unsafe" list is then mapped over - from this, we will keep all checkpoints _newer_ than `retain-newer-than` and delete all of the remaining checkpoints that are _older_.

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -21,7 +21,7 @@
                   (map #(.truncatedTo ^Instant % ChronoUnit/HOURS))
                   (take 20))))))
 
-(defn checkpoint [{:keys [approx-frequency tx-id-override ::cp/cp-format dir]} checkpoints]
+(defn checkpoint [{:keys [approx-frequency tx-id-override ::cp/cp-format dir retention-policy]} checkpoints]
   (let [!checkpoints (atom checkpoints)]
     (with-open [bus ^Closeable (bus/->bus)
                 _ (bus/->bus-stop {:bus bus})]
@@ -29,6 +29,7 @@
                       :dir dir
                       :bus bus
                       :approx-frequency approx-frequency
+                      :retention-policy retention-policy
                       :store (reify cp/CheckpointStore
                                (available-checkpoints [_ {:keys [::cp/cp-format]}]
                                  (->> (reverse @!checkpoints)
@@ -42,7 +43,15 @@
                                                        (into {} (map (juxt #(.getName ^File %)
                                                                            (comp read-string slurp)))))}]
                                    (swap! !checkpoints conj cp)
-                                   cp))),
+                                   cp))
+                               (cleanup-checkpoint [_ {:keys [tx cp-at ::cp/cp-format] :as keys}]
+                                 (let [cp-removed (remove
+                                                   (fn [cp]
+                                                     (and (= (:tx cp) tx)
+                                                          (= (::cp/cp-format cp) cp-format)
+                                                          (= (::cp/checkpoint-at cp) cp-at)))
+                                                   @!checkpoints)]
+                                   (reset! !checkpoints cp-removed)))),
                       :src (let [!tx-id (atom 0)]
                              (reify cp/CheckpointSource
                                (save-checkpoint [_ dir]
@@ -82,7 +91,7 @@
           cp-2 {:tx {::xt/tx-id 2},
                 ::cp/cp-format ::foo-format,
                 :files {"hello.edn" {:msg "Hello world!", :tx-id 2}}}]
-      (t/testing "first checkpoint"
+      (t/testing "first checkpoint, no prior checkpoints"
         (t/is (= [cp-1]
                  (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
                                    ::cp/cp-format ::foo-format
@@ -99,12 +108,12 @@
                                    :dir cp-dir
                                    ;; would be same tx-id as above (ie, same tx)
                                    :tx-id-override 1}
-                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.) 
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
                                                                       (.toInstant)
                                                                       (.minus (Duration/ofSeconds 2))
                                                                       (Date/from)))])
                       (map #(dissoc % ::cp/checkpoint-at))))))
-      
+
       (t/testing "makes a second checkpoint as it has a new latest tx"
         (t/is (= [cp-1 cp-2]
                  (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
@@ -130,6 +139,154 @@
         (t/is (= ::foo-format (::cp/cp-format res)))
                  ;; Check if checkpoint-at (sent to upload-checkpoint as cp-at) satisfies Inst, should be a Date
         (t/is (inst? (::cp/checkpoint-at res)))))))
+
+(t/deftest test-retention-retain-at-least
+  (fix/with-tmp-dir "cp" [cp-dir]
+    (let [cp-1 {:tx {::xt/tx-id 1},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 1}}}
+          cp-2 {:tx {::xt/tx-id 2},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 2}}}]
+      (t/testing "first checkpoint, retain at least 1 - should return 1 checkpoint"
+        (t/is (= [cp-1]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 1}}
+                                  [])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint, retain at least 1 - old checkpoint should be removed"
+        (t/is (= [cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 1}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [cp-1])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint, retain at least 2 - should return both checkpoints"
+        (t/is (= [cp-1 cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 2}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [cp-1])
+                      (map #(dissoc % ::cp/checkpoint-at)))))))))
+
+(t/deftest test-retention-retain-newer-than
+  (fix/with-tmp-dir "cp" [cp-dir]
+    (let [cp-1 {:tx {::xt/tx-id 1},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 1}}}
+          cp-2 {:tx {::xt/tx-id 2},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 2}}}]
+      (t/testing "first checkpoint, retain newer than 1 day ago - should return 1 checkpoint"
+        (t/is (= [cp-1]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-newer-than (Duration/ofDays 1)}}
+                                  [])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint, retain newer than 1 day ago - old checkpoint should be removed (as it is 2 days old)"
+        (t/is (= [cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-newer-than (Duration/ofDays 1)}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
+                                                                      (.toInstant)
+                                                                      (.minus (Duration/ofDays 2))
+                                                                      (Date/from)))])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint, retain newer than 3 days ago - should return both checkpoints"
+        (t/is (= [cp-1 cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-newer-than (Duration/ofDays 3)}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
+                                                                      (.toInstant)
+                                                                      (.minus (Duration/ofDays 2))
+                                                                      (Date/from)))])
+                      (map #(dissoc % ::cp/checkpoint-at)))))))))
+
+(t/deftest test-retention-both-args
+  (fix/with-tmp-dir "cp" [cp-dir]
+    (let [cp-1 {:tx {::xt/tx-id 1},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 1}}}
+          cp-2 {:tx {::xt/tx-id 2},
+                ::cp/cp-format ::foo-format,
+                :files {"hello.edn" {:msg "Hello world!", :tx-id 2}}}]
+
+      (t/testing "first checkpoint, retain at least 1 & retain newer than 1 day ago - should return 1 checkpoint"
+        (t/is (= [cp-1]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 1
+                                                      :retain-newer-than (Duration/ofDays 1)}}
+                                  [])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint from 2 days ago, retain at least 1 & retain newer than 1 day ago - old checkpoint should be removed"
+        (t/is (= [cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 1
+                                                      :retain-newer-than (Duration/ofDays 1)}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
+                                                                      (.toInstant)
+                                                                      (.minus (Duration/ofDays 2))
+                                                                      (Date/from)))])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint from 2 days ago, retain at least 2 & retain newer than 1 day ago - old checkpoint should be kept"
+        (t/is (= [cp-1 cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 2
+                                                      :retain-newer-than (Duration/ofDays 1)}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
+                                                                      (.toInstant)
+                                                                      (.minus (Duration/ofDays 2))
+                                                                      (Date/from)))])
+                      (map #(dissoc % ::cp/checkpoint-at))))))
+
+      (t/testing "second checkpoint, 1 prior checkpoint from 2 days ago, retain at least 1 & retain newer than 3 days ago - old checkpoint should be kept"
+        (t/is (= [cp-1 cp-2]
+                 (->> (checkpoint {:approx-frequency (Duration/ofSeconds 1)
+                                   ::cp/cp-format ::foo-format
+                                   :dir cp-dir
+                                   :retention-policy {:retain-at-least 1
+                                                      :retain-newer-than (Duration/ofDays 3)}
+                                   ;; different tx-id to available-checkpoint (ie, new)
+                                   :tx-id-override 2}
+                                  [(assoc cp-1 ::cp/checkpoint-at (-> (Date.)
+                                                                      (.toInstant)
+                                                                      (.minus (Duration/ofDays 2))
+                                                                      (Date/from)))])
+                      (map #(dissoc % ::cp/checkpoint-at)))))))))
 
 (t/deftest test-checkpointer
   (fix/with-tmp-dir "cp" [cp-dir]


### PR DESCRIPTION
Resolves #2589 

Adds `retention-policy` settings to the checkpointer:
- Takes two options, retain-newer-than and retain-at-least
- When we upload a checkpoint, we then enforce the retention rules:
  - If we specify only `retain-at-least`, then we only keep that many checkpoints.
  - If we specify only `retain-newer-than`, then we only keep checkpointers newer than the provided time. 
  - If we specify both - we keep at least `retain-at-least` checkpoints and the rest we decide whether or not to keep based on their age.
- Add tests for the above cases:
  - Both specified
  - Only `retain-at-least`.
  - Only `retain-newer-than` 
- Add a test for `retain-at-least` with a filesystem checkpoint store to sanity check behaviour at a higher level.  
- Adds documentation around configuring the retention policy.
