### PR TITLE
`cleanup-checkpoint` on NIO filestores

### DIFF
--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -12,7 +12,7 @@
            (java.lang.management BufferPoolMXBean ManagementFactory)
            (java.lang.ref PhantomReference ReferenceQueue)
            (java.net ServerSocket)
-           (java.nio.file Files FileVisitResult SimpleFileVisitor)
+           (java.nio.file Files FileVisitResult SimpleFileVisitor Path LinkOption) 
            (java.nio.file.attribute FileAttribute)
            (java.text SimpleDateFormat)
            (java.time Duration)
@@ -78,6 +78,9 @@
     (postVisitDirectory [dir _]
       (Files/delete dir)
       FileVisitResult/CONTINUE)))
+
+(defn path-exists? [^Path path]
+  (Files/exists path (make-array LinkOption 0)))
 
 (defn delete-dir [dir]
   (let [dir (io/file dir)]

--- a/core/src/xtdb/io.clj
+++ b/core/src/xtdb/io.clj
@@ -87,10 +87,11 @@
     (when (.exists dir)
       (Files/walkFileTree (.toPath dir) file-deletion-visitor))))
 
-(defn delete-file [file]
-  (let [file (io/file file)]
-    (when (.exists file)
-      (.delete file))))
+(defn delete-path [path]
+  (when (path-exists? path)
+    (if (Files/isDirectory path (make-array LinkOption 0))
+      (Files/walkFileTree path file-deletion-visitor)
+      (Files/delete path))))
 
 (defn create-tmpdir ^java.io.File [dir-name]
   (let [f (.toFile (Files/createTempDirectory dir-name (make-array FileAttribute 0)))

--- a/project.clj
+++ b/project.clj
@@ -167,6 +167,7 @@
              :with-azure-blobs-tests {:jvm-opts ["-Dxtdb.azure.blobs.test-storage-account=crux-azure-blobs-test-storage-account"
                                                  "-Dxtdb.azure.blobs.test-container=crux-azure-blobs-test-container"]}
              :with-google-cloud-storage-test {:jvm-opts ["-Dxtdb.google.cloud-storage-test.bucket=crux-gcs-test"]}
+             :with-nio-storage-test {:jvm-opts ["-Dxtdb.nio-checkpoint-test.nio-path=gs://xtdb-cloud-storage-test-bucket"]}
              :with-chm-add-opens {:jvm-opts ["--add-opens" "java.base/java.util.concurrent=ALL-UNNAMED"]}
              :nvd {:dependencies [[lein-nvd "2.0.0"]]
                    :plugins [[lein-nvd "1.5.0"]]}}

--- a/test/test/xtdb/nio_checkpoint_test.clj
+++ b/test/test/xtdb/nio_checkpoint_test.clj
@@ -1,0 +1,62 @@
+(ns xtdb.nio-checkpoint-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.checkpoint :as cp]
+            [xtdb.fixtures :as fix]
+            [xtdb.fixtures.checkpoint-store :as fix.cp-store]
+            [xtdb.io :as xio]
+            [xtdb.system :as sys])
+  (:import [java.util Date UUID]
+           [java.nio.file Paths]
+           java.net.URI))
+
+;; can be ran using
+;; lein with-profiles +with-nio-storage-test test xtdb.nio-checkpoint-test
+;; will need to be authenticated with Google Cloud (currently what we're testing against)
+
+(def nio-path
+  (System/getProperty "xtdb.nio-checkpoint-test.nio-path"))
+
+(defn ->path [filename]
+  (let [uri (URI. (str nio-path filename))]
+    (Paths/get uri)))
+
+(t/use-fixtures :once
+  (fn [f]
+    (when nio-path
+      (f))))
+
+(t/deftest test-nio-fs-checkpoint-store
+  (with-open [sys (-> (sys/prep-system {::cp/filesystem-checkpoint-store {:path (format "%s/test-%s" nio-path (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix.cp-store/test-checkpoint-store (::cp/filesystem-checkpoint-store sys))))
+
+(t/deftest test-nio-fs-checkpoint-store-failed-download
+  (with-open [sys (-> (sys/prep-system {::cp/filesystem-checkpoint-store {:path (format "%s/test-%s" nio-path (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix.cp-store/test-checkpoint-broken-store-failed-download (::cp/filesystem-checkpoint-store sys))))
+
+(t/deftest test-nio-fs-checkpoint-store-cleanup
+  (with-open [sys (-> (sys/prep-system {::cp/filesystem-checkpoint-store {:path (format "%s/test-%s" nio-path (UUID/randomUUID))}})
+                      (sys/start-system))]
+    (fix/with-tmp-dirs #{dir}
+      (let [cp-store (::cp/filesystem-checkpoint-store sys)
+            cp-at (Date.)]
+
+      ;; create file for upload
+        (spit (io/file dir "hello.txt") "Hello world")
+
+        (let [{:keys [::cp/cp-uri]} (cp/upload-checkpoint cp-store dir {::cp/cp-format ::foo-cp-format
+                                                                        :tx {::xt/tx-id 1}
+                                                                        :cp-at cp-at})]
+          (t/testing "call to upload-checkpoint creates expected folder & checkpoint metadata file for the checkpoint"
+            (t/is (xio/path-exists? (->path cp-uri)))
+            (t/is (xio/path-exists? (->path (str cp-uri ".edn")))))
+
+          (t/testing "call to `cleanup-checkpoints` entirely removes an uploaded checkpoint and metadata"
+            (cp/cleanup-checkpoint cp-store {:tx {::xt/tx-id 1}
+                                             :cp-at cp-at})
+            (t/is (= false (xio/path-exists? (->path cp-uri))))
+            (t/is (= false (xio/path-exists? (->path (str cp-uri ".edn")))))))))))
+


### PR DESCRIPTION
Resolves #2623 

Fixes and tests the previous issue of NIO file stores not deleting files on `cleanup-checkpoint`:
- Accomplishes this by using direct Java interop using Paths, rather than clojure.java.io (which does not support NIO)
- Adds some new helper functions around paths to `xtdb.io` - `path-exists?` and `delete-path`. 
- Adds a new test file (originally failing, now passing) against NIO filesystem checkpoint store (ran via lein profiles against gcloud nio)  