### PR TITLE
use select-star analysis to simplify `UPDATE`

### DIFF
--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -1,48 +1,10 @@
 (ns xtdb.metadata-test
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
-            [xtdb.metadata :as meta]
-            [xtdb.test-util :as tu]
-            [xtdb.datasets.tpch :as tpch])
-  (:import (java.time ZoneId)))
+            [xtdb.test-util :as tu]))
 
 (t/use-fixtures :each tu/with-node)
 (t/use-fixtures :once tu/with-allocator)
-
-(t/deftest test-row-id->chunk
-  (-> (tpch/submit-docs! tu/*node* 0.001)
-      (tu/then-await-tx tu/*node*))
-
-  (tu/finish-chunk! tu/*node*)
-
-  (let [metadata-mgr (tu/component ::meta/metadata-manager)]
-    (letfn [(row-id->col-names [table row-id]
-              (-> (meta/row-id->chunk metadata-mgr table row-id)
-                  (dissoc :chunk-idx)
-                  (update :col-names #(into #{} (map keyword) %))))]
-      (t/is (= {:col-names #{:xt$id
-                             :c_acctbal :c_address :c_comment :c_custkey :c_mktsegment
-                             :c_name :c_nationkey :c_phone}
-                :block-idx 0}
-               (row-id->col-names "customer" 1)))
-
-      #_#_
-      (t/is (= {:col-names #{:xt$id
-                             :o_clerk :o_comment :o_custkey :o_orderdate :o_orderkey
-                             :o_orderpriority :o_orderstatus :o_shippriority :o_totalprice}
-                :block-idx 0}
-               (row-id->col-names "orders" 500)))
-
-      (let [li-cols #{:xt$id
-                      :l_comment :l_commitdate :l_discount :l_extendedprice
-                      :l_linenumber :l_linestatus :l_orderkey :l_partkey
-                      :l_quantity :l_receiptdate :l_returnflag :l_shipdate
-                      :l_shipinstruct :l_shipmode :l_suppkey :l_tax}]
-        (t/is (= {:col-names li-cols, :block-idx 1}
-                 (row-id->col-names "lineitem" 1750)))
-
-        (t/is (= {:col-names li-cols, :block-idx 2}
-                 (row-id->col-names "lineitem" 2750)))))))
 
 (t/deftest test-param-metadata-error-310
   (let [tx1 (xt/submit-tx tu/*node*

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1,7 +1,6 @@
 (ns xtdb.sql-test
   (:require [clojure.java.io :as io]
             [clojure.test :as t :refer [deftest]]
-            [xtdb.sql.analyze :as sem]
             [xtdb.logical-plan :as lp]
             [xtdb.sql :as sql])
 

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -1,39 +1,39 @@
 [:update
  {:table "users"}
  [:rename
-  {x2 xt$id,
-   x3 _iid,
-   x4 _row_id,
-   x7 xt$system_from,
-   x8 xt$system_to,
+  {x3 _iid,
+   x5 xt$system_to,
+   x6 _row_id,
+   x7 xt$id,
+   x8 xt$system_from,
    x10 first_name,
    x11 xt$valid_from,
    x12 xt$valid_to}
   [:project
-   [x2
-    x3
-    x4
+   [x3
+    x5
+    x6
     x7
     x8
     {x10 ?_2}
-    {x11 (cast-tstz (greatest x5 ?_0))}
-    {x12 (cast-tstz (least x6 ?_1))}]
+    {x11 (cast-tstz (greatest x4 ?_0))}
+    {x12 (cast-tstz (least x2 ?_1))}]
    [:rename
     {id x1,
-     xt$id x2,
+     xt$valid_to x2,
      _iid x3,
-     _row_id x4,
-     xt$valid_from x5,
-     xt$valid_to x6,
-     xt$system_from x7,
-     xt$system_to x8}
+     xt$valid_from x4,
+     xt$system_to x5,
+     _row_id x6,
+     xt$id x7,
+     xt$system_from x8}
     [:scan
      {:table users, :for-valid-time [:between ?_0 ?_1]}
      [{id (= id ?_3)}
-      xt$id
-      _iid
-      _row_id
-      xt$valid_from
       xt$valid_to
-      xt$system_from
-      xt$system_to]]]]]]
+      _iid
+      xt$valid_from
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -1,30 +1,30 @@
 [:update
  {:table "t1"}
  [:rename
-  {x1 xt$id,
-   x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
+  {x2 _iid,
+   x4 xt$system_to,
+   x5 _row_id,
+   x6 xt$id,
+   x7 xt$system_from,
    x9 col1,
    x10 xt$valid_from,
    x11 xt$valid_to}
   [:project
-   [x1 x2 x3 x6 x7 {x9 ?_0} {x10 (cast-tstz x4)} {x11 (cast-tstz x5)}]
+   [x2 x4 x5 x6 x7 {x9 ?_0} {x10 (cast-tstz x3)} {x11 (cast-tstz x1)}]
    [:rename
-    {xt$id x1,
+    {xt$valid_to x1,
      _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$valid_from x3,
+     xt$system_to x4,
+     _row_id x5,
+     xt$id x6,
+     xt$system_from x7}
     [:scan
      {:table t1}
-     (xt$id
+     (xt$valid_to
       _iid
-      _row_id
       xt$valid_from
-      xt$valid_to
-      xt$system_from
-      xt$system_to)]]]]]
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
@@ -1,29 +1,29 @@
 [:delete
  {:table "users"}
  [:rename
-  {x1 xt$id,
-   x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
+  {x2 _iid,
+   x4 xt$system_to,
+   x5 _row_id,
+   x6 xt$id,
+   x7 xt$system_from,
    x9 xt$valid_from,
    x10 xt$valid_to}
   [:project
-   [x1 x2 x3 x6 x7 {x9 (cast-tstz x4)} {x10 (cast-tstz x5)}]
+   [x2 x4 x5 x6 x7 {x9 (cast-tstz x3)} {x10 (cast-tstz x1)}]
    [:rename
-    {xt$id x1,
+    {xt$valid_to x1,
      _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$valid_from x3,
+     xt$system_to x4,
+     _row_id x5,
+     xt$id x6,
+     xt$system_from x7}
     [:scan
      {:table users, :for-valid-time :all-time}
-     (xt$id
+     (xt$valid_to
       _iid
-      _row_id
       xt$valid_from
-      xt$valid_to
-      xt$system_from
-      xt$system_to)]]]]]
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
@@ -1,37 +1,37 @@
 [:update
  {:table "users"}
  [:rename
-  {x1 xt$id,
-   x2 _iid,
-   x3 _row_id,
-   x6 xt$system_from,
-   x7 xt$system_to,
+  {x2 _iid,
+   x4 xt$system_to,
+   x5 _row_id,
+   x6 xt$id,
+   x7 xt$system_from,
    x9 first_name,
    x10 xt$valid_from,
    x11 xt$valid_to}
   [:project
-   [x1
-    x2
-    x3
+   [x2
+    x4
+    x5
     x6
     x7
     {x9 "Sue"}
-    {x10 (cast-tstz x4)}
-    {x11 (cast-tstz x5)}]
+    {x10 (cast-tstz x3)}
+    {x11 (cast-tstz x1)}]
    [:rename
-    {xt$id x1,
+    {xt$valid_to x1,
      _iid x2,
-     _row_id x3,
-     xt$valid_from x4,
-     xt$valid_to x5,
-     xt$system_from x6,
-     xt$system_to x7}
+     xt$valid_from x3,
+     xt$system_to x4,
+     _row_id x5,
+     xt$id x6,
+     xt$system_from x7}
     [:scan
      {:table users, :for-valid-time :all-time}
-     (xt$id
+     (xt$valid_to
       _iid
-      _row_id
       xt$valid_from
-      xt$valid_to
-      xt$system_from
-      xt$system_to)]]]]]
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -1,39 +1,39 @@
 [:delete
  {:table "users"}
  [:rename
-  {x2 xt$id,
-   x3 _iid,
-   x4 _row_id,
-   x7 xt$system_from,
-   x8 xt$system_to,
+  {x3 _iid,
+   x5 xt$system_to,
+   x6 _row_id,
+   x7 xt$id,
+   x8 xt$system_from,
    x10 xt$valid_from,
    x11 xt$valid_to}
   [:project
-   [x2
-    x3
-    x4
+   [x3
+    x5
+    x6
     x7
     x8
-    {x10 (cast-tstz (greatest x5 #time/date "2020-05-01"))}
-    {x11 (cast-tstz (least x6 #time/date "9999-12-31"))}]
+    {x10 (cast-tstz (greatest x4 #time/date "2020-05-01"))}
+    {x11 (cast-tstz (least x2 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
-     xt$id x2,
+     xt$valid_to x2,
      _iid x3,
-     _row_id x4,
-     xt$valid_from x5,
-     xt$valid_to x6,
-     xt$system_from x7,
-     xt$system_to x8}
+     xt$valid_from x4,
+     xt$system_to x5,
+     _row_id x6,
+     xt$id x7,
+     xt$system_from x8}
     [:scan
      {:table users,
       :for-valid-time
       [:between #time/date "2020-05-01" #time/date "9999-12-31"]}
      [{id (= id ?_0)}
-      xt$id
-      _iid
-      _row_id
-      xt$valid_from
       xt$valid_to
-      xt$system_from
-      xt$system_to]]]]]]
+      _iid
+      xt$valid_from
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -1,32 +1,32 @@
 [:update
  {:table "foo"}
  [:rename
-  {x2 xt$id,
-   x3 _iid,
-   x4 _row_id,
-   x7 xt$system_from,
-   x8 xt$system_to,
+  {x3 _iid,
+   x5 xt$system_to,
+   x6 _row_id,
+   x7 xt$id,
+   x8 xt$system_from,
    x1 bar,
    x10 xt$valid_from,
    x11 xt$valid_to}
   [:project
-   [x2 x3 x4 x7 x8 x1 {x10 (cast-tstz x5)} {x11 (cast-tstz x6)}]
+   [x3 x5 x6 x7 x8 x1 {x10 (cast-tstz x4)} {x11 (cast-tstz x2)}]
    [:rename
     {baz x1,
-     xt$id x2,
+     xt$valid_to x2,
      _iid x3,
-     _row_id x4,
-     xt$valid_from x5,
-     xt$valid_to x6,
-     xt$system_from x7,
-     xt$system_to x8}
+     xt$valid_from x4,
+     xt$system_to x5,
+     _row_id x6,
+     xt$id x7,
+     xt$system_from x8}
     [:scan
      {:table foo}
      (baz
-      xt$id
-      _iid
-      _row_id
-      xt$valid_from
       xt$valid_to
-      xt$system_from
-      xt$system_to)]]]]]
+      _iid
+      xt$valid_from
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -1,20 +1,20 @@
 [:update
  {:table "foo"}
  [:rename
-  {x5 xt$id,
-   x6 _iid,
-   x7 _row_id,
-   x1 xt$system_from,
+  {x5 _iid,
    x2 xt$system_to,
+   x6 _row_id,
+   x7 xt$id,
+   x1 xt$system_from,
    x9 bar,
    x10 xt$valid_from,
    x11 xt$valid_to}
   [:project
    [x5
+    x2
     x6
     x7
     x1
-    x2
     {x9 (and (< x1 x4) (> x2 x3))}
     {x10 (cast-tstz x3)}
     {x11 (cast-tstz x4)}]
@@ -23,15 +23,15 @@
      xt$system_to x2,
      xt$valid_from x3,
      xt$valid_to x4,
-     xt$id x5,
-     _iid x6,
-     _row_id x7}
+     _iid x5,
+     _row_id x6,
+     xt$id x7}
     [:scan
      {:table foo}
      (xt$system_from
       xt$system_to
       xt$valid_from
       xt$valid_to
-      xt$id
       _iid
-      _row_id)]]]]]
+      _row_id
+      xt$id)]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -1,41 +1,41 @@
 [:update
  {:table "users"}
  [:rename
-  {x2 xt$id,
-   x3 _iid,
-   x4 _row_id,
-   x7 xt$system_from,
-   x8 xt$system_to,
+  {x3 _iid,
+   x5 xt$system_to,
+   x6 _row_id,
+   x7 xt$id,
+   x8 xt$system_from,
    x10 first_name,
    x11 xt$valid_from,
    x12 xt$valid_to}
   [:project
-   [x2
-    x3
-    x4
+   [x3
+    x5
+    x6
     x7
     x8
     {x10 "Sue"}
-    {x11 (cast-tstz (greatest x5 #time/date "2021-07-01"))}
-    {x12 (cast-tstz (least x6 #time/date "9999-12-31"))}]
+    {x11 (cast-tstz (greatest x4 #time/date "2021-07-01"))}
+    {x12 (cast-tstz (least x2 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
-     xt$id x2,
+     xt$valid_to x2,
      _iid x3,
-     _row_id x4,
-     xt$valid_from x5,
-     xt$valid_to x6,
-     xt$system_from x7,
-     xt$system_to x8}
+     xt$valid_from x4,
+     xt$system_to x5,
+     _row_id x6,
+     xt$id x7,
+     xt$system_from x8}
     [:scan
      {:table users,
       :for-valid-time
       [:between #time/date "2021-07-01" #time/date "9999-12-31"]}
      [{id (= id ?_0)}
-      xt$id
-      _iid
-      _row_id
-      xt$valid_from
       xt$valid_to
-      xt$system_from
-      xt$system_to]]]]]]
+      _iid
+      xt$valid_from
+      xt$system_to
+      _row_id
+      xt$id
+      xt$system_from]]]]]]


### PR DESCRIPTION
Now that we have select-star in the SQL analysis, we can also use a similar pattern to project out unchanged columns in UPDATE statements. This means that we no longer need the shenanigans in the SQL update indexer (nor the supporting utilities) - indeed, we can go so far as to combine the insert and update indexers, because both 'just' take the result of a (carefully crafted) SQL query and upsert all of the returned rows as if they were simple 'put' operations :slightly_smiling_face: 