### PR TITLE
Add getObjectRange request to the object store protocol

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,8 @@ dependencies {
     testImplementation("cheshire", "cheshire", "5.11.0")
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.3.0")
     testImplementation("org.clojure", "test.check", "1.1.1")
+    // for AWS profiles (managing datasets)
+    devImplementation("software.amazon.awssdk", "sts", "2.16.76")
 }
 
 if (hasProperty("fin")) {

--- a/core/src/main/clojure/xtdb/object_store.clj
+++ b/core/src/main/clojure/xtdb/object_store.clj
@@ -5,6 +5,7 @@
             [clojure.spec.alpha :as s])
   (:import java.io.Closeable
            java.nio.ByteBuffer
+           (java.nio.channels FileChannel$MapMode)
            [java.nio.file CopyOption Files FileSystems FileVisitOption LinkOption OpenOption Path StandardOpenOption]
            [java.util.concurrent CompletableFuture ConcurrentSkipListMap Executors ExecutorService]
            java.util.function.Supplier
@@ -18,6 +19,15 @@
    "Asynchonously returns the given object in a ByteBuffer
     If the object doesn't exist, the CF completes with an IllegalStateException.")
 
+  (^java.util.concurrent.CompletableFuture #_<ByteBuffer> getObjectRange
+    [^String k ^long start ^long len]
+    "Asynchonously returns the given len bytes starting from start (inclusive) of the object in a ByteBuffer
+    If the object doesn't exist, the CF completes with an IllegalStateException.
+
+    Exceptions are thrown immediately if the start is negative, or the len is zero or below. This is
+    to ensure consistent boundary behaviour between different object store implementations. You should check for these conditions and deal with them
+    before calling getObjectRange.")
+
   (^java.util.concurrent.CompletableFuture #_<Path> getObject [^String k, ^java.nio.file.Path out-path]
    "Asynchronously writes the object to the given path.
     If the object doesn't exist, the CF completes with an IllegalStateException.")
@@ -26,6 +36,12 @@
   (^java.lang.Iterable #_<String> listObjects [])
   (^java.lang.Iterable #_<String> listObjects [^String dir])
   (^java.util.concurrent.CompletableFuture #_<?> deleteObject [^String k]))
+
+(defn ensure-shared-range-oob-behaviour [^long i ^long len]
+  (when (< i 0)
+    (throw (IndexOutOfBoundsException. "Negative range indexes are not permitted")))
+  (when (< len 1)
+    (throw (IllegalArgumentException. "Negative or zero range requests are not permitted"))))
 
 (defn obj-missing-exception [k]
   (IllegalStateException. (format "Object '%s' doesn't exist." k)))
@@ -50,6 +66,13 @@
                                                                                   StandardOpenOption/TRUNCATE_EXISTING}))]
              (.write ch buf)
              out-path))))))
+
+  (getObjectRange [_this k start len]
+    (ensure-shared-range-oob-behaviour start len)
+    (CompletableFuture/completedFuture
+      (let [^ByteBuffer buf (or (.get os k) (throw (obj-missing-exception k)))
+            new-pos (+ (.position buf) start)]
+        (.slice buf new-pos len))))
 
   (putObject [_this k buf]
     (.putIfAbsent os k (.slice buf))
@@ -78,6 +101,28 @@
 
 (derive ::memory-object-store :xtdb/object-store)
 
+(comment
+
+  (def mos
+    (->> (ig/prep-key ::memory-object-store {})
+         (ig/init-key ::memory-object-store)))
+
+  (.close mos)
+
+  @(.putObject mos "foo.txt" (ByteBuffer/wrap (.getBytes "hello, world!")))
+
+  (let [buf @(.getObject mos "foo.txt")
+        arr (byte-array (.remaining buf))]
+    (.get buf arr)
+    (String. arr))
+
+  (let [buf @(.getObjectRange mos "foo.txt" 2 5)
+        arr (byte-array (.remaining buf))]
+    (.get buf arr)
+    (String. arr))
+
+  )
+
 (deftype FileSystemObjectStore [^Path root-path, ^ExecutorService pool]
   ObjectStore
   (getObject [_this k]
@@ -87,6 +132,15 @@
          (throw (obj-missing-exception k)))
 
        (util/->mmap-path from-path))))
+
+  (getObjectRange [_this k start len]
+    (ensure-shared-range-oob-behaviour start len)
+    (CompletableFuture/completedFuture
+      (let [from-path (.resolve root-path k)]
+        (when-not (util/path-exists from-path)
+          (throw (obj-missing-exception k)))
+
+        (util/->mmap-path from-path FileChannel$MapMode/READ_ONLY start len))))
 
   (getObject [_this k out-path]
     (CompletableFuture/supplyAsync
@@ -152,3 +206,25 @@
 
 (defmethod ig/halt-key! ::file-system-object-store [_ ^FileSystemObjectStore os]
   (.close os))
+
+(comment
+
+  (def fos
+    (->> (ig/prep-key ::file-system-object-store {:root-path "tmp/fos"})
+         (ig/init-key ::file-system-object-store)))
+
+  (.close fos)
+
+  @(.putObject fos "foo.txt" (ByteBuffer/wrap (.getBytes "hello, world!")))
+
+  (let [buf @(.getObject fos "foo.txt")
+        arr (byte-array (.remaining buf))]
+    (.get buf arr)
+    (String. arr))
+
+  (let [buf @(.getObjectRange fos "foo.txt" 2 5)
+        arr (byte-array (.remaining buf))]
+    (.get buf arr)
+    (String. arr))
+
+  )

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -279,7 +279,12 @@
    (with-open [in (->file-channel path (if (= FileChannel$MapMode/READ_ONLY map-mode)
                                          #{:read}
                                          #{:read :write}))]
-     (.map in map-mode 0 (.size in)))))
+     (.map in map-mode 0 (.size in))))
+  (^java.nio.MappedByteBuffer [^Path path ^FileChannel$MapMode map-mode ^long start ^long len]
+   (with-open [in (->file-channel path (if (= FileChannel$MapMode/READ_ONLY map-mode)
+                                         #{:read}
+                                         #{:read :write}))]
+     (.map in map-mode start len))))
 
 (def ^:private file-deletion-visitor
   (proxy [SimpleFileVisitor] []

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -43,6 +43,17 @@
         blob-client (.getBlobContainerClient blob-service-client container)]
     (os/->AzureBlobObjectStore blob-client prefix)))
 
+(comment
+
+  (def os (->> (ig/prep-key ::blob-object-store {:storage-account "xtdbazureobjectstoretest"
+                                                 :container "xtdb-test"
+                                                 :prefix (str "xtdb.azure-test." (random-uuid))})
+               (ig/init-key ::blob-object-store)))
+
+  @(.getObject os "foo.txt")
+
+  )
+
 (s/def ::namespace string?)
 (s/def ::event-hub-name string?)
 (s/def ::create-event-hub? boolean?)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -1,13 +1,14 @@
 (ns xtdb.azure-test
-  (:require [clojure.test :as t]
+  (:require [clojure.java.shell :as sh]
+            [clojure.test :as t]
             [juxt.clojars-mirrors.integrant.core :as ig]
             [xtdb.api :as xt]
             [xtdb.azure :as azure]
             [xtdb.object-store-test :as os-test]
             [xtdb.node :as node]
-            [xtdb.test-util :as tu]
             [clojure.tools.logging :as log])
-  (:import java.util.UUID))
+  (:import java.util.UUID
+           (java.io Closeable)))
 
 (def resource-group-name "azure-modules-test")
 (def storage-account "xtdbazureobjectstoretest")
@@ -18,31 +19,48 @@
                                  (System/getenv "AZURE_TENANT_ID")
                                  (System/getenv "AZURE_SUBSCRIPTION_ID"))))
 
-(def ^:dynamic *obj-store*)
+(defn cli-available? []
+  (= 0 (:exit (sh/sh "az" "--help"))))
 
-(os-test/def-obj-store-tests ^:azure azure [f]
-  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
-  (when config-present?
-    (let [sys (-> {::azure/blob-object-store {:storage-account storage-account
-                                              :container container
-                                              :prefix (str "xtdb.azure-test." (UUID/randomUUID))}}
-                  ig/prep
-                  ig/init)]
-      (try
-        (binding [*obj-store* (::azure/blob-object-store sys)]
-          (f *obj-store*))
-        (finally
-          (ig/halt! sys))))))
+(defn logged-in? []
+  (= 0 (:exit (sh/sh "az" "account" "show"))))
+
+(defn run-if-auth-available [f]
+  (if (cli-available?)
+    (if (logged-in?)
+      (f)
+      (log/warn "azure cli appears to be available but you are not logged in, run `az login` before running the tests"))
+    (if config-present?
+      (f)
+      (log/warn "azure cli is unavailable and the auth env vars are not set: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID"))))
+
+(t/use-fixtures :once run-if-auth-available)
+
+(defn object-store ^Closeable [prefix]
+  (->> (ig/prep-key ::azure/blob-object-store {:storage-account storage-account
+                                               :container container
+                                               :prefix (str "xtdb.azure-test." prefix)})
+       (ig/init-key ::azure/blob-object-store)))
+
+(t/deftest ^:azure put-delete-test
+  (let [os (object-store (random-uuid))]
+    (os-test/test-put-delete os)))
+
+(t/deftest ^:azure range-test
+  (let [os (object-store (random-uuid))]
+    (os-test/test-range os)))
+
+(t/deftest ^:azure list-test
+  (let [os (object-store (random-uuid))]
+    (os-test/test-list-objects os)))
 
 (t/deftest ^:azure test-eventhub-log
-  (log/info "Azure config present (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID & AZURE_TENANT_ID set)? - " config-present?)
-  (when config-present?
-    (with-open [node (node/start-node {::azure/event-hub-log {:namespace eventhub-namespace
-                                                              :resource-group-name resource-group-name
-                                                              :event-hub-name (str "xtdb.azure-test-hub." (UUID/randomUUID))
-                                                              :create-event-hub? true
-                                                              :retention-period-in-days 1}})]
-      (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
-      (t/is (= [{:id :foo}]
-               (xt/q node '{:find [id]
-                            :where [($ :xt_docs [{:xt/id id}])]}))))))
+  (with-open [node (node/start-node {::azure/event-hub-log {:namespace eventhub-namespace
+                                                            :resource-group-name resource-group-name
+                                                            :event-hub-name (str "xtdb.azure-test-hub." (UUID/randomUUID))
+                                                            :create-event-hub? true
+                                                            :retention-period-in-days 1}})]
+    (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
+    (t/is (= [{:id :foo}]
+             (xt/q node '{:find [id]
+                          :where [($ :xt_docs [{:xt/id id}])]})))))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -1,36 +1,59 @@
 (ns xtdb.object-store-test
-  (:require [clojure.test :as t]
+  (:require [clojure.edn :as edn]
+            [clojure.test :as t]
             [xtdb.object-store :as os]
-            [xtdb.test-util :as tu]
             [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import xtdb.object_store.ObjectStore
            java.io.Closeable
            java.nio.ByteBuffer
            java.nio.charset.StandardCharsets
            java.nio.file.attribute.FileAttribute
-           java.nio.file.Files))
+           java.nio.file.Files
+           (clojure.lang IDeref)))
 
-(defn- get-object [^ObjectStore obj-store, k]
+(defn- get-edn [^ObjectStore obj-store, k]
   (-> (let [^ByteBuffer buf @(.getObject obj-store (name k))]
-        (read-string (str (.decode StandardCharsets/UTF_8 buf))))
+        (edn/read-string (str (.decode StandardCharsets/UTF_8 buf))))
       (util/rethrowing-cause)))
 
-(defn- put-object [^ObjectStore obj-store k obj]
+(defn- put-edn [^ObjectStore obj-store k obj]
   (let [^ByteBuffer buf (.encode StandardCharsets/UTF_8 (pr-str obj))]
     @(.putObject obj-store (name k) buf)))
 
-(defn ^::os-test test-put-delete [^ObjectStore obj-store]
+(defn put-bytes [^ObjectStore obj-store k bytes]
+  @(.putObject obj-store k (ByteBuffer/wrap bytes)))
+
+(defn byte-buf->bytes [^ByteBuffer buf]
+  (let [arr (byte-array (.remaining buf))
+        pos (.position buf)]
+    (.get buf arr)
+    (.position buf pos)
+    arr))
+
+(defn get-bytes [^ObjectStore obj-store k start len]
+  (byte-buf->bytes @(.getObjectRange obj-store k start len)))
+
+(defn- in-memory ^Closeable []
+  (->> (ig/prep-key ::os/memory-object-store {})
+       (ig/init-key ::os/memory-object-store)))
+
+(defn- fs ^Closeable [path]
+  (->> (ig/prep-key ::os/file-system-object-store {:root-path path, :pool-size 2})
+       (ig/init-key ::os/file-system-object-store)))
+
+(defn test-put-delete [^ObjectStore obj-store]
   (let [alice {:xt/id :alice, :name "Alice"}]
-    (put-object obj-store :alice alice)
+    (put-edn obj-store :alice alice)
 
-    (t/is (= alice (get-object obj-store :alice)))
+    (t/is (= alice (get-edn obj-store :alice)))
 
-    (t/is (thrown? IllegalStateException (get-object obj-store :bob)))
+    (t/is (thrown? IllegalStateException (get-edn obj-store :bob)))
 
     (t/testing "doesn't override if present"
-      (put-object obj-store :alice {:xt/id :alice, :name "Alice", :version 2})
-      (t/is (= alice (get-object obj-store :alice))))
+      (put-edn obj-store :alice {:xt/id :alice, :name "Alice", :version 2})
+      (t/is (= alice (get-edn obj-store :alice))))
 
     (let [temp-path @(.getObject obj-store (name :alice)
                                  (doto (Files/createTempFile "alice" ".edn"
@@ -40,34 +63,68 @@
 
     @(.deleteObject obj-store (name :alice))
 
-    (t/is (thrown? IllegalStateException (get-object obj-store :alice)))))
+    (t/is (thrown? IllegalStateException (get-edn obj-store :alice)))))
 
-(defn ^::os-test test-list-objects [^ObjectStore obj-store]
-  (put-object obj-store "bar/alice" :alice)
-  (put-object obj-store "foo/alan" :alan)
-  (put-object obj-store "bar/bob" :bob)
+(defn test-list-objects [^ObjectStore obj-store]
+  (put-edn obj-store "bar/alice" :alice)
+  (put-edn obj-store "foo/alan" :alan)
+  (put-edn obj-store "bar/bob" :bob)
 
   (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
   (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar"))))
 
-(def os-tests
-  (->> (ns-interns (create-ns 'xtdb.object-store-test))
-       (into {} (filter (comp ::os-test meta val)))))
+(defn test-range [^ObjectStore obj-store]
 
-(defmacro def-obj-store-tests [sym [binding] & body]
-  `(do
-     ~@(for [test-name (keys os-tests)]
-         `(t/deftest ~(-> (symbol (str sym "-" test-name))
-                          (with-meta (meta sym)))
-            (let [~binding (get os-tests '~test-name)]
-              ~@body)))
-     '~sym))
+  (put-bytes obj-store "digits" (byte-array (range 10)))
 
-(def-obj-store-tests in-mem [f]
-  (with-open [^Closeable os (ig/init-key ::os/memory-object-store {})]
-    (f os)))
+  (t/is (= [0] (vec (get-bytes obj-store "digits" 0 1))))
+  (t/is (= [4 5 6 7] (vec (get-bytes obj-store "digits" 4 4))))
+  (t/is (= [9] (vec (get-bytes obj-store "digits" 9 1))))
 
-(def-obj-store-tests fs [f]
-  (tu/with-tmp-dirs #{os-path}
-    (with-open [^Closeable os (ig/init-key ::os/file-system-object-store {:root-path os-path, :pool-size 2})]
-      (f os))))
+  ;; OOB behaviour is 'any exception', just whatever is thrown by impl
+  (->> "len 0 is not permitted due to potential ambiguities that arise in the bounds behaviour for len 0 across impls"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 0))))
+
+  (->> "OOB for negative index"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" -1 3))))
+
+  (->> "OOB for negative len"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1))))
+
+  (->> "OOB for last index"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 10 1)))))
+
+;; ---
+;; memory-object-store
+;; ---
+
+(t/deftest in-memory-put-delete-test
+  (with-open [obj-store (in-memory)]
+    (test-put-delete obj-store)))
+
+(t/deftest in-memory-list-test
+  (with-open [obj-store (in-memory)]
+    (test-list-objects obj-store)))
+
+(t/deftest in-memory-range-test
+  (with-open [obj-store (in-memory)]
+    (test-range obj-store)))
+
+;; ---
+;; file-system-object-store
+;; ---
+
+(t/deftest fs-put-delete-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-put-delete obj-store))))
+
+(t/deftest fs-list-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-list-objects obj-store))))
+
+(t/deftest fs-range-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-range obj-store))))


### PR DESCRIPTION
Linked to #2579

This PR includes a .getObjectRange implementation for the memory, filesystem, s3 and azure blob object stores.

Boundary cases currently must be dealt with for every implementation to meet the tests. Zero length and negative indexes are not permitted due to inconsistencies in implementation behaviour. This might later change. 