### PR TITLE
Option to replace colons with dashes in filesystemstore.

### DIFF
--- a/core/src/xtdb/checkpoint.clj
+++ b/core/src/xtdb/checkpoint.clj
@@ -198,12 +198,12 @@
       (Files/isRegularFile from-path (make-array LinkOption 0))
       (Files/copy from-path to-path ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0)))))
 
-(defn format-fs-date [{:keys [no-colons-in-filenames]} date]
+(defn format-fs-date [{:keys [no-colons-in-filenames?]} date]
   (when date
     (cond-> (xio/format-rfc3339-date date)
-      no-colons-in-filenames (string/replace #":" "-"))))
+      no-colons-in-filenames? (string/replace #":" "-"))))
 
-(defrecord FileSystemCheckpointStore [^Path root-path no-colons-in-filenames]
+(defrecord FileSystemCheckpointStore [^Path root-path no-colons-in-filenames?]
   CheckpointStore
   (available-checkpoints [_ {::keys [cp-format]}]
     (when (Files/exists root-path (make-array LinkOption 0))
@@ -265,8 +265,8 @@
 
 (defn ->filesystem-checkpoint-store {::sys/args {:path {:spec ::sys/path, 
                                                         :required? true}
-                                                 :no-colons-in-filenames {:spec ::sys/boolean
+                                                 :no-colons-in-filenames? {:spec ::sys/boolean
                                                                           :required? true
                                                                           :default false}}} 
-  [{:keys [path no-colons-in-filenames]}]
-  (->FileSystemCheckpointStore path no-colons-in-filenames))
+  [{:keys [path no-colons-in-filenames?]}]
+  (->FileSystemCheckpointStore path no-colons-in-filenames?))

--- a/docs/administration/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/administration/modules/ROOT/pages/checkpointing.adoc
@@ -90,7 +90,7 @@ EDN::
 
 == `FileSystem` Checkpoint Store parameters
 * `path` (required, string/`File`/`Path`/`URI`): path to store checkpoints.
-* `no-colons-in-filenames` (optional, boolean, defaults to `false`): whether or not to replace the colons in the checkpoint filenames, This is optional, though required to be  `true` on **Windows** as it does not accept colons in filenames.
+* `no-colons-in-filenames?` (optional, boolean, defaults to `false`): whether or not to replace the colons in the checkpoint filenames, This is optional, though required to be  `true` on **Windows** as it does not accept colons in filenames.
 
 === Note about using `FileSystem` Checkpoint Store
 

--- a/docs/administration/modules/ROOT/pages/checkpointing.adoc
+++ b/docs/administration/modules/ROOT/pages/checkpointing.adoc
@@ -90,6 +90,7 @@ EDN::
 
 == `FileSystem` Checkpoint Store parameters
 * `path` (required, string/`File`/`Path`/`URI`): path to store checkpoints.
+* `no-colons-in-filenames` (optional, boolean, defaults to `false`): whether or not to replace the colons in the checkpoint filenames, This is optional, though required to be  `true` on **Windows** as it does not accept colons in filenames.
 
 === Note about using `FileSystem` Checkpoint Store
 

--- a/test/src/xtdb/fixtures/checkpoint_store.clj
+++ b/test/src/xtdb/fixtures/checkpoint_store.clj
@@ -5,7 +5,8 @@
             [clojure.java.io :as io]
             [clojure.test :as t])
   (:import  [java.nio.file NoSuchFileException CopyOption Files FileVisitOption LinkOption Path]
-            java.nio.file.attribute.FileAttribute))
+            java.nio.file.attribute.FileAttribute
+            java.util.Date))
 
 (defn test-checkpoint-store [cp-store]
   (fix/with-tmp-dirs #{local-dir}
@@ -31,7 +32,7 @@
         (spit (io/file src-dir "hello.txt") "Hello world")
 
         (t/is (= cp-1
-                 (-> (cp/upload-checkpoint cp-store src-dir cp-1)
+                 (-> (cp/upload-checkpoint cp-store src-dir (assoc cp-1 :cp-at (Date.)))
                      (select-keys #{::cp/cp-format :tx}))))
 
         (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::bar-cp-format})))
@@ -49,7 +50,7 @@
         (spit (io/file src-dir "ivan.txt") "Hey Ivan!")
 
         (t/is (= cp-2
-                 (-> (cp/upload-checkpoint cp-store src-dir cp-2)
+                 (-> (cp/upload-checkpoint cp-store src-dir (assoc cp-2 :cp-at (Date.)))
                      (select-keys #{::cp/cp-format :tx}))))
 
         (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::bar-cp-format})))

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -450,7 +450,7 @@
           (t/is (= false (.exists (io/file cp-uri))))
           (t/is (= false (.exists (io/file (str cp-uri ".edn"))))))))))
 
-(t/deftest test-fs-checkpoint-store-with-no-colons-in-filenames
+(t/deftest test-fs-checkpoint-store-with-no-colons-in-filenames?
   (fix/with-tmp-dirs #{cp-store-dir}
     (fix.cp-store/test-checkpoint-store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)
-                                                                           :no-colons-in-filenames true}))))
+                                                                           :no-colons-in-filenames? true}))))

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -449,3 +449,8 @@
                                            :cp-at cp-at})
           (t/is (= false (.exists (io/file cp-uri))))
           (t/is (= false (.exists (io/file (str cp-uri ".edn"))))))))))
+
+(t/deftest test-fs-checkpoint-store-with-no-colons-in-filenames
+  (fix/with-tmp-dirs #{cp-store-dir}
+    (fix.cp-store/test-checkpoint-store (cp/->filesystem-checkpoint-store {:path (.toPath cp-store-dir)
+                                                                           :no-colons-in-filenames true}))))


### PR DESCRIPTION
Should go some way to help with the issues seen within #1814 

- Can provide a parameter to the filesystem store, `no-colons-in-filenames`:
  - This is optional, defaults to `false`. 
  - When set, when formatting dates in the filesystem checkpoint store, we replace any colons with dashes.
- Also updates the checkpoint store fixture to use `cp-at`, so that we're testing behaviour with dates (as it would be when used with a checkpointer)

I've not tested this directly against windows - but I have seen that the filenames it generates seem to be fine to create on my personal PC.

Naming could be better? Open for suggestions.