### PR TITLE
Ensure cleanup-checkpoint on checkpoint stores deletes the checkpoint metadata

### DIFF
--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -203,6 +203,7 @@
   (cleanup-checkpoint [_ {:keys [tx cp-at]}]
     (let [cp-prefix (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))
           to-path (io/file (.toString root-path) cp-prefix)]
+      (xio/delete-file (str to-path ".edn"))
       (xio/delete-dir to-path))))
 
 (defn ->filesystem-checkpoint-store {::sys/args {:path {:spec ::sys/path, :required? true}}} [{:keys [path]}]

--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -84,6 +84,11 @@
     (when (.exists dir)
       (Files/walkFileTree (.toPath dir) file-deletion-visitor))))
 
+(defn delete-file [file]
+  (let [file (io/file file)]
+    (when (.exists file)
+      (.delete file))))
+
 (defn create-tmpdir ^java.io.File [dir-name]
   (let [f (.toFile (Files/createTempDirectory dir-name (make-array FileAttribute 0)))
         known-files (swap! files-to-delete conj f)]

--- a/modules/s3/src/xtdb/s3/checkpoint.clj
+++ b/modules/s3/src/xtdb/s3/checkpoint.clj
@@ -75,15 +75,20 @@
                                                                ::cp/checkpoint-at cp-at}))})
         cp)))
 
-  (cleanup-checkpoint [this  {:keys [tx cp-at]}]
-    (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))
-          files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
-                  (keep (fn [[type arg]]
-                          (when (= type :object)
-                            arg)) $)
-                  (vec $)
-                  (conj $ s3-dir))]
-      (s3/delete-objects this files)))
+  (cleanup-checkpoint [this {:keys [tx cp-at]}]
+    (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+
+      ;; Delete EDN file first
+      (s3/delete-objects this [(str s3-dir ".edn")])
+
+      ;; List & delete directory contents
+      (let [files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
+                    (keep (fn [[type arg]]
+                            (when (= type :object)
+                              arg)) $)
+                    (vec $)
+                    (conj $ s3-dir))]
+        (s3/delete-objects this files))))
 
   Closeable
   (close [_]

--- a/modules/s3/src/xtdb/s3/checkpoint_transfer_manager.clj
+++ b/modules/s3/src/xtdb/s3/checkpoint_transfer_manager.clj
@@ -114,14 +114,19 @@
         cp)))
   
   (cleanup-checkpoint [this {:keys [tx cp-at]}]
-                      (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))
-                            files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
-                                    (keep (fn [[type arg]]
-                                            (when (= type :object)
-                                              arg)) $)
-                                    (vec $)
-                                    (conj $ s3-dir))]
-                        (s3/delete-objects this files)))
+    (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+
+      ;; Delete EDN file first
+      (s3/delete-objects this [(str s3-dir ".edn")])
+
+      ;; List & delete directory contents
+      (let [files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
+                      (keep (fn [[type arg]]
+                              (when (= type :object)
+                                arg)) $)
+                      (vec $)
+                      (conj $ s3-dir))]
+          (s3/delete-objects this files))))
 
   Closeable
   (close [_]

--- a/modules/s3/src/xtdb/s3/checkpoint_transfer_manager.clj
+++ b/modules/s3/src/xtdb/s3/checkpoint_transfer_manager.clj
@@ -112,6 +112,16 @@
                                                                ::s3-dir (str s3-dir "/")
                                                                ::cp/checkpoint-at cp-at}))})
         cp)))
+  
+  (cleanup-checkpoint [this {:keys [tx cp-at]}]
+                      (let [s3-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))
+                            files (as-> (s3/list-objects this {:path s3-dir :recursive? true}) $
+                                    (keep (fn [[type arg]]
+                                            (when (= type :object)
+                                              arg)) $)
+                                    (vec $)
+                                    (conj $ s3-dir))]
+                        (s3/delete-objects this files)))
 
   Closeable
   (close [_]

--- a/modules/s3/test/xtdb/s3/checkpoint_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_test.clj
@@ -51,3 +51,36 @@
           (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
                                            :cp-at cp-at})
           (t/is (empty? (s3/list-objects cp-store {}))))))))
+
+(t/deftest test-checkpoint-store-failed-cleanup
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3c/->cp-store
+                                                :configurator `s3t/->configurator
+                                                :bucket s3t/test-s3-bucket
+                                                :prefix (str "s3-cp-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::s3c/s3-dir] :as res} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                               :tx {::xt/tx-id 1}
+                                                                               :cp-at cp-at})]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [object-info (into {} (s3/list-objects cp-store {}))]
+            (t/is (= s3-dir (:common-prefix object-info)))
+            (t/is (= (string/replace s3-dir #"/" ".edn")
+                     (:object object-info)))))
+
+        (t/testing "error in `cleanup-checkpoints` after deleting checkpoint metadata file still leads to checkpoint not being available"
+          (with-redefs [s3/list-objects (fn [_ _] (throw (Exception. "Test Exception")))]
+            (t/is (thrown-with-msg? Exception
+                                    #"Test Exception"
+                                    (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                                                     :cp-at cp-at}))))
+          ;; Only directory should be available - checkpoint metadata file should have been deleted
+          (t/is (= [[:common-prefix s3-dir]]
+                   (vec (s3/list-objects cp-store {}))))
+          ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
+          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))

--- a/modules/s3/test/xtdb/s3/checkpoint_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_test.clj
@@ -1,16 +1,22 @@
 (ns xtdb.s3.checkpoint-test
-  (:require [clojure.test :as t]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.checkpoint :as cp]
+            [xtdb.fixtures :as fix]
             [xtdb.fixtures.checkpoint-store :as fix.cp-store]
+            [xtdb.s3 :as s3]
             [xtdb.s3-test :as s3t]
             [xtdb.s3.checkpoint :as s3c]
-            [xtdb.s3.checkpoint-transfer-manager :as s3ctm]
             [xtdb.system :as sys])
   (:import xtdb.s3.S3Configurator
            java.util.UUID
+           java.util.Date
            software.amazon.awssdk.regions.Region
            software.amazon.awssdk.services.s3.S3AsyncClient))
 
-(t/use-fixtures :once s3t/with-s3-client)
+(t/use-fixtures :each s3t/with-s3-client)
 
 (t/deftest test-checkpoint-store
   (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3c/->cp-store
@@ -19,3 +25,29 @@
                                                 :prefix (str "s3-cp-" (UUID/randomUUID))}})
                       (sys/start-system))]
     (fix.cp-store/test-checkpoint-store (:store sys))))
+
+(t/deftest test-checkpoint-store-cleanup
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3c/->cp-store
+                                                :configurator `s3t/->configurator
+                                                :bucket s3t/test-s3-bucket
+                                                :prefix (str "s3-cp-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::s3c/s3-dir] :as res} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                               :tx {::xt/tx-id 1}
+                                                                               :cp-at cp-at})]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [object-info (into {} (s3/list-objects cp-store {}))]
+            (t/is (= s3-dir (:common-prefix object-info)))
+            (t/is (= (string/replace s3-dir #"/" ".edn")
+                     (:object object-info)))))
+
+        (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (s3/list-objects cp-store {}))))))))

--- a/modules/s3/test/xtdb/s3/checkpoint_transfer_manager_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_transfer_manager_test.clj
@@ -1,12 +1,18 @@
 (ns xtdb.s3.checkpoint-transfer-manager-test
-  (:require [clojure.test :as t]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.checkpoint :as cp]
+            [xtdb.fixtures :as fix]
             [xtdb.fixtures.checkpoint-store :as fix.cp-store]
+            [xtdb.s3 :as s3]
             [xtdb.s3-test :as s3t]
-            [xtdb.s3.checkpoint :as s3c]
             [xtdb.s3.checkpoint-transfer-manager :as s3ctm]
             [xtdb.system :as sys])
   (:import xtdb.s3.S3Configurator
            java.util.UUID
+           java.util.Date
            software.amazon.awssdk.regions.Region
            software.amazon.awssdk.services.s3.S3AsyncClient))
 
@@ -20,7 +26,7 @@
       (binding [*crt-client* (.build builder)]
         (f)))))
 
-(t/use-fixtures :once with-s3-crt-client)
+(t/use-fixtures :each with-s3-crt-client)
 
 (defn ->crt-configurator [_]
   (reify S3Configurator
@@ -34,3 +40,30 @@
                                                 :prefix (str "s3-cp-" (UUID/randomUUID))}})
                       (sys/start-system))]
     (fix.cp-store/test-checkpoint-store (:store sys))))
+
+(t/deftest test-checkpoint-store-cleanup
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3ctm/->cp-store
+                                                :configurator `->crt-configurator
+                                                :bucket s3t/test-s3-bucket
+                                                :transfer-manager? true
+                                                :prefix (str "s3-cp-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::s3ctm/s3-dir] :as res} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                                 :tx {::xt/tx-id 1}
+                                                                                 :cp-at cp-at})]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [object-info (into {} (s3/list-objects cp-store {}))]
+            (t/is (= s3-dir (:common-prefix object-info)))
+            (t/is (= (string/replace s3-dir #"/" ".edn")
+                     (:object object-info)))))
+
+        (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (s3/list-objects cp-store {}))))))))

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -165,7 +165,7 @@
                 _ (bus/->bus-stop {:bus bus})]
       (with-redefs [xtdb.checkpoint/sync-path @#'fix.cp-store/sync-path-throw]
         (let [store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)})]
-          (t/testing "no leftovers after failed checkpoint"
+          (t/testing "no leftovers (of what _was_ uploaded) after failed checkpoint - this doesn't include the temp EDN file as we fail prior to that"
             (t/is (thrown-with-msg?
                    Exception #"broken!"
                    (cp/checkpoint {::cp/cp-format ::foo-format
@@ -182,3 +182,25 @@
                                                       (pr-str {:msg "Hello world!", :tx-id tx-id}))
                                                 {:tx {::xt/tx-id tx-id}}))))})))
             (t/is (= 0 (.count (java.nio.file.Files/list (.toPath cp-store-dir)))))))))))
+
+(t/deftest test-fs-checkpoint-store-cleanup
+  (fix/with-tmp-dirs #{cp-store-dir dir}
+    (let [cp-store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)})
+          cp-at (Date.)]
+      
+      ;; create file for upload
+      (spit (io/file dir "hello.txt") "Hello world")
+      
+      (let [{:keys [::cp/cp-uri]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                      :tx {::xt/tx-id 1}
+                                                                      :cp-at cp-at})]
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (t/is (.exists (io/file cp-uri)))
+          (t/is (.exists (io/file (str cp-uri ".edn")))))
+        
+        (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (= false (.exists (io/file cp-uri))))
+          (t/is (= false (.exists (io/file (str cp-uri ".edn"))))))))))
+


### PR DESCRIPTION
Resolves #2593 

Within this PR:
- Ensure `cleanup-checkpoint` on the filesystem checkpoint store deletes everything (including the metadata file), add test for this.
- Test that the s3 checkpoint store deletes all files on `cleanup-checkpoint`:
  - Ensure we explicitly call to delete the metadata file first. 
- Add `cleanup-checkpoint` to s3 transfer manager, test behaviour:
  - Similar to it's implementation of `available-checkpoints` - this is copied from the s3 checkpoint store. 