### PR TITLE
Implement google cloud storage object store

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ allprojects {
 
         tasks.test {
             useJUnitPlatform {
-                excludeTags("integration", "kafka", "jdbc", "timescale", "s3", "slt", "docker", "azure")
+                excludeTags("integration", "kafka", "jdbc", "timescale", "s3", "slt", "docker", "azure", "google-cloud")
             }
         }
 
@@ -162,6 +162,7 @@ dependencies {
     projectDep(":modules:kafka")
     projectDep(":modules:s3")
     projectDep(":modules:azure")
+    projectDep(":modules:google-cloud")
 
     projectDep(":modules:bench")
     projectDep(":modules:c1-import")

--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,7 @@
         com.xtdb.labs/xtdb-kafka {:local/root "modules/kafka"}
         com.xtdb.labs/xtdb-s3 {:local/root "modules/s3"}
         com.xtdb.labs/xtdb-azure {:local/root "modules/azure"}
+        com.xtdb.labs/xtdb-google-cloud {:local/root "modules/google-cloud"}
         com.xtdb.labs/xtdb-jdbc {:local/root "modules/jdbc"}
         com.xtdb.labs/xtdb-bench {:local/root "modules/bench"}
         com.xtdb.labs/xtdb-c1-import {:local/root "modules/c1-import"}
@@ -57,7 +58,7 @@
                             "-XX:MaxMetaspaceSize=1g"]}
 
            :test {:exec-fn cognitect.test-runner.api/test
-                  :exec-args {:excludes [:integration :timescale :s3 :kafka :jdbc :slt :docker :azure]
+                  :exec-args {:excludes [:integration :timescale :s3 :kafka :jdbc :slt :docker :azure :google-cloud]
                               :dirs ["src/test/clojure"]}}
 
            :integration-test {:exec-fn cognitect.test-runner.api/test

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":modules:jdbc"))
     implementation(project(":modules:kafka"))
     implementation(project(":modules:azure"))
+    implementation(project(":modules:google-cloud"))
     implementation(project(":modules:flight-sql"))
     implementation("ch.qos.logback", "logback-classic", "1.4.5")
 }

--- a/modules/google-cloud/README.adoc
+++ b/modules/google-cloud/README.adoc
@@ -1,0 +1,61 @@
+# Google Cloud Module
+
+Within our XTDB node, we can make use of Google Cloud Services for certain purposes. Currently, we can:
+
+* Use *Google Cloud Storage* as the XTDB Object Store.
+
+### Project Dependency 
+
+In order to use any of the Azure services, you will need to include a dependency on the xtdb.azure module.
+
+_deps.edn_
+```
+com.xtdb.labs/xtdb-google-cloud {:mvn/version "2.0.0-SNAPSHOT"}
+```
+
+_pom.xml_
+```
+<dependency>
+    <groupId>com.xtdb.labs</groupId>
+    <artifactId>xtdb-google-cloud</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+### Authentication
+
+Authentication for both the document store and checkpoint store components within the module is handled via Google’s "Application Default Credentials" - see the https://github.com/googleapis/google-auth-library-java/blob/main/README.md#application-default-credentials[*relevant documentation*] to get set up. You will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules. 
+
+## Google Cloud Storage Object Store
+
+We can swap out the implementation of the object store with one based on Azure Blob Storage. To do so, we add the `xtdb.google-cloud/blob-object-store` key within the integrant config for our node, alongside any config:
+```clojure
+{
+  ...
+  {:xtdb.google-cloud/blob-object-store {:project-id "your-project-id"
+                                         :bucket "your-storage-bucket"}}
+  ...
+}
+```
+
+### Parameters
+
+These are the following parameters that can be passed within the config for our `xtdb.google-cloud/blob-object-store`:
+[cols="1,1,2,1"]
+|===
+| *Name* | *Type* | *Description* | *Required?*
+| `project-id`
+| String
+| The name of the GCP project that the bucket is contained within
+| Yes
+
+| `bucket`
+| String 
+| The cloud storage bucket which the documents will be stored within
+| Yes
+
+|`prefix`
+| String 
+| A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
+| No
+|=== 

--- a/modules/google-cloud/README.adoc
+++ b/modules/google-cloud/README.adoc
@@ -6,7 +6,7 @@ Within our XTDB node, we can make use of Google Cloud Services for certain purpo
 
 ### Project Dependency 
 
-In order to use any of the Azure services, you will need to include a dependency on the xtdb.azure module.
+In order to use any of the Google Cloud services, you will need to include a dependency on the `xtdb-google-cloud` module.
 
 _deps.edn_
 ```
@@ -24,11 +24,11 @@ _pom.xml_
 
 ### Authentication
 
-Authentication for both the document store and checkpoint store components within the module is handled via Google’s "Application Default Credentials" - see the https://github.com/googleapis/google-auth-library-java/blob/main/README.md#application-default-credentials[*relevant documentation*] to get set up. You will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules. 
+Authentication for both the document store and checkpoint store components within the module is handled via Google’s "Application Default Credentials" - see the https://github.com/googleapis/google-auth-library-java/blob/main/README.md#application-default-credentials[*relevant documentation*] to get set up. You will need to setup authentication using any of the methods listed within the documentation to be able to make use of the operations inside the modules. 
 
 ## Google Cloud Storage Object Store
 
-We can swap out the implementation of the object store with one based on Azure Blob Storage. To do so, we add the `xtdb.google-cloud/blob-object-store` key within the integrant config for our node, alongside any config:
+We can swap out the implementation of the object store with one based on Google Cloud Blob Storage. To do so, we add the `xtdb.google-cloud/blob-object-store` key within the integrant config for our node, alongside any config:
 ```clojure
 {
   ...

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -19,5 +19,4 @@ dependencies {
     api(project(":core"))
 
     api("com.google.cloud", "google-cloud-storage", "2.23.0")
-    api("com.google.guava", "guava", "31.0.1-jre")
 }

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `java-library`
+    id("dev.clojurephant.clojure")
+    `maven-publish`
+    signing
+}
+
+publishing {
+    publications.create("maven", MavenPublication::class) {
+        pom {
+            name.set("XTDB Google Cloud")
+            description.set("XTDB Google Cloud")
+        }
+    }
+}
+
+dependencies {
+    api(project(":api"))
+    api(project(":core"))
+
+    api("com.google.cloud", "google-cloud-storage", "2.23.0")
+    api("com.google.guava", "guava", "31.0.1-jre")
+}

--- a/modules/google-cloud/deps.edn
+++ b/modules/google-cloud/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src/main/clojure" "target/classes"]
+ 
+ :deps {com.xtdb.labs/xtdb-api {:local/root "../../api"}
+        com.xtdb.labs/xtdb-core {:local/root "../../core"}
+
+        com.google.cloud/google-cloud-storage {:mvn/version "2.23.0"}
+        com.google.guava/guava {:mvn/version "31.0.1-jre"}}}

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
@@ -1,0 +1,34 @@
+(ns xtdb.google-cloud
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.google-cloud.object-store :as os]
+            [xtdb.util :as util])
+  (:import [com.google.cloud.storage StorageOptions]))
+
+(derive ::blob-object-store :xtdb/object-store)
+
+(defn- parse-prefix [prefix]
+  (cond
+    (string/blank? prefix) ""
+    (string/ends-with? prefix "/") prefix
+    :else (str prefix "/")))
+
+(s/def ::project-id string?)
+(s/def ::bucket string?)
+(s/def ::prefix string?)
+
+(defmethod ig/prep-key ::blob-object-store [_ opts]
+  (-> opts
+      (util/maybe-update :prefix parse-prefix)))
+
+(defmethod ig/pre-init-spec ::blob-object-store [_]
+  (s/keys :req-un [::project-id ::bucket]
+          :opt-un [::prefix]))
+
+(defmethod ig/init-key ::blob-object-store [_ {:keys [project-id bucket prefix]}]
+  (let [storage-service (-> (StorageOptions/newBuilder)
+                            (.setProjectId project-id)
+                            (.build)
+                            (.getService))]
+    (os/->GoogleCloudStorageObjectStore storage-service bucket prefix)))

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
@@ -1,0 +1,104 @@
+(ns xtdb.google-cloud.object-store
+  (:require [xtdb.object-store :as os]
+            [xtdb.util :as util])
+  (:import [com.google.cloud.storage Blob BlobId BlobInfo Storage Blob$BlobSourceOption Storage$BlobListOption
+            Storage$BlobSourceOption Storage$BlobWriteOption StorageException]
+           [com.google.common.io ByteStreams]
+           [java.nio ByteBuffer]
+           [java.util.concurrent CompletableFuture]
+           [java.util.function Supplier]
+           [xtdb.object_store ObjectStore]))
+
+(def blob-source-opts (into-array Blob$BlobSourceOption []))
+
+(defn get-blob [{:keys [^Storage storage-service bucket-name prefix]} blob-name]
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
+        blob-byte-buffer (some-> (.get storage-service blob-id)
+                                 (.getContent blob-source-opts)
+                                 (ByteBuffer/wrap))]
+    (if blob-byte-buffer
+      blob-byte-buffer
+      (throw (os/obj-missing-exception blob-name)))))
+
+(def read-options (into-array Storage$BlobSourceOption []))
+
+(defn- get-blob-range [{:keys [^Storage storage-service bucket-name prefix]} blob-name start len]
+  (os/ensure-shared-range-oob-behaviour start len)
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
+        blob (.get storage-service blob-id)
+        out (ByteBuffer/allocate len)]
+    (if blob
+      ;; Read contents of reader into the allocated ByteBuffer
+      (with-open [reader (.reader blob blob-source-opts)]
+        (.seek reader start)
+        ;; limit on google cloud readchannel starts from the beginning, so we need to add the start to the
+        ;; specified length for desired behaviour - see:
+        ;; https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.ReadChannel
+        (.limit reader (+ start len))
+        (.read reader out)
+        (.flip out))
+      (throw (os/obj-missing-exception blob-name)))))
+
+;; Want to only put blob if a version doesn't already exist
+(def write-options (into-array Storage$BlobWriteOption [(Storage$BlobWriteOption/doesNotExist)]))
+
+(defn put-blob
+  ([{:keys [^Storage storage-service bucket-name prefix]} blob-name byte-buf]
+   (let [blob-id (BlobId/of bucket-name (str prefix blob-name))
+         blob-info (.build (BlobInfo/newBuilder blob-id))]
+
+     (try
+       (with-open [writer (.writer storage-service blob-info write-options)]
+         (.write writer byte-buf))
+       (catch StorageException e
+         (when-not (= 412 (.getCode e))
+           (throw e)))))))
+
+(defn list-blobs
+  [{:keys [^Storage storage-service bucket-name prefix]} obj-prefix]
+  (let [list-prefix (str prefix obj-prefix)
+        list-blob-opts (into-array Storage$BlobListOption
+                                   (if (not-empty list-prefix)
+                                     [(Storage$BlobListOption/prefix list-prefix)]
+                                     []))]
+    (->> (.list storage-service bucket-name list-blob-opts)
+         (.iterateAll)
+         (mapv (fn [^Blob blob]
+                 (subs (.getName blob) (count prefix)))))))
+
+(defn delete-blob [{:keys [^Storage storage-service bucket-name prefix]} blob-name]
+  (let [blob-id (BlobId/of bucket-name (str prefix blob-name))]
+    (.delete storage-service blob-id)))
+
+(defrecord GoogleCloudStorageObjectStore [^Storage storage-service bucket-name prefix]
+  ObjectStore
+  (getObject [this k]
+    (CompletableFuture/completedFuture
+     (get-blob this k)))
+
+  (getObject [this k out-path]
+    (CompletableFuture/supplyAsync
+     (reify Supplier
+       (get [_]
+         (let [blob-buffer (get-blob this k)]
+           (util/write-buffer-to-path blob-buffer out-path)
+
+           out-path)))))
+
+  (getObjectRange [this k start len]
+    (CompletableFuture/completedFuture
+     (get-blob-range this k start len)))
+
+  (putObject [this k buf]
+    (put-blob this k buf)
+    (CompletableFuture/completedFuture nil))
+
+  (listObjects [this]
+    (.listObjects this nil))
+
+  (listObjects [this obj-prefix]
+    (list-blobs this obj-prefix))
+
+  (deleteObject [this k]
+    (delete-blob this k)
+    (CompletableFuture/completedFuture nil)))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,6 @@ include("api", "core", "wire-formats")
 include("http-server", "http-client-clj", "pgwire-server")
 include("docker")
 
-include("modules:jdbc", "modules:kafka", "modules:s3", "modules:azure")
+include("modules:jdbc", "modules:kafka", "modules:s3", "modules:azure", "modules:google-cloud")
 include("modules:c1-import", "modules:flight-sql")
 include("modules:bench", "modules:datasets")

--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -1,0 +1,59 @@
+(ns xtdb.google-cloud-test
+  (:require [clojure.java.shell :as sh]
+            [clojure.tools.logging :as log]
+            [clojure.test :as t]
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.google-cloud :as google-cloud]
+            [xtdb.object-store-test :as os-test])
+  (:import [java.io Closeable]
+           [com.google.cloud.storage StorageOptions Storage$BucketGetOption Bucket$BucketSourceOption StorageException]))
+
+(def project-id "xtdb-scratch")
+(def test-bucket "xtdb-cloud-storage-test-bucket")
+
+(defn config-present? []
+  (try
+    (let [storage (-> (StorageOptions/newBuilder)
+                      (.setProjectId project-id)
+                      (.build)
+                      (.getService))
+          bucket (.get storage test-bucket (into-array Storage$BucketGetOption []))]
+      (.exists bucket (into-array Bucket$BucketSourceOption [])))
+    (catch StorageException e
+      (when-not (= 401 (.getCode e))
+        (throw e)))))
+
+(defn cli-available? []
+  (= 0 (:exit (sh/sh "gcloud" "--help"))))
+
+(defn run-if-auth-available [f]
+  (cond
+    (config-present?) (f)
+
+    (not (cli-available?))
+    (log/warn "gcloud cli is unavailable, and application default credentials are not set")
+
+    :else
+    (log/warn "gcloud cli appears to be available but you are not authenticated, run `gcloud auth application-default login` before running the tests")))
+
+(t/use-fixtures :once run-if-auth-available)
+
+(defn object-store ^Closeable [prefix]
+  (->> (ig/prep-key ::google-cloud/blob-object-store {:project-id project-id
+                                                      :bucket test-bucket
+                                                      :prefix (str "xtdb.google-cloud-test." prefix)})
+       (ig/init-key ::google-cloud/blob-object-store)))
+
+(t/deftest ^:google-cloud put-delete-test
+  (let [os (object-store (random-uuid))]
+    
+    (os-test/test-put-delete os)))
+
+;; Current fails since it DOESNT error for "OOB for last index"
+(t/deftest ^:google-cloud range-test
+  (let [os (object-store (random-uuid))]
+    (os-test/test-range os)))
+
+(t/deftest ^:google-cloud list-test
+  (let [os (object-store (random-uuid))]
+    (os-test/test-list-objects os)))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -92,7 +92,10 @@
        (t/is (thrown? Exception (get-bytes obj-store "digits" -1 3))))
 
   (->> "OOB for negative len"
-       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1)))))
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1))))
+  
+  (->> "IllegalStateException thrown if object does not exist"
+       (t/is (thrown? IllegalStateException (get-bytes obj-store "does-not-exist" 0 1)))))
 
 ;; ---
 ;; memory-object-store

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -92,10 +92,7 @@
        (t/is (thrown? Exception (get-bytes obj-store "digits" -1 3))))
 
   (->> "OOB for negative len"
-       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1))))
-
-  (->> "OOB for last index"
-       (t/is (thrown? Exception (get-bytes obj-store "digits" 10 1)))))
+       (t/is (thrown? Exception (get-bytes obj-store "digits" 0 -1)))))
 
 ;; ---
 ;; memory-object-store


### PR DESCRIPTION
Resolves #2628 

Implements a new object store using Azure Blob Storage, alongside:
- All of the related integrant config to add it to a node.
- Including the module within various places - namely the xtdb standalone deps and dev dependencies.
- Documentation in the form of a README in the module.
- A test file making use of the object-store tests.
  - Expects various bits of auth & the specified bucket to be present
- Updates to `object-store-test/test-range`:
  - Remove assertion where we expect an error if starting position > object length (this is _undefined_ behaviour, we don't necessarily expect an error to be thrown, thanks @wotbrew !)
  - Add an assertion that the method throws an `IllegalStateException` if the object doesn't exist/is not found)  

As a note on the behaviour:
- I'm _fairly sure_ using reader on google cloud blobs shouldnt read the whole file - [https://javadoc.io/doc/com.google.cloud/google-cloud-storage/latest/com/google/cloud/storage/Storage.html#reader-com.google.c[…]BlobSourceOption...-](https://javadoc.io/doc/com.google.cloud/google-cloud-storage/latest/com/google/cloud/storage/Storage.html#reader-com.google.cloud.storage.BlobId-com.google.cloud.storage.Storage.BlobSourceOption...-)
- It's using `ReadableByteChannel` under the hood, which seems to read byte by byte, so I'm assuming should have the kinda behaviour we're looking for.
- Was following https://cloud.google.com/storage/docs/samples/storage-download-byte-range initially, though have had to dip into `ReadableByteChannel` itself to read the content into a `ByteBuffer`