### PR TITLE
Writing out transactions + content to a T1 diff trie, #2573

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   clojure:
     working_directory: ~/core2
     docker:
-      - image: clojure:openjdk-11-tools-deps
+      - image: clojure:openjdk-17-tools-deps
 
 parameters:
   run-slt:

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11">
+    <bytecodeTargetLevel target="17">
       <module name="core2.docker" target="17" />
       <module name="core2.docker.main" target="17" />
       <module name="core2.docker.test" target="17" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="java-17-openjdk" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="java-17-openjdk" project-jdk-type="JavaSDK" />
 </project>

--- a/api/build.clj
+++ b/api/build.clj
@@ -6,7 +6,7 @@
 (defn prep [_opts]
   (b/javac {:basis basis
             :src-dirs ["src"]
-            :javac-opts ["-source" "11" "-target" "11"
+            :javac-opts ["-source" "17" "-target" "17"
                          "-XDignore.symbol.file"
                          "-Xlint:all,-options,-path"
                          "-Werror"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
 
     if (plugins.hasPlugin("java-library")) {
         java {
-            sourceCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_17
 
             withSourcesJar()
             withJavadocJar()

--- a/core/build.clj
+++ b/core/build.clj
@@ -6,7 +6,7 @@
 (defn prep [_opts]
   (b/javac {:basis basis
             :src-dirs ["src/main/java"]
-            :javac-opts ["-source" "11" "-target" "11"
+            :javac-opts ["-source" "17" "-target" "17"
                          "-XDignore.symbol.file"
                          "-Xlint:all,-options,-path"
                          "-Werror"

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -1,0 +1,303 @@
+(ns xtdb.indexer.live-index
+  (:require [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.api.protocols :as xtp]
+            xtdb.buffer-pool
+            xtdb.object-store
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.indirect :as iv]
+            [xtdb.vector.writer :as vw])
+  (:import (java.lang AutoCloseable)
+           (java.util Arrays HashMap Map)
+           (java.util.concurrent CompletableFuture)
+           (java.util.concurrent.atomic AtomicInteger)
+           (java.util.function BiConsumer Consumer Function IntConsumer)
+           (java.util.stream IntStream)
+           (org.apache.arrow.memory BufferAllocator)
+           [org.apache.arrow.memory.util ArrowBufPointer]
+           (org.apache.arrow.vector FixedSizeBinaryVector VectorSchemaRoot)
+           (org.apache.arrow.vector.types.pojo ArrowType$Union Schema)
+           org.apache.arrow.vector.types.UnionMode
+           (xtdb.api.protocols TransactionInstant)
+           (xtdb.buffer_pool IBufferPool)
+           (xtdb.object_store ObjectStore)
+           (xtdb.trie HashTrie HashTrie$Leaf HashTrie$Visitor TrieKeys MemoryHashTrie)
+           (xtdb.vector IIndirectRelation IIndirectVector IRelationWriter IRowCopier)))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface ILiveTableTx
+  (^xtdb.vector.IRelationWriter writer [])
+  (^void commit [])
+  (^void close []))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface ILiveTable
+  (^xtdb.indexer.live_index.ILiveTableTx startTx [tx])
+  (^java.util.concurrent.CompletableFuture #_<?> finishChunk [^long chunkIdx]))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface ILiveIndexTx
+  (^xtdb.indexer.live_index.ILiveTableTx liveTable [tableName])
+  (^void commit []))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface ILiveIndex
+  (^xtdb.indexer.live_index.ILiveTable liveTable [tableName])
+  (^xtdb.indexer.live_index.ILiveIndexTx startTx [^xtdb.api.protocols.TransactionInstant tx])
+  (^void finishChunk [^long chunkIdx]))
+
+(def ^:private ^org.apache.arrow.vector.types.pojo.Schema index-schema
+  (Schema. [(types/col-type->field "xt$iid" [:fixed-size-binary 16])
+            (types/col-type->field "xt$valid_from" types/nullable-temporal-type)
+            (types/col-type->field "xt$valid_to" types/nullable-temporal-type)
+            (types/col-type->field "xt$system_from" types/nullable-temporal-type)
+            (types/col-type->field "xt$system_to" types/nullable-temporal-type)
+            (types/col-type->field "xt$doc" [:struct {}])]))
+
+(defn- open-index-root ^xtdb.vector.IRelationWriter [^BufferAllocator allocator]
+  (vw/root->writer (VectorSchemaRoot/create index-schema allocator)))
+
+(defn- ->t1-key-adapter ^xtdb.trie.TrieKeys [^IRelationWriter rel]
+  (let [^FixedSizeBinaryVector iid-vec (.getVector (.writerForName rel "xt$iid"))
+        left-abp (ArrowBufPointer.)
+        right-abp (ArrowBufPointer.)]
+    (reify TrieKeys
+      (groupFor [_ idx lvl]
+        (.getDataPointer iid-vec idx left-abp)
+
+        (let [lvl-offset-bits (* (inc lvl) HashTrie/LEVEL_BITS)]
+          (-> (.getByte (.getBuf left-abp)
+                        (+ (.getOffset left-abp)
+                           (quot lvl-offset-bits Byte/SIZE)))
+
+              (bit-shift-right (mod lvl-offset-bits Byte/SIZE))
+              (bit-and HashTrie/LEVEL_MASK))))
+
+      (compare [_ left-idx right-idx]
+        (.compareTo (.getDataPointer iid-vec left-idx left-abp)
+                    (.getDataPointer iid-vec right-idx right-abp))))))
+
+(defn- ->row-adder [^IRelationWriter rel]
+  (let [wp (.writerPosition rel)]
+    (fn add-row [{:keys [^HashTrie t1]}]
+      ;; TODO figure out what tries to update
+      {:t1 (-> ^HashTrie (or t1 (MemoryHashTrie/emptyTrie (->t1-key-adapter rel)))
+               (.add (.getPosition wp)))})))
+
+(defn- wrap-writer ^xtdb.vector.IRelationWriter [^IRelationWriter rel-wtr, !tries]
+  (let [wp (.writerPosition rel-wtr)
+        add-row (->row-adder rel-wtr)]
+
+    (reify IRelationWriter
+      (writerPosition [_] wp)
+      (writerForName [_ col-name] (.writerForName rel-wtr col-name))
+      (writerForName [_ col-name col-type] (.writerForName rel-wtr col-name col-type))
+      (syncRowCount [_] (.syncRowCount rel-wtr))
+      (rowCopier [_ src-rel]
+        (let [copier (.rowCopier rel-wtr src-rel)]
+          (reify IRowCopier
+            (copyRow [_ src-idx]
+              (swap! !tries add-row)
+              (.copyRow copier src-idx)))))
+
+      Iterable
+      (iterator [_] (.iterator rel-wtr))
+
+      (endRow [_]
+        (swap! !tries add-row)
+        (.endRow rel-wtr))
+
+      (clear [_] (.clear rel-wtr))
+
+      AutoCloseable
+      (close [_] (.close rel-wtr)))))
+
+(defrecord LiveTableTx [^String table-name, ^TransactionInstant tx
+                        ^IRelationWriter static-rel, ^IRelationWriter transient-rel
+                        !static-tries !transient-tries]
+  ILiveTableTx
+  (writer [_] (-> transient-rel (wrap-writer !transient-tries)))
+
+  (commit [_]
+    (let [copier (vw/->rel-copier static-rel (vw/rel-wtr->rdr transient-rel))
+          !new-static-tries (volatile! @!static-tries)]
+      (.accept ^HashTrie (:t1 @!transient-tries)
+               (reify HashTrie$Visitor
+                 (visitBranch [visitor children]
+                   (run! #(.accept ^HashTrie % visitor) children))
+
+                 (visitLeaf [_ leaf]
+                   (-> (.indices leaf)
+                       (.forEach (reify IntConsumer
+                                   (accept [_ idx]
+                                     (vswap! !new-static-tries update :t1
+                                             (fn [t1]
+                                               (let [^HashTrie t1 (or t1 (MemoryHashTrie/emptyTrie (->t1-key-adapter static-rel)))]
+                                                 (.add t1 (.copyRow copier idx))))))))))))
+
+      (reset! !static-tries @!new-static-tries)))
+
+  AutoCloseable
+  (close [_]
+    (util/close transient-rel)))
+
+(def ^org.apache.arrow.vector.types.pojo.Schema trie-schema
+  (Schema. [(types/->field "nodes" (ArrowType$Union. UnionMode/Dense (int-array (range 3))) false
+                           (types/col-type->field "nil" :null)
+                           (types/col-type->field "branch" [:list [:union #{:null :i32}]])
+                           ;; TODO metadata
+                           (types/col-type->field "leaf" '[:struct {page-idx :i32}]))]))
+
+(defn- write-t1-chunk!
+  ^java.util.concurrent.CompletableFuture [^BufferAllocator allocator, ^ObjectStore obj-store, ^HashTrie t1
+                                           ^String chunk-idx, ^String table-name
+                                           ^IIndirectRelation static-rel]
+
+  (util/with-close-on-catch [t1-leaf-vsr (VectorSchemaRoot/create (Schema. (for [^IIndirectVector rdr static-rel]
+                                                                             (.getField (.getVector rdr))))
+                                                                  allocator)
+                             t1-trie-vsr (VectorSchemaRoot/create trie-schema allocator)]
+    (let [t1-leaf-wtr (vw/root->writer t1-leaf-vsr)
+          t1-trie-wtr (vw/root->writer t1-trie-vsr)
+
+          node-wtr (.writerForName t1-trie-wtr "nodes")
+          node-wp (.writerPosition node-wtr)
+
+          nil-wtr (.writerForTypeId node-wtr (byte 0))
+          branch-wtr (.writerForTypeId node-wtr (byte 1))
+          branch-el-wtr (.listElementWriter branch-wtr)
+
+          leaf-wtr (.writerForTypeId node-wtr (byte 2))
+          page-idx-wtr (.structKeyWriter leaf-wtr "page-idx")
+          !page-idx (AtomicInteger. 0)
+          copier (vw/->rel-copier t1-leaf-wtr static-rel)]
+
+      (-> (.putObject obj-store
+                      (format "tables/%s/t1-diff/leaf-c%s.arrow" table-name chunk-idx)
+                      (util/build-arrow-ipc-byte-buffer t1-leaf-vsr :file
+                        (fn [write-batch!]
+                          (.accept t1
+                                   (reify HashTrie$Visitor
+                                     (visitBranch [visitor children]
+                                       (let [!page-idxs (IntStream/builder)]
+                                         (doseq [^HashTrie child children]
+                                           (.add !page-idxs (if child
+                                                              (do
+                                                                (.accept child visitor)
+                                                                (dec (.getPosition node-wp)))
+                                                              -1)))
+                                         (.startList branch-wtr)
+                                         (.forEach (.build !page-idxs)
+                                                   (reify IntConsumer
+                                                     (accept [_ idx]
+                                                       (if (= idx -1)
+                                                         (.writeNull branch-el-wtr nil)
+                                                         (.writeInt branch-el-wtr idx)))))
+                                         (.endList branch-wtr)
+                                         (.endRow t1-trie-wtr)))
+
+                                     (visitLeaf [_ leaf]
+                                       (-> (.indices leaf)
+                                           (.forEach (reify IntConsumer
+                                                       (accept [_ idx]
+                                                         (.copyRow copier idx)))))
+
+                                       (.syncRowCount t1-leaf-wtr)
+                                       (write-batch!)
+                                       (.clear t1-leaf-wtr)
+                                       (.clear t1-leaf-vsr)
+
+                                       (.startStruct leaf-wtr)
+                                       (.writeInt page-idx-wtr (.getAndIncrement !page-idx))
+                                       (.endStruct leaf-wtr)
+                                       (.endRow t1-trie-wtr)))))))
+          (util/then-compose
+            (fn [_]
+              (.syncRowCount t1-trie-wtr)
+              (.putObject obj-store
+                          (format "tables/%s/t1-diff/trie-c%s.arrow" table-name chunk-idx)
+                          (util/root->arrow-ipc-byte-buffer t1-trie-vsr :file))))
+          (.whenComplete (reify BiConsumer
+                           (accept [_ _ _]
+                             (util/try-close t1-trie-vsr)
+                             (util/try-close t1-leaf-vsr))))))))
+
+(defrecord LiveTable [^BufferAllocator allocator, ^ObjectStore obj-store, ^String table-name
+                      ^IRelationWriter static-rel, !static-tries]
+  ILiveTable
+  (startTx [_ tx]
+    (LiveTableTx. table-name tx
+                  static-rel (open-index-root allocator)
+                  !static-tries (atom {})))
+
+  (finishChunk [_ chunk-idx]
+    (let [{:keys [t1]} @!static-tries
+          chunk-idx-str (util/->lex-hex-string chunk-idx)
+          static-rel-rdr (vw/rel-wtr->rdr static-rel)]
+      (write-t1-chunk! allocator obj-store t1 chunk-idx-str table-name static-rel-rdr)))
+
+  AutoCloseable
+  (close [_]
+    (util/close static-rel)))
+
+(defrecord LiveIndexTx [^BufferAllocator allocator, ^ObjectStore obj-store
+                        ^TransactionInstant tx
+                        ^Map live-tables, ^Map live-table-txs]
+  ILiveIndexTx
+  (liveTable [_ table-name]
+    (letfn [(->live-table [_]
+              (LiveTable. allocator obj-store table-name (open-index-root allocator) (atom {})))
+
+            (->live-table-tx [table-name]
+              (-> ^ILiveTable (.computeIfAbsent live-tables table-name
+                                                (util/->jfn ->live-table))
+                  (.startTx tx)))]
+
+      (.computeIfAbsent live-table-txs (util/str->normal-form-str table-name)
+                        (util/->jfn ->live-table-tx))))
+
+  (commit [_]
+    (doseq [^ILiveTableTx live-table (.values live-table-txs)]
+      (.commit live-table)))
+
+  AutoCloseable
+  (close [_]
+    (util/close live-table-txs)))
+
+(defrecord LiveIndex [^BufferAllocator allocator
+                      ^ObjectStore object-store
+                      ^Map live-tables]
+  ILiveIndex
+  (liveTable [_ table-name]
+    (.computeIfAbsent live-tables (util/str->normal-form-str table-name)
+                      (reify Function
+                        (apply [_ table-name]
+                          (LiveTable. allocator object-store table-name
+                                      (open-index-root allocator) (atom {}))))))
+
+  (startTx [_ tx]
+    (LiveIndexTx. allocator object-store tx live-tables (HashMap.)))
+
+  (finishChunk [_ chunk-idx]
+    @(CompletableFuture/allOf (->> (for [^ILiveTable live-table (.values live-tables)]
+                                     (.finishChunk live-table chunk-idx))
+
+                                   (into-array CompletableFuture)))
+
+    (util/close live-tables)
+    (.clear live-tables))
+
+  AutoCloseable
+  (close [_]
+    (util/close live-tables)))
+
+(defmethod ig/prep-key :xtdb.indexer/live-index [_ opts]
+  (merge {:allocator (ig/ref :xtdb/allocator)
+          :object-store (ig/ref :xtdb/object-store)}
+         opts))
+
+(defmethod ig/init-key :xtdb.indexer/live-index [_ {:keys [allocator object-store]}]
+  (LiveIndex. allocator object-store (HashMap.)))
+
+(defmethod ig/halt-key! :xtdb.indexer/live-index [_ live-idx]
+  (util/close live-idx))

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -126,6 +126,7 @@
                           :xtdb/indexer {}
                           :xtdb.indexer/internal-id-manager {}
                           :xtdb/live-chunk {}
+                          :xtdb.indexer/live-index {}
                           :xtdb.indexer/log-indexer {}
                           :xtdb/ingester {}
                           :xtdb.metadata/metadata-manager {}

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -809,7 +809,7 @@
    (->writer (-> (types/col-type->field col-name col-type)
                  (.createVector allocator)))))
 
-(defn- ->rel-copier [^IRelationWriter rel-wtr, ^IIndirectRelation in-rel]
+(defn ->rel-copier ^xtdb.vector.IRowCopier [^IRelationWriter rel-wtr, ^IIndirectRelation in-rel]
   (let [wp (.writerPosition rel-wtr)
         copiers (vec (concat (for [^IIndirectVector in-vec in-rel]
                                (.rowCopier in-vec (.writerForName rel-wtr (.getName in-vec))))

--- a/core/src/main/java/xtdb/trie/ArrowHashTrie.java
+++ b/core/src/main/java/xtdb/trie/ArrowHashTrie.java
@@ -1,0 +1,122 @@
+package xtdb.trie;
+
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.arrow.vector.ipc.message.ArrowBlock;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class ArrowHashTrie {
+
+    private static final byte BRANCH_TYPE_ID = 1;
+    private static final byte LEAF_TYPE_ID = 2;
+
+    private final DenseUnionVector nodesVec;
+    private final ListVector branchVec;
+    private final IntVector branchElVec;
+    private final StructVector leafVec;
+    private final IntVector pageIdxVec;
+
+    private final ArrowFileReader leafReader;
+    private final List<ArrowBlock> leafBlocks;
+    private final VectorSchemaRoot leafRoot;
+
+    static class Branch implements HashTrie {
+
+        private final HashTrie[] children;
+
+        public Branch(HashTrie[] children) {
+            this.children = children;
+        }
+
+        @Override
+        public HashTrie add(int idx) {
+            throw new UnsupportedOperationException("read only trie");
+        }
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+            return visitor.visitBranch(children);
+        }
+    }
+
+    class Leaf implements HashTrie {
+
+        private final ArrowBlock leafBlock;
+
+        public Leaf(ArrowBlock leafBlock) {
+            this.leafBlock = leafBlock;
+        }
+
+        @Override
+        public HashTrie add(int idx) {
+            throw new UnsupportedOperationException("read only trie");
+        }
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+            try {
+                leafReader.loadRecordBatch(leafBlock);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            var rowCount = leafRoot.getRowCount();
+
+            return visitor.visitLeaf(new Leaf() {
+                @Override
+                public int size() {
+                    return rowCount;
+                }
+
+                @Override
+                public int get(int idx) {
+                    return idx;
+                }
+
+                @Override
+                public IntStream indices() {
+                    return IntStream.range(0, rowCount);
+                }
+            });
+        }
+    }
+
+    private ArrowHashTrie(VectorSchemaRoot trieRoot, ArrowFileReader leafReader) throws IOException {
+        nodesVec = ((DenseUnionVector) trieRoot.getVector("nodes"));
+        branchVec = (ListVector) nodesVec.getVectorByType(BRANCH_TYPE_ID);
+        branchElVec = (IntVector) branchVec.getDataVector();
+        leafVec = (StructVector) nodesVec.getVectorByType(LEAF_TYPE_ID);
+        pageIdxVec = leafVec.getChild("page-idx", IntVector.class);
+
+        this.leafReader = leafReader;
+        leafBlocks = leafReader.getRecordBlocks();
+        leafRoot = leafReader.getVectorSchemaRoot();
+    }
+
+    private HashTrie forIndex(int idx) {
+        var nodeOffset = nodesVec.getOffset(idx);
+        return switch (nodesVec.getTypeId(idx)) {
+            case 0 -> null;
+
+            case BRANCH_TYPE_ID -> new Branch(
+                    IntStream.range(branchVec.getElementStartIndex(nodeOffset), branchVec.getElementEndIndex(nodeOffset))
+                            .mapToObj(childIdx -> forIndex(branchElVec.get(childIdx)))
+                            .toArray(HashTrie[]::new));
+
+            case LEAF_TYPE_ID -> new Leaf(leafBlocks.get(pageIdxVec.get(nodeOffset)));
+
+            default -> throw new UnsupportedOperationException();
+        };
+    }
+
+    public static HashTrie from(VectorSchemaRoot trieRoot, ArrowFileReader leafReader) throws IOException {
+        return new ArrowHashTrie(trieRoot, leafReader).forIndex(trieRoot.getRowCount() - 1);
+    }
+}

--- a/core/src/main/java/xtdb/trie/HashTrie.java
+++ b/core/src/main/java/xtdb/trie/HashTrie.java
@@ -1,0 +1,37 @@
+package xtdb.trie;
+
+import java.util.stream.IntStream;
+
+public interface HashTrie {
+
+    int LEVEL_BITS = 4;
+    int LEVEL_WIDTH = 1 << LEVEL_BITS;
+    int LEVEL_MASK = LEVEL_WIDTH - 1;
+
+    HashTrie add(int idx);
+
+    interface Leaf {
+        int size();
+
+        int get(int idx);
+
+        default IntStream indices() {
+            return IntStream.range(0, size()).map(this::get);
+        }
+    }
+
+    interface Visitor<R> {
+        default R visitBranch(HashTrie[] children) {
+            for (HashTrie child : children) {
+                child.accept(this);
+            }
+
+            return null;
+        }
+
+        R visitLeaf(Leaf leaf);
+    }
+
+    <R> R accept(Visitor<R> visitor);
+}
+

--- a/core/src/main/java/xtdb/trie/MemoryHashTrie.java
+++ b/core/src/main/java/xtdb/trie/MemoryHashTrie.java
@@ -1,0 +1,199 @@
+package xtdb.trie;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public final class MemoryHashTrie {
+    private MemoryHashTrie() {
+    }
+
+    public record Config(TrieKeys keys, int logLimit, int pageLimit) {
+        public static class Builder {
+            private final TrieKeys keys;
+
+            private int logLimit = 64;
+            private int pageLimit = 1024;
+
+            public Builder(TrieKeys keys) {
+                this.keys = keys;
+            }
+
+            @SuppressWarnings("unused")
+            public void setLogLimit(int logLimit) {
+                this.logLimit = logLimit;
+            }
+
+            @SuppressWarnings("unused")
+            public void setPageLimit(int pageLimit) {
+                this.pageLimit = pageLimit;
+            }
+
+            public HashTrie build() {
+                var trieConfig = new Config(keys, logLimit, pageLimit);
+                return new Leaf(trieConfig, 0, new int[0], new int[logLimit], 0);
+            }
+        }
+    }
+
+    public static Config.Builder builder(TrieKeys keys) {
+        return new Config.Builder(keys);
+    }
+
+    @SuppressWarnings("unused")
+    public static HashTrie emptyTrie(TrieKeys keys) {
+        return builder(keys).build();
+    }
+
+    public record Branch(Config config, int level, HashTrie[] children) implements HashTrie {
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+            return visitor.visitBranch(children);
+        }
+
+        @Override
+        public HashTrie add(int idx) {
+            var bucket = config.keys().groupFor(idx, level);
+
+            var newChildren = IntStream.range(0, children.length)
+                    .mapToObj(childIdx -> {
+                        var child = children[childIdx];
+                        if (bucket == childIdx) {
+                            if (child == null) {
+                                child = new MemoryHashTrie.Leaf(config, level + 1, new int[0], new int[config.logLimit()], 0);
+                            }
+                            child = child.add(idx);
+                        }
+                        return child;
+                    }).toArray(HashTrie[]::new);
+
+            return new Branch(config, level, newChildren);
+        }
+    }
+
+    public record Leaf(Config config, int level, int[] data, int[] log, int logCount) implements HashTrie {
+
+        private int[] mergeSort(int[] data, int[] log, int logCount) {
+            TrieKeys keys = config.keys();
+            int dataCount = data.length;
+
+            var res = IntStream.builder();
+            var dataIdx = 0;
+            var logIdx = 0;
+
+            while (true) {
+                if (dataIdx == dataCount) {
+                    IntStream.range(logIdx, logCount).forEach(idx -> {
+                        if (idx == logCount - 1 || keys.compare(log[idx], log[idx + 1]) != 0) {
+                            res.add(log[idx]);
+                        }
+                    });
+                    break;
+                }
+
+                if (logIdx == logCount) {
+                    IntStream.range(dataIdx, dataCount).forEach(idx -> res.add(data[idx]));
+                    break;
+                }
+
+                var dataKey = data[dataIdx];
+                var logKey = log[logIdx];
+
+                // this collapses down multiple duplicate values within the log
+                if (logIdx + 1 < logCount && keys.compare(logKey, log[logIdx + 1]) == 0) {
+                    logIdx++;
+                    continue;
+                }
+
+                switch (Integer.signum(keys.compare(dataKey, logKey))) {
+                    case -1 -> {
+                        res.add(dataKey);
+                        dataIdx++;
+                    }
+                    case 0 -> {
+                        res.add(logKey);
+                        dataIdx++;
+                        logIdx++;
+                    }
+                    case 1 -> {
+                        res.add(logKey);
+                        logIdx++;
+                    }
+                }
+            }
+
+            return res.build().toArray();
+        }
+
+        private int[] sortLog(int[] log, int logCount) {
+            // this is a little convoluted, but AFAICT this is the only way to guarantee a 'stable' sort,
+            // (`Stream.sorted()` doesn't guarantee it), which is required for the log (to preserve insertion order)
+            var boxedArray = Arrays.stream(log).limit(logCount).boxed().toArray(Integer[]::new);
+            Arrays.sort(boxedArray, config.keys::compare);
+            return Arrays.stream(boxedArray).mapToInt(i -> i).toArray();
+        }
+
+        private Stream<int[]> idxBuckets(int[] idxs, int level) {
+            var entryGroups = new IntStream.Builder[LEVEL_WIDTH];
+            for (int i : idxs) {
+                int groupIdx = config.keys().groupFor(i, level);
+                var group = entryGroups[groupIdx];
+                if (group == null) {
+                    entryGroups[groupIdx] = group = IntStream.builder();
+                }
+
+                group.add(i);
+            }
+
+            return Arrays.stream(entryGroups).map(b -> b == null ? null : b.build().toArray());
+        }
+
+        @Override
+        public HashTrie add(int newIdx) {
+            var data = this.data;
+            var log = this.log;
+            var logCount = this.logCount;
+            var logLimit = config.logLimit();
+            log[logCount++] = newIdx;
+
+            if (logCount == logLimit) {
+                data = mergeSort(data, sortLog(log, logCount), logCount);
+                log = new int[logLimit];
+                logCount = 0;
+
+                if (data.length > config.pageLimit()) {
+                    var childNodes = idxBuckets(data, level)
+                            .map(group -> group == null ? null : new MemoryHashTrie.Leaf(config, level + 1, group, new int[logLimit], 0))
+                            .toArray(HashTrie[]::new);
+
+                    return new Branch(config, level, childNodes);
+                }
+            }
+
+            return new MemoryHashTrie.Leaf(config, level, data, log, logCount);
+        }
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+            var data = mergeSort(this.data, sortLog(log, logCount), logCount);
+
+            return visitor.visitLeaf(new Leaf() {
+                @Override
+                public int size() {
+                    return data.length;
+                }
+
+                @Override
+                public int get(int idx) {
+                    return data[idx];
+                }
+
+                @Override
+                public IntStream indices() {
+                    return Arrays.stream(data);
+                }
+            });
+        }
+    }
+}

--- a/core/src/main/java/xtdb/trie/TrieKeys.java
+++ b/core/src/main/java/xtdb/trie/TrieKeys.java
@@ -1,0 +1,7 @@
+package xtdb.trie;
+
+public interface TrieKeys {
+    int groupFor(int idx, int level);
+
+    int compare(int leftIdx, int rightIdx);
+}

--- a/modules/s3/build.clj
+++ b/modules/s3/build.clj
@@ -6,7 +6,7 @@
 (defn prep [_opts]
   (b/javac {:basis basis
             :src-dirs ["src/main/java"]
-            :javac-opts ["-source" "11" "-target" "11"
+            :javac-opts ["-source" "17" "-target" "17"
                          "-XDignore.symbol.file"
                          "-Xlint:all,-options,-path"
                          "-Werror"

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -1,6 +1,7 @@
 (ns xtdb.test-util
   (:require [clojure.spec.alpha :as s]
             [clojure.test :as t]
+            [juxt.clojars-mirrors.integrant.core :as ig]
             [xtdb.api.protocols :as api]
             [xtdb.client :as client]
             [xtdb.indexer :as idx]
@@ -61,6 +62,20 @@
   (util/with-open [node (node/start-node *node-opts*)]
     (binding [*node* node]
       (f))))
+
+(def ^:dynamic *sys*)
+
+(defn with-system [sys-opts]
+  (fn [f]
+    (let [sys (-> sys-opts
+                  (doto ig/load-namespaces)
+                  ig/prep
+                  ig/init)]
+      (try
+        (binding [*sys* sys]
+          (f))
+        (finally
+          (ig/halt! sys))))))
 
 (defn free-port ^long []
   (with-open [s (ServerSocket. 0)]

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -1,0 +1,75 @@
+(ns xtdb.indexer.live-index-test
+  (:require [clojure.test :as t]
+            [xtdb.api.protocols :as xtp]
+            xtdb.indexer.live-index
+            xtdb.object-store
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
+  (:import [java.util Random UUID]
+           [org.apache.arrow.memory BufferAllocator]
+           [org.apache.arrow.vector ValueVector]
+           [org.apache.arrow.vector.ipc ArrowFileReader]
+           xtdb.indexer.live_index.ILiveIndex
+           xtdb.object_store.ObjectStore
+           (xtdb.trie ArrowHashTrie HashTrie HashTrie$Visitor)))
+
+(def with-live-index
+  (tu/with-system {:xtdb/allocator {}
+                   :xtdb.indexer/live-index {}
+                   :xtdb.object-store/memory-object-store {}}))
+
+(t/use-fixtures :each with-live-index)
+
+(defn- render-trie [^HashTrie ht, ^ValueVector iid-vec]
+  (.accept ht
+           (reify HashTrie$Visitor
+             (visitBranch [visitor children]
+               (mapcat #(.accept ^HashTrie % visitor) children))
+
+             (visitLeaf [_ leaf]
+               (->> (.toArray (.indices leaf))
+                    (mapv #(vec (.getObject iid-vec %))))))))
+
+(t/deftest test-t1-chunk
+  (let [{^BufferAllocator allocator :xtdb/allocator
+         ^ILiveIndex live-index :xtdb.indexer/live-index
+         ^ObjectStore obj-store :xtdb.object-store/memory-object-store} tu/*sys*
+
+        iids (let [rnd (Random. 0)]
+               (repeatedly 12000 #(UUID. (.nextLong rnd) (.nextLong rnd))))
+
+        iid-bytes (->> (sort-by #(.getMostSignificantBits ^UUID %) #(Long/compareUnsigned %1 %2) iids)
+                       (mapv (comp vec util/uuid->bytes)))]
+
+    (t/testing "commit"
+      (util/with-open [live-tx (.startTx live-index (xtp/->TransactionInstant 0 (.toInstant #inst "2020")))]
+        (let [live-table-tx (.liveTable live-tx "foo")
+              wtr (.writer live-table-tx)
+              iid-wtr (.writerForName wtr "xt$iid")]
+
+          (doseq [iid iids]
+            (vw/write-value! iid iid-wtr)
+            (.endRow wtr))
+
+          (.commit live-table-tx)
+
+          (let [{:keys [static-rel !static-tries]} live-table-tx
+                iid-vec (-> (vw/rel-wtr->rdr static-rel)
+                            (.vectorForName "xt$iid")
+                            (.getVector))
+                {:keys [^HashTrie t1]} @!static-tries]
+
+            (t/is (= iid-bytes (render-trie t1 iid-vec)))))))
+
+    (t/testing "finish chunk"
+      (.finishChunk live-index 0)
+
+      (let [trie-buf @(.getObject obj-store "tables/foo/t1-diff/trie-c00.arrow")
+            leaf-buf @(.getObject obj-store "tables/foo/t1-diff/leaf-c00.arrow")]
+        (with-open [trie-rdr (ArrowFileReader. (util/->seekable-byte-channel trie-buf) allocator)
+                    leaf-rdr (ArrowFileReader. (util/->seekable-byte-channel leaf-buf) allocator)]
+          (.loadNextBatch trie-rdr)
+          (t/is (= iid-bytes
+                   (render-trie (ArrowHashTrie/from (.getVectorSchemaRoot trie-rdr) leaf-rdr)
+                                (.getVector (.getVectorSchemaRoot leaf-rdr) "xt$iid")))))))))

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -86,7 +86,7 @@
         last-tx-key (xtp/map->TransactionInstant {:tx-id 8165, :system-time (util/->instant #inst "2020-01-02")})]
     (util/delete-dir node-dir)
 
-    (with-open [node (tu/->local-node {:node-dir node-dir})]
+    (util/with-open [node (tu/->local-node {:node-dir node-dir})]
       (let [^BufferAllocator a (tu/component node :xtdb/allocator)
             ^ObjectStore os (tu/component node ::os/file-system-object-store)
             ^IBufferPool bp (tu/component node ::bp/buffer-pool)

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/t1-diff/leaf-c31fe5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/t1-diff/leaf-c31fe5.arrow.json
@@ -1,0 +1,230 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "xt$iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$doc",
+      "nullable" : false,
+      "type" : {
+        "name" : "struct"
+      },
+      "children" : [{
+        "name" : "xt$id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "api_version",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "manufacturer",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "model",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "os_name",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 2,
+    "columns" : [{
+      "name" : "xt$iid",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : ["248daaa010bf702848523e4fa63f996c","ef4f71005524e9af20ffaca545cde6e1"]
+    },{
+      "name" : "xt$valid_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1577923200000000,1577836800000000]
+    },{
+      "name" : "xt$valid_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$system_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1577923200000000,1577836800000000]
+    },{
+      "name" : "xt$system_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$doc",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "children" : [{
+        "name" : "xt$id",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,22,44],
+          "DATA" : ["device-info-demo000001","device-info-demo000000"]
+        }]
+      },{
+        "name" : "api_version",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,2,4],
+          "DATA" : ["23","23"]
+        }]
+      },{
+        "name" : "manufacturer",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,6,12],
+          "DATA" : ["iobeam","iobeam"]
+        }]
+      },{
+        "name" : "model",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,7,12],
+          "DATA" : ["mustang","pinto"]
+        }]
+      },{
+        "name" : "os_name",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,5,10],
+          "DATA" : ["6.0.1","6.0.1"]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/t1-diff/trie-c31fe5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/t1-diff/trie-c31fe5.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/t1-diff/leaf-c31fe5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/t1-diff/leaf-c31fe5.arrow.json
@@ -1,0 +1,483 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "xt$iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$doc",
+      "nullable" : false,
+      "type" : {
+        "name" : "struct"
+      },
+      "children" : [{
+        "name" : "mem_used",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "rssi",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "cpu_avg_5min",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "ssid",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "time",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "timestamp-tz-micro-utc",
+          "nullable" : false,
+          "type" : {
+            "name" : "timestamp",
+            "unit" : "MICROSECOND",
+            "timezone" : "UTC"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "cpu_avg_1min",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "battery_temperature",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "xt$id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "bssid",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "battery_level",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "device_id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "battery_status",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "mem_free",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "cpu_avg_15min",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "f64",
+          "nullable" : false,
+          "type" : {
+            "name" : "floatingpoint",
+            "precision" : "DOUBLE"
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 2,
+    "columns" : [{
+      "name" : "xt$iid",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : ["58941814a63f68d05acf4177ec17d3ba","6bd5602dd9300d63410ca07b677f0041"]
+    },{
+      "name" : "xt$valid_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1577836800000000,1577923200000000]
+    },{
+      "name" : "xt$valid_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$system_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1577836800000000,1577923200000000]
+    },{
+      "name" : "xt$system_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$doc",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "children" : [{
+        "name" : "mem_used",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [5.89988922E8,2.79257668E8]
+        }]
+      },{
+        "name" : "rssi",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [-50.0,-61.0]
+        }]
+      },{
+        "name" : "cpu_avg_5min",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [10.802,8.106]
+        }]
+      },{
+        "name" : "ssid",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,8,19],
+          "DATA" : ["demo-net","stealth-net"]
+        }]
+      },{
+        "name" : "time",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "timestamp-tz-micro-utc",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [1479211200000000,1479211200000000]
+        }]
+      },{
+        "name" : "cpu_avg_1min",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [24.81,4.93]
+        }]
+      },{
+        "name" : "battery_temperature",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [89.5,93.7]
+        }]
+      },{
+        "name" : "xt$id",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,18,36],
+          "DATA" : ["reading-demo000000","reading-demo000001"]
+        }]
+      },{
+        "name" : "bssid",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,17,34],
+          "DATA" : ["01:02:03:04:05:06","A0:B1:C5:D2:E0:F3"]
+        }]
+      },{
+        "name" : "battery_level",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [59.0,86.0]
+        }]
+      },{
+        "name" : "device_id",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,22,44],
+          "DATA" : ["device-info-demo000000","device-info-demo000001"]
+        }]
+      },{
+        "name" : "battery_status",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,11,22],
+          "DATA" : ["discharging","discharging"]
+        }]
+      },{
+        "name" : "mem_free",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [4.10011078E8,7.20742332E8]
+        }]
+      },{
+        "name" : "cpu_avg_15min",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "f64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : [8.654,8.822]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/t1-diff/trie-c31fe5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/t1-diff/trie-c31fe5.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/t1-diff/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/t1-diff/leaf-c00.arrow.json
@@ -1,0 +1,439 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "xt$iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$doc",
+      "nullable" : false,
+      "type" : {
+        "name" : "struct"
+      },
+      "children" : [{
+        "name" : "xt$id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        },{
+          "name" : "i64",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 64,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "keyword",
+          "nullable" : false,
+          "type" : {
+            "name" : "KeywordType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "xt/clj-keyword",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        }]
+      },{
+        "name" : "list",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "list",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "$data$",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "f64",
+              "nullable" : false,
+              "type" : {
+                "name" : "floatingpoint",
+                "precision" : "DOUBLE"
+              },
+              "children" : [ ]
+            },{
+              "name" : "utf8",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "timestamp-tz-micro-utc",
+              "nullable" : false,
+              "type" : {
+                "name" : "timestamp",
+                "unit" : "MICROSECOND",
+                "timezone" : "UTC"
+              },
+              "children" : [ ]
+            },{
+              "name" : "bool",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          }]
+        },{
+          "name" : "absent",
+          "nullable" : false,
+          "type" : {
+            "name" : "AbsentType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "absent",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        }]
+      },{
+        "name" : "struct",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "absent",
+          "nullable" : false,
+          "type" : {
+            "name" : "AbsentType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "absent",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        },{
+          "name" : "struct",
+          "nullable" : false,
+          "type" : {
+            "name" : "struct"
+          },
+          "children" : [{
+            "name" : "a",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "i64",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bool",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          },{
+            "name" : "b",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "utf8",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "absent",
+              "nullable" : false,
+              "type" : {
+                "name" : "AbsentType"
+              },
+              "children" : [ ],
+              "metadata" : [{
+                "value" : "absent",
+                "key" : "ARROW:extension:name"
+              },{
+                "value" : "",
+                "key" : "ARROW:extension:metadata"
+              }]
+            }]
+          },{
+            "name" : "c",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "absent",
+              "nullable" : false,
+              "type" : {
+                "name" : "AbsentType"
+              },
+              "children" : [ ],
+              "metadata" : [{
+                "value" : "absent",
+                "key" : "ARROW:extension:name"
+              },{
+                "value" : "",
+                "key" : "ARROW:extension:metadata"
+              }]
+            },{
+              "name" : "utf8",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 6,
+    "columns" : [{
+      "name" : "xt$iid",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["55bfc78e47207dc5125af00a5f52d66c","64b0cf833d08d23b08185c18bb7a0ef2","9e3f856e68998313827ff18dd4d88e78","bfc55eb61f526d86de90b2bb2e648a89","d9c7fae2a04e047164936265ba33cf80","fbfa9e45ee9bd2f827b8dde9e41d3814"]
+    },{
+      "name" : "xt$valid_from",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : [1577836800000000,1577836800000000,1577836800000000,1577836800000000,1577836800000000,1577836800000000]
+    },{
+      "name" : "xt$valid_to",
+      "count" : 6,
+      "VALIDITY" : [0,0,0,0,0,0],
+      "DATA" : [0,0,0,0,0,0]
+    },{
+      "name" : "xt$system_from",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : [1577836800000000,1577836800000000,1577836800000000,1577836800000000,1577836800000000,1577836800000000]
+    },{
+      "name" : "xt$system_to",
+      "count" : 6,
+      "VALIDITY" : [0,0,0,0,0,0],
+      "DATA" : [0,0,0,0,0,0]
+    },{
+      "name" : "xt$doc",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "children" : [{
+        "name" : "xt$id",
+        "count" : 6,
+        "TYPE_ID" : [1,1,0,2,0,2],
+        "OFFSET" : [0,1,0,0,1,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,3,6],
+          "DATA" : ["bar","foo"]
+        },{
+          "name" : "i64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : ["52","24"]
+        },{
+          "name" : "keyword",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,3,7],
+          "DATA" : ["baz","quux"]
+        }]
+      },{
+        "name" : "list",
+        "count" : 6,
+        "TYPE_ID" : [1,1,0,1,0,1],
+        "OFFSET" : [0,1,0,2,1,3],
+        "children" : [{
+          "name" : "list",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,2,4],
+          "children" : [{
+            "name" : "$data$",
+            "count" : 4,
+            "TYPE_ID" : [2,3,0,1],
+            "OFFSET" : [0,0,0,0],
+            "children" : [{
+              "name" : "f64",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [12.0]
+            },{
+              "name" : "utf8",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "OFFSET" : [0,3],
+              "DATA" : ["foo"]
+            },{
+              "name" : "timestamp-tz-micro-utc",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [1577836800000000]
+            },{
+              "name" : "bool",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [0]
+            }]
+          }]
+        },{
+          "name" : "absent",
+          "count" : 4
+        }]
+      },{
+        "name" : "struct",
+        "count" : 6,
+        "TYPE_ID" : [0,0,0,1,0,1],
+        "OFFSET" : [0,1,2,0,3,1],
+        "children" : [{
+          "name" : "absent",
+          "count" : 4
+        },{
+          "name" : "struct",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "children" : [{
+            "name" : "a",
+            "count" : 2,
+            "TYPE_ID" : [0,1],
+            "OFFSET" : [0,0],
+            "children" : [{
+              "name" : "i64",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : ["1"]
+            },{
+              "name" : "bool",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [1]
+            }]
+          },{
+            "name" : "b",
+            "count" : 2,
+            "TYPE_ID" : [0,1],
+            "OFFSET" : [0,0],
+            "children" : [{
+              "name" : "utf8",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "OFFSET" : [0,1],
+              "DATA" : ["b"]
+            },{
+              "name" : "absent",
+              "count" : 1
+            }]
+          },{
+            "name" : "c",
+            "count" : 2,
+            "TYPE_ID" : [0,1],
+            "OFFSET" : [0,0],
+            "children" : [{
+              "name" : "absent",
+              "count" : 1
+            },{
+              "name" : "utf8",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "OFFSET" : [0,1],
+              "DATA" : ["c"]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/t1-diff/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/t1-diff/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/t1-diff/leaf-c316d5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/t1-diff/leaf-c316d5.arrow.json
@@ -1,0 +1,445 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "xt$iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$doc",
+      "nullable" : false,
+      "type" : {
+        "name" : "struct"
+      },
+      "children" : [{
+        "name" : "xt$id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        },{
+          "name" : "keyword",
+          "nullable" : false,
+          "type" : {
+            "name" : "KeywordType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "xt/clj-keyword",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        },{
+          "name" : "i64",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 64,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "list",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "list",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "$data$",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "f64",
+              "nullable" : false,
+              "type" : {
+                "name" : "floatingpoint",
+                "precision" : "DOUBLE"
+              },
+              "children" : [ ]
+            },{
+              "name" : "utf8",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "timestamp-tz-micro-utc",
+              "nullable" : false,
+              "type" : {
+                "name" : "timestamp",
+                "unit" : "MICROSECOND",
+                "timezone" : "UTC"
+              },
+              "children" : [ ]
+            },{
+              "name" : "bool",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          }]
+        },{
+          "name" : "absent",
+          "nullable" : false,
+          "type" : {
+            "name" : "AbsentType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "absent",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        }]
+      },{
+        "name" : "struct",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "absent",
+          "nullable" : false,
+          "type" : {
+            "name" : "AbsentType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "absent",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        },{
+          "name" : "struct",
+          "nullable" : false,
+          "type" : {
+            "name" : "struct"
+          },
+          "children" : [{
+            "name" : "a",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "i64",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bool",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          },{
+            "name" : "b",
+            "nullable" : false,
+            "type" : {
+              "name" : "union",
+              "mode" : "Dense",
+              "typeIds" : [ ]
+            },
+            "children" : [{
+              "name" : "utf8",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "struct",
+              "nullable" : false,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "c",
+                "nullable" : false,
+                "type" : {
+                  "name" : "union",
+                  "mode" : "Dense",
+                  "typeIds" : [ ]
+                },
+                "children" : [{
+                  "name" : "utf8",
+                  "nullable" : false,
+                  "type" : {
+                    "name" : "utf8"
+                  },
+                  "children" : [ ]
+                }]
+              },{
+                "name" : "d",
+                "nullable" : false,
+                "type" : {
+                  "name" : "union",
+                  "mode" : "Dense",
+                  "typeIds" : [ ]
+                },
+                "children" : [{
+                  "name" : "utf8",
+                  "nullable" : false,
+                  "type" : {
+                    "name" : "utf8"
+                  },
+                  "children" : [ ]
+                }]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 6,
+    "columns" : [{
+      "name" : "xt$iid",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["47a6245d9effb01c6b67db10b5d9aaa8","55bfc78e47207dc5125af00a5f52d66c","64b0cf833d08d23b08185c18bb7a0ef2","d9c7fae2a04e047164936265ba33cf80","f4f7e2b0aae952281ff649b14ba5a6dc","fbfa9e45ee9bd2f827b8dde9e41d3814"]
+    },{
+      "name" : "xt$valid_from",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : [1577836800000000,1577923200000000,1577836800000000,1577836800000000,1577836800000000,1577923200000000]
+    },{
+      "name" : "xt$valid_to",
+      "count" : 6,
+      "VALIDITY" : [0,0,0,0,0,0],
+      "DATA" : [0,0,0,0,0,0]
+    },{
+      "name" : "xt$system_from",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : [1577836800000000,1577923200000000,1577836800000000,1577836800000000,1577836800000000,1577923200000000]
+    },{
+      "name" : "xt$system_to",
+      "count" : 6,
+      "VALIDITY" : [0,0,0,0,0,0],
+      "DATA" : [0,0,0,0,0,0]
+    },{
+      "name" : "xt$doc",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "children" : [{
+        "name" : "xt$id",
+        "count" : 6,
+        "TYPE_ID" : [0,2,2,0,1,1],
+        "OFFSET" : [0,0,1,1,0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,3,6],
+          "DATA" : ["baz","foo"]
+        },{
+          "name" : "keyword",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,3,7],
+          "DATA" : ["bar","quux"]
+        },{
+          "name" : "i64",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "DATA" : ["52","24"]
+        }]
+      },{
+        "name" : "list",
+        "count" : 6,
+        "TYPE_ID" : [0,1,1,0,1,1],
+        "OFFSET" : [0,0,1,1,2,3],
+        "children" : [{
+          "name" : "list",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,2,4],
+          "children" : [{
+            "name" : "$data$",
+            "count" : 4,
+            "TYPE_ID" : [2,3,0,1],
+            "OFFSET" : [0,0,0,0],
+            "children" : [{
+              "name" : "f64",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [12.0]
+            },{
+              "name" : "utf8",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "OFFSET" : [0,3],
+              "DATA" : ["foo"]
+            },{
+              "name" : "timestamp-tz-micro-utc",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [1577836800000000]
+            },{
+              "name" : "bool",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [0]
+            }]
+          }]
+        },{
+          "name" : "absent",
+          "count" : 4
+        }]
+      },{
+        "name" : "struct",
+        "count" : 6,
+        "TYPE_ID" : [0,0,0,0,1,1],
+        "OFFSET" : [0,1,2,3,0,1],
+        "children" : [{
+          "name" : "absent",
+          "count" : 4
+        },{
+          "name" : "struct",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "children" : [{
+            "name" : "a",
+            "count" : 2,
+            "TYPE_ID" : [0,1],
+            "OFFSET" : [0,0],
+            "children" : [{
+              "name" : "i64",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : ["1"]
+            },{
+              "name" : "bool",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "DATA" : [1]
+            }]
+          },{
+            "name" : "b",
+            "count" : 2,
+            "TYPE_ID" : [0,1],
+            "OFFSET" : [0,0],
+            "children" : [{
+              "name" : "utf8",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "OFFSET" : [0,1],
+              "DATA" : ["b"]
+            },{
+              "name" : "struct",
+              "count" : 1,
+              "VALIDITY" : [1],
+              "children" : [{
+                "name" : "c",
+                "count" : 1,
+                "TYPE_ID" : [0],
+                "OFFSET" : [0],
+                "children" : [{
+                  "name" : "utf8",
+                  "count" : 1,
+                  "VALIDITY" : [1],
+                  "OFFSET" : [0,1],
+                  "DATA" : ["c"]
+                }]
+              },{
+                "name" : "d",
+                "count" : 1,
+                "TYPE_ID" : [0],
+                "OFFSET" : [0],
+                "children" : [{
+                  "name" : "utf8",
+                  "count" : 1,
+                  "VALIDITY" : [1],
+                  "OFFSET" : [0,1],
+                  "DATA" : ["d"]
+                }]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/t1-diff/trie-c316d5.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/t1-diff/trie-c316d5.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/t1-diff/leaf-c3199a.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/t1-diff/leaf-c3199a.arrow.json
@@ -1,0 +1,163 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "xt$iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$valid_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_from",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$system_to",
+      "nullable" : true,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "xt$doc",
+      "nullable" : false,
+      "type" : {
+        "name" : "struct"
+      },
+      "children" : [{
+        "name" : "xt$id",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "month",
+        "nullable" : false,
+        "type" : {
+          "name" : "union",
+          "mode" : "Dense",
+          "typeIds" : [ ]
+        },
+        "children" : [{
+          "name" : "absent",
+          "nullable" : false,
+          "type" : {
+            "name" : "AbsentType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "absent",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        },{
+          "name" : "utf8",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 2,
+    "columns" : [{
+      "name" : "xt$iid",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : ["9e3f856e68998313827ff18dd4d88e78","d9c7fae2a04e047164936265ba33cf80"]
+    },{
+      "name" : "xt$valid_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1585699200000000,1577836800000000]
+    },{
+      "name" : "xt$valid_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$system_from",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : [1578009600000000,1577836800000000]
+    },{
+      "name" : "xt$system_to",
+      "count" : 2,
+      "VALIDITY" : [0,0],
+      "DATA" : [0,0]
+    },{
+      "name" : "xt$doc",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "children" : [{
+        "name" : "xt$id",
+        "count" : 2,
+        "TYPE_ID" : [0,0],
+        "OFFSET" : [0,1],
+        "children" : [{
+          "name" : "utf8",
+          "count" : 2,
+          "VALIDITY" : [1,1],
+          "OFFSET" : [0,3,6],
+          "DATA" : ["bar","foo"]
+        }]
+      },{
+        "name" : "month",
+        "count" : 2,
+        "TYPE_ID" : [1,0],
+        "OFFSET" : [0,0],
+        "children" : [{
+          "name" : "absent",
+          "count" : 1
+        },{
+          "name" : "utf8",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,5],
+          "DATA" : ["april"]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/t1-diff/trie-c3199a.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/t1-diff/trie-c3199a.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}


### PR DESCRIPTION
First part of #2573 - not complete as yet but wanted to get some eyes on it, get it merged (mainly to avoid conflicts in the indexer) and start working on reading the files in scan (#2574).

* Add `HashTrie` interface, implemented by in-memory and Arrow-backed concretions
* Create `xtdb.indexer.live-index` (similar to live-chunk) which maintains an in-flight tx, commits, and finishes a chunk of the T1 trie
* Wire live-index into the indexer - not read yet

Notes:

* The trie itself doesn't know anything about content, it only stores ints - assumed to be indices into another structure. This is so that we can write content to an append-only Arrow vector and not worry about needing to re-order it/mutate it in place/take copies of the content etc.
* The in-memory trie is an implementation of a 'hitchhiker' HAMT - leaf nodes additionally have an unsorted log to take into account as well as their sorted data. 
  * This is implemented in Java as it makes a lot of use of primitive ints, int-arrays, `IntStream`s, etc.
  * It's a persistent data structure - all fields are immutable, and `add` returns a new trie.
  * Because the trie doesn't know anything about the content, the in-memory trie requires a helper that'll compare two indices, and give it the bucket index for a given index at a given trie level.
  * The log is only at the leaf level in our trie (compared to the Hitchhiker trie talk which puts logs at every level) - this is because it's much easier to resolve the diff if it's only one data array and one log (rather than needing to go all the way back up the trie), and also because we benefit from the hash trie - it's much less effort for us to know exactly which leaf a value belongs in, rather than a B-trie whose structure changes on rebalance.
* This brings the minimum Java version for XTDB v2 to 17 - if we're going to write Java, let's at least write _modern_ Java :slightly_smiling_face: 

Next up:

* Add support for more tries: at the moment we just overwrite the value in the T1 trie - we'll need to find the existing value and add corresponding entries into T2-T4.
* To do this, we probably might as well get TPC-H working in scan - this will be a simpler read of these tries than's required for the full ingest