### PR TITLE
Updates to the Azure Blobs module

### DIFF
--- a/docs/administration/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/administration/modules/ROOT/pages/checkpointing.adoc
@@ -12,6 +12,7 @@ The checkpoint store is a pluggable module - there are a number of officially su
 - Java's NIO FileSystem (below)
 - AWS's xref:{page-component-version}@storage::aws-s3.adoc#checkpoint-store[S3]
 - GCP's xref:{page-component-version}@storage::google-cloud-storage.adoc#checkpoint-store[Cloud Storage]
+- Azure's xref:{page-component-version}@storage::azure-blobs.adoc#checkpoint-store[Blob Storage]
 
 XTDB nodes in a cluster don't explicitly communicate regarding which one is responsible for creating a checkpoint - instead, they check at random intervals to see whether any other node has recently created a checkpoint, and create one if necessary.
 The desired frequency of checkpoints can be set using `approx-frequency`.

--- a/docs/storage/modules/ROOT/pages/azure-blobs.adoc
+++ b/docs/storage/modules/ROOT/pages/azure-blobs.adoc
@@ -1,9 +1,28 @@
 = Azure Blobs
 :page-aliases: reference::azure-blobs.adoc
 
-You can use Azure's Blob Storage as XTDB's 'document store'.
+You can use Azure's Blob Storage as either: 
+
+* XTDB's 'document store'
+* An implementation of the XTDB query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].
 
 Documents are serialized via https://github.com/ptaoussanis/nippy[Nippy].
+
+In both cases, you will require both a `Storage Account`, and a `Container` to store their respective files. See the relevant Azure Blobs Quickstart[Quickstart documentation] from the Azure docs. 
+
+== Authentication 
+
+Authentication for both the document store and checkpoint store components within the module is handled via the https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable[**DefaultAzureCredential**] class - you will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules.
+
+Whichever method of Authentication you use, ensure that they at least have the permissions to:
+
+* Read blobs from a container
+* Write blobs to a container
+
+If using the **checkpoint store**, you will need the following permissions in addition to the above:
+
+* List blobs from a container
+* Delete blobs from a container
 
 == Project Dependency
 
@@ -30,7 +49,7 @@ pom.xml::
 ----
 ====
 
-== Using Azure Blobs
+== Using Azure Blobs as a document store
 
 Replace the implementation of the document store with `+xtdb.azure.blobs/->document-store+`
 
@@ -43,9 +62,9 @@ JSON::
 {
   "xtdb/document-store": {
     "xtdb/module": "xtdb.azure.blobs/->document-store",
-    "sas-token": "your-sas-token",
     "storage-account": "your-storage-account",
-    "container": "your-container-name"
+    "container": "your-container-name",
+    "prefix": "optional-containing-folder"
   },
 }
 ----
@@ -55,9 +74,9 @@ Clojure::
 [source,clojure]
 ----
 {:xtdb/document-store {:xtdb/module 'xtdb.azure.blobs/->document-store
-                       :sas-token "your-sas-token"
                        :storage-account "your-storage-account"
-                       :container "your-container-name"}}
+                       :container "your-container-name",
+                       :prefix "optional-containing-folder" }}
 ----
 
 EDN::
@@ -65,26 +84,38 @@ EDN::
 [source,clojure]
 ----
 {:xtdb/document-store {:xtdb/module xtdb.azure.blobs/->document-store
-                       :sas-token "your-sas-token"
                        :storage-account "your-storage-account"
-                       :container "your-container-name"}}
+                       :container "your-container-name",
+                       :prefix "optional-containing-folder" }}
 ----
 ====
 
-You'll need to create a `Storage Account`, then a `Container` for storing the documents.
+=== Parameters
 
-Then you need to create a SAS token for the Storage Account via the https://portal.azure.com[Azure portal].
-
-* Under `Storage Account`, go to `Settings`.
-* Then click `Shared access signature`.
-* Create a new SAS token with `Allowed services`: `Blob`, `Allowed resources types`: `Container` and `Object`.
-  You can select all allowed permissions.
-* Select needed `Start and expiry date/time`, `Allowed IP addresses` if applicable and `HTTPS only`.
-  Leave the rest of the options as-is.
-
-== Parameters
-
-* `sas-token` (string, required): 'shared access signature' for your chosen container.
-* `storage-account` (string, required)
-* `container` (string, required)
+* `storage-account` (string, required) - Storage account name that the document store container lives under 
+* `container` (string, required) - The container which the documents will be stored within
+* `prefix` (string, optional) - An optional prefix/folder name which will be used within document names (ie, could create a subfolder on a container called 'xtdb-document-store', and all of the document store files will be located under the folder)
 * `cache-size` (int): size of in-memory document cache (number of entries, not bytes)
+
+[#checkpoint-store]
+== Using Azure Blobs as a checkpoint store
+
+Azure blobs can be used as a query index **checkpoint store**. For more advice/config around the checkpointing itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
+
+[source,clojure]
+----
+;; under :xtdb/index-store -> :kv-store -> :checkpointer
+;; see the Checkpointing guide for other parameters
+{:checkpointer {...
+                :store {:xtdb/module 'xtdb.azure.blobs/->cp-store
+                        :storage-account "..."
+                        :container "..."
+                        :prefix "..." 
+                 ...}}
+----
+
+=== Parameters
+
+* `storage-account` (string, required) - Storage account name that the checkpoint store container lives under 
+* `container` (string, required) - The container which the checkpoints will be stored within
+* `prefix` (string, optional) - An optional prefix/folder name which will be used within checkpoint names (ie, could create a subfolder on a container called 'xtdb-checkpoints', and all of the checkpoint files will be located under the folder)

--- a/modules/azure-blobs/project.clj
+++ b/modules/azure-blobs/project.clj
@@ -14,7 +14,19 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
-                 [pro.juxt.clojars-mirrors.clj-http/clj-http "3.12.2"]]
+                 [com.azure/azure-storage-blob "12.22.0"]
+                 [com.azure/azure-identity "1.9.0"
+                  :exclusions [net.minidev/json-smart
+                               com.nimbusds/lang-tag]]
+
+                 ;; remove misc dependency warnings
+                 [com.azure/azure-core "1.39.0"]
+                 [com.azure/azure-core-http-netty "1.13.3"]
+                 [net.java.dev.jna/jna "5.13.0"]
+                 [net.java.dev.jna/jna-platform "5.13.0"]
+                 [io.netty/netty-transport "4.1.89.Final"]
+                 [net.minidev/json-smart "2.4.10"]
+                 [com.nimbusds/lang-tag "1.4.3"]]
 
   :profiles {:test {:dependencies [[com.xtdb/xtdb-test]]}}
 

--- a/modules/azure-blobs/src/xtdb/azure/blobs.clj
+++ b/modules/azure-blobs/src/xtdb/azure/blobs.clj
@@ -1,64 +1,95 @@
 (ns xtdb.azure.blobs
-  (:require [juxt.clojars-mirrors.clj-http.v3v12v2.clj-http.client :as http]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
             [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
             [xtdb.db :as db]
             [xtdb.io :as xio]
             [xtdb.system :as sys]
-            [xtdb.document-store :as ds]))
+            [xtdb.document-store :as ds])
+  (:import com.azure.core.util.BinaryData
+           [com.azure.storage.blob BlobServiceClientBuilder]
+           [com.azure.identity DefaultAzureCredentialBuilder]
+           [com.azure.storage.blob.models BlobStorageException ListBlobsOptions BlobItem]
+           [com.azure.storage.blob BlobContainerClient]))
 
-(defn- get-blob [sas-token storage-account container blob-name]
-  ;; TODO : ETag
+(defn- get-blob [{:keys [^BlobContainerClient blob-container-client]} blob-name]
   (try
-    (-> (format "https://%s.blob.core.windows.net/%s/%s?%s" storage-account container blob-name sas-token)
-        http/get
-        :body
-        ((fn [^String s] (.getBytes s))))
-    (catch Exception e
-      (if (= 404 (:status (ex-data e)))
+    (-> (.getBlobClient blob-container-client blob-name)
+        (.downloadContent)
+        (.toBytes))
+    (catch BlobStorageException e
+      (if (= 404 (.getStatusCode e))
         nil
         (throw e)))))
 
-(defn- put-blob [sas-token storage-account container blob-name blob-bytes]
-  ;; TODO ETag
-  (-> (format "https://%s.blob.core.windows.net/%s/%s?%s" storage-account container blob-name sas-token)
-      (http/put {:headers {"x-ms-blob-type" "BlockBlob"}
-                 :body blob-bytes})))
+(defn- put-blob 
+  ([opts blob-name blob-bytes]
+   (put-blob opts blob-name blob-bytes false))
+  ([{:keys [^BlobContainerClient blob-container-client]} blob-name blob-bytes overwrite?]
+   (try
+     (-> (.getBlobClient blob-container-client blob-name)
+         (.upload (BinaryData/fromBytes blob-bytes) overwrite?))
+     (catch BlobStorageException e
+       (if (= 409 (.getStatusCode e))
+         nil
+         (throw e))))))
 
-(defrecord AzureBlobsDocumentStore [sas-token storage-account container]
+(defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
+  (-> (.getBlobClient blob-container-client blob-name)
+      (.deleteIfExists)))
+
+(defn- list-blobs [^BlobContainerClient blob-container-client prefix obj-prefix]
+  (let [list-blob-opts (cond-> (ListBlobsOptions.)
+                         obj-prefix (.setPrefix obj-prefix))]
+    (->> (.listBlobs blob-container-client list-blob-opts nil)
+         (.iterator)
+         (iterator-seq)
+         (mapv (fn [^BlobItem blob-item]
+                 (subs (.getName blob-item) (count prefix)))))))
+(defrecord AzureBlobsDocumentStore [^BlobContainerClient blob-container-client prefix]
   db/DocumentStore
-  (submit-docs [_ docs]
+  (submit-docs [this docs]
     (->> (for [[id doc] docs]
            (future
-             (put-blob sas-token storage-account container
-                       (str id)
-                       (nippy/freeze doc))))
+             ;; Put blob - key set to prefix + id, blob is nippy compressed document, overwrite set to true
+             (put-blob this (str prefix id) (nippy/freeze doc) true)))
          vec
          (run! deref)))
 
-  (fetch-docs [_ docs]
+  (fetch-docs [this docs]
     (xio/with-nippy-thaw-all
       (reduce
-       #(if-let [doc (get-blob sas-token storage-account container (str %2))]
+       #(if-let [doc (get-blob this (str prefix %2))]
           (assoc %1 %2 (nippy/thaw doc))
           %1)
        {}
        docs))))
 
+(s/def ::prefix (s/and ::sys/string
+                       (s/conformer (fn [prefix]
+                                      (cond
+                                        (string/blank? prefix) ""
+                                        (string/ends-with? prefix "/") prefix
+                                        :else (str prefix "/"))))))
+
 (defn ->document-store {::sys/deps {:document-cache 'xtdb.cache/->cache}
-                        ::sys/args {:sas-token {:required? true
-                                                :spec ::sys/string
-                                                :doc "Azure Blob Storage SAS Token"}
-                                    :storage-account {:required? true
+                        ::sys/args {:storage-account {:required? true
                                                       :spec ::sys/string
                                                       :doc "Azure Storage Account Name"}
                                     :container {:required? true,
                                                 :spec ::sys/string
-                                                :doc "Azure Blob Storage Container"}}}
-  [{:keys [sas-token storage-account container document-cache] :as opts}]
-  (ds/->cached-document-store
-   (assoc opts
-          :document-cache document-cache
-          :document-store
-          (->AzureBlobsDocumentStore sas-token
-                                     storage-account
-                                     container))))
+                                                :doc "Azure Blob Storage Container"}
+                                    :prefix {:required? false
+                                             :spec ::prefix
+                                             :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb files will be located under a 'foo' directory)"}}}
+  [{:keys [storage-account container prefix document-cache] :as opts}]
+  (let [blob-service-client (cond-> (-> (BlobServiceClientBuilder.)
+                                        (.endpoint (str "https://" storage-account ".blob.core.windows.net"))
+                                        (.credential (.build (DefaultAzureCredentialBuilder.)))
+                                        (.buildClient)))
+        blob-client (.getBlobContainerClient blob-service-client container)]
+    (ds/->cached-document-store
+     (assoc opts
+            :document-cache document-cache
+            :document-store
+            (->AzureBlobsDocumentStore blob-client prefix)))))

--- a/modules/azure-blobs/src/xtdb/azure/blobs.clj
+++ b/modules/azure-blobs/src/xtdb/azure/blobs.clj
@@ -1,46 +1,59 @@
 (ns xtdb.azure.blobs
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.edn :as edn]
+            [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
+            [xtdb.checkpoint :as cp]
+            [xtdb.api :as xt]
             [xtdb.db :as db]
             [xtdb.io :as xio]
             [xtdb.system :as sys]
-            [xtdb.document-store :as ds])
+            [xtdb.document-store :as ds]
+            [clojure.java.io :as io])
   (:import com.azure.core.util.BinaryData
+           java.io.File
+           java.nio.file.Path
            [com.azure.storage.blob BlobServiceClientBuilder]
            [com.azure.identity DefaultAzureCredentialBuilder]
            [com.azure.storage.blob.models BlobStorageException ListBlobsOptions BlobItem]
            [com.azure.storage.blob BlobContainerClient]))
 
-(defn- get-blob [{:keys [^BlobContainerClient blob-container-client]} blob-name]
+(defn get-blob [{:keys [^BlobContainerClient blob-container-client prefix]} blob-name]
   (try
-    (-> (.getBlobClient blob-container-client blob-name)
-        (.downloadContent)
-        (.toBytes))
+    (-> (.getBlobClient blob-container-client (str prefix blob-name))
+        (.downloadContent))
     (catch BlobStorageException e
       (if (= 404 (.getStatusCode e))
         nil
         (throw e)))))
 
-(defn- put-blob 
-  ([opts blob-name blob-bytes]
-   (put-blob opts blob-name blob-bytes false))
-  ([{:keys [^BlobContainerClient blob-container-client]} blob-name blob-bytes overwrite?]
+(defn get-blob-to-file [{:keys [^BlobContainerClient blob-container-client prefix]} blob-name to-file]
+  (try
+    (-> (.getBlobClient blob-container-client (str prefix blob-name))
+        (.downloadToFile to-file))
+    (catch BlobStorageException e
+      (if (= 404 (.getStatusCode e))
+        nil
+        (throw e)))))
+
+(defn put-blob
+  ([this blob-name data]
+   (put-blob this blob-name data false))
+  ([{:keys [^BlobContainerClient blob-container-client prefix]} blob-name ^BinaryData data overwrite?]
    (try
-     (-> (.getBlobClient blob-container-client blob-name)
-         (.upload (BinaryData/fromBytes blob-bytes) overwrite?))
+     (-> (.getBlobClient blob-container-client (str prefix blob-name))
+         (.upload data overwrite?))
      (catch BlobStorageException e
        (if (= 409 (.getStatusCode e))
          nil
          (throw e))))))
 
-(defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
-  (-> (.getBlobClient blob-container-client blob-name)
+(defn delete-blob [{:keys [^BlobContainerClient blob-container-client prefix]} blob-name]
+  (-> (.getBlobClient blob-container-client (str prefix blob-name))
       (.deleteIfExists)))
 
-(defn- list-blobs [^BlobContainerClient blob-container-client prefix obj-prefix]
-  (let [list-blob-opts (cond-> (ListBlobsOptions.)
-                         obj-prefix (.setPrefix obj-prefix))]
+(defn list-blobs [{:keys [^BlobContainerClient blob-container-client prefix]} obj-prefix]
+  (let [list-blob-opts (.setPrefix (ListBlobsOptions.) (str prefix obj-prefix))]
     (->> (.listBlobs blob-container-client list-blob-opts nil)
          (.iterator)
          (iterator-seq)
@@ -51,19 +64,88 @@
   (submit-docs [this docs]
     (->> (for [[id doc] docs]
            (future
-             ;; Put blob - key set to prefix + id, blob is nippy compressed document, overwrite set to true
-             (put-blob this (str prefix id) (nippy/freeze doc) true)))
+             ;; Put blob - key set to id, blob is nippy compressed document 
+             ;; converted to BinaryData, overwrite? set to true
+             (put-blob this
+                       id
+                       (BinaryData/fromBytes (nippy/freeze doc))
+                       true)))
          vec
          (run! deref)))
 
   (fetch-docs [this docs]
     (xio/with-nippy-thaw-all
       (reduce
-       #(if-let [doc (get-blob this (str prefix %2))]
-          (assoc %1 %2 (nippy/thaw doc))
+       #(if-let [doc (get-blob this %2)]
+          (assoc %1 %2 (nippy/thaw (.toBytes doc)))
           %1)
        {}
        docs))))
+(defrecord AzureBlobsCheckpointStore [^BlobContainerClient blob-container-client prefix]
+  cp/CheckpointStore
+  (available-checkpoints [this {::cp/keys [cp-format]}]
+    (->> (list-blobs this "metadata-")
+         (sort-by (fn [path]
+                    (let [[_ tx-id checkpoint-at] (re-matches #"metadata-checkpoint-(\d+)-(.+).edn" path)]
+                      [(Long/parseLong tx-id) checkpoint-at]))
+                  #(compare %2 %1))
+         (keep (fn [cp-metadata-path]
+                 (let [resp (some-> (get-blob this cp-metadata-path)
+                                    (.toString)
+                                    (edn/read-string))]
+                   (when (= (::cp/cp-format resp) cp-format)
+                     resp))))))
+
+  (download-checkpoint [this {::keys [azure-dir] :as checkpoint} dir]
+    (when-not (empty? (.listFiles ^File dir))
+      (throw (IllegalArgumentException. (str "non-empty checkpoint restore dir: " dir))))
+
+    (let [azure-paths (list-blobs this azure-dir)
+          blob-files (->> azure-paths
+                          (mapv (fn [azure-path]
+                                  (let [output-file (io/file dir (subs azure-path (count azure-dir)))
+                                        _ (io/make-parents output-file)
+                                        blob-properties (get-blob-to-file this azure-path (str output-file))]
+                                    (when (.exists output-file)
+                                      [azure-path blob-properties]))))
+                          (into {}))]
+
+      (when-not (= (set (keys blob-files)) (set azure-paths))
+        (xio/delete-dir dir)
+        (throw (ex-info "incomplete checkpoint restore" {:expected azure-paths
+                                                         :actual (keys blob-files)})))
+      checkpoint))
+
+  (upload-checkpoint [this dir {:keys [tx cp-at ::cp/cp-format]}]
+    (let [dir-path (.toPath ^File dir)
+          azure-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+      
+      (->> (file-seq dir)
+           (mapv (fn [^File file]
+                   (when (.isFile file)
+                     (let [file-path (.toPath file)
+                           blob-name (str azure-dir "/" (.relativize dir-path (.toPath file)))]
+                       (put-blob this blob-name (BinaryData/fromFile file-path)))))))
+
+      (let [cp {::cp/cp-format cp-format,
+                :tx tx
+                ::azure-dir (str azure-dir "/")
+                ::cp/checkpoint-at cp-at}]
+        (put-blob this
+                  (str "metadata-" azure-dir ".edn")
+                  (BinaryData/fromString (pr-str cp)))
+        
+        cp)))
+
+  (cleanup-checkpoint [this {:keys [tx cp-at]}]
+    (let [azure-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+
+      ;; Delete EDN file first
+      (delete-blob this (str "metadata-" azure-dir ".edn"))
+
+      ;; List & delete directory contents
+      (let [files (list-blobs this azure-dir)]
+        (mapv #(delete-blob this %) files)))))
 
 (s/def ::prefix (s/and ::sys/string
                        (s/conformer (fn [prefix]
@@ -93,3 +175,20 @@
             :document-cache document-cache
             :document-store
             (->AzureBlobsDocumentStore blob-client prefix)))))
+
+(defn ->cp-store {::sys/args {:storage-account {:required? true
+                                                :spec ::sys/string
+                                                :doc "Azure Storage Account Name"}
+                              :container {:required? true,
+                                          :spec ::sys/string
+                                          :doc "Azure Blob Storage Container"}
+                              :prefix {:required? false
+                                       :spec ::prefix
+                                       :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb files will be located under a 'foo' directory)"}}}
+  [{:keys [storage-account container prefix]}]
+  (let [blob-service-client (cond-> (-> (BlobServiceClientBuilder.)
+                                        (.endpoint (str "https://" storage-account ".blob.core.windows.net"))
+                                        (.credential (.build (DefaultAzureCredentialBuilder.)))
+                                        (.buildClient)))
+        blob-client (.getBlobContainerClient blob-service-client container)]
+    (->AzureBlobsCheckpointStore blob-client prefix)))

--- a/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
+++ b/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
@@ -1,12 +1,19 @@
 (ns xtdb.azure.blobs-test
-  (:require [clojure.test :as t]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :as t]
             [clojure.tools.logging :as log]
+            [xtdb.api :as xt]
             [xtdb.azure.blobs :as azb]
+            [xtdb.checkpoint :as cp]
             [xtdb.codec :as c]
             [xtdb.db :as db]
+            [xtdb.fixtures :as fix]
+            [xtdb.fixtures.checkpoint-store :as fix.cp-store]
             [xtdb.fixtures.document-store :as fix.ds]
             [xtdb.system :as sys])
-   (:import java.util.UUID))
+   (:import java.util.UUID
+            java.util.Date))
 
 (def storage-account "xtdbazureobjectstoretest")
 (def container "xtdb-test")
@@ -62,3 +69,74 @@
 
           (t/is (= {uuid-key uuid-document}
                    (db/fetch-docs doc-store [uuid-key]))))))))
+
+(t/deftest test-checkpoint-store
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
+    (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `azb/->cp-store
+                                                  :storage-account storage-account
+                                                  :container container
+                                                  :prefix (str "test-checkpoint-" (UUID/randomUUID))}})
+                        (sys/start-system))]
+      (fix.cp-store/test-checkpoint-store (:store sys)))))
+
+(t/deftest test-checkpoint-store-cleanup
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `azb/->cp-store
+                                                :storage-account storage-account
+                                                :container container
+                                                :prefix (str "test-checkpoint-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::azb/azure-dir]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                          :tx {::xt/tx-id 1}
+                                                                          :cp-at cp-at})
+            metadata-file (string/replace (str "metadata-" azure-dir) #"/" ".edn")]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [blob-set (set (azb/list-blobs cp-store nil))]
+            (t/is (= 2 (count blob-set)))
+            (t/is (contains? blob-set metadata-file))
+            (t/is (contains? blob-set (str azure-dir "hello.txt")))))
+
+        (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (azb/list-blobs cp-store nil))))))))
+
+(t/deftest test-checkpoint-store-failed-cleanup
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `azb/->cp-store
+                                                :storage-account storage-account
+                                                :container container
+                                                :prefix (str "test-checkpoint-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::azb/azure-dir]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                          :tx {::xt/tx-id 1}
+                                                                          :cp-at cp-at})
+            metadata-file (string/replace (str "metadata-" azure-dir) #"/" ".edn")]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [blob-set (set (azb/list-blobs cp-store nil))]
+            (t/is (= 2 (count blob-set)))
+            (t/is (contains? blob-set metadata-file))
+            (t/is (contains? blob-set (str azure-dir "hello.txt")))))
+
+        (t/testing "error in `cleanup-checkpoints` after deleting checkpoint metadata file still leads to checkpoint not being available"
+          (with-redefs [azb/list-blobs (fn [_ _] (throw (Exception. "Test Exception")))]
+            (t/is (thrown-with-msg? Exception
+                                    #"Test Exception"
+                                    (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                                                     :cp-at cp-at}))))
+          ;; Only directory should be available - checkpoint metadata file should have been deleted
+          (t/is (= [(str azure-dir "hello.txt")]
+                   (azb/list-blobs cp-store nil)))
+          ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
+          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))

--- a/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
+++ b/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
@@ -1,9 +1,12 @@
 (ns xtdb.azure.blobs-test
-  (:require [xtdb.azure.blobs :as azb]
-            [clojure.test :as t]
+  (:require [clojure.test :as t]
             [clojure.tools.logging :as log]
+            [xtdb.azure.blobs :as azb]
+            [xtdb.codec :as c]
+            [xtdb.db :as db]
             [xtdb.fixtures.document-store :as fix.ds]
-            [xtdb.system :as sys]))
+            [xtdb.system :as sys])
+   (:import java.util.UUID))
 
 (def storage-account "xtdbazureobjectstoretest")
 (def container "xtdb-test")
@@ -21,3 +24,30 @@
                         (sys/start-system))]
 
       (fix.ds/test-doc-store (::azb/document-store sys)))))
+
+(t/deftest test-blobs-issue-2602
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
+    (with-open [sys (-> (sys/prep-system {::azb/document-store
+                                          {:storage-account storage-account
+                                           :container container}})
+                        (sys/start-system))]
+      (let [doc-store (::azb/document-store sys)
+            keyword-document {:xt/id :test-entity
+                              :name "test entity with keyword"}
+            keyword-key (c/new-id keyword-document)
+            uuid-document {:xt/id (UUID/randomUUID)
+                           :name "test entity with UUID"}
+            uuid-key (c/new-id uuid-document)]
+
+        (t/testing "can insert and fetch keyword id document"
+          (db/submit-docs doc-store {keyword-key keyword-document})
+
+          (t/is (= {keyword-key keyword-document}
+                   (db/fetch-docs doc-store [keyword-key]))))
+
+        (t/testing "can insert and fetch UUID document"
+          (db/submit-docs doc-store {uuid-key uuid-document})
+
+          (t/is (= {uuid-key uuid-document}
+                   (db/fetch-docs doc-store [uuid-key]))))))))

--- a/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
+++ b/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
@@ -1,28 +1,23 @@
 (ns xtdb.azure.blobs-test
   (:require [xtdb.azure.blobs :as azb]
             [clojure.test :as t]
+            [clojure.tools.logging :as log]
             [xtdb.fixtures.document-store :as fix.ds]
             [xtdb.system :as sys]))
 
-(def test-azure-blobs-sas-token
-  (System/getenv "XTDB_AZURE_BLOBS_TEST_SAS_TOKEN"))
-
-(def test-azure-blobs-storage-account
-  (or (System/getProperty "xtdb.azure.blobs.test-storage-account")
-      (System/getenv "XTDB_AZURE_BLOBS_TEST_STORAGE_ACCOUNT")))
-
-(def test-azure-blobs-container
-  (or (System/getProperty "xtdb.azure.blobs.test-container")
-      (System/getenv "XTDB_AZURE_BLOBS_TEST_CONTAINER")))
+(def storage-account "xtdbazureobjectstoretest")
+(def container "xtdb-test")
+(def config-present? (some? (and (System/getenv "AZURE_CLIENT_ID")
+                                 (System/getenv "AZURE_CLIENT_SECRET")
+                                 (System/getenv "AZURE_TENANT_ID")
+                                 (System/getenv "AZURE_SUBSCRIPTION_ID"))))
 
 (t/deftest test-blobs-doc-store
-  (when (and test-azure-blobs-sas-token
-             test-azure-blobs-storage-account
-             test-azure-blobs-container)
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
     (with-open [sys (-> (sys/prep-system {::azb/document-store
-                                          {:sas-token test-azure-blobs-sas-token
-                                           :storage-account test-azure-blobs-storage-account
-                                           :container test-azure-blobs-container}})
+                                          {:storage-account storage-account
+                                           :container container}})
                         (sys/start-system))]
 
       (fix.ds/test-doc-store (::azb/document-store sys)))))

--- a/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
+++ b/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
@@ -25,6 +25,17 @@
 
       (fix.ds/test-doc-store (::azb/document-store sys)))))
 
+(t/deftest test-blobs-doc-store-with-prefix
+  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
+  (when config-present?
+    (with-open [sys (-> (sys/prep-system {::azb/document-store
+                                          {:storage-account storage-account
+                                           :container container
+                                           :prefix (str "test-prefix-" (UUID/randomUUID))}})
+                        (sys/start-system))]
+
+      (fix.ds/test-doc-store (::azb/document-store sys)))))
+
 (t/deftest test-blobs-issue-2602
   (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
   (when config-present?


### PR DESCRIPTION
Fixes #2602 and resolves #2603.

- Re-implement the document store in terms of the Azure API
  - Using the default credential chain of said API
  - Essentially a port of core2 object store ported to v1 document stores.
- Explicitly test for #2602 - seems to work fine with the new document store.
- Implement and test a new implementation of `checkpoint-store` 
- Update docs for both the azure blobs document store and for the new checkpoint store
  - Point to Azure docs with regards to setting up and auth 