### PR TITLE
Remove Trie visitor pattern, abstract over two trie types

### DIFF
--- a/core/src/main/java/xtdb/trie/HashTrie.java
+++ b/core/src/main/java/xtdb/trie/HashTrie.java
@@ -1,0 +1,31 @@
+package xtdb.trie;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public interface HashTrie<N extends HashTrie.Node<N>> {
+
+    Node<N> rootNode();
+
+    default List<? extends Node<N>> leaves() {
+        return rootNode().leaves();
+    }
+
+    interface Node<N extends Node<N>> {
+        byte[] path();
+
+        N[] children();
+
+        default Stream<? extends HashTrie.Node<N>> leafStream() {
+            var children = children();
+            return children == null
+                    ? Stream.of(this)
+                    : Arrays.stream(children).flatMap(child -> child == null ? null : child.leafStream());
+        }
+
+        default List<? extends Node<N>> leaves() {
+            return leafStream().toList();
+        }
+    }
+}


### PR DESCRIPTION
* `HashTrie.Node` gives the ability to get `path()` and `children()` whether it's a live hash trie or an arrow hash trie
* Use `(nil? (.children node))` to determine whether you're at a branch or a leaf
* Cast at the leaves to get specific leaf behaviour (e.g. `(.getPageIndex ^ArrowHashTrie$Node node)`)