### PR TITLE
Basic external sort for order-by

### DIFF
--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -1,15 +1,27 @@
 (ns xtdb.operator.order-by
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [xtdb.expression.comparator :as expr.comp]
             [xtdb.logical-plan :as lp]
+            [xtdb.types :as types]
             [xtdb.util :as util]
+            [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
-  (:import (java.util Comparator)
+  (:import (clojure.lang IPersistentMap PersistentVector)
+           (java.io File OutputStream)
+           (java.nio.channels Channels)
+           java.nio.file.Path
+           (java.util HashMap PriorityQueue)
+           (java.util Comparator)
            (java.util.function Consumer ToIntFunction)
            java.util.stream.IntStream
-           org.apache.arrow.memory.BufferAllocator
+           (org.apache.arrow.memory BufferAllocator)
+           (org.apache.arrow.vector ValueVector VectorSchemaRoot)
+           (org.apache.arrow.vector.ipc ArrowStreamReader ArrowStreamWriter)
+           [org.apache.arrow.vector.ipc ArrowStreamReader]
+           org.apache.arrow.vector.VectorSchemaRoot
            xtdb.ICursor
-           xtdb.vector.RelationReader))
+           (xtdb.vector IRowCopier IVectorPosition IVectorReader RelationReader)))
 
 (s/def ::direction #{:asc :desc})
 (s/def ::null-ordering #{:nulls-first :nulls-last})
@@ -24,18 +36,28 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn- accumulate-relations ^xtdb.vector.RelationReader [allocator ^ICursor in-cursor]
-  (let [rel-writer (vw/->rel-writer allocator)]
-    (try
-      (.forEachRemaining in-cursor
-                         (reify Consumer
-                           (accept [_ src-rel]
-                             (vw/append-rel rel-writer src-rel))))
-      (catch Exception e
-        (.close rel-writer)
-        (throw e)))
+(def ^:dynamic *chunk-size* (int 102400))
 
-    (vw/rel-wtr->rdr rel-writer)))
+(defn- ->file [tmp-dir batch-idx file-idx]
+  (io/file tmp-dir (format "temp-sort-%d-%d.arrow" batch-idx file-idx)))
+
+(defn- write-rel [^BufferAllocator allocator, ^RelationReader rdr, ^OutputStream os]
+  (let [new-vecs (for [^IVectorReader col rdr]
+                   (let [^ValueVector new-vec (.createVector (-> (.getField col)
+                                                                 (types/field-with-name (.getName col)))
+                                                             allocator)]
+
+                     (.copyTo col new-vec)
+                     new-vec))]
+    (try
+      (with-open [root (VectorSchemaRoot. ^PersistentVector (vec new-vecs))]
+        (let [writer (ArrowStreamWriter. root nil (Channels/newChannel os))]
+          (.start writer)
+          (.writeBatch writer)
+          (.end writer)))
+      (catch Throwable e
+        (run! util/close new-vecs)
+        (throw e)))))
 
 (defn- sorted-idxs ^ints [^RelationReader read-rel, order-specs]
   (-> (IntStream/range 0 (.rowCount read-rel))
@@ -59,20 +81,206 @@
                    (applyAsInt [_ x] x)))
       (.toArray)))
 
+(defn- write-out-rels [allocator ^ICursor in-cursor, order-specs tmp-dir first-filename]
+  (loop [filenames [first-filename] file-idx 1] ;; file-idx 1 as first-filename contains 0
+    (if-let [filename (with-open [rel-writer (vw/->rel-writer allocator)]
+                        (let [pos (.writerPosition rel-writer)]
+                          (while (and (<= (.getPosition pos) ^int *chunk-size*)
+                                      (.tryAdvance in-cursor
+                                                   (reify Consumer
+                                                     (accept [_ src-rel]
+                                                       (vw/append-rel rel-writer src-rel))))))
+                          (when (pos? (.getPosition pos))
+                            (let [read-rel (vw/rel-wtr->rdr rel-writer)
+                                  out-filename (->file tmp-dir 0 file-idx)]
+                              (with-open [out-rel (.select read-rel (sorted-idxs read-rel order-specs))
+
+                                          os (io/output-stream out-filename)]
+                                (write-rel allocator out-rel os)
+                                out-filename)))))]
+      (recur (conj filenames filename) (inc file-idx))
+      (mapv io/file filenames))))
+
+(defn mk-irel-comparator [^RelationReader irel1 ^RelationReader irel2 order-specs]
+  (reduce (fn [^Comparator acc, [column {:keys [direction null-ordering]
+                                         :or {direction :asc, null-ordering :nulls-last}}]]
+            (let [read-col1 (.readerForName irel1 (name column))
+                  read-col2 (.readerForName irel2 (name column))
+                  col-comparator (expr.comp/->comparator read-col1 read-col2 null-ordering)
+
+                  ^Comparator
+                  comparator (cond-> (reify Comparator
+                                       (compare [_ left right]
+                                         (.applyAsInt col-comparator left right)))
+                               (= :desc direction) (.reversed))]
+              (if acc
+                (.thenComparing acc comparator)
+                comparator)))
+          nil
+          order-specs))
+
+(defn- fields->vsr ^VectorSchemaRoot [^BufferAllocator allocator fields]
+  (VectorSchemaRoot. ^PersistentVector (vec (for [[col-name field] fields]
+                                              (.createVector (types/field-with-name field (str col-name))
+                                                             allocator)))))
+
+(defn k-way-merge [^BufferAllocator allocator filenames order-specs fields tmp-dir batch-idx file-idx]
+  (let [k (count filenames)
+        out-file (->file tmp-dir batch-idx file-idx)
+        rdrs (object-array (mapv #(ArrowStreamReader. (io/input-stream %) allocator) filenames))
+        vsrs (object-array (mapv #(.getVectorSchemaRoot ^ArrowStreamReader %) rdrs))
+        rel-rdrs (object-array k)
+        copiers (object-array k)
+        positions (object-array (repeatedly k #(IVectorPosition/build)))]
+    (try
+      (with-open [root-out (fields->vsr allocator fields)
+                  wrt (ArrowStreamWriter. root-out nil (io/output-stream out-file))
+                  rel-wrt (vw/root->writer root-out)]
+        (let [rel-wrt-cnt (IVectorPosition/build)]
+          (letfn [(load-next-rel [i]
+                    (when (aget rel-rdrs i)
+                      (util/close (aget rel-rdrs i)))
+                    (when (.loadNextBatch ^ArrowStreamReader (aget rdrs i))
+                      (aset rel-rdrs i (vr/<-root (aget vsrs i)))
+                      (aset copiers i (.rowCopier rel-wrt (aget rel-rdrs i)))
+                      (.setPosition ^IVectorPosition (aget positions i) 0)
+                      true))]
+            (.start wrt)
+            (let [cmps (HashMap.)
+                  pq (PriorityQueue. (fn [^long i ^long j]
+                                       (if (< i j)
+                                         (.compare ^java.util.Comparator
+                                                   (.get cmps [i j])
+                                                   (.getPosition ^IVectorPosition (aget positions i))
+                                                   (.getPosition ^IVectorPosition (aget positions j)))
+                                         (* -1 (.compare ^java.util.Comparator
+                                                         (.get cmps [j i])
+                                                         (.getPosition ^IVectorPosition (aget positions j))
+                                                         (.getPosition ^IVectorPosition (aget positions i)))))))]
+              (doseq [i (range k)]
+                (load-next-rel i))
+
+              (doseq [i (range k)
+                      j (range i)]
+                (.put cmps [j i] (mk-irel-comparator (aget rel-rdrs j) (aget rel-rdrs i) order-specs)))
+
+              (doseq [i (range k)]
+                (when-let [^RelationReader rel-rdr (aget rel-rdrs i)]
+                  (when (pos-int? (.rowCount rel-rdr))
+                    (.add pq i))))
+
+              (while (not (.isEmpty pq))
+                (let [^long i (.poll pq)
+                      ^IVectorPosition position (aget positions i)]
+                  (.copyRow ^IRowCopier (aget copiers i) (.getPositionAndIncrement position))
+                  (if (< (.getPosition position) (.rowCount ^RelationReader (aget rel-rdrs i)))
+                    (.add pq i)
+                    (when (load-next-rel i)
+                      ;; TODO can this extra comparator creation be avoided?
+                      (let [new-rdr (aget rel-rdrs i)]
+                        (doseq [^long j (range k)
+                                :when (not= i j)]
+                          (if (< i j)
+                            (.put cmps [i j] (mk-irel-comparator new-rdr (aget rel-rdrs j) order-specs))
+                            (.put cmps [j i] (mk-irel-comparator (aget rel-rdrs j) new-rdr order-specs)))))
+                      (.add pq i)))
+                  ;; spill next chunk
+                  (when (< ^int *chunk-size* (.getPositionAndIncrement rel-wrt-cnt))
+                    (.syncRowCount rel-wrt)
+                    (.writeBatch wrt)
+                    (.clear rel-wrt)
+                    (.setPosition rel-wrt-cnt 0)
+                    (doseq [i (range k)]
+                      (aset copiers i (.rowCopier rel-wrt (aget rel-rdrs i))))))))
+            ;; spill remaining rows
+            (when (pos-int? (.getPosition rel-wrt-cnt))
+              (.syncRowCount rel-wrt)
+              (.writeBatch wrt))
+            (.end wrt)
+            out-file)))
+      (finally
+        (run! util/close rdrs)
+        (run! util/close vsrs)))))
+
+(def ^:private k-way-constant 4)
+
+(defn- external-sort [allocator ^ICursor in-cursor, order-specs, fields, tmp-dir, first-filename]
+  (let [batches (write-out-rels allocator in-cursor order-specs tmp-dir first-filename)]
+    (loop [batches batches batch-idx 1]
+      (if-not (< 1 (count batches))
+        (first batches)
+        (recur
+         (loop [batches batches new-batches [] file-idx 0]
+           (if-let [files (seq (take k-way-constant batches))]
+             (let [new-batch (k-way-merge allocator files order-specs fields tmp-dir batch-idx file-idx)]
+               (dorun (map io/delete-file files))
+               (recur (drop k-way-constant batches)
+                      (conj new-batches new-batch)
+                      (inc file-idx)))
+             new-batches))
+         (inc batch-idx))))))
+
 (deftype OrderByCursor [^BufferAllocator allocator
                         ^ICursor in-cursor
-                        order-specs]
+                        ^IPersistentMap static-fields
+                        order-specs
+                        ^:unsynchronized-mutable ^boolean consumed?
+                        ^:unsynchronized-mutable ^Path sort-dir
+                        ^:unsynchronized-mutable ^ArrowStreamReader reader
+                        ^:unsynchronized-mutable ^VectorSchemaRoot read-root
+                        ^:unsynchronized-mutable ^File sorted-file]
   ICursor
-  (tryAdvance [_ c]
-    (with-open [read-rel (accumulate-relations allocator in-cursor)]
-      (if (pos? (.rowCount read-rel))
-        (do
-          (with-open [out-rel (.select read-rel (sorted-idxs read-rel order-specs))]
-            (.accept c out-rel)
-            true))
-        false)))
+  (tryAdvance [this c]
+    (if-not consumed?
+      (letfn [(load-next-batch []
+                (if (.loadNextBatch ^ArrowStreamReader (.reader this))
+                  (with-open [out-rel (vr/<-root (.read-root this))]
+                    (.accept c out-rel)
+                    true)
+                  (do
+                    (io/delete-file (.sorted-file this))
+                    (set! (.consumed? this) true)
+                    false)))]
+        (if-not (nil? reader)
+          (load-next-batch)
+          (with-open [rel-writer (vw/->rel-writer allocator)]
+            (let [pos (.writerPosition rel-writer)]
+              (while (and (<= (.getPosition pos) ^int *chunk-size*)
+                          (.tryAdvance in-cursor
+                                       (reify Consumer
+                                         (accept [_ src-rel]
+                                           (vw/append-rel rel-writer src-rel))))))
+              (let [read-rel (vw/rel-wtr->rdr rel-writer)]
+                (if (<= (.getPosition pos) ^int *chunk-size*)
+                  ;; in memory case
+                  (if (zero? (.getPosition pos))
+                    (do (set! (.consumed? this) true)
+                        false)
+                    (do (.accept c (.select read-rel (sorted-idxs read-rel order-specs)))
+                        (set! (.consumed? this) true)
+                        true))
+
+                  ;; first batch from external sort
+                  (let [sort-dir (util/tmp-dir "external-sort")
+                        ^java.io.File tmp-dir (io/file (.getPath (.toUri sort-dir)))
+                        first-filename (->file tmp-dir 0 0)]
+                    (set! (.sort-dir this) sort-dir)
+                    (.mkdirs tmp-dir)
+                    (with-open [out-rel (.select read-rel (sorted-idxs read-rel order-specs))
+                                os (io/output-stream first-filename)]
+                      (write-rel allocator out-rel os))
+
+                    (let [sorted-file (external-sort allocator in-cursor order-specs static-fields tmp-dir first-filename)]
+                      (set! (.sorted-file this) sorted-file)
+                      (set! (.reader this) (ArrowStreamReader. (io/input-stream sorted-file) allocator))
+                      (set! (.read-root this) (.getVectorSchemaRoot reader))
+                      (load-next-batch)))))))
+          ))
+      false))
 
   (close [_]
+    (util/try-close read-root)
+    (util/try-close reader)
     (util/try-close in-cursor)))
 
 (defmethod lp/emit-expr :order-by [{:keys [order-specs relation]} args]
@@ -80,4 +288,4 @@
     (fn [fields]
       {:fields fields
        :->cursor (fn [{:keys [allocator]} in-cursor]
-                   (OrderByCursor. allocator in-cursor order-specs))})))
+                   (OrderByCursor. allocator in-cursor fields order-specs false nil nil nil nil))})))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -625,3 +625,26 @@
 
 (defn ->child-allocator [^BufferAllocator allocator name]
   (.newChildAllocator allocator name (.getInitReservation allocator) (.getLimit allocator)))
+
+(defn with-tmp-dir* [prefix f]
+  (let [dir (Files/createTempDirectory prefix (make-array FileAttribute 0))]
+    (try
+      (f dir)
+      (finally
+        (delete-dir dir)))))
+
+(defn tmp-dir
+  (^Path [] (tmp-dir ""))
+  (^Path [prefix] (Files/createTempDirectory prefix (make-array FileAttribute 0)) ))
+
+(defmacro with-tmp-dirs
+  "Usage:
+    (with-tmp-dirs #{log-dir objects-dir}
+      ...)"
+  [[dir-binding & more-bindings] & body]
+  (if dir-binding
+    `(with-tmp-dir* ~(name dir-binding)
+       (fn [~(vary-meta dir-binding assoc :tag 'java.nio.file.Path)]
+         (with-tmp-dirs #{~@more-bindings}
+           ~@body)))
+    `(do ~@body)))


### PR DESCRIPTION
This creates a first version of an external sort for order by. The rough algorithm is as follows:
- Consume batches until a chunk is full and then flush that chunk to disk.
- Do k-way-merges (k configurable) of these chunk files until we hit one file.
- The k-way-merge flushes out sorted chunks for the next k-way-merge. So overall this means we should never have more then (k+1) chunks in memory. These (k+1) chunks can of course still vary greatly based on the number of columns that are projected out.
- From the one sorted file we consume chunks as we move along (batch chunking still todo).

There is no memory mapping of these files as ArrowRecordBatches should assure that we always have only one chunk per file in memory.
 
Todo / possible improvements
- [ ] ~batch chunking~ to test if we actual need it
- [x] cleanup files as we merge
- [x] ~can object (re)creation (readers, comparators, copiers) be avoided?~ to some extent
- [ ] ~optimisations of all sorts~ (probably good for another ticket)