### PR TITLE
[PoC] Datalog fixpoint operator

### DIFF
--- a/core/src/main/clojure/xtdb/live_chunk.clj
+++ b/core/src/main/clojure/xtdb/live_chunk.clj
@@ -119,13 +119,17 @@
 
   (^long chunkIdx [])
   (^boolean isChunkFull [])
-  (^boolean isBlockFull [])
+  (^long rowsPerBlock [])
+  (^long blockRowCount [])
 
   (^void finishBlock [])
   (^void nextBlock [])
   (^java.util.concurrent.CompletableFuture finishChunk [^xtdb.api.protocols.TransactionInstant latestCompletedTx])
   (^void nextChunk [])
   (^void close []))
+
+(defn block-full? [^ILiveChunk live-chunk]
+  (<= (.rowsPerBlock live-chunk) (.blockRowCount live-chunk)))
 
 (defn- ->excluded-block-idxs ^org.roaringbitmap.RoaringBitmap [^ITableMetadata table-metadata, ^IMetadataPredicate metadata-pred]
   (let [exclude-block-idxs (RoaringBitmap.)]
@@ -401,7 +405,8 @@
         (close [_] (util/close wms)))))
 
   (chunkIdx [_] chunk-idx)
-  (isBlockFull [_] (>= (.blockRowCount row-counter) rows-per-block))
+  (rowsPerBlock [_] rows-per-block)
+  (blockRowCount [_] (.blockRowCount row-counter))
   (isChunkFull [_] (>= (.chunkRowCount row-counter) rows-per-chunk))
 
   (finishBlock [_]

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -124,3 +124,26 @@
 (defn ->notifying-subscriber-handler [latest-submitted-tx-id]
   (->NotifyingSubscriberHandler (atom {:latest-submitted-tx-id latest-submitted-tx-id
                                        :semaphores #{}})))
+
+;; header bytes
+(def ^:const hb-user-arrow-transaction
+  "Header byte for log records representing an arrow user transaction.
+
+  A standard arrow stream IPC buffer will contain this byte, so you do not need to prefix."
+  255)
+
+(def ^:const hb-flush-chunk
+  "Header byte for log records representing a signal to flush the live chunk to durable storage.
+
+  Can be useful to protect against data loss potential when a retention period is used for the log, so messages do not remain in the log forever.
+
+  Record layout:
+
+  - header (byte=2)
+
+  - expected-last-tx-id in previous chunk (long)
+  If this tx-id match the last tx-id who has been indexed in durable storage, then this signal is ignored.
+  This is to avoid a herd effect in multi-node environments where multiple flush signals for the same chunk might be received.
+
+  See xtdb.stagnant-log-flusher"
+  2)

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -119,26 +119,29 @@
   (cond-> opts
     (not (ig/find-derived opts parent-k)) (assoc impl-k {})))
 
+(defn node-system [opts]
+  (-> (into {::node {}
+             :xtdb/allocator {}
+             :xtdb/default-tz nil
+             :xtdb/indexer {}
+             :xtdb.indexer/internal-id-manager {}
+             :xtdb/live-chunk {}
+             :xtdb.indexer/live-index {}
+             :xtdb/ingester {}
+             :xtdb.metadata/metadata-manager {}
+             :xtdb.temporal/temporal-manager {}
+             :xtdb.buffer-pool/buffer-pool {}
+             :xtdb.operator.scan/scan-emitter {}
+             :xtdb.operator/ra-query-source {}
+             ::txp/tx-producer {}}
+            opts)
+      (doto ig/load-namespaces)
+      (with-default-impl :xtdb/log :xtdb.log/memory-log)
+      (with-default-impl :xtdb/object-store :xtdb.object-store/memory-object-store)
+      (doto ig/load-namespaces)))
+
 (defn start-node ^xtdb.node.Node [opts]
-  (let [system (-> (into {::node {}
-                          :xtdb/allocator {}
-                          :xtdb/default-tz nil
-                          :xtdb/indexer {}
-                          :xtdb.indexer/internal-id-manager {}
-                          :xtdb/live-chunk {}
-                          :xtdb.indexer/live-index {}
-                          :xtdb/ingester {}
-                          :xtdb.metadata/metadata-manager {}
-                          :xtdb.temporal/temporal-manager {}
-                          :xtdb.buffer-pool/buffer-pool {}
-                          :xtdb.operator.scan/scan-emitter {}
-                          :xtdb.operator/ra-query-source {}
-                          ::txp/tx-producer {}}
-                         opts)
-                   (doto ig/load-namespaces)
-                   (with-default-impl :xtdb/log :xtdb.log/memory-log)
-                   (with-default-impl :xtdb/object-store :xtdb.object-store/memory-object-store)
-                   (doto ig/load-namespaces)
+  (let [system (-> (node-system opts)
                    ig/prep
                    ig/init)]
 

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -133,7 +133,8 @@
              :xtdb.buffer-pool/buffer-pool {}
              :xtdb.operator.scan/scan-emitter {}
              :xtdb.operator/ra-query-source {}
-             ::txp/tx-producer {}}
+             ::txp/tx-producer {}
+             :xtdb.stagnant-log-flusher/flusher {}}
             opts)
       (doto ig/load-namespaces)
       (with-default-impl :xtdb/log :xtdb.log/memory-log)

--- a/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
+++ b/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
@@ -1,0 +1,96 @@
+(ns xtdb.stagnant-log-flusher
+  (:require [clojure.tools.logging :as log]
+            [xtdb.log :as xt-log]
+            [xtdb.indexer]
+            [xtdb.node :as node]
+            [xtdb.tx-producer]
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.util :as util])
+  (:import (java.nio ByteBuffer)
+           (java.nio.channels ClosedByInterruptException)
+           (java.time Duration)
+           (java.util.concurrent ExecutorService Executors ThreadFactory TimeUnit)
+           (xtdb.indexer IIndexer)
+           (xtdb.log Log)))
+
+;; see https://github.com/xtdb/xtdb/issues/2548
+
+(defmethod ig/prep-key ::flusher
+  [_ opts]
+  (merge {:indexer (ig/ref :xtdb/indexer)
+          :log (ig/ref :xtdb/log)}
+         opts))
+
+(defmethod ig/init-key ::flusher
+  [_ {:keys [^IIndexer indexer
+             ^Log log
+             duration
+             ;; callback hook used to control timing in tests
+             ;; receives a map of the :last-flush, :last-seen tx-keys
+             on-heartbeat]
+      :or {duration #time/duration "PT4H"
+           on-heartbeat (constantly nil)}}]
+  (let [exr-tf (util/->prefix-thread-factory "xtdb.stagnant-log-flush")
+        exr (Executors/newSingleThreadScheduledExecutor exr-tf)
+
+        ;; the tx-key of the last seen chunk tx
+        previously-seen-chunk-tx-id (atom nil)
+        ;; the tx-key of the last flush msg sent by me
+        !last-flush-tx-id (atom nil)
+
+        ^Runnable f
+        (bound-fn heartbeat []
+          (on-heartbeat {:last-flush @!last-flush-tx-id, :last-seen @previously-seen-chunk-tx-id})
+          (when-some [{latest-tx-id :tx-id} (.latestCompletedTx indexer)]
+            (let [{latest-chunk-tx-id :tx-id} (.latestCompletedChunkTx indexer)]
+              (try
+                (when (and (= @previously-seen-chunk-tx-id latest-chunk-tx-id)
+                           (or (nil? @!last-flush-tx-id)
+                               (< @!last-flush-tx-id latest-tx-id)))
+                  (log/infof "last chunk tx-id %s, flushing any pending writes" latest-chunk-tx-id)
+
+                  (let [record-buf (-> (ByteBuffer/allocate 9)
+                                       (.put (byte xt-log/hb-flush-chunk))
+                                       (.putLong (or latest-chunk-tx-id -1))
+                                       .flip)
+                        record @(.appendRecord log record-buf)]
+                   (reset! !last-flush-tx-id (:tx-id (:tx record)))))
+                (catch InterruptedException _)
+                (catch ClosedByInterruptException _)
+                (catch Throwable e
+                  (log/error e "exception caught submitting flush record"))
+                (finally
+                  (reset! previously-seen-chunk-tx-id latest-chunk-tx-id))))))]
+    {:executor exr
+     :task (.scheduleAtFixedRate exr f 0 (.toMillis ^Duration duration) TimeUnit/MILLISECONDS)}))
+
+(defmethod ig/halt-key! ::flusher [_ {:keys [^ExecutorService executor, task]}]
+  (future-cancel task)
+  (.shutdown executor)
+  (let [timeout-secs 10]
+    (when-not (.awaitTermination executor timeout-secs TimeUnit/SECONDS)
+      (log/warnf "flusher did not shutdown within %d seconds" timeout-secs))))
+
+(comment
+
+  ((requiring-resolve 'xtdb.test-util/set-log-level!)
+   'xtdb.indexer :debug)
+
+  (require 'xtdb.node)
+
+  (def sys
+    (-> (node/node-system {::flusher {:duration #time/duration "PT5S"}})
+        (ig/prep)
+        (ig/init [::flusher])))
+
+  (ig/halt! sys)
+
+  (::flusher sys)
+
+  (.latestCompletedTx (:xtdb/indexer sys))
+
+  (defn submit [tx] (.submitTx (:xtdb.tx-producer/tx-producer sys) tx {}))
+
+  @(submit [[:put :foo {:xt/id 42, :msg "Hello, world!"}]])
+
+  )

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -80,9 +80,14 @@
       :mem-free 7.20742332E8,
       :mem-used 2.79257668E8}]]])
 
+(def magic-last-tx-id
+  "This value will change if you vary the structure of log entries, such 
+  as adding new legs to the tx-ops vector, as in memory the tx-id is a byte offset."
+  8165)
+
 (t/deftest can-build-chunk-as-arrow-ipc-file-format
   (let [node-dir (util/->path "target/can-build-chunk-as-arrow-ipc-file-format")
-        last-tx-key (xtp/map->TransactionInstant {:tx-id 8165, :system-time (util/->instant #inst "2020-01-02")})]
+        last-tx-key (xtp/map->TransactionInstant {:tx-id magic-last-tx-id, :system-time (util/->instant #inst "2020-01-02")})]
     (util/delete-dir node-dir)
 
     (util/with-open [node (tu/->local-node {:node-dir node-dir})]
@@ -364,7 +369,7 @@
 
 (t/deftest can-stop-node-without-writing-chunks
   (let [node-dir (util/->path "target/can-stop-node-without-writing-chunks")
-        last-tx-key (xtp/map->TransactionInstant {:tx-id 8165, :system-time (util/->instant #inst "2020-01-02")})]
+        last-tx-key (xtp/map->TransactionInstant {:tx-id magic-last-tx-id, :system-time (util/->instant #inst "2020-01-02")})]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]

--- a/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
+++ b/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
@@ -1,0 +1,180 @@
+(ns xtdb.stagnant-log-flusher-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.log :as xt-log]
+            [xtdb.log :as log]
+            [xtdb.node :as node]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as ivr])
+  (:import (java.io Closeable)
+           (java.nio ByteBuffer)
+           (java.util.concurrent Semaphore)
+           (org.apache.arrow.memory BufferAllocator)
+           (org.apache.arrow.vector.ipc ArrowStreamReader)
+           (xtdb.indexer Indexer)
+           (xtdb.log Log)
+           (xtdb.object_store ObjectStore)))
+
+(set! *warn-on-reflection* false)
+
+(defonce log-level :error)
+
+(comment
+  (def log-level :debug)
+  (def log-level :info)
+  (def log-level :error)
+  )
+
+(defmacro spin-until
+  [ms expr]
+  `(loop [ret# ~expr
+          wait-until# (+ ~ms (System/currentTimeMillis))]
+     (cond
+       ret# ret#
+       (< wait-until# (System/currentTimeMillis)) ret#
+       :else (recur ~expr wait-until#))))
+
+(defmacro spin-ensure [ms expr]
+  `(loop [ret# ~expr
+          wait-until# (+ ~ms (System/currentTimeMillis))]
+     (cond
+       (not ret#) ret#
+       (< wait-until# (System/currentTimeMillis)) ret#
+       :else (recur ~expr wait-until#))))
+
+(def ^:dynamic *spin-ms*
+  "Change if tolerances change and tests need more time (such as slower CI machines), used for `spin`."
+  500)
+
+(defmacro spin [expr] `(spin-until *spin-ms* ~expr))
+
+(defn each-fixture [f]
+  (tu/with-log-levels
+    {'xtdb.stagnant-log-flusher log-level
+     'xtdb.indexer log-level
+     'xtdb.ingester log-level}
+    (binding [*spin-ms* *spin-ms*]
+      (f))))
+
+(t/use-fixtures :each each-fixture)
+
+(defn log-seq [^Log log ^BufferAllocator allocator]
+  (letfn [(clj-record [record]
+            (condp = (Byte/toUnsignedInt (.get ^ByteBuffer (:record record) 0))
+              xt-log/hb-flush-chunk
+              {:header-byte xt-log/hb-flush-chunk
+               :flush-tx-id (.getLong ^ByteBuffer (:record record) 1)
+               :tx (:tx record)}
+
+              xt-log/hb-user-arrow-transaction
+              (with-open [tx-ops-ch (util/->seekable-byte-channel (:record record))
+                          sr (ArrowStreamReader. tx-ops-ch allocator)
+                          tx-root (.getVectorSchemaRoot sr)]
+                (.loadNextBatch sr)
+                {:header-byte xt-log/hb-user-arrow-transaction
+                 :tx (:tx record)
+                 :record (first (ivr/rel->rows (ivr/<-root tx-root)))})
+              (throw (Exception. "Unrecognized record header"))))]
+    ((fn ! [offset]
+       (lazy-seq
+         (when-some [records (seq (.readRecords log (long offset) 100))]
+           (concat
+             (map clj-record records)
+             (! (:tx-id (:tx (last records))))))))
+     -1)))
+
+(defn node-log [node]
+  (let [log (tu/component node ::log/memory-log)
+        alloc (tu/component node :xtdb/allocator)]
+    (log-seq log alloc)))
+
+(defn log-indexed? [node]
+  (let [^Indexer indexer (tu/component node :xtdb/indexer)]
+    (= (:tx (last (node-log node))) (.latestCompletedTx indexer))))
+
+(defn start-node [flusher-duration & flusher-opts]
+  (node/start-node {:xtdb/live-chunk {:rows-per-chunk 1024, :rows-per-block 64}
+                    :xtdb.stagnant-log-flusher/flusher (apply hash-map :duration flusher-duration flusher-opts)}))
+
+(t/deftest if-log-does-not-get-a-new-msg-in-xx-time-we-submit-a-flush-test
+  (with-open [node (start-node #time/duration "PT0.001S")]
+    (t/testing "sent after a first message"
+      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (t/is (spin (log-indexed? node)))
+      (t/is (spin (= 2 (count (node-log node)))))
+      (let [[_ msg2] (node-log node)]
+        (let [flush-tx-id (:flush-tx-id msg2)]
+          (t/is flush-tx-id)
+          (t/is (= -1 flush-tx-id)))))
+
+    (t/testing "sent after a second message"
+      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (t/is (spin (= 4 (count (node-log node)))))
+      (let [[_ _ _ msg4] (node-log node)]
+        (let [flush-tx-id (:flush-tx-id msg4)]
+          (t/is flush-tx-id)
+          (t/is (= (:tx-id (.latestCompletedChunkTx (tu/component node :xtdb/indexer))) flush-tx-id))))))
+
+
+  (t/testing "test :duration actually does something"
+    (with-open [node (start-node #time/duration "PT1H")]
+      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (t/is (spin (= 1 (count (node-log node)))))
+      (t/is (spin-ensure 10 (= 1 (count (node-log node)))))))
+
+  (t/testing "logs receiving messages will stop flushes"
+    (let [control (Semaphore. 0)
+          control-close (reify Closeable (close [_] (.release control (- Integer/MAX_VALUE 1000))))
+          on-heartbeat (fn [_] (.acquire control))
+          heartbeat (fn [] (.release control))]
+      (with-open [node (start-node #time/duration "PT0.001S" :on-heartbeat on-heartbeat)
+                  _ control-close]
+        (let [send-msg (fn [] (xt/submit-tx node [[:put :foo {:xt/id 42}]]))
+              check-sync (fn [] (spin (log-indexed? node)))
+              check-count (fn [n] (spin (= n (count (node-log node)))))
+              check-count-remains (fn [n] (spin-ensure 10 (= n (count (node-log node)))))]
+          (t/testing "the first heartbeat does flush"
+            (send-msg)
+            (t/is (check-count 1))
+            (t/is (check-sync))
+            (heartbeat)
+            (t/is (check-sync))
+            (t/is (check-count 2))
+            (t/is (check-count-remains 2)))
+
+          (t/testing "the second heartbeat will not flush, as no new messages"
+            (check-sync)
+            (heartbeat)
+            (t/is (check-count-remains 2)))
+
+          ;; note, right now if another node submits a flush message - that will trigger a new flush msg, which will herd/cascade.
+          ;; however the conditional flush in the indexer **should** stop this being a problem
+          (t/testing "the next heartbeat(s) will not flush, as we have just flushed that tx-id"
+            (dotimes [_ 100]
+              (check-sync)
+              (heartbeat))
+            (.drainPermits control)
+            (t/is (check-count 2))
+            (t/is (check-count-remains 2)))
+
+          (t/testing "sending a second message, will flush"
+            (send-msg)
+            (t/is (check-sync))
+            (heartbeat)
+            (t/is (check-count 4))
+            (t/is (check-count-remains 4))))))))
+
+(defn chunk-path-seq [node]
+  (let [obj (tu/component node :xtdb.object-store/memory-object-store)]
+    (filter #(re-matches #"chunk-\p{XDigit}+/temporal\.arrow" %) (.listObjects ^ObjectStore obj))))
+
+(t/deftest indexer-flushes-block-and-chunk-if-flush-op-test
+  (with-open [node (start-node #time/duration "PT0.001S")]
+    (t/is (spin-ensure 10 (= 0 (count (chunk-path-seq node)))))
+    (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+    (t/is (spin (= 1 (count (chunk-path-seq node))))))
+
+  (with-open [node (start-node #time/duration "PT1H")]
+    (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+    (t/is (spin-ensure 10 (= 0 (count (chunk-path-seq node)))))))


### PR DESCRIPTION
This PR creates a new operator `match-recursive` which tries to expose the RA fixpoint operator.
The syntax is as follows
```clj
(match-recursive <table> <match-spec> ?temporal-opts [sub-queries*])
```
The sub-queries than contain the base as well as the recursive queries (no matter the order).
A code example snippet speaks a thousand words. Here is a transitive closure for a graph relation with columns `x` and `y`
```clj 
{:find [start end]
 :where [(match-recursive
          :closure {:x start :y end}
          [{:find [x y]
            :where [(match :graph [x y])]}
           {:find [x y]
            :where [(match :closure {:x x :y z})
                    (match :closure {:x z :y y})]}])]}
```
There are more examples in the tests. 
- [ ] There is an issue with `mega-join` and the recursive tables when rewriting the logical plan. That's why it's currently disabled.
- [ ] Deal with `unwind`
- [ ] deal with temporal opts

There is probably some more edge cases /issues that I have missed.