### PR TITLE
Numerous checkpoint store test additions & fixes

### DIFF
--- a/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
+++ b/modules/azure-blobs/test/xtdb/azure/blobs_test.clj
@@ -139,7 +139,7 @@
           (t/is (= [(str azure-dir "hello.txt")]
                    (azb/list-blobs cp-store nil)))
           ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
-          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))
+          (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format}))))))))
 
 (t/deftest test-checkpoint-store-cleanup-no-edn-file
   (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `azb/->cp-store

--- a/modules/s3/test/xtdb/s3/checkpoint_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_test.clj
@@ -83,7 +83,7 @@
           (t/is (= [[:common-prefix s3-dir]]
                    (vec (s3/list-objects cp-store {}))))
           ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
-          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))
+          (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format}))))))))
 
 (t/deftest test-checkpoint-store-cleanup-no-edn-file
   (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3c/->cp-store

--- a/modules/s3/test/xtdb/s3/checkpoint_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_test.clj
@@ -84,3 +84,29 @@
                    (vec (s3/list-objects cp-store {}))))
           ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
           (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))
+
+(t/deftest test-checkpoint-store-cleanup-no-edn-file
+  (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3c/->cp-store
+                                                :configurator `s3t/->configurator
+                                                :bucket s3t/test-s3-bucket
+                                                :prefix (str "s3-cp-" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (:store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::s3c/s3-dir] :as res} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                               :tx {::xt/tx-id 1}
+                                                                               :cp-at cp-at})]
+        ;; delete the checkpoint file
+        (s3/delete-objects cp-store [s3-dir])
+
+        (t/testing "checkpoint folder present, edn file should be deleted"
+          (let [object-info (into {} (s3/list-objects cp-store {}))]
+            (t/is (= s3-dir (:common-prefix object-info)))))
+
+        (t/testing "call to `cleanup-checkpoints` with no edn file should still remove an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (s3/list-objects cp-store {}))))))))

--- a/modules/s3/test/xtdb/s3/checkpoint_transfer_manager_test.clj
+++ b/modules/s3/test/xtdb/s3/checkpoint_transfer_manager_test.clj
@@ -100,7 +100,7 @@
           (t/is (= [[:common-prefix s3-dir]]
                    (vec (s3/list-objects cp-store {}))))
           ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
-          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format))))))))
+          (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format}))))))))
 
 (t/deftest test-checkpoint-store-cleanup-no-edn-file
   (with-open [sys (-> (sys/prep-system {:store {:xtdb/module `s3ctm/->cp-store

--- a/test/test/xtdb/checkpoint_test.clj
+++ b/test/test/xtdb/checkpoint_test.clj
@@ -382,7 +382,7 @@
           (t/is (.exists (io/file cp-uri)))
           (t/is (= false (.exists (io/file (str cp-uri ".edn")))))
           ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
-          (t/is (empty? (cp/available-checkpoints cp-store ::foo-cp-format)))))))
+          (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format})))))))
 
 
 (t/deftest test-fs-retention-policy


### PR DESCRIPTION
Resolves #2601

A few tests have been added/cleaned up here:
- Validate the behaviour of cleanup checkpoint without metadata file present, #2601
  - This caused no particular issues in any of the modules, but added some tests to verify that as such.
- Added a missing test around failed cleanups to the filesystem checkpoint store.
- Added a minor fix to the final assertion of the 'failed-cleanup' tests - was passing in the cp-format incorrectly, so we were always returning an empty list (which would negate the usefullness of the test)
