### PR TITLE
Local Filename caching for S3 

### DIFF
--- a/core/src/main/clojure/xtdb/file_list.clj
+++ b/core/src/main/clojure/xtdb/file_list.clj
@@ -1,0 +1,8 @@
+(ns xtdb.file-list
+  (:require [clojure.string :as string])
+  (:import java.util.NavigableSet))
+
+(defn list-files-under-prefix [^NavigableSet file-name-cache prefix]
+  (->> (.tailSet ^NavigableSet file-name-cache prefix)
+       (take-while #(string/starts-with? % prefix))
+       (into [])))

--- a/modules/s3/README.adoc
+++ b/modules/s3/README.adoc
@@ -30,8 +30,6 @@ The paramaterized stack expects the following to be provided:
 
 * The name of S3 Bucket that will be used by the created object store bucket and referenced in associated resources
 ** If unset, uses a default value of `xtdb-object-store`
-* The name of the XTDB IAM user to create.
-** If unset, uses a default value of `xtdb-user`
 
 ### Created Resources
 
@@ -40,13 +38,11 @@ The cloudformation stack will create the following resources within the specifie
 * The S3 bucket, with the user confirgured bucket name.
 * An SNS topic which receives notifications from the S3 bucket around object creation/deletion
 ** An SNS topic policy to allow the bucket to publish to the topic.
-* An IAM User, with a user configurable username. This contains a policy with all of the relevant permissions for:
+* An IAM Role, with all of the relevant permissions for:
 ** Using the created S3 bucket (Get, Put, Delete and List).
 ** Subscribe to the SNS topic.
 ** Creating and operating on SQS queues
 *** Said queues handle their own permissions, and subscribe to the SNS topic.
-* An AccessKey for the XTDB IAM User.
-* A `SecretsManager` secret containing the access key id and secret access key of the above, ready for use.
 
 ### Outputs
 
@@ -54,8 +50,7 @@ Using the cloudformation template will output a number of things, some of which 
 
 * The S3 Bucket Name (**this will be used in config**)
 * The SNS Topic ARN (**this will be used in config**)
-* ARN of the created XTDB user 
-* ARN of the Secret containing the access key for the XTDB user. 
+* ARN of the created XTDB IAM Role (this, or something with equivalent permissions, will be required to use all of the above) 
 
 NOTE: The SNS topic and SQS queues are used to a local copy of files on S3, saving on expensive/lengthy operations to list objects on S3. If not using the cloudformation template, ensure that you at have a similar setup with the SNS topic setup to receive notifications from your bucket, and that XTDB having all the relevant permissions it needs with S3, SNS, and SQS.
 
@@ -63,7 +58,7 @@ NOTE: The SNS topic and SQS queues are used to a local copy of files on S3, savi
 
 Authentication for both the document store and checkpoint store components within the module is handled via the S3 API, which in turn uses the Default AWS Credential Provider Chain. See the https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[AWS documentation] on the various methods which you can handle authentication to be able to make use of the operations inside the modules. 
 
-Within the provided Cloudformation stack, we create an XTDB user will all the necessary permissions, an access key, and a secret containing said access key. This can be used directly to provide all necessary permissions for XTDB and the resources it is using on AWS, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services. See the IAM policy set on the XTDBUser in the link:cloudformation/s3-stack.yml[Cloudformation stack] for what exactly that includes.
+Within the provided Cloudformation stack, we create an XTDB IAM role. One can use this role to provide all necessary permissions for XTDB and the resources it is using on AWS, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services. See the IAM policy set on the XTDBIamRole in the link:cloudformation/s3-stack.yml[Cloudformation stack] for what exactly that includes.
 
 ## S3 Object Store config
 

--- a/modules/s3/README.adoc
+++ b/modules/s3/README.adoc
@@ -1,0 +1,127 @@
+# S3 Module
+
+Within our XTDB node, we can make use of **AWS S3** as the XTDB Object Store.
+
+## Project Dependency 
+
+In order to use S3 as an object store, you will need to include a dependency on the xtdb.s3 module:
+
+_deps.edn_
+```
+com.xtdb.labs/xtdb-s3 {:mvn/version "2.0.0-SNAPSHOT"}
+```
+
+_pom.xml_
+```
+<dependency>
+    <groupId>com.xtdb.labs</groupId>
+    <artifactId>xtdb-s3</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+## Cloudformation Stack
+
+In order to handle the various bits of AWS infrastructure required to use S3 as an XTDB object store, we provide a link:cloudformation/s3-stack.yml[parameterized cloudformation stack] to setup everything that you should need.
+
+### Inputs to the stack
+
+The paramaterized stack expects the following to be provided:
+
+* The name of S3 Bucket that will be used by the created object store bucket and referenced in associated resources
+** If unset, uses a default value of `xtdb-object-store`
+* The name of the XTDB IAM user to create.
+** If unset, uses a default value of `xtdb-user`
+
+### Created Resources
+
+The cloudformation stack will create the following resources within the specified region in AWS:
+
+* The S3 bucket, with the user confirgured bucket name.
+* An SNS topic which receives notifications from the S3 bucket around object creation/deletion
+** An SNS topic policy to allow the bucket to publish to the topic.
+* An IAM User, with a user configurable username. This contains a policy with all of the relevant permissions for:
+** Using the created S3 bucket (Get, Put, Delete and List).
+** Subscribe to the SNS topic.
+** Creating and operating on SQS queues
+*** Said queues handle their own permissions, and subscribe to the SNS topic.
+* An AccessKey for the XTDB IAM User.
+* A `SecretsManager` secret containing the access key id and secret access key of the above, ready for use.
+
+### Outputs
+
+Using the cloudformation template will output a number of things, some of which will be needed configuring your node:
+
+* The S3 Bucket Name (**this will be used in config**)
+* The SNS Topic ARN (**this will be used in config**)
+* ARN of the created XTDB user 
+* ARN of the Secret containing the access key for the XTDB user. 
+
+NOTE: The SNS topic and SQS queues are used to a local copy of files on S3, saving on expensive/lengthy operations to list objects on S3. If not using the cloudformation template, ensure that you at have a similar setup with the SNS topic setup to receive notifications from your bucket, and that XTDB having all the relevant permissions it needs with S3, SNS, and SQS.
+
+## Authentication
+
+Authentication for both the document store and checkpoint store components within the module is handled via the S3 API, which in turn uses the Default AWS Credential Provider Chain. See the https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[AWS documentation] on the various methods which you can handle authentication to be able to make use of the operations inside the modules. 
+
+Within the provided Cloudformation stack, we create an XTDB user will all the necessary permissions, an access key, and a secret containing said access key. This can be used directly to provide all necessary permissions for XTDB and the resources it is using on AWS, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services. See the IAM policy set on the XTDBUser in the link:cloudformation/s3-stack.yml[Cloudformation stack] for what exactly that includes.
+
+## S3 Object Store config
+
+We can swap out the implementation of the object store with one based on S3. To do so, we add the `xtdb.s3/object-store` key within the integrant config for our node, alongside any config:
+
+```clojure
+{
+  ...
+  {:xtdb.s3/object-store {:bucket "xtdb-object-store",
+                          :sns-topic-arn "arn:aws:sns:region:account-id:xtdb-object-store-bucket-events"}}
+  ...
+}
+```
+
+### Parameters
+
+These are the following parameters that can be passed within the config for our `xtdb.s3/object-store`:
+[cols="1,1,2,1"]
+|===
+| *Name* | *Type* | *Description* | *Required?*
+| `bucket`
+| String 
+| The name of the https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html[S3 Bucket] to use an an object store
+| Yes
+
+| `sns-topic-arn`
+| String
+| The https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html[ARN] of the https://aws.amazon.com/sns/[SNS topic] which is collecting notifications from the S3 bucket you are using. 
+| Yes
+
+|`prefix`
+| String 
+| A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
+| No
+
+| `configurator`
+| `S3Configurator`
+| The https://github.com/xtdb/xtdb/blob/2.x/modules/s3/src/main/java/xtdb/s3/S3Configurator.java[`xtdb.s3.S3Configurator`] with extra s3 configuration options to be used by the object store
+| Yes
+|=== 
+
+### Configuring S3 requests
+
+WARNING: This is unfortunately currently only accessible from Clojure - we plan to expose it outside of Clojure soon.
+
+While the above is sufficient to get `xtdb-s3` working out of the box, there are a plethora of configuration options in S3 - how to get credentials, object properties, serialisation of the documents, etc.
+We expose these via the https://github.com/xtdb/xtdb/blob/2.x/modules/s3/src/main/java/xtdb/s3/S3Configurator.java[`xtdb.s3.S3Configurator`] interface - you can supply an instance using the following in your node configuration.
+
+Through this interface, you can supply an `S3AsyncClient` for xtdb-s3 to use, adapt the `PutObjectRequest`/`GetObjectRequest` as required, and choose the serialisation format.
+By default, we get credentials through the usual AWS credentials provider.
+
+```clojure
+{:xtdb.s3/object-store {:bucket "xtdb-object-store",
+                        :sns-topic-arn "arn:aws:sns:region:account-id:xtdb-object-store-bucket-events"}
+                        :configurator (fn [_]
+                                       (reify S3Configurator
+                                         ...))}
+```
+
+
+

--- a/modules/s3/README.adoc
+++ b/modules/s3/README.adoc
@@ -1,39 +1,41 @@
-# S3 Module
+= S3 Module
 
 Within our XTDB node, we can make use of **AWS S3** as the XTDB Object Store.
 
-## Project Dependency 
+== Project Dependency
 
 In order to use S3 as an object store, you will need to include a dependency on the xtdb.s3 module:
 
-_deps.edn_
-```
+.deps.edn
+[source,clojure]
+----
 com.xtdb.labs/xtdb-s3 {:mvn/version "2.0.0-SNAPSHOT"}
-```
+----
 
-_pom.xml_
-```
+.pom.xml
+[source,xml]
+----
 <dependency>
     <groupId>com.xtdb.labs</groupId>
     <artifactId>xtdb-s3</artifactId>
     <version>2.0.0-SNAPSHOT</version>
 </dependency>
-```
+----
 
-## Cloudformation Stack
+== CloudFormation Stack
 
-In order to handle the various bits of AWS infrastructure required to use S3 as an XTDB object store, we provide a link:cloudformation/s3-stack.yml[parameterized cloudformation stack] to setup everything that you should need.
+In order to handle the various bits of AWS infrastructure required to use S3 as an XTDB object store, we provide a link:cloudformation/s3-stack.yml[parameterized CloudFormation stack] to setup everything that you should need.
 
-### Inputs to the stack
+=== Inputs to the stack
 
 The paramaterized stack expects the following to be provided:
 
 * The name of S3 Bucket that will be used by the created object store bucket and referenced in associated resources
 ** If unset, uses a default value of `xtdb-object-store`
 
-### Created Resources
+=== Created Resources
 
-The cloudformation stack will create the following resources within the specified region in AWS:
+The CloudFormation stack will create the following resources within the specified region in AWS:
 
 * The S3 bucket, with the user confirgured bucket name.
 * An SNS topic which receives notifications from the S3 bucket around object creation/deletion
@@ -44,36 +46,41 @@ The cloudformation stack will create the following resources within the specifie
 ** Creating and operating on SQS queues
 *** Said queues handle their own permissions, and subscribe to the SNS topic.
 
-### Outputs
+=== Outputs
 
-Using the cloudformation template will output a number of things, some of which will be needed configuring your node:
+Using the CloudFormation template will output a number of things, some of which will be needed configuring your node:
 
 * The S3 Bucket Name (**this will be used in config**)
 * The SNS Topic ARN (**this will be used in config**)
 * ARN of the created XTDB IAM Role (this, or something with equivalent permissions, will be required to use all of the above) 
 
-NOTE: The SNS topic and SQS queues are used to a local copy of files on S3, saving on expensive/lengthy operations to list objects on S3. If not using the cloudformation template, ensure that you at have a similar setup with the SNS topic setup to receive notifications from your bucket, and that XTDB having all the relevant permissions it needs with S3, SNS, and SQS.
+NOTE: The SNS topic and SQS queues are used to a local copy of files on S3, saving on expensive/lengthy operations to list objects on S3.
+If not using the CloudFormation template, ensure that you at have a similar setup with the SNS topic setup to receive notifications from your bucket, and that XTDB having all the relevant permissions it needs with S3, SNS, and SQS.
 
-## Authentication
+== Authentication
 
-Authentication for both the document store and checkpoint store components within the module is handled via the S3 API, which in turn uses the Default AWS Credential Provider Chain. See the https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[AWS documentation] on the various methods which you can handle authentication to be able to make use of the operations inside the modules. 
+Authentication for both the document store and checkpoint store components within the module is handled via the S3 API, which in turn uses the Default AWS Credential Provider Chain.
+See the https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[AWS documentation] on the various methods which you can handle authentication to be able to make use of the operations inside the modules.
 
-Within the provided Cloudformation stack, we create an XTDB IAM role. One can use this role to provide all necessary permissions for XTDB and the resources it is using on AWS, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services. See the IAM policy set on the XTDBIamRole in the link:cloudformation/s3-stack.yml[Cloudformation stack] for what exactly that includes.
+Within the provided CloudFormation stack, we create an XTDB IAM role.
+One can use this role to provide all necessary permissions for XTDB and the resources it is using on AWS, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services.
+See the IAM policy set on the XTDBIamRole in the link:cloudformation/s3-stack.yml[CloudFormation stack] for what exactly that includes.
 
-## S3 Object Store config
+== S3 Object Store config
 
 We can swap out the implementation of the object store with one based on S3. To do so, we add the `xtdb.s3/object-store` key within the integrant config for our node, alongside any config:
 
-```clojure
+[source,clojure]
+----
 {
   ...
   {:xtdb.s3/object-store {:bucket "xtdb-object-store",
                           :sns-topic-arn "arn:aws:sns:region:account-id:xtdb-object-store-bucket-events"}}
   ...
 }
-```
+----
 
-### Parameters
+=== Parameters
 
 These are the following parameters that can be passed within the config for our `xtdb.s3/object-store`:
 [cols="1,1,2,1"]
@@ -100,7 +107,7 @@ These are the following parameters that can be passed within the config for our 
 | Yes
 |=== 
 
-### Configuring S3 requests
+=== Configuring S3 requests
 
 WARNING: This is unfortunately currently only accessible from Clojure - we plan to expose it outside of Clojure soon.
 
@@ -110,13 +117,11 @@ We expose these via the https://github.com/xtdb/xtdb/blob/2.x/modules/s3/src/mai
 Through this interface, you can supply an `S3AsyncClient` for xtdb-s3 to use, adapt the `PutObjectRequest`/`GetObjectRequest` as required, and choose the serialisation format.
 By default, we get credentials through the usual AWS credentials provider.
 
-```clojure
+[source,clojure]
+----
 {:xtdb.s3/object-store {:bucket "xtdb-object-store",
                         :sns-topic-arn "arn:aws:sns:region:account-id:xtdb-object-store-bucket-events"}
                         :configurator (fn [_]
                                        (reify S3Configurator
                                          ...))}
-```
-
-
-
+----

--- a/modules/s3/build.gradle.kts
+++ b/modules/s3/build.gradle.kts
@@ -19,4 +19,6 @@ dependencies {
     api(project(":core"))
 
     api("software.amazon.awssdk", "s3", "2.16.76")
+    api("software.amazon.awssdk", "sqs", "2.16.76")
+    api("software.amazon.awssdk", "sns", "2.16.76")
 }

--- a/modules/s3/cloudformation/s3-stack.yml
+++ b/modules/s3/cloudformation/s3-stack.yml
@@ -6,11 +6,6 @@ Parameters:
     Type: String
     Default: xtdb-object-store
     Description: Enter the desired name of the bucket which will contain the XTDB Object Store - default is 'xtdb-object-store'
-  
-  XTDBUserName:
-    Type: String
-    Default: xtdb-user
-    Description: Enter the desired name of the XTDB IAM User - default is 'xtdb-user'
 
 Resources:
   SNSTopic: 
@@ -49,11 +44,18 @@ Resources:
       Topics:
         - !Ref SNSTopic
 
-  XTDBUser:
-    Type: AWS::IAM::User
+  XTDBIamRole:
+    Type: AWS::IAM::Role
     Properties:
-      UserName: !Ref XTDBUserName
       Path: /
+      AssumeRolePolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          - Effect: "Allow"
+            Principal: 
+              AWS: !Ref AWS::AccountId
+            Action: 
+              - "sts:AssumeRole"
       Policies:
         - PolicyName: S3Access
           PolicyDocument:
@@ -91,18 +93,6 @@ Resources:
               Resource:
                 - '*'
 
-  XTDBUserCredentials:
-    Type: AWS::IAM::AccessKey
-    Properties:
-      Status: Active
-      UserName: !Ref XTDBUser
-
-  XTDBUserCredentialsSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Name: !Sub /xtdb/credentials/${XTDBUser}
-      SecretString: !Sub '{"AWS_ACCESS_KEY_ID":"${XTDBUserCredentials}","AWS_SECRET_ACCESS_KEY":"${XTDBUserCredentials.SecretAccessKey}", "AWS_REGION":"${AWS::Region}"}'
-
 Outputs:
   BucketName:
     Description: The name of the S3 Bucket
@@ -114,14 +104,10 @@ Outputs:
     Value: !Ref SNSTopic
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'SNSTopicName' ] ]
-  XTDBUserArn:
-    Description: ARN for the XTDB IAM User (has relevant SNS and S3 permissions, and ability to create SQS queues)
-    Value: !Ref XTDBUser
+  XTDBRoleArn :
+    Description: ARN of the created XTDB IAM Role (has relevant SNS and S3 permissions, and ability to create SQS queues)
+    Value: !GetAtt XTDBIamRole.Arn 
     Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'XTDBUserArn' ] ]
-  XTDBUserCredentialsSecretArn:
-    Description: ARN for the secret containing the XTDB IAM User's access credentials
-    Value: !Ref XTDBUserCredentialsSecret
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'XTDBUserCredentialsSecretArn' ] ]
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'XTDBRoleArn' ] ]
+
 

--- a/modules/s3/cloudformation/s3-stack.yml
+++ b/modules/s3/cloudformation/s3-stack.yml
@@ -1,0 +1,127 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A stack for setting up XTDB S3 object store and associated resources (SNS topics for changes, XTDB user)
+
+Parameters:
+  S3BucketName:
+    Type: String
+    Default: xtdb-object-store
+    Description: Enter the desired name of the bucket which will contain the XTDB Object Store - default is 'xtdb-object-store'
+  
+  XTDBUserName:
+    Type: String
+    Default: xtdb-user
+    Description: Enter the desired name of the XTDB IAM User - default is 'xtdb-user'
+
+Resources:
+  SNSTopic: 
+    Type: AWS::SNS::Topic
+    Properties: 
+      TopicName: !Join [ '-', [ !Ref S3BucketName, 'bucket-events' ] ]
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Ref S3BucketName
+      AccessControl: Private
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: !Ref SNSTopic
+            Event: 's3:ObjectCreated:*'
+          - Topic: !Ref SNSTopic
+            Event: 's3:ObjectRemoved:*'
+  
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: 's3.amazonaws.com'
+            Action: sns:Publish
+            Resource: !Ref SNSTopic
+            Condition:
+              ArnEquals:
+                aws:SourceArn:  !Join [ '', [ 'arn:aws:s3:::', !Ref S3BucketName] ]
+              StringEquals:
+                aws:SourceAccount: !Ref 'AWS::AccountId'
+      Topics:
+        - !Ref SNSTopic
+
+  XTDBUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: !Ref XTDBUserName
+      Path: /
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+                - 's3:GetObject'
+                - 's3:PutObject'
+                - 's3:DeleteObject'
+                - 's3:ListBucket'
+              Resource:
+                -  !Join [ '', [ 'arn:aws:s3:::', !Ref S3BucketName] ]
+                -  !Join [ '', [ 'arn:aws:s3:::', !Ref S3BucketName, '/*'] ]
+        - PolicyName: SNSAccess
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+                - 'sns:Subscribe'
+                - 'sns:Unsubscribe'
+              Resource:
+                - !Ref SNSTopic 
+        - PolicyName: SQSAccess
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action:
+                - 'sqs:CreateQueue'
+                - 'sqs:GetQueueUrl'
+                - 'sqs:GetQueueAttributes'
+                - 'sqs:DeleteQueue'
+                - 'sqs:DeleteMessage'
+                - 'sqs:ReceiveMessage'
+                - 'sqs:SetQueueAttributes'
+              Resource:
+                - '*'
+
+  XTDBUserCredentials:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      Status: Active
+      UserName: !Ref XTDBUser
+
+  XTDBUserCredentialsSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub /xtdb/credentials/${XTDBUser}
+      SecretString: !Sub '{"AWS_ACCESS_KEY_ID":"${XTDBUserCredentials}","AWS_SECRET_ACCESS_KEY":"${XTDBUserCredentials.SecretAccessKey}", "AWS_REGION":"${AWS::Region}"}'
+
+Outputs:
+  BucketName:
+    Description: The name of the S3 Bucket
+    Value: !Ref S3Bucket
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'BucketName' ] ]
+  SNSTopicArn:
+    Description: The ARN of the SNS Topic with the S3 notifications
+    Value: !Ref SNSTopic
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'SNSTopicName' ] ]
+  XTDBUserArn:
+    Description: ARN for the XTDB IAM User (has relevant SNS and S3 permissions, and ability to create SQS queues)
+    Value: !Ref XTDBUser
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'XTDBUserArn' ] ]
+  XTDBUserCredentialsSecretArn:
+    Description: ARN for the secret containing the XTDB IAM User's access credentials
+    Value: !Ref XTDBUserCredentialsSecret
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'XTDBUserCredentialsSecretArn' ] ]
+

--- a/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
+++ b/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
@@ -1,0 +1,152 @@
+(ns xtdb.s3.file-list
+  (:require [clojure.data.json :as json]
+            [clojure.string :as string])
+  (:import [java.util UUID NavigableSet]
+           [software.amazon.awssdk.services.sqs.model Message CreateQueueRequest DeleteMessageRequest DeleteQueueRequest ReceiveMessageRequest SetQueueAttributesRequest GetQueueAttributesRequest QueueDoesNotExistException]
+           [software.amazon.awssdk.services.sns.model SubscribeRequest UnsubscribeRequest]
+           [software.amazon.awssdk.services.s3.model ListObjectsV2Request ListObjectsV2Response S3Object]
+           software.amazon.awssdk.core.exception.AbortedException
+           software.amazon.awssdk.services.s3.S3AsyncClient
+           software.amazon.awssdk.services.sns.SnsClient
+           software.amazon.awssdk.services.sqs.SqsClient))
+
+;; Fns for file name init (grabbing all current files from s3 bucket)
+
+(defn list-objects [{:keys [^S3AsyncClient s3-client bucket prefix] :as s3-opts} continuation-token]
+  (vec
+   (let [^ListObjectsV2Request
+         req (-> (ListObjectsV2Request/builder)
+                 (.bucket bucket)
+                 (.prefix prefix)
+                 (cond-> continuation-token (.continuationToken continuation-token))
+                 (.build))
+
+         ^ListObjectsV2Response
+         resp (.get (.listObjectsV2 ^S3AsyncClient s3-client req))]
+
+     (concat (for [^S3Object object (.contents resp)]
+               (subs (.key object) (count prefix)))
+             (when (.isTruncated resp)
+               (list-objects s3-opts (.nextContinuationToken resp)))))))
+
+(defn file-list-init [s3-opts ^NavigableSet file-name-cache]
+  (let [filename-list (list-objects s3-opts nil)]
+    (.addAll file-name-cache filename-list)))
+
+;; Fns for file name watching (listening to SNS notifications from the bucket to add/remove files on the file name cache)
+
+(defn ->sqs-write-policy [sns-topic-arn queue-arn]
+  (json/write-str
+   {:Id "Queue_Policy"
+    :Version "2012-10-17",
+    :Statement [{:Sid "Queue_SnsTopic_SendMessage"
+                 :Effect "Allow"
+                 :Principal {:AWS "*"},
+                 :Action "SQS:SendMessage"
+                 :Resource queue-arn
+                 :Condition {:ArnLike {"aws:SourceArn" sns-topic-arn}}}]}))
+
+(defn setup-notif-queue [{:keys [sqs-client sns-client sns-topic-arn]}]
+  (let [queue-name (format "xtdb-object-store-notifs-queue-%s" (UUID/randomUUID))
+        sqs-queue (.createQueue sqs-client (-> (CreateQueueRequest/builder)
+                                               (.queueName queue-name)
+                                               (.build)))
+        queue-url (.queueUrl sqs-queue)
+        queue-arn (-> (.getQueueAttributes sqs-client (-> (GetQueueAttributesRequest/builder)
+                                                          (.queueUrl queue-url)
+                                                          (.attributeNamesWithStrings (into-array String ["QueueArn"]))
+                                                          (.build)))
+                      (.attributesAsStrings)
+                      (get "QueueArn"))
+        ;; Add permissions to SQS to allow SNS to send messages
+        _ (.setQueueAttributes sqs-client (-> (SetQueueAttributesRequest/builder)
+                                              (.queueUrl queue-url)
+                                              (.attributesWithStrings {"Policy" (->sqs-write-policy sns-topic-arn queue-arn)})
+                                              (.build)))
+        ;; Subscribe to the SNS topic
+        subscription (.subscribe sns-client (-> (SubscribeRequest/builder)
+                                                (.topicArn sns-topic-arn)
+                                                (.endpoint queue-arn)
+                                                (.protocol "sqs")
+                                                (.build)))]
+    {:queue-url queue-url
+     :subscription-arn (.subscriptionArn subscription)}))
+
+(defn parse-s3-event [message-body]
+  (-> message-body
+      (json/read-str)
+      (get "Message")
+      (json/read-str :key-fn keyword)
+      (:Records)
+      (first)))
+
+(defn file-list-watch [{:keys [sns-topic-arn prefix] :as opts} ^NavigableSet file-name-cache]
+  (let [^SqsClient sqs-client (SqsClient/create)
+        ^SnsClient sns-client (SnsClient/create)
+
+        ;; Create queue that will subscribe to sns topic for notifications
+        {:keys [queue-url subscription-arn]} (setup-notif-queue {:sqs-client sqs-client
+                                                                 :sns-client sns-client
+                                                                 :sns-topic-arn sns-topic-arn})
+
+        ;; Init the filename cache with current files
+        _ (file-list-init opts file-name-cache)
+
+        ;; Start processing messages from the queue
+        watcher-thread (Thread. (fn []
+                                  (try
+                                    (while true
+                                      (when (Thread/interrupted)
+                                        (throw (InterruptedException.)))
+
+                                      (when-let [messages (-> (.receiveMessage sqs-client (-> (ReceiveMessageRequest/builder)
+                                                                                              (.queueUrl queue-url)
+                                                                                              (.build)))
+                                                              (.messages)
+                                                              (not-empty))]
+                                        (doseq [^Message message messages]
+                                          (when (Thread/interrupted)
+                                            (throw (InterruptedException.)))
+
+                                          (let [receipt-handle (.receiptHandle message)
+                                                s3-event (parse-s3-event (.body message))
+                                                event-name (:eventName s3-event)
+                                                event-type (cond
+                                                             (string/starts-with? event-name "ObjectCreated") :create
+                                                             (string/starts-with? event-name "ObjectRemoved") :delete)
+                                                filename (get-in s3-event [:s3 :object :key])
+                                                file (if prefix
+                                                       (when (string/starts-with? filename prefix)
+                                                         (subs filename (count prefix)))
+                                                       filename)]
+                                            (when file
+                                              (cond
+                                                (= event-type :create) (.add file-name-cache file)
+                                                (= event-type :delete) (.remove file-name-cache file)))
+
+                                            (.deleteMessage sqs-client (-> (DeleteMessageRequest/builder)
+                                                                           (.queueUrl queue-url)
+                                                                           (.receiptHandle receipt-handle)
+                                                                           (.build))))))
+                                      (Thread/sleep 10))
+                                    (catch InterruptedException _)
+                                    (catch QueueDoesNotExistException _)
+                                    (catch AbortedException _))))]
+    (.start watcher-thread)
+    
+    {:watcher-thread watcher-thread
+     :sns-client sns-client
+     :sqs-client sqs-client
+     :queue-url queue-url
+     :subscription-arn subscription-arn}))
+
+(defn watcher-close-fn [{:keys [watcher-thread sns-client sqs-client queue-url subscription-arn]}]
+  (.interrupt watcher-thread)
+  (.join watcher-thread)
+  (.unsubscribe sns-client (-> (UnsubscribeRequest/builder)
+                               (.subscriptionArn subscription-arn)
+                               (.build)))
+  (.deleteQueue sqs-client (-> (DeleteQueueRequest/builder)
+                               (.queueUrl queue-url)
+                               (.build))))
+

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -144,15 +144,15 @@
     (with-open [os (fs path)]
       (put-edn os "alice" :alice)
       (put-edn os "alan" :alan)
-      (t/is (= ["alan" "alice"] (.listObjects os))))
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
     (with-open [os (fs path)]
       (t/testing "prior objects will still be there, should be available on a list request"
-        (t/is (= ["alan" "alice"] (.listObjects os))))
+        (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
       (t/testing "should be able to delete prior objects and have that reflected in list objects output"
-        (Thread/sleep 1000)
-        (t/is (= ["alan"] (.listObjects os)))))))
+        @(.deleteObject ^ObjectStore os "alice")
+        (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
 
 (t/deftest fs-range-test
   (tu/with-tmp-dirs #{path}

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -18,7 +18,7 @@
         (edn/read-string (str (.decode StandardCharsets/UTF_8 buf))))
       (util/rethrowing-cause)))
 
-(defn- put-edn [^ObjectStore obj-store k obj]
+(defn put-edn [^ObjectStore obj-store k obj]
   (let [^ByteBuffer buf (.encode StandardCharsets/UTF_8 (pr-str obj))]
     @(.putObject obj-store (name k) buf)))
 
@@ -65,13 +65,19 @@
 
     (t/is (thrown? IllegalStateException (get-edn obj-store :alice)))))
 
-(defn test-list-objects [^ObjectStore obj-store]
-  (put-edn obj-store "bar/alice" :alice)
-  (put-edn obj-store "foo/alan" :alan)
-  (put-edn obj-store "bar/bob" :bob)
+(defn test-list-objects 
+  ([^ObjectStore obj-store]
+   (test-list-objects obj-store 1000))
+  ([^ObjectStore obj-store wait-time-ms]
+   (put-edn obj-store "bar/alice" :alice)
+   (put-edn obj-store "foo/alan" :alan)
+   (put-edn obj-store "bar/bob" :bob)
 
-  (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
-  (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar"))))
+  ;; Allow some time for files to get processed and added to the list
+   (Thread/sleep wait-time-ms)
+
+   (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
+   (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar")))))
 
 (defn test-range [^ObjectStore obj-store]
 

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -3,7 +3,8 @@
             [juxt.clojars-mirrors.integrant.core :as ig]
             [xtdb.object-store-test :as os-test]
             [xtdb.s3 :as s3])
-  (:import (java.io Closeable)))
+  (:import (java.io Closeable)
+           xtdb.object_store.ObjectStore))
 
 ;; Setup the stack via cloudformation - see modules/s3/cloudformation/s3-test-stack.yml
 ;; Will need to create and set an access token for the S3TestUser
@@ -43,13 +44,13 @@
       (os-test/put-edn os "alice" :alice)
       (os-test/put-edn os "alan" :alan)
       (Thread/sleep wait-time-ms)
-      (t/is (= ["alan" "alice"] (.listObjects os))))
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
     (with-open [os (object-store prefix)]
       (t/testing "prior objects will still be there, should be available on a list request"
-        (t/is (= ["alan" "alice"] (.listObjects os))))
+        (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
       (t/testing "should be able to delete prior objects and have that reflected in list objects output"
-        @(.deleteObject os "alice")
+        @(.deleteObject ^ObjectStore os "alice")
         (Thread/sleep wait-time-ms)
-        (t/is (= ["alan"] (.listObjects os)))))))
+        (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -7,7 +7,11 @@
 
 (def bucket
   (or (System/getProperty "xtdb.s3-test.bucket")
-      "xtdb-s3-test"))
+      "xtdb-s3-test-object-store"))
+
+(def sns-topic-arn
+  (or (System/getProperty "xtdb.s3-test.sns-topic-arn")
+      "arn:aws:sns:eu-west-1:199686536682:xtdb-object-store-s3-test-bucket-events"))
 
 (defn object-store ^Closeable [prefix]
   (->> (ig/prep-key ::s3/object-store {:bucket bucket, :prefix (str prefix)})

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -5,16 +5,22 @@
             [xtdb.s3 :as s3])
   (:import (java.io Closeable)))
 
+;; Setup the stack via cloudformation - see modules/s3/cloudformation/s3-test-stack.yml
+;; Will need to create and set an access token for the S3TestUser
+;; Ensure region is set locally to wherever cloudformation stack is created (ie, eu-west-1 if stack on there)
+
 (def bucket
   (or (System/getProperty "xtdb.s3-test.bucket")
-      "xtdb-s3-test-object-store"))
+      "xtdb-object-store-s3-test"))
 
 (def sns-topic-arn
   (or (System/getProperty "xtdb.s3-test.sns-topic-arn")
       "arn:aws:sns:eu-west-1:199686536682:xtdb-object-store-s3-test-bucket-events"))
 
 (defn object-store ^Closeable [prefix]
-  (->> (ig/prep-key ::s3/object-store {:bucket bucket, :prefix (str prefix)})
+  (->> (ig/prep-key ::s3/object-store {:bucket bucket,
+                                       :prefix (str prefix)
+                                       :sns-topic-arn sns-topic-arn})
        (ig/init-key ::s3/object-store)))
 
 (t/deftest ^:s3 put-delete-test
@@ -25,6 +31,25 @@
   (with-open [os (object-store (random-uuid))]
     (os-test/test-range os)))
 
+(def wait-time-ms 10000)
+
 (t/deftest ^:s3 list-test
   (with-open [os (object-store (random-uuid))]
-    (os-test/test-list-objects os)))
+    (os-test/test-list-objects os wait-time-ms)))
+
+(t/deftest ^:s3 list-test-with-prior-objects
+  (let [prefix (random-uuid)]
+    (with-open [os (object-store prefix)]
+      (os-test/put-edn os "alice" :alice)
+      (os-test/put-edn os "alan" :alan)
+      (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects os))))
+
+    (with-open [os (object-store prefix)]
+      (t/testing "prior objects will still be there, should be available on a list request"
+        (t/is (= ["alan" "alice"] (.listObjects os))))
+
+      (t/testing "should be able to delete prior objects and have that reflected in list objects output"
+        @(.deleteObject os "alice")
+        (Thread/sleep wait-time-ms)
+        (t/is (= ["alan"] (.listObjects os)))))))


### PR DESCRIPTION
Resolves #2578

Currently implemented:
- The general filename caching approach, used on s3 object stores 
  - We use a `NavigableSet` under the hood for filename caching purposes.
  - We run a function against this to start handling the list - firstly, we subscribe to file changes (how this is handled is up to the implementation), then we do an "init" function which lists the current files in the object store, and then we handle the stream of file changes by either adding/removing from the cache.
  - List functions on object store essentially become either return the set as a vector, or doing some filtering based on prefixed and then returning all results which contain the prefix (a helper function is available for this)    
- S3 related setup:
  - Created cloudformation templates (one for regular use, one specifically for our testing), that set up:
    - An SNS topic  
    - An S3 bucket, sending notifications to the SNS topic on object creation & deletion.
    - An SNS topic policy that allows the S3 bucket to send messages to the topic. 
    - An XTDB IAM Role, with all relevant permissions for S3, SNS, and SQS (for the creation and usage of queues in code) 
  - Added an implementation of file listing using the cache approach:
    - S3 object store now requires `topic-arn` for the SNS topic to be passed in, alongside all the permissions of the XTDB IAM User
    - We firstly setup our sqs queue subscribed to the SNS topic alongside all relevant permissins.
    - We then do our 'init' behaviour, which uses s3 list-objects to get all current bucket contents.    
    - We then start handling the notifications from the sqs queue - polling for messages in a loop (running on a thread):
      - When it receives a creation event, will add the filename to the cache.
      - When it receives a removal event, removes the filename from the cache. 
- Some updates to the object store tests to ensure that they fit new behaviour.
   - Essentially, these have to wait for a while while we catch up the filename list internally. 
- Added a README to S3 containing info on config/using cloudformation. 
