### PR TITLE
Add getObjectRange request to the object store protocol

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,8 @@ dependencies {
     testImplementation("cheshire", "cheshire", "5.11.0")
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.3.0")
     testImplementation("org.clojure", "test.check", "1.1.1")
+    // for AWS profiles (managing datasets)
+    devImplementation("software.amazon.awssdk", "sts", "2.16.76")
 }
 
 if (hasProperty("fin")) {

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -272,7 +272,12 @@
    (with-open [in (->file-channel path (if (= FileChannel$MapMode/READ_ONLY map-mode)
                                          #{:read}
                                          #{:read :write}))]
-     (.map in map-mode 0 (.size in)))))
+     (.map in map-mode 0 (.size in))))
+  (^java.nio.MappedByteBuffer [^Path path ^FileChannel$MapMode map-mode ^long start ^long len]
+   (with-open [in (->file-channel path (if (= FileChannel$MapMode/READ_ONLY map-mode)
+                                         #{:read}
+                                         #{:read :write}))]
+     (.map in map-mode start len))))
 
 (def ^:private file-deletion-visitor
   (proxy [SimpleFileVisitor] []

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -43,6 +43,17 @@
         blob-client (.getBlobContainerClient blob-service-client container)]
     (os/->AzureBlobObjectStore blob-client prefix)))
 
+(comment
+
+  (def os (->> (ig/prep-key ::blob-object-store {:storage-account "xtdbazureobjectstoretest"
+                                                 :container "xtdb-test"
+                                                 :prefix (str "xtdb.azure-test." (random-uuid))})
+               (ig/init-key ::blob-object-store)))
+
+  @(.getObject os "foo.txt")
+
+  )
+
 (s/def ::namespace string?)
 (s/def ::event-hub-name string?)
 (s/def ::create-event-hub? boolean?)

--- a/modules/jdbc/src/main/clojure/xtdb/jdbc.clj
+++ b/modules/jdbc/src/main/clojure/xtdb/jdbc.clj
@@ -65,7 +65,8 @@
       (.getObject os k)
       (reify Function
         (apply [_ buf]
-          (.slice ^ByteBuffer buf start len)))))
+          (let [^ByteBuffer buf buf]
+            (.slice buf (int start) (int (max 1 (min len (- (.remaining buf) start))))))))))
 
   (getObject [_ k out-path]
     (CompletableFuture/supplyAsync

--- a/modules/jdbc/src/main/clojure/xtdb/jdbc.clj
+++ b/modules/jdbc/src/main/clojure/xtdb/jdbc.clj
@@ -13,7 +13,8 @@
            java.nio.ByteBuffer
            (java.nio.file Files OpenOption)
            java.util.concurrent.CompletableFuture
-           java.util.function.Supplier))
+           java.util.function.Supplier
+           (java.util.function Consumer Function)))
 
 (defprotocol Dialect
   (db-type [dialect])
@@ -57,6 +58,14 @@
      (reify Supplier
        (get [_]
          (ByteBuffer/wrap (get-object pool k))))))
+
+  (getObjectRange [os k start len]
+    (os/ensure-shared-range-oob-behaviour start len)
+    (.thenApply
+      (.getObject os k)
+      (reify Function
+        (apply [_ buf]
+          (.slice ^ByteBuffer buf start len)))))
 
   (getObject [_ k out-path]
     (CompletableFuture/supplyAsync

--- a/src/test/clojure/xtdb/jdbc_test.clj
+++ b/src/test/clojure/xtdb/jdbc_test.clj
@@ -1,25 +1,39 @@
 (ns xtdb.jdbc-test
-  (:require [xtdb.jdbc :as xt-jdbc]
+  (:require [clojure.test :as t]
+            [xtdb.jdbc :as xt-jdbc]
             [xtdb.jdbc.postgresql :as xt-psql]
             [xtdb.object-store-test :as ost]
             [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
             [juxt.clojars-mirrors.integrant.core :as ig]))
 
-(defn- with-obj-store [opts f]
-  (let [sys (-> (merge opts {::xt-jdbc/object-store {}})
-                ig/prep
-                ig/init)]
-    (try
-      (f (::xt-jdbc/object-store sys))
-      (finally
-        (ig/halt! sys)))))
-
-(ost/def-obj-store-tests ^:requires-docker ^:jdbc jdbc-postgres [f]
+(defn postgres-sys []
   (let [db-spec {:user "postgres", :password "postgres", :database "xtdbtest"}]
     (with-open [conn (jdbc/get-connection (merge db-spec {:dbtype "postgresql"}))]
       (jdbc/execute! conn ["DROP DATABASE IF EXISTS xtdbtest"])
       (jdbc/execute! conn ["CREATE DATABASE xtdbtest"]))
+    (-> {::xt-psql/dialect {:drop-tables? true}
+         ::xt-jdbc/default-pool {:db-spec db-spec}
+         ::xt-jdbc/object-store {}}
+        ig/prep
+        ig/init)))
 
-    (with-obj-store {::xt-psql/dialect {:drop-tables? true}
-                     ::xt-jdbc/default-pool {:db-spec db-spec}}
-      f)))
+(t/deftest ^:requires-docker ^:jdbc put-delete-test
+  (let [sys (postgres-sys)]
+    (try
+      (ost/test-put-delete (::xt-jdbc/object-store sys))
+      (finally
+        (ig/halt! sys)))))
+
+(t/deftest ^:requires-docker ^:jdbc list-test
+  (let [sys (postgres-sys)]
+    (try
+      (ost/test-list-objects (::xt-jdbc/object-store sys))
+      (finally
+        (ig/halt! sys)))))
+
+(t/deftest ^:requires-docker ^:jdbc range-test
+  (let [sys (postgres-sys)]
+    (try
+      (ost/test-range (::xt-jdbc/object-store sys))
+      (finally
+        (ig/halt! sys)))))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -81,6 +81,9 @@
   (t/is (= [4 5 6 7] (vec (get-bytes obj-store "digits" 4 4))))
   (t/is (= [9] (vec (get-bytes obj-store "digits" 9 1))))
 
+  (t/is (= (vec (range 10)) (vec (get-bytes obj-store "digits" 0 20))))
+  (t/is (= [9] (vec (get-bytes obj-store "digits" 9 2))))
+
   ;; OOB behaviour is 'any exception', just whatever is thrown by impl
   (->> "len 0 is not permitted due to potential ambiguities that arise in the bounds behaviour for len 0 across impls"
        (t/is (thrown? Exception (get-bytes obj-store "digits" 0 0))))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -1,36 +1,59 @@
 (ns xtdb.object-store-test
-  (:require [clojure.test :as t]
+  (:require [clojure.edn :as edn]
+            [clojure.test :as t]
             [xtdb.object-store :as os]
-            [xtdb.test-util :as tu]
             [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import xtdb.object_store.ObjectStore
            java.io.Closeable
            java.nio.ByteBuffer
            java.nio.charset.StandardCharsets
            java.nio.file.attribute.FileAttribute
-           java.nio.file.Files))
+           java.nio.file.Files
+           (clojure.lang IDeref)))
 
-(defn- get-object [^ObjectStore obj-store, k]
+(defn- get-edn [^ObjectStore obj-store, k]
   (-> (let [^ByteBuffer buf @(.getObject obj-store (name k))]
-        (read-string (str (.decode StandardCharsets/UTF_8 buf))))
+        (edn/read-string (str (.decode StandardCharsets/UTF_8 buf))))
       (util/rethrowing-cause)))
 
-(defn- put-object [^ObjectStore obj-store k obj]
+(defn- put-edn [^ObjectStore obj-store k obj]
   (let [^ByteBuffer buf (.encode StandardCharsets/UTF_8 (pr-str obj))]
     @(.putObject obj-store (name k) buf)))
 
-(defn ^::os-test test-put-delete [^ObjectStore obj-store]
+(defn put-bytes [^ObjectStore obj-store k bytes]
+  @(.putObject obj-store k (ByteBuffer/wrap bytes)))
+
+(defn byte-buf->bytes [^ByteBuffer buf]
+  (let [arr (byte-array (.remaining buf))
+        pos (.position buf)]
+    (.get buf arr)
+    (.position buf pos)
+    arr))
+
+(defn get-bytes [^ObjectStore obj-store k start len]
+  (byte-buf->bytes @(.getObjectRange obj-store k start len)))
+
+(defn- in-memory ^Closeable []
+  (->> (ig/prep-key ::os/memory-object-store {})
+       (ig/init-key ::os/memory-object-store)))
+
+(defn- fs ^Closeable [path]
+  (->> (ig/prep-key ::os/file-system-object-store {:root-path path, :pool-size 2})
+       (ig/init-key ::os/file-system-object-store)))
+
+(defn test-put-delete [^ObjectStore obj-store]
   (let [alice {:xt/id :alice, :name "Alice"}]
-    (put-object obj-store :alice alice)
+    (put-edn obj-store :alice alice)
 
-    (t/is (= alice (get-object obj-store :alice)))
+    (t/is (= alice (get-edn obj-store :alice)))
 
-    (t/is (thrown? IllegalStateException (get-object obj-store :bob)))
+    (t/is (thrown? IllegalStateException (get-edn obj-store :bob)))
 
     (t/testing "doesn't override if present"
-      (put-object obj-store :alice {:xt/id :alice, :name "Alice", :version 2})
-      (t/is (= alice (get-object obj-store :alice))))
+      (put-edn obj-store :alice {:xt/id :alice, :name "Alice", :version 2})
+      (t/is (= alice (get-edn obj-store :alice))))
 
     (let [temp-path @(.getObject obj-store (name :alice)
                                  (doto (Files/createTempFile "alice" ".edn"
@@ -40,34 +63,68 @@
 
     @(.deleteObject obj-store (name :alice))
 
-    (t/is (thrown? IllegalStateException (get-object obj-store :alice)))))
+    (t/is (thrown? IllegalStateException (get-edn obj-store :alice)))))
 
-(defn ^::os-test test-list-objects [^ObjectStore obj-store]
-  (put-object obj-store "bar/alice" :alice)
-  (put-object obj-store "foo/alan" :alan)
-  (put-object obj-store "bar/bob" :bob)
+(defn test-list-objects [^ObjectStore obj-store]
+  (put-edn obj-store "bar/alice" :alice)
+  (put-edn obj-store "foo/alan" :alan)
+  (put-edn obj-store "bar/bob" :bob)
 
   (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
   (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar"))))
 
-(def os-tests
-  (->> (ns-interns (create-ns 'xtdb.object-store-test))
-       (into {} (filter (comp ::os-test meta val)))))
+(defn test-range [^ObjectStore obj-store]
 
-(defmacro def-obj-store-tests [sym [binding] & body]
-  `(do
-     ~@(for [test-name (keys os-tests)]
-         `(t/deftest ~(-> (symbol (str sym "-" test-name))
-                          (with-meta (meta sym)))
-            (let [~binding (get os-tests '~test-name)]
-              ~@body)))
-     '~sym))
+  (put-bytes obj-store "digits" (byte-array (range 10)))
 
-(def-obj-store-tests in-mem [f]
-  (with-open [^Closeable os (ig/init-key ::os/memory-object-store {})]
-    (f os)))
+  (t/is (= [0] (vec (get-bytes obj-store "digits" 0 1))))
+  (t/is (= [4 5 6 7] (vec (get-bytes obj-store "digits" 4 4))))
+  (t/is (= [9] (vec (get-bytes obj-store "digits" 9 1))))
 
-(def-obj-store-tests fs [f]
-  (tu/with-tmp-dirs #{os-path}
-    (with-open [^Closeable os (ig/init-key ::os/file-system-object-store {:root-path os-path, :pool-size 2})]
-      (f os))))
+  ;; OOB behaviour is 'any exception', just whatever is thrown by impl
+  (->> "len 0 is not permitted due to potential ambiguities that arise in the bounds behaviour for len 0 across impls"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 0))))
+
+  (->> "OOB for negative index"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" -1 3))))
+
+  (->> "OOB for negative len"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1))))
+
+  (->> "OOB for last index"
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 10 1)))))
+
+;; ---
+;; memory-object-store
+;; ---
+
+(t/deftest in-memory-put-delete-test
+  (with-open [obj-store (in-memory)]
+    (test-put-delete obj-store)))
+
+(t/deftest in-memory-list-test
+  (with-open [obj-store (in-memory)]
+    (test-list-objects obj-store)))
+
+(t/deftest in-memory-range-test
+  (with-open [obj-store (in-memory)]
+    (test-range obj-store)))
+
+;; ---
+;; file-system-object-store
+;; ---
+
+(t/deftest fs-put-delete-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-put-delete obj-store))))
+
+(t/deftest fs-list-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-list-objects obj-store))))
+
+(t/deftest fs-range-test
+  (tu/with-tmp-dirs #{path}
+    (with-open [obj-store (fs path)]
+      (test-range obj-store))))


### PR DESCRIPTION
Linked to #2579

This PR includes a .getObjectRange implementation for the memory, filesystem, s3 and azure blob object stores. JDBC works but is not optimised, given the anaemic state of JDBC at the moment I figured this could be forgiven.

Boundary cases currently must be dealt with for every implementation to meet the tests. Zero-length and negative indexes are not permitted due to inconsistencies in implementation behaviour. This might later change. 