### PR TITLE
Pass `xt/id` through to indexer in sql ops

### DIFF
--- a/core/src/main/clojure/xtdb/sql/analyze.clj
+++ b/core/src/main/clojure/xtdb/sql/analyze.clj
@@ -651,7 +651,9 @@
                           :let [identifier (last identifiers)]]
                       {:identifier identifier
                        :qualified-column [correlation-name identifier]})
-                    (for [col-name ["_iid" "_row_id"
+                    ;; TODO _iid (and possibly _row_id) can go once we remove the old temporal-indexer
+                    ;; also see below
+                    (for [col-name ["xt$id" "_iid" "_row_id"
                                     "xt$valid_from" "xt$valid_to"
                                     "xt$system_from" "xt$system_to"]]
                       {:identifier col-name
@@ -677,7 +679,7 @@
     (:update_statement__searched :delete_statement__searched)
     [(let [{:keys [correlation-name], :as table} (table ag)]
        (vec
-        (concat (->> (for [col-name ["_iid" "_row_id"
+        (concat (->> (for [col-name ["xt$id" "_iid" "_row_id"
                                      "xt$valid_from" "xt$valid_to"
                                      "xt$system_from" "xt$system_to"]]
                        {:identifier col-name
@@ -693,7 +695,7 @@
 
     :erase_statement__searched
     [(let [{:keys [correlation-name], :as table} (table ag)]
-       (->> (for [col-name ["_iid" "_row_id"
+       (->> (for [col-name ["xt$id" "_iid" "_row_id"
                             "xt$valid_from" "xt$valid_to"
                             "xt$system_from" "xt$system_to"]]
               {:identifier col-name

--- a/src/test/resources/xtdb/indexer-test/can-build-temporal-and-content-log/chunk-00/temporal-log.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-temporal-and-content-log/chunk-00/temporal-log.arrow.json
@@ -156,7 +156,7 @@
             "name" : "iid",
             "count" : 6,
             "VALIDITY" : [1,1,1,1,1,1],
-            "DATA" : ["32e5271f2289be5ebe3c92dfa544b551","27d9ba7a01db456ad596da9f07f4140e","27d9ba7a01db456ad596da9f07f4140e","4cd9b7672d7fbee8fb51fb1e049f6903","00000000000000000000000000000000","420fce314175df402adbeae3cfbbb856"]
+            "DATA" : ["32e5271f2289be5ebe3c92dfa544b551","27d9ba7a01db456ad596da9f07f4140e","27d9ba7a01db456ad596da9f07f4140e","4cd9b7672d7fbee8fb51fb1e049f6903","4cd9b7672d7fbee8fb51fb1e049f6903","420fce314175df402adbeae3cfbbb856"]
           },{
             "name" : "row-id",
             "count" : 6,
@@ -181,7 +181,7 @@
             "name" : "iid",
             "count" : 2,
             "VALIDITY" : [1,1],
-            "DATA" : ["32e5271f2289be5ebe3c92dfa544b551","00000000000000000000000000000000"]
+            "DATA" : ["32e5271f2289be5ebe3c92dfa544b551","4cd9b7672d7fbee8fb51fb1e049f6903"]
           },{
             "name" : "valid-from",
             "count" : 2,
@@ -201,7 +201,7 @@
             "name" : "iid",
             "count" : 2,
             "VALIDITY" : [1,1],
-            "DATA" : ["27d9ba7a01db456ad596da9f07f4140e","00000000000000000000000000000000"]
+            "DATA" : ["27d9ba7a01db456ad596da9f07f4140e","4cd9b7672d7fbee8fb51fb1e049f6903"]
           }]
         }]
       }]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -1,32 +1,36 @@
 [:update
  {:table "users"}
  [:rename
-  {x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
-   x9 first_name,
-   x10 xt$valid_from,
-   x11 xt$valid_to}
+  {x2 xt$id,
+   x3 _iid,
+   x4 _row_id,
+   x7 xt$system_from,
+   x8 xt$system_to,
+   x10 first_name,
+   x11 xt$valid_from,
+   x12 xt$valid_to}
   [:project
    [x2
     x3
-    x6
+    x4
     x7
-    {x9 ?_2}
-    {x10 (cast-tstz (greatest x4 ?_0))}
-    {x11 (cast-tstz (least x5 ?_1))}]
+    x8
+    {x10 ?_2}
+    {x11 (cast-tstz (greatest x5 ?_0))}
+    {x12 (cast-tstz (least x6 ?_1))}]
    [:rename
     {id x1,
-     _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$id x2,
+     _iid x3,
+     _row_id x4,
+     xt$valid_from x5,
+     xt$valid_to x6,
+     xt$system_from x7,
+     xt$system_to x8}
     [:scan
      {:table users, :for-valid-time [:between ?_0 ?_1]}
      [{id (= id ?_3)}
+      xt$id
       _iid
       _row_id
       xt$valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -1,25 +1,28 @@
 [:update
  {:table "t1"}
  [:rename
-  {x1 _iid,
-   x2 _row_id,
-   x5 xt$system_from,
-   x6 xt$system_to,
-   x8 col1,
-   x9 xt$valid_from,
-   x10 xt$valid_to}
+  {x1 xt$id,
+   x2 _iid,
+   x3 _row_id,
+   x6 xt$system_from,
+   x7 xt$system_to,
+   x9 col1,
+   x10 xt$valid_from,
+   x11 xt$valid_to}
   [:project
-   [x1 x2 x5 x6 {x8 ?_0} {x9 (cast-tstz x3)} {x10 (cast-tstz x4)}]
+   [x1 x2 x3 x6 x7 {x9 ?_0} {x10 (cast-tstz x4)} {x11 (cast-tstz x5)}]
    [:rename
-    {_iid x1,
-     _row_id x2,
-     xt$valid_from x3,
-     xt$valid_to x4,
-     xt$system_from x5,
-     xt$system_to x6}
+    {xt$id x1,
+     _iid x2,
+     _row_id x3,
+     xt$valid_from x4,
+     xt$valid_to x5,
+     xt$system_from x6,
+     xt$system_to x7}
     [:scan
      {:table t1}
-     (_iid
+     (xt$id
+      _iid
       _row_id
       xt$valid_from
       xt$valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
@@ -1,24 +1,27 @@
 [:delete
  {:table "users"}
  [:rename
-  {x1 _iid,
-   x2 _row_id,
-   x5 xt$system_from,
-   x6 xt$system_to,
-   x8 xt$valid_from,
-   x9 xt$valid_to}
+  {x1 xt$id,
+   x2 _iid,
+   x3 _row_id,
+   x6 xt$system_from,
+   x7 xt$system_to,
+   x9 xt$valid_from,
+   x10 xt$valid_to}
   [:project
-   [x1 x2 x5 x6 {x8 (cast-tstz x3)} {x9 (cast-tstz x4)}]
+   [x1 x2 x3 x6 x7 {x9 (cast-tstz x4)} {x10 (cast-tstz x5)}]
    [:rename
-    {_iid x1,
-     _row_id x2,
-     xt$valid_from x3,
-     xt$valid_to x4,
-     xt$system_from x5,
-     xt$system_to x6}
+    {xt$id x1,
+     _iid x2,
+     _row_id x3,
+     xt$valid_from x4,
+     xt$valid_to x5,
+     xt$system_from x6,
+     xt$system_to x7}
     [:scan
      {:table users, :for-valid-time :all-time}
-     (_iid
+     (xt$id
+      _iid
       _row_id
       xt$valid_from
       xt$valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
@@ -1,25 +1,35 @@
 [:update
  {:table "users"}
  [:rename
-  {x1 _iid,
-   x2 _row_id,
-   x5 xt$system_from,
-   x6 xt$system_to,
-   x8 first_name,
-   x9 xt$valid_from,
-   x10 xt$valid_to}
+  {x1 xt$id,
+   x2 _iid,
+   x3 _row_id,
+   x6 xt$system_from,
+   x7 xt$system_to,
+   x9 first_name,
+   x10 xt$valid_from,
+   x11 xt$valid_to}
   [:project
-   [x1 x2 x5 x6 {x8 "Sue"} {x9 (cast-tstz x3)} {x10 (cast-tstz x4)}]
+   [x1
+    x2
+    x3
+    x6
+    x7
+    {x9 "Sue"}
+    {x10 (cast-tstz x4)}
+    {x11 (cast-tstz x5)}]
    [:rename
-    {_iid x1,
-     _row_id x2,
-     xt$valid_from x3,
-     xt$valid_to x4,
-     xt$system_from x5,
-     xt$system_to x6}
+    {xt$id x1,
+     _iid x2,
+     _row_id x3,
+     xt$valid_from x4,
+     xt$valid_to x5,
+     xt$system_from x6,
+     xt$system_to x7}
     [:scan
      {:table users, :for-valid-time :all-time}
-     (_iid
+     (xt$id
+      _iid
       _row_id
       xt$valid_from
       xt$valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -1,32 +1,36 @@
 [:delete
  {:table "users"}
  [:rename
-  {x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
-   x9 xt$valid_from,
-   x10 xt$valid_to}
+  {x2 xt$id,
+   x3 _iid,
+   x4 _row_id,
+   x7 xt$system_from,
+   x8 xt$system_to,
+   x10 xt$valid_from,
+   x11 xt$valid_to}
   [:project
    [x2
     x3
-    x6
+    x4
     x7
-    {x9 (cast-tstz (greatest x4 #time/date "2020-05-01"))}
-    {x10 (cast-tstz (least x5 #time/date "9999-12-31"))}]
+    x8
+    {x10 (cast-tstz (greatest x5 #time/date "2020-05-01"))}
+    {x11 (cast-tstz (least x6 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
-     _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$id x2,
+     _iid x3,
+     _row_id x4,
+     xt$valid_from x5,
+     xt$valid_to x6,
+     xt$system_from x7,
+     xt$system_to x8}
     [:scan
      {:table users,
       :for-valid-time
       [:between #time/date "2020-05-01" #time/date "9999-12-31"]}
      [{id (= id ?_0)}
+      xt$id
       _iid
       _row_id
       xt$valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -1,26 +1,29 @@
 [:update
  {:table "foo"}
  [:rename
-  {x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
+  {x2 xt$id,
+   x3 _iid,
+   x4 _row_id,
+   x7 xt$system_from,
+   x8 xt$system_to,
    x1 bar,
-   x9 xt$valid_from,
-   x10 xt$valid_to}
+   x10 xt$valid_from,
+   x11 xt$valid_to}
   [:project
-   [x2 x3 x6 x7 x1 {x9 (cast-tstz x4)} {x10 (cast-tstz x5)}]
+   [x2 x3 x4 x7 x8 x1 {x10 (cast-tstz x5)} {x11 (cast-tstz x6)}]
    [:rename
     {baz x1,
-     _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$id x2,
+     _iid x3,
+     _row_id x4,
+     xt$valid_from x5,
+     xt$valid_to x6,
+     xt$system_from x7,
+     xt$system_to x8}
     [:scan
      {:table foo}
      (baz
+      xt$id
       _iid
       _row_id
       xt$valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -1,33 +1,37 @@
 [:update
  {:table "foo"}
  [:rename
-  {x5 _iid,
-   x6 _row_id,
+  {x5 xt$id,
+   x6 _iid,
+   x7 _row_id,
    x1 xt$system_from,
    x2 xt$system_to,
-   x8 bar,
-   x9 xt$valid_from,
-   x10 xt$valid_to}
+   x9 bar,
+   x10 xt$valid_from,
+   x11 xt$valid_to}
   [:project
    [x5
     x6
+    x7
     x1
     x2
-    {x8 (and (< x1 x4) (> x2 x3))}
-    {x9 (cast-tstz x3)}
-    {x10 (cast-tstz x4)}]
+    {x9 (and (< x1 x4) (> x2 x3))}
+    {x10 (cast-tstz x3)}
+    {x11 (cast-tstz x4)}]
    [:rename
     {xt$system_from x1,
      xt$system_to x2,
      xt$valid_from x3,
      xt$valid_to x4,
-     _iid x5,
-     _row_id x6}
+     xt$id x5,
+     _iid x6,
+     _row_id x7}
     [:scan
      {:table foo}
      (xt$system_from
       xt$system_to
       xt$valid_from
       xt$valid_to
+      xt$id
       _iid
       _row_id)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -1,34 +1,38 @@
 [:update
  {:table "users"}
  [:rename
-  {x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
-   x9 first_name,
-   x10 xt$valid_from,
-   x11 xt$valid_to}
+  {x2 xt$id,
+   x3 _iid,
+   x4 _row_id,
+   x7 xt$system_from,
+   x8 xt$system_to,
+   x10 first_name,
+   x11 xt$valid_from,
+   x12 xt$valid_to}
   [:project
    [x2
     x3
-    x6
+    x4
     x7
-    {x9 "Sue"}
-    {x10 (cast-tstz (greatest x4 #time/date "2021-07-01"))}
-    {x11 (cast-tstz (least x5 #time/date "9999-12-31"))}]
+    x8
+    {x10 "Sue"}
+    {x11 (cast-tstz (greatest x5 #time/date "2021-07-01"))}
+    {x12 (cast-tstz (least x6 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
-     _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$id x2,
+     _iid x3,
+     _row_id x4,
+     xt$valid_from x5,
+     xt$valid_to x6,
+     xt$system_from x7,
+     xt$system_to x8}
     [:scan
      {:table users,
       :for-valid-time
       [:between #time/date "2021-07-01" #time/date "9999-12-31"]}
      [{id (= id ?_0)}
+      xt$id
       _iid
       _row_id
       xt$valid_from


### PR DESCRIPTION
Closes #2611. Potential followup remove `iid` and possibly `row-id` from getting passed through once the old temporal indexer goes.