### PR TITLE
Use the google cloud storage API for the google cloud storage docs store/checkpoint store

### DIFF
--- a/docs/storage/modules/ROOT/pages/azure-blobs.adoc
+++ b/docs/storage/modules/ROOT/pages/azure-blobs.adoc
@@ -100,7 +100,7 @@ EDN::
 [#checkpoint-store]
 == Using Azure Blobs as a checkpoint store
 
-Azure blobs can be used as a query index **checkpoint store**. For more advice/config around the checkpointing itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
+Azure blobs can be used as a query index **checkpoint store**. For more advice/configuration concerning the checkpointer itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
 
 [source,clojure]
 ----

--- a/docs/storage/modules/ROOT/pages/google-cloud-storage.adoc
+++ b/docs/storage/modules/ROOT/pages/google-cloud-storage.adoc
@@ -99,7 +99,7 @@ EDN::
 [#checkpoint-store]
 == Checkpoint store
 
-GCS can be used as a query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].  For more advice/config around the checkpointing itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
+GCS can be used as a query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].  For more advice/configuration concerning the checkpointer itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
 
 [source,clojure]
 ----

--- a/docs/storage/modules/ROOT/pages/google-cloud-storage.adoc
+++ b/docs/storage/modules/ROOT/pages/google-cloud-storage.adoc
@@ -1,9 +1,28 @@
 = Google Cloud Storage
 :page-aliases: reference::google-cloud-storage.adoc
 
-You can use Google's Cloud Storage (GCS) as XTDB's 'document store' or 'checkpoint store'.
+You can use Google's Cloud Storage (GCS) as either: 
+
+* XTDB's 'document store'
+* An implementation of the XTDB query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].
 
 Documents are serialized via https://github.com/ptaoussanis/nippy[Nippy].
+
+In both cases, you will require a Google Cloud Project with a bucket to store the files in. See the https://cloud.google.com/storage/docs/creating-buckets["Create Buckets" documentation] from the Google Cloud docs. 
+
+== Authentication 
+
+Authentication for both the document store and checkpoint store components within the module is handled via Google's "Application Default Credentials" - see the https://github.com/googleapis/google-auth-library-java/blob/main/README.md#application-default-credentials[relevant documentation] to get set up.
+
+Whichever method of Authentication you use, ensure that they at least have the permissions to:
+
+* Read objects from a bucket
+* Write objects to a bucket
+
+If using the **checkpoint store**, you will need the following permissions in addition to the above:
+
+* List objects from a bucket
+* Delete objects from a bucket
 
 == Project Dependency
 
@@ -30,7 +49,7 @@ pom.xml::
 ----
 ====
 
-== Using GCS
+== Using GCS as a document store
 
 Replace the implementation of the document store with `+xtdb.google.cloud-storage/->document-store+`
 
@@ -43,7 +62,9 @@ JSON::
 {
   "xtdb/document-store": {
     "xtdb/module": "xtdb.google.cloud-storage/->document-store",
-    "root-path": "gs://bucket/prefix"
+    "project-id": "your-project-id",
+    "bucket": "your-storage-bucket",
+    "prefix": "optional-containing-folder/"
   },
 }
 ----
@@ -53,7 +74,9 @@ Clojure::
 [source,clojure]
 ----
 {:xtdb/document-store {:xtdb/module 'xtdb.google.cloud-storage/->document-store
-                       :root-path "gs://bucket/prefix"}}
+                       :project-id "your-project-id",
+                       :bucket "your-storage-bucket",
+                       :prefix "optional-containing-folder/"}}
 ----
 
 EDN::
@@ -61,25 +84,22 @@ EDN::
 [source,clojure]
 ----
 {:xtdb/document-store {:xtdb/module xtdb.google.cloud-storage/->document-store
-                       :root-path "gs://bucket/prefix"}}
+                       :project-id "your-project-id",
+                       :bucket "your-storage-bucket",
+                       :prefix "optional-containing-folder/"}}
 ----
 ====
 
-Follow the GCS https://github.com/googleapis/google-cloud-java#authentication[Authentication Guide] to get set up.
-
 == Parameters
 
-* `root-path` (string/`Path`, required): path where documents will be stored, `gs://bucket/prefix`
-* `cache-size` (int): size of in-memory document cache (number of entries, not bytes)
-* `pool-size` (int, default 4): size of thread-pool for GCS operations
-
+* `project-id` (string, required) - The name of the GCP project that the bucket is contained within 
+* `bucket` (string, required) - The cloud storage bucket which the documents will be stored within
+* `prefix` (string, optional) - An optional prefix/folder name which will be used within document names (ie, could create a subfolder on a container called 'xtdb-document-store', and all of the document store files will be located under the folder)
 
 [#checkpoint-store]
 == Checkpoint store
 
-GCS can be used as a query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].
-
-Checkpoints aren't GC'd by XTDB - we recommend you set a lifecycle policy on GCS to remove older checkpoints.
+GCS can be used as a query index xref:{page-component-version}@administration::checkpointing.adoc[checkpoint store].  For more advice/config around the checkpointing itself, see xref:{page-component-version}@administration::checkpointing.adoc[Checkpointing].  
 
 [source,clojure]
 ----
@@ -87,9 +107,13 @@ Checkpoints aren't GC'd by XTDB - we recommend you set a lifecycle policy on GCS
 ;; see the Checkpointing guide for other parameters
 {:checkpointer {...
                 :store {:xtdb/module 'xtdb.google.cloud-storage/->checkpoint-store
-                        :path "gs://bucket/prefix"}}
+                        :project-id "your-project-id",
+                        :bucket "your-storage-bucket",
+                        :prefix "optional-containing-folder/"}}
 ----
 
 === Parameters
 
-* `path` (string/`URI`, required): URI of the form `"gs://bucket/prefix"`
+* `project-id` (string, required) - The name of the GCP project that the bucket is contained within 
+* `bucket` (string, required) - The cloud storage bucket which the checkpoints will be stored within
+* `prefix` (string, optional) - An optional prefix/folder name which will be used within checkpoint names (ie, could create a subfolder on a container called 'xtdb-checkpoints', and all of the checkpoint files will be located under the folder)

--- a/modules/azure-blobs/src/xtdb/azure/blobs.clj
+++ b/modules/azure-blobs/src/xtdb/azure/blobs.clj
@@ -73,14 +73,15 @@
          vec
          (run! deref)))
 
-  (fetch-docs [this docs]
+  (fetch-docs [this ids]
     (xio/with-nippy-thaw-all
       (reduce
-       #(if-let [doc (get-blob this %2)]
-          (assoc %1 %2 (nippy/thaw (.toBytes doc)))
-          %1)
+       (fn [docs id]
+         (if-let [doc (get-blob this id)]
+           (assoc docs id (nippy/thaw (.toBytes doc)))
+           docs))
        {}
-       docs))))
+       ids))))
 (defrecord AzureBlobsCheckpointStore [^BlobContainerClient blob-container-client prefix]
   cp/CheckpointStore
   (available-checkpoints [this {::cp/keys [cp-format]}]

--- a/modules/google-cloud-storage/project.clj
+++ b/modules/google-cloud-storage/project.clj
@@ -14,7 +14,6 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
-                 [com.google.cloud/google-cloud-nio "0.124.10"]
                  [com.google.cloud/google-cloud-storage "2.23.0"]
                  [com.google.guava/guava "31.0.1-jre"]]
 

--- a/modules/google-cloud-storage/project.clj
+++ b/modules/google-cloud-storage/project.clj
@@ -14,7 +14,9 @@
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
                  [com.xtdb/xtdb-core]
-                 [com.google.cloud/google-cloud-nio "0.124.10"]]
+                 [com.google.cloud/google-cloud-nio "0.124.10"]
+                 [com.google.cloud/google-cloud-storage "2.23.0"]
+                 [com.google.guava/guava "31.0.1-jre"]]
 
   :profiles {:test {:dependencies [[com.xtdb/xtdb-test]]}}
 

--- a/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
+++ b/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
@@ -62,14 +62,15 @@
          vec
          (run! deref)))
 
-  (fetch-docs [this docs]
+  (fetch-docs [this ids]
     (xio/with-nippy-thaw-all
       (reduce
-       #(if-let [doc (get-blob this %2)]
-          (assoc %1 %2 (nippy/thaw doc))
-          %1)
+       (fn [docs id]
+         (if-let [doc (get-blob this id)]
+           (assoc docs id (nippy/thaw doc))
+           docs))
        {}
-       docs))))
+       ids))))
 
 (defrecord GoogleCloudStorageCheckpointStore [^Storage storage-service bucket-name prefix]
   cp/CheckpointStore

--- a/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
+++ b/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
@@ -1,24 +1,57 @@
 (ns xtdb.google.cloud-storage
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
+            [xtdb.api :as xt]
             [xtdb.checkpoint :as cp]
             [xtdb.document-store :as ds]
             [xtdb.db :as db]
             [xtdb.io :as xio]
             [xtdb.system :as sys])
-  (:import [com.google.cloud.storage Blob$BlobSourceOption BlobId BlobInfo Storage StorageOptions Storage$BlobTargetOption]))
+  (:import [com.google.cloud.storage Blob BlobId BlobInfo Storage StorageOptions
+            Blob$BlobSourceOption Storage$BlobListOption Storage$BlobWriteOption Storage$BlobTargetOption]
+           java.io.File
+           java.nio.charset.StandardCharsets))
 
 (defn get-blob [{:keys [^Storage storage-service bucket-name prefix]} blob-name]
   (let [blob-id (BlobId/of bucket-name (str prefix blob-name))]
     (some-> (.get storage-service blob-id)
             (.getContent (into-array Blob$BlobSourceOption [])))))
 
+(defn get-blob-to-file [{:keys [^Storage storage-service bucket-name prefix]} blob-name file-path]
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))]
+    (some-> (.get storage-service blob-id)
+            (.downloadTo file-path (into-array Blob$BlobSourceOption [])))))
+
 (defn put-blob-bytes
-  ([{:keys [^Storage ^Storage storage-service bucket-name prefix]} blob-name data]
+  ([{:keys [^Storage storage-service bucket-name prefix]} blob-name data]
    (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
          blob-info (.build (BlobInfo/newBuilder blob-id))]
      (.create storage-service blob-info data (into-array Storage$BlobTargetOption [])))))
+
+(defn put-blob-from-file
+  ([{:keys [^Storage storage-service bucket-name prefix]} blob-name file-path]
+   (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
+         blob-info (.build (BlobInfo/newBuilder blob-id))]
+     (.createFrom storage-service blob-info file-path (into-array Storage$BlobWriteOption [])))))
+
+(defn list-blobs 
+  [{:keys [^Storage storage-service bucket-name prefix]} obj-prefix]
+   (let [list-prefix (str prefix obj-prefix)
+         list-blob-opts (into-array Storage$BlobListOption
+                                    (if (not-empty list-prefix)
+                                      [(Storage$BlobListOption/prefix (str prefix obj-prefix))]
+                                      []))]
+     (->> (.list storage-service bucket-name list-blob-opts)
+          (.iterateAll)
+          (mapv (fn [^Blob blob]
+                  (subs (.getName blob) (count prefix)))))))
+
+(defn delete-blob [{:keys [^Storage storage-service bucket-name prefix]} blob-name]
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))]
+    (.delete storage-service blob-id)))
 (defrecord GoogleCloudStorageDocumentStore [^Storage storage-service bucket-name prefix]
   db/DocumentStore
   (submit-docs [this docs]
@@ -38,6 +71,72 @@
        {}
        docs))))
 
+(defrecord GoogleCloudStorageCheckpointStore [^Storage storage-service bucket-name prefix]
+  cp/CheckpointStore
+  (available-checkpoints [this {::cp/keys [cp-format]}]
+    (->> (list-blobs this "metadata-")
+         (sort-by (fn [path]
+                    (let [[_ tx-id checkpoint-at] (re-matches #"metadata-checkpoint-(\d+)-(.+).edn" path)]
+                      [(Long/parseLong tx-id) checkpoint-at]))
+                  #(compare %2 %1))
+         (keep (fn [cp-metadata-path]
+                 (let [resp (some-> (get-blob this cp-metadata-path)
+                                    (String. StandardCharsets/UTF_8)
+                                    (edn/read-string))]
+                   (when (= (::cp/cp-format resp) cp-format)
+                     resp))))))
+
+  (download-checkpoint [this {::keys [gcs-dir] :as checkpoint} dir]
+    (when-not (empty? (.listFiles ^File dir))
+      (throw (IllegalArgumentException. (str "non-empty checkpoint restore dir: " dir))))
+
+    (let [gcs-paths (list-blobs this gcs-dir)
+          blob-files (->> gcs-paths
+                          (mapv (fn [gcs-path]
+                                  (let [output-file (io/file dir (subs gcs-path (count gcs-dir)))
+                                        _ (io/make-parents output-file)
+                                        blob (get-blob-to-file this gcs-path (.toPath output-file))]
+                                    (when (.exists output-file)
+                                      [gcs-path blob]))))
+                          (into {}))]
+
+      (when-not (= (set (keys blob-files)) (set gcs-paths))
+        (xio/delete-dir dir)
+        (throw (ex-info "incomplete checkpoint restore" {:expected gcs-paths
+                                                         :actual (keys blob-files)})))
+      checkpoint))
+
+  (upload-checkpoint [this dir {:keys [tx cp-at ::cp/cp-format]}]
+    (let [dir-path (.toPath ^File dir)
+          gcs-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+
+      (->> (file-seq dir)
+           (mapv (fn [^File file]
+                   (when (.isFile file)
+                     (let [file-path (.toPath file)
+                           blob-name (str gcs-dir "/" (.relativize dir-path file-path))]
+                       (put-blob-from-file this blob-name file-path))))))
+
+      (let [cp {::cp/cp-format cp-format,
+                :tx tx
+                ::gcs-dir (str gcs-dir "/")
+                ::cp/checkpoint-at cp-at}]
+        (put-blob-bytes this
+                        (str "metadata-" gcs-dir ".edn")
+                        (.getBytes (pr-str cp) StandardCharsets/UTF_8))
+
+        cp)))
+
+  (cleanup-checkpoint [this {:keys [tx cp-at]}]
+    (let [azure-dir (format "checkpoint-%s-%s" (::xt/tx-id tx) (xio/format-rfc3339-date cp-at))]
+
+      ;; Delete EDN file first
+      (delete-blob this (str "metadata-" azure-dir ".edn"))
+
+      ;; List & delete directory contents
+      (let [files (list-blobs this azure-dir)]
+        (mapv #(delete-blob this %) files)))))
+
 (s/def ::prefix (s/and ::sys/string
                        (s/conformer (fn [prefix]
                                       (cond
@@ -54,7 +153,7 @@
                                              :doc "The name of your GCS bucket"}
                                     :prefix {:required? false
                                              :spec ::prefix
-                                             :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb files will be located under a 'foo' directory)"}}}
+                                             :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb documents will be located under a 'foo' directory)"}}}
   [{:keys [project-id bucket prefix document-cache] :as opts}]
   (let [storage-service (-> (StorageOptions/newBuilder)
                             (.setProjectId project-id)
@@ -66,7 +165,18 @@
             :document-store
             (->GoogleCloudStorageDocumentStore storage-service bucket prefix)))))
 
-(defn ->checkpoint-store {::sys/deps (::sys/deps (meta #'cp/->filesystem-checkpoint-store))
-                          ::sys/args (::sys/args (meta #'cp/->filesystem-checkpoint-store))}
-  [opts]
-  (cp/->filesystem-checkpoint-store opts))
+(defn ->checkpoint-store {::sys/args {:project-id {:required? true
+                                                   :spec ::sys/string
+                                                   :doc "The name of your GCP project"}
+                                      :bucket {:required? true,
+                                               :spec ::sys/string
+                                               :doc "The name of your GCS bucket"}
+                                      :prefix {:required? false
+                                               :spec ::prefix
+                                               :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb checkpoint files will be located under a 'foo' directory)"}}}
+  [{:keys [project-id bucket prefix]}]
+  (let [storage-service (-> (StorageOptions/newBuilder)
+                            (.setProjectId project-id)
+                            (.build)
+                            (.getService))]
+    (->GoogleCloudStorageCheckpointStore storage-service bucket prefix)))

--- a/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
+++ b/modules/google-cloud-storage/src/xtdb/google/cloud_storage.clj
@@ -1,12 +1,70 @@
 (ns xtdb.google.cloud-storage
-  (:require [xtdb.system :as sys]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [juxt.clojars-mirrors.nippy.v3v1v1.taoensso.nippy :as nippy]
+            [xtdb.checkpoint :as cp]
             [xtdb.document-store :as ds]
-            [xtdb.checkpoint :as cp]))
+            [xtdb.db :as db]
+            [xtdb.io :as xio]
+            [xtdb.system :as sys])
+  (:import [com.google.cloud.storage Blob$BlobSourceOption BlobId BlobInfo Storage StorageOptions Storage$BlobTargetOption]))
 
-(defn ->document-store {::sys/deps (::sys/deps (meta #'ds/->nio-document-store))
-                        ::sys/args (::sys/args (meta #'ds/->nio-document-store))}
-  [opts]
-  (ds/->nio-document-store opts))
+(defn get-blob [{:keys [^Storage storage-service bucket-name prefix]} blob-name]
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))]
+    (some-> (.get storage-service blob-id)
+            (.getContent (into-array Blob$BlobSourceOption [])))))
+
+(defn put-blob-bytes
+  ([{:keys [^Storage ^Storage storage-service bucket-name prefix]} blob-name data]
+   (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
+         blob-info (.build (BlobInfo/newBuilder blob-id))]
+     (.create storage-service blob-info data (into-array Storage$BlobTargetOption [])))))
+(defrecord GoogleCloudStorageDocumentStore [^Storage storage-service bucket-name prefix]
+  db/DocumentStore
+  (submit-docs [this docs]
+    (->> (for [[id doc] docs]
+           (future
+             ;; Put blob - key set to id, blob is nippy compressed document byte array
+             (put-blob-bytes this id (nippy/freeze doc))))
+         vec
+         (run! deref)))
+
+  (fetch-docs [this docs]
+    (xio/with-nippy-thaw-all
+      (reduce
+       #(if-let [doc (get-blob this %2)]
+          (assoc %1 %2 (nippy/thaw doc))
+          %1)
+       {}
+       docs))))
+
+(s/def ::prefix (s/and ::sys/string
+                       (s/conformer (fn [prefix]
+                                      (cond
+                                        (string/blank? prefix) ""
+                                        (string/ends-with? prefix "/") prefix
+                                        :else (str prefix "/"))))))
+
+(defn ->document-store {::sys/deps {:document-cache 'xtdb.cache/->cache}
+                        ::sys/args {:project-id {:required? true
+                                                 :spec ::sys/string
+                                                 :doc "The name of your GCP project"}
+                                    :bucket {:required? true,
+                                             :spec ::sys/string
+                                             :doc "The name of your GCS bucket"}
+                                    :prefix {:required? false
+                                             :spec ::prefix
+                                             :doc "A string to prefix all of your files with (ie, if 'foo' is provided all xtdb files will be located under a 'foo' directory)"}}}
+  [{:keys [project-id bucket prefix document-cache] :as opts}]
+  (let [storage-service (-> (StorageOptions/newBuilder)
+                            (.setProjectId project-id)
+                            (.build)
+                            (.getService))]
+    (ds/->cached-document-store
+     (assoc opts
+            :document-cache document-cache
+            :document-store
+            (->GoogleCloudStorageDocumentStore storage-service bucket prefix)))))
 
 (defn ->checkpoint-store {::sys/deps (::sys/deps (meta #'cp/->filesystem-checkpoint-store))
                           ::sys/args (::sys/args (meta #'cp/->filesystem-checkpoint-store))}

--- a/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
+++ b/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
@@ -30,7 +30,9 @@
     (fix.ds/test-doc-store (::gcs/document-store sys))))
 
 (t/deftest test-cp-store
-  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:path (format "gs://%s/test-%s" test-bucket (UUID/randomUUID))}})
+  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:project-id project-id
+                                                                :bucket test-bucket
+                                                                :prefix (format "test-checkpoint-store-%s" (UUID/randomUUID))}})
                       (sys/start-system))]
 
     (fix.cp/test-checkpoint-store (::gcs/checkpoint-store sys))))

--- a/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
+++ b/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
@@ -1,10 +1,16 @@
 (ns xtdb.google.cloud-storage-test
-  (:require [xtdb.google.cloud-storage :as gcs]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.checkpoint :as cp]
+            [xtdb.fixtures :as fix]
             [xtdb.fixtures.document-store :as fix.ds]
             [xtdb.fixtures.checkpoint-store :as fix.cp]
+            [xtdb.google.cloud-storage :as gcs]
             [xtdb.system :as sys])
-  (:import java.util.UUID))
+  (:import java.util.UUID
+           java.util.Date))
 
 (def project-id "xtdb-scratch")
 (def test-bucket "xtdb-cloud-storage-test-bucket")
@@ -36,3 +42,92 @@
                       (sys/start-system))]
 
     (fix.cp/test-checkpoint-store (::gcs/checkpoint-store sys))))
+
+(t/deftest test-checkpoint-store-cleanup
+  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:project-id project-id
+                                                                :bucket test-bucket
+                                                                :prefix (format "test-checkpoint-store-%s" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (::gcs/checkpoint-store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::gcs/gcs-dir]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                        :tx {::xt/tx-id 1}
+                                                                        :cp-at cp-at})
+            metadata-file (string/replace (str "metadata-" gcs-dir) #"/" ".edn")]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [blob-set (set (gcs/list-blobs cp-store nil))]
+            (t/is (= 2 (count blob-set)))
+            (t/is (contains? blob-set metadata-file))
+            (t/is (contains? blob-set (str gcs-dir "hello.txt")))))
+
+        (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (gcs/list-blobs cp-store nil))))))))
+
+
+(t/deftest test-checkpoint-store-failed-cleanup
+  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:project-id project-id
+                                                                :bucket test-bucket
+                                                                :prefix (format "test-checkpoint-store-%s" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (::gcs/checkpoint-store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::gcs/gcs-dir]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                        :tx {::xt/tx-id 1}
+                                                                        :cp-at cp-at})
+            metadata-file (string/replace (str "metadata-" gcs-dir) #"/" ".edn")]
+
+        (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+          (let [blob-set (set (gcs/list-blobs cp-store nil))]
+            (t/is (= 2 (count blob-set)))
+            (t/is (contains? blob-set metadata-file))
+            (t/is (contains? blob-set (str gcs-dir "hello.txt")))))
+
+        (t/testing "error in `cleanup-checkpoints` after deleting checkpoint metadata file still leads to checkpoint not being available"
+          (with-redefs [gcs/list-blobs (fn [_ _] (throw (Exception. "Test Exception")))]
+            (t/is (thrown-with-msg? Exception
+                                    #"Test Exception"
+                                    (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                                                     :cp-at cp-at}))))
+          ;; Only directory should be available - checkpoint metadata file should have been deleted
+          (t/is (= [(str gcs-dir "hello.txt")]
+                   (gcs/list-blobs cp-store nil)))
+          ;; Should not be able to fetch checkpoint as checkpoint metadata file is gone
+          (t/is (empty? (cp/available-checkpoints cp-store {::cp/cp-format ::foo-cp-format}))))))))
+
+(t/deftest test-checkpoint-store-cleanup-no-edn-file
+  (with-open [sys (-> (sys/prep-system {::gcs/checkpoint-store {:project-id project-id
+                                                                :bucket test-bucket
+                                                                :prefix (format "test-checkpoint-store-%s" (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-at (Date.)
+            cp-store (::gcs/checkpoint-store sys)
+            ;; create file for upload
+            _ (spit (io/file dir "hello.txt") "Hello world")
+            {:keys [::gcs/gcs-dir]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                        :tx {::xt/tx-id 1}
+                                                                        :cp-at cp-at})
+            metadata-file (string/replace (str "metadata-" gcs-dir) #"/" ".edn")]
+
+        ;; delete the checkpoint file
+        (gcs/delete-blob cp-store metadata-file)
+
+        (t/testing "checkpoint folder present, edn file should be deleted"
+          (let [blob-set (set (gcs/list-blobs cp-store nil))]
+            (t/is (= 1 (count blob-set)))
+            (t/is (not (contains? blob-set metadata-file)))
+            (t/is (contains? blob-set (str gcs-dir "hello.txt")))))
+
+        (t/testing "call to `cleanup-checkpoints` with no edn file should still remove an uploaded checkpoint and metadata"
+          (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                           :cp-at cp-at})
+          (t/is (empty? (gcs/list-blobs cp-store nil))))))))

--- a/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
+++ b/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
@@ -6,8 +6,7 @@
             [xtdb.system :as sys])
   (:import java.util.UUID))
 
-(def test-bucket
-  (System/getProperty "xtdb.google.cloud-storage-test.bucket"))
+(def test-bucket "xtdb-cloud-storage-test-bucket")
 
 (t/use-fixtures :once
   (fn [f]

--- a/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
+++ b/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
@@ -28,8 +28,7 @@
         (when (.exists bucket (into-array Bucket$BucketSourceOption []))
           (f)))
       (catch StorageException e
-        (if (= 401(.getCode e))
-          nil
+        (when-not (= 401 (.getCode e))
           (throw e))))))
 
 (t/deftest test-doc-store

--- a/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
+++ b/modules/google-cloud-storage/test/xtdb/google/cloud_storage_test.clj
@@ -6,6 +6,7 @@
             [xtdb.system :as sys])
   (:import java.util.UUID))
 
+(def project-id "xtdb-scratch")
 (def test-bucket "xtdb-cloud-storage-test-bucket")
 
 (t/use-fixtures :once
@@ -14,7 +15,16 @@
       (f))))
 
 (t/deftest test-doc-store
-  (with-open [sys (-> (sys/prep-system {::gcs/document-store {:root-path (format "gs://%s/test-%s" test-bucket (UUID/randomUUID))}})
+  (with-open [sys (-> (sys/prep-system {::gcs/document-store {:project-id project-id
+                                                              :bucket test-bucket}})
+                      (sys/start-system))]
+
+    (fix.ds/test-doc-store (::gcs/document-store sys))))
+
+(t/deftest test-doc-store-with-prefix
+  (with-open [sys (-> (sys/prep-system {::gcs/document-store {:project-id project-id
+                                                              :bucket test-bucket
+                                                              :prefix (format "test-doc-store-%s" (UUID/randomUUID))}})
                       (sys/start-system))]
 
     (fix.ds/test-doc-store (::gcs/document-store sys))))

--- a/project.clj
+++ b/project.clj
@@ -166,7 +166,6 @@
              :with-s3-tests {:jvm-opts ["-Dxtdb.s3.test-bucket=crux-s3-test"]}
              :with-azure-blobs-tests {:jvm-opts ["-Dxtdb.azure.blobs.test-storage-account=crux-azure-blobs-test-storage-account"
                                                  "-Dxtdb.azure.blobs.test-container=crux-azure-blobs-test-container"]}
-             :with-google-cloud-storage-test {:jvm-opts ["-Dxtdb.google.cloud-storage-test.bucket=crux-gcs-test"]}
              :with-nio-storage-test {:jvm-opts ["-Dxtdb.nio-checkpoint-test.nio-path=gs://xtdb-cloud-storage-test-bucket"]}
              :with-chm-add-opens {:jvm-opts ["--add-opens" "java.base/java.util.concurrent=ALL-UNNAMED"]}
              :nvd {:dependencies [[lein-nvd "2.0.0"]]


### PR DESCRIPTION
Resolves #1865, and Resolves #2616

Modeled off of the updated Azure blobs module - utilizing some similar tricks. 
- Metadata files are prefixed with `metadata-` as the list function is recursive (no configuration to prevent this, as far as I can tell, so we use the same prefix behaviour as azure blobs).
- Authentication handled as it was before (default google auth)
- Added extra tests for cleanup checkpoint behaviour based on those used against the other checkpoint stores  
- Updated docs
