### PR TITLE
point/point queries for live tries

### DIFF
--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -131,7 +131,7 @@
         (openWatermark [_ retain?]
           (locking this-table
             (let [wm-live-rel (open-wm-live-rel live-rel retain?)
-                  wm-live-trie live-trie]
+                  wm-live-trie (.compactLogs ^LiveHashTrie @!transient-trie)]
               (reify ILiveTableWatermark
                 (liveRelation [_] wm-live-rel)
                 (liveTrie [_] wm-live-trie)
@@ -155,7 +155,7 @@
   (openWatermark [this retain?]
     (locking this
       (let [wm-live-rel (open-wm-live-rel live-rel retain?)
-            wm-live-trie live-trie]
+            wm-live-trie (.compactLogs live-trie)]
         (reify ILiveTableWatermark
           (liveRelation [_] wm-live-rel)
           (liveTrie [_] wm-live-trie)

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -26,9 +26,9 @@
 (definterface ILiveTableTx
   (^xtdb.indexer.live_index.ILiveTableWatermark openWatermark [^boolean retain])
   (^xtdb.vector.IVectorWriter docWriter [])
-  (^void logPut [^bytes iid, ^long validFrom, ^long validTo, writeDocFn])
-  (^void logDelete [^bytes iid, ^long validFrom, ^long validTo])
-  (^void logEvict [^bytes iid])
+  (^void logPut [^bytes iid, ^long legacyIid, ^long validFrom, ^long validTo, writeDocFn])
+  (^void logDelete [^bytes iid, ^long legacyIid, ^long validFrom, ^long validTo])
+  (^void logEvict [^bytes iid, ^long legacyIid])
   (^void commit [])
   (^void close []))
 
@@ -78,7 +78,7 @@
 
 (deftype LiveTable [^BufferAllocator allocator, ^ObjectStore obj-store, ^String table-name
                     ^IRelationWriter live-rel, ^:unsynchronized-mutable ^LiveHashTrie live-trie
-                    ^IVectorWriter iid-wtr, ^IVectorWriter system-from-wtr
+                    ^IVectorWriter iid-wtr, ^IVectorWriter legacy-iid-wtr, ^IVectorWriter system-from-wtr
                     ^IVectorWriter put-wtr, ^IVectorWriter put-valid-from-wtr, ^IVectorWriter put-valid-to-wtr, ^IVectorWriter put-doc-wtr
                     ^IVectorWriter delete-wtr, ^IVectorWriter delete-valid-from-wtr, ^IVectorWriter delete-valid-to-wtr
                     ^IVectorWriter evict-wtr]
@@ -89,10 +89,11 @@
       (reify ILiveTableTx
         (docWriter [_] put-doc-wtr)
 
-        (logPut [_ iid valid-from valid-to write-doc!]
+        (logPut [_ iid legacy-iid valid-from valid-to write-doc!]
           (.startRow live-rel)
 
           (.writeBytes iid-wtr (ByteBuffer/wrap iid))
+          (.writeLong legacy-iid-wtr legacy-iid)
           (.writeLong system-from-wtr system-from-µs)
 
           (.startStruct put-wtr)
@@ -105,8 +106,9 @@
 
           (swap! !transient-trie #(.add ^LiveHashTrie % (dec (.getPosition (.writerPosition live-rel))))))
 
-        (logDelete [_ iid valid-from valid-to]
+        (logDelete [_ iid legacy-iid valid-from valid-to]
           (.writeBytes iid-wtr (ByteBuffer/wrap iid))
+          (.writeLong legacy-iid-wtr legacy-iid)
           (.writeLong system-from-wtr system-from-µs)
 
           (.startStruct delete-wtr)
@@ -118,8 +120,9 @@
 
           (swap! !transient-trie #(.add ^LiveHashTrie % (dec (.getPosition (.writerPosition live-rel))))))
 
-        (logEvict [_ iid]
+        (logEvict [_ iid legacy-iid]
           (.writeBytes iid-wtr (ByteBuffer/wrap iid))
+          (.writeLong legacy-iid-wtr legacy-iid)
           (.writeLong system-from-wtr system-from-µs)
 
           (.writeNull evict-wtr nil)
@@ -181,7 +184,7 @@
           delete-wtr (.writerForField op-wtr trie/delete-field)]
       (LiveTable. allocator object-store table-name rel
                   (LiveHashTrie/emptyTrie (.getVector iid-wtr))
-                  iid-wtr (.writerForName rel "xt$system_from")
+                  iid-wtr (.writerForName rel "xt$legacy_iid") (.writerForName rel "xt$system_from")
                   put-wtr (.structKeyWriter put-wtr "xt$valid_from") (.structKeyWriter put-wtr "xt$valid_to") (.structKeyWriter put-wtr "xt$doc")
                   delete-wtr (.structKeyWriter delete-wtr "xt$valid_from") (.structKeyWriter delete-wtr "xt$valid_to")
                   (.writerForField op-wtr trie/evict-field)))))

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -38,6 +38,7 @@
 
 (def ^:private ^org.apache.arrow.vector.types.pojo.Schema leaf-schema
   (Schema. [(types/col-type->field "xt$iid" [:fixed-size-binary 16])
+            (types/col-type->field "xt$legacy_iid" :i64)
             (types/col-type->field "xt$system_from" types/temporal-col-type)
             (types/->field "op" (ArrowType$Union. UnionMode/Dense (int-array (range 3))) false
                            put-field delete-field evict-field)]))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -110,6 +110,10 @@
              (.putLong (.getLeastSignificantBits uuid)))]
     (.array bb)))
 
+(defn bytes->uuid ^UUID [^bytes bytes]
+  (let [bb (ByteBuffer/wrap bytes)]
+    (UUID. (.getLong bb) (.getLong bb))))
+
 (defn ->lex-hex-string
   "Turn a long into a lexicographically-sortable hex string by prepending the length"
   [^long l]

--- a/core/src/main/clojure/xtdb/vector/reader.clj
+++ b/core/src/main/clojure/xtdb/vector/reader.clj
@@ -61,7 +61,7 @@
 
 ;; we don't allocate anything here, but we need it because BaseValueVector
 ;; (a distant supertype of AbsentVector) thinks it needs one.
-(defn with-absent-cols [^RelationReader rel, ^BufferAllocator allocator, col-names]
+(defn with-absent-cols ^xtdb.vector.RelationReader [^RelationReader rel, ^BufferAllocator allocator, col-names]
   (let [row-count (.rowCount rel)
         available-col-names (into #{} (map #(.getName ^IVectorReader %)) rel)]
     (rel-reader (concat rel

--- a/core/src/main/java/xtdb/vector/IndirectVectorReader.java
+++ b/core/src/main/java/xtdb/vector/IndirectVectorReader.java
@@ -119,7 +119,8 @@ class IndirectVectorReader implements IVectorReader {
 
     @Override
     public IVectorReader structKeyReader(String colName) {
-        return new IndirectVectorReader(reader.structKeyReader(colName), indirection);
+        IVectorReader inner = reader.structKeyReader(colName);
+        return inner == null ? null : new IndirectVectorReader(inner, indirection);
     }
 
     @Override

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -16,7 +16,8 @@
             [xtdb.util :as util]
             [xtdb.vector :as vec]
             [xtdb.vector.reader :as vr]
-            [xtdb.vector.writer :as vw])
+            [xtdb.vector.writer :as vw]
+            [xtdb.operator.scan :as scan])
   (:import [ch.qos.logback.classic Level Logger]
            clojure.lang.ExceptionInfo
            java.net.ServerSocket
@@ -297,3 +298,10 @@
        ~@body
        (finally
          (set-log-level! ~ns level#)))))
+
+(defmacro without-tries [& body]
+  `(with-redefs [scan/*use-tries?* false]
+     ~@body))
+
+(defn no-tries [f]
+  (without-tries (f)))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -298,10 +298,3 @@
        ~@body
        (finally
          (set-log-level! ~ns level#)))))
-
-(defmacro without-tries [& body]
-  `(with-redefs [scan/*use-tries?* false]
-     ~@body))
-
-(defn no-tries [f]
-  (without-tries (f)))

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -114,28 +114,29 @@
                           {:default-tz (ZoneId/of "Europe/London")})))))))
 
 (t/deftest can-manually-specify-system-time-47
-  (let [tx1 (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :foo}]]
-                          {:system-time #inst "2012"})
+  (tu/without-tries
+   (let [tx1 (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :foo}]]
+                           {:system-time #inst "2012"})
 
-        _invalid-tx (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :bar}]]
-                                  {:system-time #inst "2011"})
+         _invalid-tx (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :bar}]]
+                                   {:system-time #inst "2011"})
 
-        tx3 (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :baz}]])]
+         tx3 (xt/submit-tx *node* '[[:put :xt_docs {:xt/id :baz}]])]
 
-    (t/is (= (xtp/map->TransactionInstant {:tx-id 0, :system-time (util/->instant #inst "2012")})
-             tx1))
+     (t/is (= (xtp/map->TransactionInstant {:tx-id 0, :system-time (util/->instant #inst "2012")})
+              tx1))
 
-    (letfn [(q-at [tx]
-              (->> (xt/q *node*
-                         '{:find [id]
-                           :where [(match :xt_docs {:xt/id e})
-                                   [e :xt/id id]]}
-                         {:basis {:tx tx}
-                          :basis-timeout (Duration/ofSeconds 1)})
-                   (into #{} (map :id))))]
+     (letfn [(q-at [tx]
+               (->> (xt/q *node*
+                          '{:find [id]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :xt/id id]]}
+                          {:basis {:tx tx}
+                           :basis-timeout (Duration/ofSeconds 1)})
+                    (into #{} (map :id))))]
 
-      (t/is (= #{:foo} (q-at tx1)))
-      (t/is (= #{:foo :baz} (q-at tx3))))))
+       (t/is (= #{:foo} (q-at tx1)))
+       (t/is (= #{:foo :baz} (q-at tx3)))))))
 
 (def ^:private devs
   '[[:put :users {:xt/id :jms, :name "James"}]
@@ -154,9 +155,9 @@
 (t/deftest test-sql-dynamic-params-103
   (xt/submit-tx *node* devs)
 
-  (t/is (= [{:name "James"} {:name "Matt"}]
-           (xt/q *node* ["SELECT u.name FROM users u WHERE u.name IN (?, ?)"
-                         "James" "Matt"]))))
+  (t/is (= #{{:name "James"} {:name "Matt"}}
+           (set (xt/q *node* ["SELECT u.name FROM users u WHERE u.name IN (?, ?)"
+                              "James" "Matt"])))))
 
 (t/deftest start-and-query-empty-node-re-231-test
   (with-open [n (node/start-node {})]
@@ -233,167 +234,170 @@
              (xt/q *node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo")))))
 
 (deftest test-dml-default-all-valid-time-flag-339
-  (let [tt1 (util/->zdt #inst "2020-01-01")
-        tt2 (util/->zdt #inst "2020-01-02")
-        tt5 (util/->zdt #inst "2020-01-05")
-        eot (util/->zdt util/end-of-time)]
-    (letfn [(q []
-              (set (xt/q *node*
-                         "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                         {:default-all-valid-time? true})))]
-      (xt/submit-tx *node*
-                    [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                            "foo", 0]]])
+  (tu/without-tries
+   (let [tt1 (util/->zdt #inst "2020-01-01")
+         tt2 (util/->zdt #inst "2020-01-02")
+         tt5 (util/->zdt #inst "2020-01-05")
+         eot (util/->zdt util/end-of-time)]
+     (letfn [(q []
+               (set (xt/q *node*
+                          "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                          {:default-all-valid-time? true})))]
+       (xt/submit-tx *node*
+                     [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
+                             "foo", 0]]])
 
-      (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to eot}}
-               (q)))
+       (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to eot}}
+                (q)))
 
-      (t/testing "update as-of-now"
-        (xt/submit-tx *node*
-                      [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]]
-                      {:default-all-valid-time? false})
+       (t/testing "update as-of-now"
+         (xt/submit-tx *node*
+                       [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]]
+                       {:default-all-valid-time? false})
 
-        (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
-                   {:version 1, :xt$valid_from tt2, :xt$valid_to eot}}
-                 (q))))
+         (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
+                    {:version 1, :xt$valid_from tt2, :xt$valid_to eot}}
+                  (q))))
 
-      (t/testing "`FOR PORTION OF` means flag is ignored"
-        (xt/submit-tx *node*
-                      [[:sql [(str "UPDATE foo "
-                                   "FOR PORTION OF VALID_TIME FROM ? TO ? "
-                                   "SET version = 2 WHERE foo.xt$id = 'foo'")
-                              tt1 tt2]]]
-                      {:default-all-valid-time? false})
-        (t/is (= #{{:version 2, :xt$valid_from tt1, :xt$valid_to tt2}
-                   {:version 1, :xt$valid_from tt2, :xt$valid_to eot}}
-                 (q))))
+       (t/testing "`FOR PORTION OF` means flag is ignored"
+         (xt/submit-tx *node*
+                       [[:sql [(str "UPDATE foo "
+                                    "FOR PORTION OF VALID_TIME FROM ? TO ? "
+                                    "SET version = 2 WHERE foo.xt$id = 'foo'")
+                               tt1 tt2]]]
+                       {:default-all-valid-time? false})
+         (t/is (= #{{:version 2, :xt$valid_from tt1, :xt$valid_to tt2}
+                    {:version 1, :xt$valid_from tt2, :xt$valid_to eot}}
+                  (q))))
 
-      (t/testing "UPDATE for-all-time"
-        (xt/submit-tx *node*
-                      [[:sql "UPDATE foo SET version = 3 WHERE foo.xt$id = 'foo'"]]
-                      {:default-all-valid-time? true})
+       (t/testing "UPDATE for-all-time"
+         (xt/submit-tx *node*
+                       [[:sql "UPDATE foo SET version = 3 WHERE foo.xt$id = 'foo'"]]
+                       {:default-all-valid-time? true})
 
-        (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
-                   {:version 3, :xt$valid_from tt2, :xt$valid_to eot}}
-                 (q))))
+         (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
+                    {:version 3, :xt$valid_from tt2, :xt$valid_to eot}}
+                  (q))))
 
-      (t/testing "DELETE as-of-now"
-        (xt/submit-tx *node*
-                      [[:sql "DELETE FROM foo WHERE foo.xt$id = 'foo'"]]
-                      {:default-all-valid-time? false})
+       (t/testing "DELETE as-of-now"
+         (xt/submit-tx *node*
+                       [[:sql "DELETE FROM foo WHERE foo.xt$id = 'foo'"]]
+                       {:default-all-valid-time? false})
 
-        (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
-                   {:version 3, :xt$valid_from tt2, :xt$valid_to tt5}}
-                 (q))))
+         (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
+                    {:version 3, :xt$valid_from tt2, :xt$valid_to tt5}}
+                  (q))))
 
-      (t/testing "UPDATE FOR ALL VALID_TIME"
-        (xt/submit-tx *node*
-                      [[:sql "UPDATE foo FOR ALL VALID_TIME
+       (t/testing "UPDATE FOR ALL VALID_TIME"
+         (xt/submit-tx *node*
+                       [[:sql "UPDATE foo FOR ALL VALID_TIME
                                     SET version = 4 WHERE foo.xt$id = 'foo'"]]
-                      {:default-all-valid-time? false})
+                       {:default-all-valid-time? false})
 
-        (t/is (= #{{:version 4, :xt$valid_from tt1, :xt$valid_to tt2}
-                   {:version 4, :xt$valid_from tt2, :xt$valid_to tt5}}
-                 (q))))
+         (t/is (= #{{:version 4, :xt$valid_from tt1, :xt$valid_to tt2}
+                    {:version 4, :xt$valid_from tt2, :xt$valid_to tt5}}
+                  (q))))
 
-      (t/testing "DELETE FOR ALL VALID_TIME"
-        (xt/submit-tx *node*
-                      [[:sql "DELETE FROM foo FOR ALL VALID_TIME
+       (t/testing "DELETE FOR ALL VALID_TIME"
+         (xt/submit-tx *node*
+                       [[:sql "DELETE FROM foo FOR ALL VALID_TIME
                                     WHERE foo.xt$id = 'foo'"]]
-                      {:default-all-valid-time? false})
+                       {:default-all-valid-time? false})
 
-        (t/is (= #{} (q)))))))
+         (t/is (= #{} (q))))))))
 
 (deftest test-dql-as-of-now-flag-339
-  (let [tt1 (util/->zdt #inst "2020-01-01")
-        tt2 (util/->zdt #inst "2020-01-02")
-        eot (util/->zdt util/end-of-time)]
+  (tu/without-tries
+   (let [tt1 (util/->zdt #inst "2020-01-01")
+         tt2 (util/->zdt #inst "2020-01-02")
+         eot (util/->zdt util/end-of-time)]
 
-    (xt/submit-tx *node*
-                  [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                          "foo", 0]]])
+     (xt/submit-tx *node*
+                   [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
+                           "foo", 0]]])
 
-    (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to eot}]
-             (xt/q *node*
-                   "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                   {:default-all-valid-time? false})))
+     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to eot}]
+              (xt/q *node*
+                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                    {:default-all-valid-time? false})))
 
-    (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to eot}]
-             (xt/q *node*
-                   "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
+     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to eot}]
+              (xt/q *node*
+                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
 
-    (xt/submit-tx *node*
-                  [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]])
+     (xt/submit-tx *node*
+                   [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]])
 
-    (t/is (= [{:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
-             (xt/q *node*
-                   "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"))
-          "without flag it returns as of now")
+     (t/is (= [{:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
+              (xt/q *node*
+                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"))
+           "without flag it returns as of now")
 
-    (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
-              {:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
-             (xt/q *node*
-                   "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                   {:default-all-valid-time? true})))
+     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
+               {:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
+              (xt/q *node*
+                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                    {:default-all-valid-time? true})))
 
-    (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}]
-             (xt/q *node*
-                   [(str "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to "
-                         "FROM foo FOR VALID_TIME AS OF ?")
-                    tt1]
-                   {:default-all-valid-time? true}))
-          "`FOR VALID_TIME AS OF` overrides flag")
+     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}]
+              (xt/q *node*
+                    [(str "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to "
+                          "FROM foo FOR VALID_TIME AS OF ?")
+                     tt1]
+                    {:default-all-valid-time? true}))
+           "`FOR VALID_TIME AS OF` overrides flag")
 
-    (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
-              {:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
-             (xt/q *node*
-                   "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to
+     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
+               {:version 1, :xt$valid_from tt2, :xt$valid_to eot}]
+              (xt/q *node*
+                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to
                              FROM foo FOR ALL VALID_TIME"
-                   {:default-all-valid-time? false}))
-          "FOR ALL VALID_TIME ignores flag and returns all app-time")))
+                    {:default-all-valid-time? false}))
+           "FOR ALL VALID_TIME ignores flag and returns all app-time"))))
 
 (t/deftest test-erase
-  (letfn [(q [tx]
-            (set (xt/q *node*
-                       "SELECT foo.xt$id, foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                       {:basis {:tx tx}
-                        :default-all-valid-time? true})))]
-    (let [tx1 (xt/submit-tx *node*
-                            [[:sql-batch ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                                          ["foo", 0]
-                                          ["bar", 0]]]])
-          tx2 (xt/submit-tx *node* [[:sql "UPDATE foo SET version = 1"]])
-          v0 {:version 0,
-              :xt$valid_from (util/->zdt #inst "2020-01-01"),
-              :xt$valid_to (util/->zdt #inst "2020-01-02")}
+  (tu/without-tries
+   (letfn [(q [tx]
+             (set (xt/q *node*
+                        "SELECT foo.xt$id, foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                        {:basis {:tx tx}
+                         :default-all-valid-time? true})))]
+     (let [tx1 (xt/submit-tx *node*
+                             [[:sql-batch ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
+                                           ["foo", 0]
+                                           ["bar", 0]]]])
+           tx2 (xt/submit-tx *node* [[:sql "UPDATE foo SET version = 1"]])
+           v0 {:version 0,
+               :xt$valid_from (util/->zdt #inst "2020-01-01"),
+               :xt$valid_to (util/->zdt #inst "2020-01-02")}
 
-          v1 {:version 1,
-              :xt$valid_from (util/->zdt #inst "2020-01-02"),
-              :xt$valid_to (util/->zdt util/end-of-time)}]
+           v1 {:version 1,
+               :xt$valid_from (util/->zdt #inst "2020-01-02"),
+               :xt$valid_to (util/->zdt util/end-of-time)}]
 
-      (t/is (= #{{:xt$id "foo", :version 0,
-                  :xt$valid_from (util/->zdt #inst "2020-01-01")
-                  :xt$valid_to (util/->zdt util/end-of-time)}
-                 {:xt$id "bar", :version 0,
-                  :xt$valid_from (util/->zdt #inst "2020-01-01")
-                  :xt$valid_to (util/->zdt util/end-of-time)}}
-               (q tx1)))
+       (t/is (= #{{:xt$id "foo", :version 0,
+                   :xt$valid_from (util/->zdt #inst "2020-01-01")
+                   :xt$valid_to (util/->zdt util/end-of-time)}
+                  {:xt$id "bar", :version 0,
+                   :xt$valid_from (util/->zdt #inst "2020-01-01")
+                   :xt$valid_to (util/->zdt util/end-of-time)}}
+                (q tx1)))
 
-      (t/is (= #{(assoc v0 :xt$id "foo")
-                 (assoc v0 :xt$id "bar")
-                 (assoc v1 :xt$id "foo")
-                 (assoc v1 :xt$id "bar")}
-               (q tx2)))
+       (t/is (= #{(assoc v0 :xt$id "foo")
+                  (assoc v0 :xt$id "bar")
+                  (assoc v1 :xt$id "foo")
+                  (assoc v1 :xt$id "bar")}
+                (q tx2)))
 
-      (let [tx3 (xt/submit-tx *node*
-                              [[:sql "ERASE FROM foo WHERE foo.xt$id = 'foo'"]])]
-        (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx3)))
-        (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx2)))
+       (let [tx3 (xt/submit-tx *node*
+                               [[:sql "ERASE FROM foo WHERE foo.xt$id = 'foo'"]])]
+         (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx3)))
+         (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx2)))
 
-        (t/is (= #{{:xt$id "bar", :version 0,
-                    :xt$valid_from (util/->zdt #inst "2020-01-01")
-                    :xt$valid_to (util/->zdt util/end-of-time)}}
-                 (q tx1)))))))
+         (t/is (= #{{:xt$id "bar", :version 0,
+                     :xt$valid_from (util/->zdt #inst "2020-01-01")
+                     :xt$valid_to (util/->zdt util/end-of-time)}}
+                  (q tx1))))))))
 
 (t/deftest throws-static-tx-op-errors-on-submit-346
   (t/is (thrown-with-msg?
@@ -431,29 +435,30 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                (q-all))))))
 
 (deftest test-insert-from-other-table-with-as-of-now
-  (xt/submit-tx *node*
-                [[:sql
-                  "INSERT INTO posts (xt$id, user_id, text, xt$valid_from)
+  (tu/without-tries
+   (xt/submit-tx *node*
+                 [[:sql
+                   "INSERT INTO posts (xt$id, user_id, text, xt$valid_from)
                     VALUES (9012, 5678, 'Happy 2050!', DATE '2050-01-01')"]])
 
-  (t/is (= [{:text "Happy 2050!"}]
-           (xt/q *node*
-                 "SELECT posts.text FROM posts FOR VALID_TIME AS OF DATE '2050-01-02'")))
+   (t/is (= [{:text "Happy 2050!"}]
+            (xt/q *node*
+                  "SELECT posts.text FROM posts FOR VALID_TIME AS OF DATE '2050-01-02'")))
 
-  (t/is (= []
-           (xt/q *node*
-                 "SELECT posts.text FROM posts"
-                 {:default-all-valid-time? false})))
+   (t/is (= []
+            (xt/q *node*
+                  "SELECT posts.text FROM posts"
+                  {:default-all-valid-time? false})))
 
-  (xt/submit-tx *node*
-                [[:sql
-                  "INSERT INTO t1 SELECT posts.xt$id, posts.text FROM posts"]]
-                {:default-all-valid-time? false})
+   (xt/submit-tx *node*
+                 [[:sql
+                   "INSERT INTO t1 SELECT posts.xt$id, posts.text FROM posts"]]
+                 {:default-all-valid-time? false})
 
-  (t/is (= []
-           (xt/q *node*
-                 "SELECT t1.text FROM t1 FOR ALL VALID_TIME"
-                 {:default-all-valid-time? false}))))
+   (t/is (= []
+            (xt/q *node*
+                  "SELECT t1.text FROM t1 FOR ALL VALID_TIME"
+                  {:default-all-valid-time? false})))))
 
 (deftest test-submit-tx-system-time-opt
   (t/is (thrown-with-msg?

--- a/src/test/clojure/xtdb/as_of_test.clj
+++ b/src/test/clojure/xtdb/as_of_test.clj
@@ -4,7 +4,7 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util]))
 
-(t/use-fixtures :once tu/with-allocator)
+(t/use-fixtures :once tu/no-tries tu/with-allocator)
 (t/use-fixtures :each tu/with-node)
 
 (def end-of-time-zdt (util/->zdt util/end-of-time))

--- a/src/test/clojure/xtdb/as_of_test.clj
+++ b/src/test/clojure/xtdb/as_of_test.clj
@@ -4,7 +4,7 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util]))
 
-(t/use-fixtures :once tu/no-tries tu/with-allocator)
+(t/use-fixtures :once tu/with-allocator)
 (t/use-fixtures :each tu/with-node)
 
 (def end-of-time-zdt (util/->zdt util/end-of-time))

--- a/src/test/clojure/xtdb/as_of_test.clj
+++ b/src/test/clojure/xtdb/as_of_test.clj
@@ -37,20 +37,20 @@
 
 (t/deftest test-app-time
   (let [{:keys [system-time]} (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :doc, :version 1}]
-                                                    [:put :xt_docs {:xt/id :doc-with-app-time}
-                                                     {:for-valid-time [:in #inst "2021"]}]])
+                                                       [:put :xt_docs {:xt/id :doc-with-app-time}
+                                                        {:for-valid-time [:in #inst "2021"]}]])
         system-time (util/->zdt system-time)]
 
     (t/is (= {:doc {:xt/id :doc,
                     :xt/valid-from system-time
                     :xt/valid-to end-of-time-zdt
                     :xt/system-from system-time
-                    :xt/system-to end-of-time-zdt}
+                    :xt/system-to nil}
               :doc-with-app-time {:xt/id :doc-with-app-time,
                                   :xt/valid-from (util/->zdt #inst "2021")
                                   :xt/valid-to end-of-time-zdt
                                   :xt/system-from system-time
-                                  :xt/system-to end-of-time-zdt}}
+                                  :xt/system-to nil}}
              (->> (tu/query-ra '[:scan {:table xt_docs}
                                  [xt/id
                                   xt/valid-from xt/valid-to

--- a/src/test/clojure/xtdb/current_row_ids_test.clj
+++ b/src/test/clojure/xtdb/current_row_ids_test.clj
@@ -11,7 +11,7 @@
            org.apache.arrow.memory.RootAllocator
            java.time.Duration))
 
-(t/use-fixtures :each tu/with-mock-clock tu/with-node)
+(t/use-fixtures :each tu/with-mock-clock tu/with-node tu/no-tries)
 
 (def
   tx1

--- a/src/test/clojure/xtdb/current_row_ids_test.clj
+++ b/src/test/clojure/xtdb/current_row_ids_test.clj
@@ -11,7 +11,7 @@
            org.apache.arrow.memory.RootAllocator
            java.time.Duration))
 
-(t/use-fixtures :each tu/with-mock-clock tu/with-node tu/no-tries)
+(t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
 (def
   tx1

--- a/src/test/clojure/xtdb/current_row_ids_test.clj
+++ b/src/test/clojure/xtdb/current_row_ids_test.clj
@@ -131,63 +131,6 @@
                        :order-by [[name :asc]]}
                      {:basis {:current-time #time/instant "2020-01-03T00:00:00Z"}}))))))
 
-(deftest test-queries-that-can-use-current-row-id-cache
-  (with-redefs [scan/get-current-row-ids
-                (fn [_ _]
-                  (throw (Exception. "Scan tried to use current-row-id cache")))]
-
-    (t/is
-     (xt/q
-      tu/*node*
-      '{:find [id]
-        :where [(match :xt_docs {:xt/id id})]})
-     "query against empty db should not use current-row-id")
-
-    (let [tx1 (xt/submit-tx tu/*node*
-                            '[[:put :xt_docs {:xt/id 1}]])]
-      (xt/submit-tx tu/*node*
-                    '[[:put :xt_docs {:xt/id 2}]])
-
-      (t/testing "queries that cannot use current-row-ids cache"
-
-        (t/is
-         (xt/q tu/*node*
-               '{:find [id]
-                 :where [(match :xt_docs {:xt/id id})]}
-               {:basis {:tx tx1}})
-         "query at previous tx")
-
-        (t/is
-         (xt/q tu/*node*
-               '{:find [id]
-                 :where [(match :xt_docs {:xt/id id})]}
-               {:basis {:current-time #time/instant "2020-01-01T00:00:00Z"}})
-         "query with current-time in past")
-
-        (t/is
-         (xt/q tu/*node*
-               '{:find [id]
-                 :where [(match :xt_docs {:xt/id id}
-                                {:for-valid-time [:at :now]
-                                 :for-system-time [:at #inst "2020-01-01"]})]})
-         "query where all any table temporal constaints aside from now are set")
-
-        (t/is
-         (xt/q tu/*node*
-               '{:find [id]
-                 :where [(match :xt_docs {:xt/id id}
-                                {:for-valid-time :all-time})]})
-         "query where all any table temporal constaints aside from now are set")
-
-        (t/is
-         (xt/q tu/*node*
-               '{:find [id]
-                 :where [(match :xt_docs
-                           {:xt/id id
-                            :xt/valid-from xt/valid-from}
-                           {:for-valid-time :all-time})]})
-         "query where all any temporal cols are projected out")))))
-
 (defn current-rows-for [system-time inserts]
   (let [kd-tree nil
         !current-row-ids (volatile! #{})]

--- a/src/test/clojure/xtdb/current_row_ids_test.clj
+++ b/src/test/clojure/xtdb/current_row_ids_test.clj
@@ -144,51 +144,9 @@
      "query against empty db should not use current-row-id")
 
     (let [tx1 (xt/submit-tx tu/*node*
-                            '[[:put :xt_docs {:xt/id 1}]])
-          tx2 (xt/submit-tx tu/*node*
-                            '[[:put :xt_docs {:xt/id 2}]])]
-
-      (t/testing "queries that can use current-row-ids cache"
-
-        (t/is
-         (thrown-with-msg?
-          Exception
-          #"Scan tried to use current-row-id cache"
-          (xt/q tu/*node*
-                '{:find [id]
-                  :where [(match :xt_docs {:xt/id id})]}))
-         "query with no temporal constraints")
-
-        (t/is
-         (thrown-with-msg?
-          Exception
-          #"Scan tried to use current-row-id cache"
-          (xt/q tu/*node*
-                '{:find [id]
-                  :where [(match :xt_docs {:xt/id id})]}
-                {:basis {:tx tx2}}))
-         "query at latest tx")
-
-        (t/is
-         (thrown-with-msg?
-          Exception
-          #"Scan tried to use current-row-id cache"
-          (xt/q tu/*node*
-                '{:find [id]
-                  :where [(match :xt_docs {:xt/id id})]}
-                {:basis {:current-time #time/instant "2020-01-03T00:00:00Z"}}))
-         "query with current-time now or in future")
-
-        (t/is
-         (thrown-with-msg?
-          Exception
-          #"Scan tried to use current-row-id cache"
-          (xt/q tu/*node*
-                '{:find [id]
-                  :where [(match :xt_docs {:xt/id id}
-                                 {:for-valid-time [:at :now]
-                                  :for-system-time [:at :now]})]}))
-         "query where all table temporal constaints are now"))
+                            '[[:put :xt_docs {:xt/id 1}]])]
+      (xt/submit-tx tu/*node*
+                    '[[:put :xt_docs {:xt/id 2}]])
 
       (t/testing "queries that cannot use current-row-ids cache"
 

--- a/src/test/clojure/xtdb/datalog/temporal_test.clj
+++ b/src/test/clojure/xtdb/datalog/temporal_test.clj
@@ -4,7 +4,7 @@
             [xtdb.api.protocols :as xtp]
             [xtdb.test-util :as tu]))
 
-(t/use-fixtures :each tu/no-tries tu/with-node)
+(t/use-fixtures :each tu/with-node)
 
 (deftest simple-temporal-tests
   (let [tx1 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :foo "2000-4000"}

--- a/src/test/clojure/xtdb/datalog/temporal_test.clj
+++ b/src/test/clojure/xtdb/datalog/temporal_test.clj
@@ -4,7 +4,7 @@
             [xtdb.api.protocols :as xtp]
             [xtdb.test-util :as tu]))
 
-(t/use-fixtures :each tu/with-node)
+(t/use-fixtures :each tu/no-tries tu/with-node)
 
 (deftest simple-temporal-tests
   (let [tx1 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :foo "2000-4000"}

--- a/src/test/clojure/xtdb/datalog_test.clj
+++ b/src/test/clojure/xtdb/datalog_test.clj
@@ -10,7 +10,8 @@
             [xtdb.james-bond :as bond]
             [xtdb.node :as node]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util]))
+            [xtdb.util :as util]
+            [xtdb.operator.scan :as scan]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
@@ -21,17 +22,17 @@
 (deftest test-scan
   (xt/submit-tx tu/*node* ivan+petr)
 
-  (t/is (= [{:name "Ivan"}
-            {:name "Petr"}]
-           (xt/q tu/*node*
-                 '{:find [name]
-                   :where [(match :xt_docs {:first-name name})]})))
+  (t/is (= #{{:name "Ivan"}
+             {:name "Petr"}}
+           (set (xt/q tu/*node*
+                      '{:find [name]
+                        :where [(match :xt_docs {:first-name name})]}))))
 
-  (t/is (= [{:e :ivan, :name "Ivan"}
-            {:e :petr, :name "Petr"}]
-           (xt/q tu/*node*
-                 '{:find [e name]
-                   :where [(match :xt_docs {:xt/id e, :first-name name})]}))
+  (t/is (= #{{:e :ivan, :name "Ivan"}
+             {:e :petr, :name "Petr"}}
+           (set (xt/q tu/*node*
+                      '{:find [e name]
+                        :where [(match :xt_docs {:xt/id e, :first-name name})]})))
         "returning eid"))
 
 (deftest test-basic-query
@@ -255,15 +256,15 @@
   (let [_tx (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :o1, :unit-price 1.49, :quantity 4}]
                                       [:put :xt_docs {:xt/id :o2, :unit-price 5.39, :quantity 1}]
                                       [:put :xt_docs {:xt/id :o3, :unit-price 0.59, :quantity 7}]])]
-    (t/is (= [{:oid :o1, :o-value 5.96}
-              {:oid :o2, :o-value 5.39}
-              {:oid :o3, :o-value 4.13}]
-             (xt/q tu/*node*
-                   '{:find [oid (* unit-price qty)]
-                     :keys [oid o-value]
-                     :where [(match :xt_docs {:xt/id oid})
-                             [oid :unit-price unit-price]
-                             [oid :quantity qty]]})))))
+    (t/is (= #{{:oid :o1, :o-value 5.96}
+               {:oid :o2, :o-value 5.39}
+               {:oid :o3, :o-value 4.13}}
+             (set (xt/q tu/*node*
+                        '{:find [oid (* unit-price qty)]
+                          :keys [oid o-value]
+                          :where [(match :xt_docs {:xt/id oid})
+                                  [oid :unit-price unit-price]
+                                  [oid :quantity qty]]}))))))
 
 (deftest test-aggregate-exprs
   (let [tx (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :foo, :category :c0, :v 1}]
@@ -482,15 +483,15 @@
                 :where [(match :xt_docs {:xt/id e})
                         [e :last-name n]
                         [e :first-name n]]})))
-    (t/is (= [{:e :sergei, :f :sergei, :n "Sergei"} {:e :sergei, :f :jeff, :n "Sergei"}]
-             (xt/q
-              tu/*node*
-              '{:find [e f n]
-                :where [(match :xt_docs {:xt/id e})
-                        (match :xt_docs {:xt/id f})
-                        [e :last-name n]
-                        [e :first-name n]
-                        [f :first-name n]]})))))
+    (t/is (= #{{:e :sergei, :f :sergei, :n "Sergei"} {:e :sergei, :f :jeff, :n "Sergei"}}
+             (set (xt/q
+                   tu/*node*
+                   '{:find [e f n]
+                     :where [(match :xt_docs {:xt/id e})
+                             (match :xt_docs {:xt/id f})
+                             [e :last-name n]
+                             [e :first-name n]
+                             [f :first-name n]]}))))))
 
 (deftest test-implicit-match-unification
   (xt/submit-tx tu/*node* '[[:put :foo {:xt/id :ivan, :name "Ivan"}]
@@ -567,31 +568,31 @@
                   [:put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
                   [:put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])
 
-  (t/is (= [{:e :ivan, :c :petr}
-            {:e :petr, :c :sergei}
-            {:e :petr, :c :jeff}
-            {:e :sergei, :c nil}
-            {:e :jeff, :c nil}]
-           (xt/q tu/*node*
-                 '{:find [e c]
-                   :where [(match :xt_docs {:xt/id e, :name name})
-                           (left-join {:find [e c]
-                                       :where [(match :xt_docs {:xt/id c})
-                                               [c :parent e]]})]}))
+  (t/is (= #{{:e :ivan, :c :petr}
+             {:e :petr, :c :sergei}
+             {:e :petr, :c :jeff}
+             {:e :sergei, :c nil}
+             {:e :jeff, :c nil}}
+           (set (xt/q tu/*node*
+                      '{:find [e c]
+                        :where [(match :xt_docs {:xt/id e, :name name})
+                                (left-join {:find [e c]
+                                            :where [(match :xt_docs {:xt/id c})
+                                                    [c :parent e]]})]})))
 
         "find people who have children")
 
-  (t/is (= [{:e :ivan, :s nil}
-            {:e :petr, :s nil}
-            {:e :sergei, :s :jeff}
-            {:e :jeff, :s :sergei}]
-           (xt/q tu/*node*
-                 '{:find [e s]
-                   :where [(match :xt_docs {:xt/id e, :name name, :parent p})
-                           (left-join {:find [s p]
-                                       :in [e]
-                                       :where [(match :xt_docs {:xt/id s, :parent p})
-                                               [(<> e s)]]})]}))
+  (t/is (= #{{:e :ivan, :s nil}
+             {:e :petr, :s nil}
+             {:e :sergei, :s :jeff}
+             {:e :jeff, :s :sergei}}
+           (set (xt/q tu/*node*
+                      '{:find [e s]
+                        :where [(match :xt_docs {:xt/id e, :name name, :parent p})
+                                (left-join {:find [s p]
+                                            :in [e]
+                                            :where [(match :xt_docs {:xt/id s, :parent p})
+                                                    [(<> e s)]]})]})))
         "find people who have siblings")
 
   (t/is (thrown-with-msg? IllegalArgumentException
@@ -612,24 +613,24 @@
                             [:put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
                             [:put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])]
 
-    (t/is (= [{:e :ivan} {:e :petr}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e, :name name})
-                             (exists? {:find [e]
-                                       :where [(match :xt_docs {:xt/id c})
-                                               [c :parent e]]})]}))
+    (t/is (= #{{:e :ivan} {:e :petr}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e, :name name})
+                                  (exists? {:find [e]
+                                            :where [(match :xt_docs {:xt/id c})
+                                                    [c :parent e]]})]})))
 
           "find people who have children")
 
-    (t/is (= [{:e :sergei} {:e :jeff}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e, :name name, :parent p})
-                             (exists? {:find [p]
-                                       :in [e]
-                                       :where [(match :xt_docs {:xt/id s, :parent p})
-                                               [(<> e s)]]})]}))
+    (t/is (= #{{:e :sergei} {:e :jeff}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e, :name name, :parent p})
+                                  (exists? {:find [p]
+                                            :in [e]
+                                            :where [(match :xt_docs {:xt/id s, :parent p})
+                                                    [(<> e s)]]})]})))
           "find people who have siblings")
 
     (t/is (thrown-with-msg? IllegalArgumentException
@@ -650,24 +651,24 @@
                [:put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov" :foo 1}]
                [:put :xt_docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1}]])]
 
-    (t/is (= [{:e :ivan} {:e :sergei}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e})
-                             [e :foo 1]
-                             (not-exists? {:find [e]
-                                           :where [(match :xt_docs {:xt/id e})
-                                                   [e :first-name "Petr"]]})]})))
+    (t/is (= #{{:e :ivan} {:e :sergei}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e})
+                                  [e :foo 1]
+                                  (not-exists? {:find [e]
+                                                :where [(match :xt_docs {:xt/id e})
+                                                        [e :first-name "Petr"]]})]}))))
 
-    (t/is (= [{:e :ivan} {:e :sergei}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e})
-                             [e :foo n]
-                             (not-exists? {:find [e n]
-                                           :where [(match :xt_docs {:xt/id e})
-                                                   [e :first-name "Petr"]
-                                                   [e :foo n]]})]})))
+    (t/is (= #{{:e :ivan} {:e :sergei}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e})
+                                  [e :foo n]
+                                  (not-exists? {:find [e n]
+                                                :where [(match :xt_docs {:xt/id e})
+                                                        [e :first-name "Petr"]
+                                                        [e :foo n]]})]}))))
 
     (t/is (= []
              (xt/q tu/*node*
@@ -678,74 +679,74 @@
                                            :where [(match :xt_docs {:xt/id e})
                                                    [e :foo n]]})]})))
 
-    (t/is (= [{:e :petr} {:e :sergei}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e})
-                             [e :foo 1]
-                             (not-exists? {:find [e]
-                                           :where [(match :xt_docs {:xt/id e})
-                                                   [e :last-name "Ivanov"]]})]})))
+    (t/is (= #{{:e :petr} {:e :sergei}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e})
+                                  [e :foo 1]
+                                  (not-exists? {:find [e]
+                                                :where [(match :xt_docs {:xt/id e})
+                                                        [e :last-name "Ivanov"]]})]}))))
 
-    (t/is (= [{:e :ivan} {:e :petr} {:e :sergei}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e})
-                             [e :foo 1]
-                             (not-exists? {:find [e]
-                                           :where [(match :xt_docs {:xt/id e})
-                                                   [e :first-name "Jeff"]]})]})))
+    (t/is (= #{{:e :ivan} {:e :petr} {:e :sergei}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e})
+                                  [e :foo 1]
+                                  (not-exists? {:find [e]
+                                                :where [(match :xt_docs {:xt/id e})
+                                                        [e :first-name "Jeff"]]})]}))))
 
-    (t/is (= [{:e :ivan} {:e :petr}]
-             (xt/q tu/*node*
-                   '{:find [e]
-                     :where [(match :xt_docs {:xt/id e})
-                             [e :foo 1]
-                             (not-exists? {:find [e]
-                                           :where [(match :xt_docs {:xt/id e})
-                                                   [e :first-name n]
-                                                   [e :last-name n]]})]})))
+    (t/is (= #{{:e :ivan} {:e :petr}}
+             (set (xt/q tu/*node*
+                        '{:find [e]
+                          :where [(match :xt_docs {:xt/id e})
+                                  [e :foo 1]
+                                  (not-exists? {:find [e]
+                                                :where [(match :xt_docs {:xt/id e})
+                                                        [e :first-name n]
+                                                        [e :last-name n]]})]}))))
 
-    (t/is (= [{:e :ivan, :first-name "Petr", :last-name "Petrov", :a "Ivan", :b "Ivanov"}
-              {:e :petr, :first-name "Ivan", :last-name "Ivanov", :a "Petr", :b "Petrov"}
-              {:e :sergei, :first-name "Ivan", :last-name "Ivanov", :a "Sergei", :b "Sergei"}
-              {:e :sergei, :first-name "Petr", :last-name "Petrov", :a "Sergei", :b "Sergei"}]
-             (xt/q tu/*node*
-                   ['{:find [e first-name last-name a b]
-                      :in [[[first-name last-name]]]
-                      :where [(match :xt_docs {:xt/id e})
-                              [e :foo 1]
-                              [e :first-name a]
-                              [e :last-name b]
-                              (not-exists? {:find [e first-name last-name]
-                                            :where [(match :xt_docs {:xt/id e})
-                                                    [e :first-name first-name]
-                                                    [e :last-name last-name]]})]}
-                    [["Ivan" "Ivanov"]
-                     ["Petr" "Petrov"]]])))
+    (t/is (= #{{:e :ivan, :first-name "Petr", :last-name "Petrov", :a "Ivan", :b "Ivanov"}
+               {:e :petr, :first-name "Ivan", :last-name "Ivanov", :a "Petr", :b "Petrov"}
+               {:e :sergei, :first-name "Ivan", :last-name "Ivanov", :a "Sergei", :b "Sergei"}
+               {:e :sergei, :first-name "Petr", :last-name "Petrov", :a "Sergei", :b "Sergei"}}
+             (set (xt/q tu/*node*
+                        ['{:find [e first-name last-name a b]
+                           :in [[[first-name last-name]]]
+                           :where [(match :xt_docs {:xt/id e})
+                                   [e :foo 1]
+                                   [e :first-name a]
+                                   [e :last-name b]
+                                   (not-exists? {:find [e first-name last-name]
+                                                 :where [(match :xt_docs {:xt/id e})
+                                                         [e :first-name first-name]
+                                                         [e :last-name last-name]]})]}
+                         [["Ivan" "Ivanov"]
+                          ["Petr" "Petrov"]]]))))
 
     (t/testing "apply anti-joins"
-      (t/is (= [{:n 1, :e :ivan} {:n 1, :e :petr} {:n 1, :e :sergei}]
-               (xt/q tu/*node*
-                     '{:find [e n]
-                       :where [(match :xt_docs {:xt/id e})
-                               [e :foo n]
-                               (not-exists? {:find [e]
-                                             :in [n]
-                                             :where [(match :xt_docs {:xt/id e})
-                                                     [e :first-name "Petr"]
-                                                     [(= n 2)]]})]})))
+      (t/is (= #{{:n 1, :e :ivan} {:n 1, :e :petr} {:n 1, :e :sergei}}
+               (set (xt/q tu/*node*
+                          '{:find [e n]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :foo n]
+                                    (not-exists? {:find [e]
+                                                  :in [n]
+                                                  :where [(match :xt_docs {:xt/id e})
+                                                          [e :first-name "Petr"]
+                                                          [(= n 2)]]})]}))))
 
-      (t/is (= [{:n 1, :e :ivan} {:n 1, :e :sergei}]
-               (xt/q tu/*node*
-                     '{:find [e n]
-                       :where [(match :xt_docs {:xt/id e})
-                               [e :foo n]
-                               (not-exists? {:find [e]
-                                             :in [n]
-                                             :where [(match :xt_docs {:xt/id e})
-                                                     [e :first-name "Petr"]
-                                                     [(= n 1)]]})]})))
+      (t/is (= #{{:n 1, :e :ivan} {:n 1, :e :sergei}}
+               (set (xt/q tu/*node*
+                          '{:find [e n]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :foo n]
+                                    (not-exists? {:find [e]
+                                                  :in [n]
+                                                  :where [(match :xt_docs {:xt/id e})
+                                                          [e :first-name "Petr"]
+                                                          [(= n 1)]]})]}))))
 
       (t/is (= []
                (xt/q tu/*node*
@@ -756,36 +757,36 @@
                                              :in [n]
                                              :where [[(= n 1)]]})]})))
 
-      (t/is (= [{:n "Petr", :e :petr} {:n "Sergei", :e :sergei}]
-               (xt/q tu/*node*
-                     '{:find [e n]
-                       :where [(match :xt_docs {:xt/id e})
-                               [e :first-name n]
-                               (not-exists? {:find []
-                                             :in [n]
-                                             :where [[(= "Ivan" n)]]})]})))
+      (t/is (= #{{:n "Petr", :e :petr} {:n "Sergei", :e :sergei}}
+               (set (xt/q tu/*node*
+                          '{:find [e n]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :first-name n]
+                                    (not-exists? {:find []
+                                                  :in [n]
+                                                  :where [[(= "Ivan" n)]]})]}))))
 
 
-      (t/is (= [{:n "Petr", :e :petr} {:n "Sergei", :e :sergei}]
-               (xt/q tu/*node*
-                     '{:find [e n]
-                       :where [(match :xt_docs {:xt/id e})
-                               [e :first-name n]
-                               (not-exists? {:find [n]
-                                             :where [(match :xt_docs {:xt/id e})
-                                                     [e :first-name n]
-                                                     [e :first-name "Ivan"]]})]})))
+      (t/is (= #{{:n "Petr", :e :petr} {:n "Sergei", :e :sergei}}
+               (set (xt/q tu/*node*
+                          '{:find [e n]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :first-name n]
+                                    (not-exists? {:find [n]
+                                                  :where [(match :xt_docs {:xt/id e})
+                                                          [e :first-name n]
+                                                          [e :first-name "Ivan"]]})]}))))
 
-      (t/is (= [{:n 1, :e :ivan} {:n 1, :e :sergei}]
-               (xt/q tu/*node*
-                     '{:find [e n]
-                       :where [(match :xt_docs {:xt/id e})
-                               [e :foo n]
-                               (not-exists? {:find [e n]
-                                             :where [(match :xt_docs {:xt/id e})
-                                                     [e :first-name "Petr"]
-                                                     [e :foo n]
-                                                     [(= n 1)]]})]})))
+      (t/is (= #{{:n 1, :e :ivan} {:n 1, :e :sergei}}
+               (set (xt/q tu/*node*
+                          '{:find [e n]
+                            :where [(match :xt_docs {:xt/id e})
+                                    [e :foo n]
+                                    (not-exists? {:find [e n]
+                                                  :where [(match :xt_docs {:xt/id e})
+                                                          [e :first-name "Petr"]
+                                                          [e :foo n]
+                                                          [(= n 1)]]})]}))))
 
 
       (t/is (thrown-with-msg?
@@ -829,12 +830,12 @@
                             [:put :xt_docs {:xt/id :slava, :age 37}]])
 
 
-  (t/is (= [{:_column_0 1, :_column_1 "foo", :xt/id :ivan}
-            {:_column_0 1, :_column_1 "foo", :xt/id :petr}
-            {:_column_0 1, :_column_1 "foo", :xt/id :slava}]
-           (xt/q tu/*node*
-                 '{:find [1 "foo" xt/id]
-                   :where [(match :xt_docs [xt/id])]}))))
+  (t/is (= #{{:_column_0 1, :_column_1 "foo", :xt/id :ivan}
+             {:_column_0 1, :_column_1 "foo", :xt/id :petr}
+             {:_column_0 1, :_column_1 "foo", :xt/id :slava}}
+           (set (xt/q tu/*node*
+                      '{:find [1 "foo" xt/id]
+                        :where [(match :xt_docs [xt/id])]})))))
 
 (deftest calling-a-function-580
   (let [_tx (xt/submit-tx tu/*node*
@@ -891,17 +892,17 @@
                             [:put :xt_docs {:xt/id :petr, :age 22, :height 240, :parent 1}]
                             [:put :xt_docs {:xt/id :slava, :age 37, :parent 2}]])]
 
-    (t/is (= [{:e1 :ivan, :e2 :petr, :e3 :slava}
-              {:e1 :petr, :e2 :ivan, :e3 :slava}]
-             (xt/q tu/*node*
-                   '{:find [e1 e2 e3]
-                     :where [(match :xt_docs {:xt/id e1})
-                             (match :xt_docs {:xt/id e2})
-                             (match :xt_docs {:xt/id e3})
-                             [e1 :age a1]
-                             [e2 :age a2]
-                             [e3 :age a3]
-                             [(= (+ a1 a2) a3)]]})))
+    (t/is (= #{{:e1 :ivan, :e2 :petr, :e3 :slava}
+               {:e1 :petr, :e2 :ivan, :e3 :slava}}
+             (set (xt/q tu/*node*
+                        '{:find [e1 e2 e3]
+                          :where [(match :xt_docs {:xt/id e1})
+                                  (match :xt_docs {:xt/id e2})
+                                  (match :xt_docs {:xt/id e3})
+                                  [e1 :age a1]
+                                  [e2 :age a2]
+                                  [e3 :age a3]
+                                  [(= (+ a1 a2) a3)]]}))))
 
     (t/is (= [{:a1 15, :a2 22, :a3 37, :sum-ages 74, :inc-sum-ages 75}]
              (xt/q tu/*node*
@@ -1001,16 +1002,16 @@
                                                         [e :xt/id :ivan]))]})))))
 
 (deftest test-union-join-with-subquery-638
-  (let [tx (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :ivan, :age 20, :role :developer}]
-                                     [:put :xt_docs {:xt/id :oleg, :age 30, :role :manager}]
-                                     [:put :xt_docs {:xt/id :petr, :age 35, :role :qa}]
-                                     [:put :xt_docs {:xt/id :sergei, :age 35, :role :manager}]])]
-    (t/is (= [{:e :oleg}]
-             (xt/q tu/*node* '{:find [e]
-                               :where [(union-join [e]
-                                                   (q {:find [e]
-                                                       :where [(match :xt_docs {:xt/id e})
-                                                               [e :age 30]]}))]})))))
+  (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :ivan, :age 20, :role :developer}]
+                            [:put :xt_docs {:xt/id :oleg, :age 30, :role :manager}]
+                            [:put :xt_docs {:xt/id :petr, :age 35, :role :qa}]
+                            [:put :xt_docs {:xt/id :sergei, :age 35, :role :manager}]])
+  (t/is (= [{:e :oleg}]
+           (xt/q tu/*node* '{:find [e]
+                             :where [(union-join [e]
+                                                 (q {:find [e]
+                                                     :where [(match :xt_docs {:xt/id e})
+                                                             [e :age 30]]}))]}))))
 
 (deftest test-nested-query
   (xt/submit-tx tu/*node* bond/tx-ops)
@@ -1095,26 +1096,27 @@
         (t/is (= 160 (count-table tx)))))))
 
 (t/deftest bug-dont-throw-on-non-existing-column-597
-  (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
-    (letfn [(submit-ops! [ids]
-              (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)}])
-                                      (partition-all 20))]
-                      (xt/submit-tx node tx-ops))))]
+  (tu/without-tries
+    (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
+      (letfn [(submit-ops! [ids]
+                (last (for [tx-ops (->> (for [id ids]
+                                          [:put :t1 {:xt/id id,
+                                                     :data (str "data" id)}])
+                                        (partition-all 20))]
+                        (xt/submit-tx node tx-ops))))]
 
-      (xt/submit-tx node '[[:put :xt_docs {:xt/id 0 :foo :bar}]])
-      (submit-ops! (range 1010))
+        (xt/submit-tx node '[[:put :xt_docs {:xt/id 0 :foo :bar}]])
+        (submit-ops! (range 1010))
 
-      (t/is (= 1010 (-> (xt/q node '{:find [(count id)]
-                                     :keys [id-count]
-                                     :where [(match :t1 {:xt/id id})]})
-                        (first)
-                        (:id-count))))
+        (t/is (= 1010 (-> (xt/q node '{:find [(count id)]
+                                       :keys [id-count]
+                                       :where [(match :t1 {:xt/id id})]})
+                          (first)
+                          (:id-count))))
 
-      (t/is (= [{:xt/id 0}]
-               (xt/q node '{:find [xt/id]
-                            :where [(match :xt_docs [xt/id some-attr])]}))))))
+        (t/is (= [{:xt/id 0}]
+                 (xt/q node '{:find [xt/id]
+                              :where [(match :xt_docs [xt/id some-attr])]})))))))
 
 (t/deftest add-better-metadata-support-for-keywords
   (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
@@ -1210,30 +1212,30 @@
                       20]))))
 
     (t/testing "testing rule with multiple args"
-      (t/is (= [{:i :petr, :age 18, :u :ivan}
-                {:i :georgy, :age 17, :u :ivan}
-                {:i :georgy, :age 17, :u :petr}]
-               (q '{:find [i age u]
-                    :where [(older-users age u)
-                            (match :xt_docs {:xt/id i})
-                            [i :age age]]
-                    :rules [[(older-users age u)
-                             (match :xt_docs {:xt/id u})
-                             [u :age age2]
-                             [(> age2 age)]]]}))))
+      (t/is (= #{{:i :petr, :age 18, :u :ivan}
+                 {:i :georgy, :age 17, :u :ivan}
+                 {:i :georgy, :age 17, :u :petr}}
+               (set (q '{:find [i age u]
+                         :where [(older-users age u)
+                                 (match :xt_docs {:xt/id i})
+                                 [i :age age]]
+                         :rules [[(older-users age u)
+                                  (match :xt_docs {:xt/id u})
+                                  [u :age age2]
+                                  [(> age2 age)]]]})))))
 
     (t/testing "testing rule with multiple args (different arg names in rule)"
-      (t/is (= [{:i :petr, :age 18, :u :ivan}
-                {:i :georgy, :age 17, :u :ivan}
-                {:i :georgy, :age 17, :u :petr}]
-               (q '{:find [i age u]
-                    :where [(older-users age u)
-                            (match :xt_docs {:xt/id i})
-                            [i :age age]]
-                    :rules [[(older-users age-other u-other)
-                             (match :xt_docs {:xt/id u-other})
-                             [u-other :age age2]
-                             [(> age2 age-other)]]]}))))
+      (t/is (= #{{:i :petr, :age 18, :u :ivan}
+                 {:i :georgy, :age 17, :u :ivan}
+                 {:i :georgy, :age 17, :u :petr}}
+               (set (q '{:find [i age u]
+                         :where [(older-users age u)
+                                 (match :xt_docs {:xt/id i})
+                                 [i :age age]]
+                         :rules [[(older-users age-other u-other)
+                                  (match :xt_docs {:xt/id u-other})
+                                  [u-other :age age2]
+                                  [(> age2 age-other)]]]})))))
 
 
     (t/testing "nested rules"
@@ -1310,19 +1312,19 @@
                                                     [(> age2 age)]]})]]}))))
 
     (t/testing "subquery in rule"
-      (t/is (= [{:i :petr, :other-age 21}
-                {:i :georgy, :other-age 21}
-                {:i :georgy, :other-age 18}]
-               (q '{:find [i other-age]
-                    :where [(match :xt_docs {:xt/id i})
-                            [i :age age]
-                            (older-ages age other-age)]
-                    :rules [[(older-ages age other-age)
-                             (q {:find [other-age]
-                                 :in [age]
-                                 :where [(match :xt_docs {:xt/id i})
-                                         [i :age other-age]
-                                         [(> other-age age)]]})]]}))))
+      (t/is (= #{{:i :petr, :other-age 21}
+                 {:i :georgy, :other-age 21}
+                 {:i :georgy, :other-age 18}}
+               (set (q '{:find [i other-age]
+                         :where [(match :xt_docs {:xt/id i})
+                                 [i :age age]
+                                 (older-ages age other-age)]
+                         :rules [[(older-ages age other-age)
+                                  (q {:find [other-age]
+                                      :in [age]
+                                      :where [(match :xt_docs {:xt/id i})
+                                              [i :age other-age]
+                                              [(> other-age age)]]})]]})))))
 
     (t/testing "subquery in rule with aggregates, expressions and order-by"
       (t/is [{:i :ivan, :max-older-age nil, :max-older-age-times2 nil}
@@ -1435,93 +1437,94 @@
 
 
 (t/deftest test-temporal-opts
-  (letfn [(q [query tx current-time]
-            (xt/q tu/*node*
-                  query
-                  {:basis {:tx tx, :current-time (util/->instant current-time)}}))]
+  (tu/without-tries
+   (letfn [(q [query tx current-time]
+             (xt/q tu/*node*
+                   query
+                   {:basis {:tx tx, :current-time (util/->instant current-time)}}))]
 
-    ;; Matthew 2015+
+     ;; Matthew 2015+
 
-    ;; tx0
-    ;; 2018/2019: Matthew, Mark
-    ;; 2021+: Matthew, Luke
+     ;; tx0
+     ;; 2018/2019: Matthew, Mark
+     ;; 2021+: Matthew, Luke
 
-    ;; tx1
-    ;; 2016-2018: Matthew, John
-    ;; 2018-2020: Matthew, Mark, John
-    ;; 2020: Matthew
-    ;; 2021-2022: Matthew, Luke
-    ;; 2023: Matthew, Mark (again)
-    ;; 2024+: Matthew
+     ;; tx1
+     ;; 2016-2018: Matthew, John
+     ;; 2018-2020: Matthew, Mark, John
+     ;; 2020: Matthew
+     ;; 2021-2022: Matthew, Luke
+     ;; 2023: Matthew, Mark (again)
+     ;; 2024+: Matthew
 
-    (let [tx0 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in #inst "2015"]}]
-                                        [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in  #inst "2018"  #inst "2020"]}]
-                                        [:put :xt_docs {:xt/id :luke} {:for-valid-time [:in #inst "2021"]}]])
+     (let [tx0 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in #inst "2015"]}]
+                                         [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in  #inst "2018"  #inst "2020"]}]
+                                         [:put :xt_docs {:xt/id :luke} {:for-valid-time [:in #inst "2021"]}]])
 
-          tx1 (xt/submit-tx tu/*node* '[[:delete :xt_docs :luke {:for-valid-time [:in #inst "2022"]}]
-                                        [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in #inst "2023" #inst "2024"]}]
-                                        [:put :xt_docs {:xt/id :john} {:for-valid-time [:in #inst "2016" #inst "2020"]}]])]
+           tx1 (xt/submit-tx tu/*node* '[[:delete :xt_docs :luke {:for-valid-time [:in #inst "2022"]}]
+                                         [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in #inst "2023" #inst "2024"]}]
+                                         [:put :xt_docs {:xt/id :john} {:for-valid-time [:in #inst "2016" #inst "2020"]}]])]
 
-      (t/is (= [{:id :matthew}, {:id :mark}]
-               (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx1, #inst "2023")))
+       (t/is (= #{{:id :matthew}, {:id :mark}}
+                (set (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx1, #inst "2023"))))
 
-      (t/is (= [{:id :matthew}, {:id :luke}]
-               (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx1, #inst "2021"))
-            "back in app-time")
+       (t/is (= #{{:id :matthew}, {:id :luke}}
+                (set (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx1, #inst "2021")))
+             "back in app-time")
 
-      (t/is (= [{:id :matthew}, {:id :luke}]
-               (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx0, #inst "2023"))
-            "back in system-time")
+       (t/is (= [{:id :matthew}, {:id :luke}]
+                (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx0, #inst "2023"))
+             "back in system-time")
 
-      (t/is (= [{:id :matthew, :app-start (util/->zdt #inst "2015"), :app-end (util/->zdt util/end-of-time)}
-                {:id :mark, :app-start (util/->zdt #inst "2018"), :app-end (util/->zdt #inst "2020")}
-                {:id :luke, :app-start (util/->zdt #inst "2021"), :app-end (util/->zdt #inst "2022")}
-                {:id :mark, :app-start (util/->zdt #inst "2023"), :app-end (util/->zdt #inst "2024")}
-                {:id :john, :app-start (util/->zdt #inst "2016"), :app-end (util/->zdt #inst "2020")}]
-               (q '{:find [id app-start app-end]
-                    :where [(match :xt_docs [{:xt/id id} {:xt/valid-from app-start
-                                                          :xt/valid-to app-end}]
-                                   {:for-valid-time :all-time})]}
-                  tx1, nil))
-            "entity history, all time")
+       (t/is (= [{:id :matthew, :app-start (util/->zdt #inst "2015"), :app-end (util/->zdt util/end-of-time)}
+                 {:id :mark, :app-start (util/->zdt #inst "2018"), :app-end (util/->zdt #inst "2020")}
+                 {:id :luke, :app-start (util/->zdt #inst "2021"), :app-end (util/->zdt #inst "2022")}
+                 {:id :mark, :app-start (util/->zdt #inst "2023"), :app-end (util/->zdt #inst "2024")}
+                 {:id :john, :app-start (util/->zdt #inst "2016"), :app-end (util/->zdt #inst "2020")}]
+                (q '{:find [id app-start app-end]
+                     :where [(match :xt_docs [{:xt/id id} {:xt/valid-from app-start
+                                                           :xt/valid-to app-end}]
+                                    {:for-valid-time :all-time})]}
+                   tx1, nil))
+             "entity history, all time")
 
-      (t/is (= [{:id :matthew, :app-start (util/->zdt #inst "2015"), :app-end (util/->zdt util/end-of-time)}
-                {:id :luke, :app-start (util/->zdt #inst "2021"), :app-end (util/->zdt #inst "2022")}]
-               (q '{:find [id app-start app-end]
-                    :where [(match :xt_docs [{:xt/id id} {:xt/valid-from app-start
-                                                          :xt/valid-to app-end}]
-                                   {:for-valid-time [:in #inst "2021", #inst "2023"]})]}
-                  tx1, nil))
-            "entity history, range")
+       (t/is (= [{:id :matthew, :app-start (util/->zdt #inst "2015"), :app-end (util/->zdt util/end-of-time)}
+                 {:id :luke, :app-start (util/->zdt #inst "2021"), :app-end (util/->zdt #inst "2022")}]
+                (q '{:find [id app-start app-end]
+                     :where [(match :xt_docs [{:xt/id id} {:xt/valid-from app-start
+                                                           :xt/valid-to app-end}]
+                                    {:for-valid-time [:in #inst "2021", #inst "2023"]})]}
+                   tx1, nil))
+             "entity history, range")
 
-      (t/is (= [{:id :matthew}, {:id :mark}]
-               (q '{:find [id],
-                    :where [(match :xt_docs {:xt/id id}
-                                   {:for-valid-time [:at #inst "2018"]})
-                            (match :xt_docs {:xt/id id}
-                                   {:for-valid-time [:at #inst "2023"]})]},
-                  tx1, nil))
-            "cross-time join - who was here in both 2018 and 2023?")
+       (t/is (= #{{:id :matthew}, {:id :mark}}
+                (set (q '{:find [id],
+                          :where [(match :xt_docs {:xt/id id}
+                                         {:for-valid-time [:at #inst "2018"]})
+                                  (match :xt_docs {:xt/id id}
+                                         {:for-valid-time [:at #inst "2023"]})]},
+                        tx1, nil)))
+             "cross-time join - who was here in both 2018 and 2023?")
 
-      (t/is (= [{:vt-start (util/->zdt #inst "2021")
-                 :vt-end (util/->zdt util/end-of-time)
-                 :tt-start (util/->zdt #inst "2020-01-01")
-                 :tt-end (util/->zdt #inst "2020-01-02")}
-                {:vt-start (util/->zdt #inst "2021")
-                 :vt-end (util/->zdt #inst "2022")
-                 :tt-start (util/->zdt #inst "2020-01-02")
-                 :tt-end (util/->zdt util/end-of-time)}]
-               (q '{:find [vt-start vt-end tt-start tt-end]
-                    :where [(match :xt_docs {:xt/id :luke
-                                             :xt/valid-from vt-start
-                                             :xt/valid-to vt-end
-                                             :xt/system-from tt-start
-                                             :xt/system-to tt-end}
-                                   {:for-valid-time :all-time
-                                    :for-system-time :all-time})]}
-                  tx1 nil))
+       (t/is (= [{:vt-start (util/->zdt #inst "2021")
+                  :vt-end (util/->zdt util/end-of-time)
+                  :tt-start (util/->zdt #inst "2020-01-01")
+                  :tt-end (util/->zdt #inst "2020-01-02")}
+                 {:vt-start (util/->zdt #inst "2021")
+                  :vt-end (util/->zdt #inst "2022")
+                  :tt-start (util/->zdt #inst "2020-01-02")
+                  :tt-end (util/->zdt util/end-of-time)}]
+                (q '{:find [vt-start vt-end tt-start tt-end]
+                     :where [(match :xt_docs {:xt/id :luke
+                                              :xt/valid-from vt-start
+                                              :xt/valid-to vt-end
+                                              :xt/system-from tt-start
+                                              :xt/system-to tt-end}
+                                    {:for-valid-time :all-time
+                                     :for-system-time :all-time})]}
+                   tx1 nil))
 
-            "for all sys time"))))
+             "for all sys time")))))
 
 (t/deftest test-for-valid-time-with-current-time-2493
   (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in nil #inst "2040"]}]])
@@ -1554,17 +1557,17 @@
     (let [tx0 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:from #inst "2015"]}]
                                         [:put :xt_docs {:xt/id :mark} {:for-valid-time [:to #inst "2050"]}]])
           tx1 (xt/submit-tx tu/*node* '[[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:to #inst "2040"]}]])]
-      (t/is (= [{:id :matthew,
-                 :vt-start #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
-                 :vt-end #time/zoned-date-time "9999-12-31T23:59:59.999999Z[UTC]"}
-                {:id :mark,
-                 :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
-                 :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
-               (q '{:find [id vt-start vt-end],
-                    :where [(match :xt_docs {:xt/id id
-                                             :xt/valid-from vt-start
-                                             :xt/valid-to vt-end})]},
-                  tx0, #inst "2023")))
+      (t/is (= #{{:id :matthew,
+                  :vt-start #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
+                  :vt-end #time/zoned-date-time "9999-12-31T23:59:59.999999Z[UTC]"}
+                 {:id :mark,
+                  :vt-start #time/zoned-date-time "2020-01-01T00:00Z[UTC]",
+                  :vt-end #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}}
+               (set (q '{:find [id vt-start vt-end],
+                         :where [(match :xt_docs {:xt/id id
+                                                  :xt/valid-from vt-start
+                                                  :xt/valid-to vt-end})]},
+                       tx0, #inst "2023"))))
 
       (t/is (= [{:id :matthew,
                  :vt-start #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
@@ -1782,7 +1785,7 @@
                            [:put :order {:xt/id 1, :customer 0, :items [{:sku "cheese", :qty 3}]}]
                            [:put :order {:xt/id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]}]])
 
-  (t/are [q result] (= result (xt/q tu/*node* q))
+  (t/are [q result] (= (into #{} result) (set (xt/q tu/*node* q)))
     '{:find [n-customers]
       :where [[(q {:find [(count id)]
                    :where [(match :customer {:xt/id id})]})
@@ -2190,23 +2193,24 @@
                    :where [(match :foo {:xt/id id})]}))))
 
 (t/deftest test-metadata-filtering-for-time-data-607
-  (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 1, :rows-per-chunk 1}})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id 1 :start-date #time/date "2000-01-01"}]
-                        [:put :xt_docs {:xt/id 2 :start-date #time/date "3000-01-01"}]])
-    (t/is (= [{:id 1}]
-             (xt/q node
-                   '{:find [id]
-                     :where [(match :xt_docs [{:xt/id id} start-date])
-                             [(>= start-date #inst "1500")]
-                             [(< start-date #inst "2500")]]})))
-    (xt/submit-tx node [[:put :xt_docs2 {:xt/id 1 :start-date #inst "2000-01-01"}]
-                        [:put :xt_docs2 {:xt/id 2 :start-date #inst "3000-01-01"}]])
-    (t/is (= [{:id 1}]
-             (xt/q node
-                   '{:find [id]
-                     :where [(match :xt_docs2 [{:xt/id id} start-date])
-                             [(< start-date #time/date "2500-01-01")]
-                             [(< start-date #time/date "2500-01-01")]]})))))
+  (tu/without-tries
+    (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 1, :rows-per-chunk 1}})]
+      (xt/submit-tx node [[:put :xt_docs {:xt/id 1 :start-date #time/date "2000-01-01"}]
+                          [:put :xt_docs {:xt/id 2 :start-date #time/date "3000-01-01"}]])
+      (t/is (= [{:id 1}]
+               (xt/q node
+                     '{:find [id]
+                       :where [(match :xt_docs [{:xt/id id} start-date])
+                               [(>= start-date #inst "1500")]
+                               [(< start-date #inst "2500")]]})))
+      (xt/submit-tx node [[:put :xt_docs2 {:xt/id 1 :start-date #inst "2000-01-01"}]
+                          [:put :xt_docs2 {:xt/id 2 :start-date #inst "3000-01-01"}]])
+      (t/is (= [{:id 1}]
+               (xt/q node
+                     '{:find [id]
+                       :where [(match :xt_docs2 [{:xt/id id} start-date])
+                               [(< start-date #time/date "2500-01-01")]
+                               [(< start-date #time/date "2500-01-01")]]}))))))
 
 (t/deftest bug-non-namespaced-nested-keys-747
   (xt/submit-tx tu/*node* [[:put :bar {:xt/id 1 :foo {:a/b "foo"}}]])
@@ -2220,33 +2224,35 @@
               {:xt/id 43, :firstname "alice", :lastname "carrol"}
               {:xt/id 44, :firstname "jim", :orders [{:sku "eggs", :qty 2}, {:sku "cheese", :qty 1}]}]]
     (xt/submit-tx tu/*node* (map (partial vector :put :customer) docs))
-    (t/is (= (mapv (fn [doc] {:c doc}) docs) (xt/q tu/*node* '{:find [c] :where [($ :customer {:xt/* c})]})))))
+    (t/is (= (set (mapv (fn [doc] {:c doc}) docs))
+             (set (xt/q tu/*node* '{:find [c] :where [($ :customer {:xt/* c})]}))))))
 
 (t/deftest test-row-alias-system-time-key-set
-  (let [inputs
-        [[{:xt/id 0, :a 0} #inst "2023-01-17T00:00:00"]
-         [{:xt/id 0, :b 0} #inst "2023-01-18T00:00:00"]
-         [{:xt/id 0, :c 0, :a 0} #inst "2023-01-19T00:00:00"]]
+  (tu/without-tries
+   (let [inputs
+         [[{:xt/id 0, :a 0} #inst "2023-01-17T00:00:00"]
+          [{:xt/id 0, :b 0} #inst "2023-01-18T00:00:00"]
+          [{:xt/id 0, :c 0, :a 0} #inst "2023-01-19T00:00:00"]]
 
-        _
-        (doseq [[doc system-time] inputs]
-          (xt/submit-tx tu/*node* [[:put :x doc]] {:system-time system-time}))
+         _
+         (doseq [[doc system-time] inputs]
+           (xt/submit-tx tu/*node* [[:put :x doc]] {:system-time system-time}))
 
-        q (partial xt/q tu/*node*)]
+         q (partial xt/q tu/*node*)]
 
-    (t/is (= [{:x {:xt/id 0, :a 0, :c 0}}]
-             (q '{:find [x]
-                  :where [($ :x {:xt/* x})]})))
+     (t/is (= [{:x {:xt/id 0, :a 0, :c 0}}]
+              (q '{:find [x]
+                   :where [($ :x {:xt/* x})]})))
 
-    (t/is (= [{:x {:xt/id 0, :b 0}}]
-             (q '{:find [x]
-                  :where [($ :x {:xt/* x})],}
-                {:basis {:tx #xt/tx-key {:tx-id 1, :system-time #time/instant "2023-01-18T00:00:00Z"}}})))
+     (t/is (= [{:x {:xt/id 0, :b 0}}]
+              (q '{:find [x]
+                   :where [($ :x {:xt/* x})],}
+                 {:basis {:tx #xt/tx-key {:tx-id 1, :system-time #time/instant "2023-01-18T00:00:00Z"}}})))
 
-    (t/is (= [{:x {:xt/id 0, :a 0}}]
-             (q '{:find [x]
-                  :where [($ :x {:xt/* x})],}
-                {:basis {:tx #xt/tx-key {:tx-id 0, :system-time #time/instant "2023-01-17T00:00:00Z"}}})))))
+     (t/is (= [{:x {:xt/id 0, :a 0}}]
+              (q '{:find [x]
+                   :where [($ :x {:xt/* x})],}
+                 {:basis {:tx #xt/tx-key {:tx-id 0, :system-time #time/instant "2023-01-17T00:00:00Z"}}}))))))
 
 (t/deftest test-row-alias-app-time-key-set
   (let [inputs
@@ -2299,12 +2305,12 @@
                                                  :xt/committed? committed?})]})))
   (xt/submit-tx tu/*node* '[[:put :xt-docs {:xt/id 2}]])
   (xt/submit-tx tu/*node* '[[:delete :xt-docs 2 {:for-valid-time [:in nil #inst "2011"]}]])
-  (t/is (= [{:tx-id 0, :committed? false}
-            {:tx-id 1, :committed? true}
-            {:tx-id 2, :committed? false}]
-           (xt/q tu/*node* '{:find [tx-id committed?]
-                             :where [($ :xt/txs {:xt/id tx-id,
-                                                 :xt/committed? committed?})]}))))
+  (t/is (= #{{:tx-id 0, :committed? false}
+             {:tx-id 1, :committed? true}
+             {:tx-id 2, :committed? false}}
+           (set (xt/q tu/*node* '{:find [tx-id committed?]
+                                  :where [($ :xt/txs {:xt/id tx-id,
+                                                      :xt/committed? committed?})]})))))
 
 (deftest test-date-and-time-literals
   (t/is (= [{:a true, :b false, :c true, :d true}]

--- a/src/test/clojure/xtdb/default_tz_test.clj
+++ b/src/test/clojure/xtdb/default_tz_test.clj
@@ -4,8 +4,6 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util]))
 
-(t/use-fixtures :once tu/no-tries)
-
 (t/use-fixtures :each
   (tu/with-opts {:xtdb/default-tz #time/zone "Europe/London"})
   (tu/with-each-api-implementation
@@ -30,25 +28,25 @@
                            {:default-tz #time/zone "America/Los_Angeles"})
           q "SELECT foo.xt$id, foo.dt, CAST(foo.dt AS TIMESTAMP WITH TIME ZONE) cast_tstz, foo.tstz FROM foo"]
 
-      (t/is (= [{:xt$id "foo", :dt #time/date "2020-08-01",
-                 :cast_tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"
-                 :tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"}
-                {:xt$id "bar", :dt #time/date "2020-08-01"
-                 :cast_tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"
-                 :tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"}]
+      (t/is (= #{{:xt$id "foo", :dt #time/date "2020-08-01",
+                  :cast_tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"
+                  :tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"}
+                 {:xt$id "bar", :dt #time/date "2020-08-01"
+                  :cast_tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"
+                  :tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"}}
 
-               (xt/q tu/*node* q {:basis {:tx tx}})))
+               (set (xt/q tu/*node* q {:basis {:tx tx}}))))
 
-      (t/is (= [{:xt$id "foo", :dt #time/date "2020-08-01",
-                 :cast_tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"
-                 :tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"}
-                {:xt$id "bar", :dt #time/date "2020-08-01"
-                 :cast_tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"
-                 :tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"}]
+      (t/is (= #{{:xt$id "foo", :dt #time/date "2020-08-01",
+                  :cast_tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"
+                  :tstz #time/zoned-date-time "2020-08-01T00:00+01:00[Europe/London]"}
+                 {:xt$id "bar", :dt #time/date "2020-08-01"
+                  :cast_tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"
+                  :tstz #time/zoned-date-time "2020-08-01T00:00-07:00[America/Los_Angeles]"}}
 
-               (xt/q tu/*node* q
-                     {:basis {:tx tx}
-                      :default-tz #time/zone "America/Los_Angeles"}))))))
+               (set (xt/q tu/*node* q
+                          {:basis {:tx tx}
+                           :default-tz #time/zone "America/Los_Angeles"})))))))
 
 (t/deftest test-datalog-default-tz
   (t/is (= [{:time #time/time "16:00"}]

--- a/src/test/clojure/xtdb/default_tz_test.clj
+++ b/src/test/clojure/xtdb/default_tz_test.clj
@@ -4,6 +4,8 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util]))
 
+(t/use-fixtures :once tu/no-tries)
+
 (t/use-fixtures :each
   (tu/with-opts {:xtdb/default-tz #time/zone "Europe/London"})
   (tu/with-each-api-implementation

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -105,20 +105,19 @@
    [[:sql "INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')"]]])
 
 (t/deftest can-build-live-index
-  (tu/without-tries
-   (let [node-dir (util/->path "target/can-build-live-index")]
-     (util/delete-dir node-dir)
+  (let [node-dir (util/->path "target/can-build-live-index")]
+    (util/delete-dir node-dir)
 
-     (with-open [node (tu/->local-node {:node-dir node-dir})]
-       (let [^ObjectStore os (tu/component node ::os/file-system-object-store)]
+    (with-open [node (tu/->local-node {:node-dir node-dir})]
+      (let [^ObjectStore os (tu/component node ::os/file-system-object-store)]
 
-         (let [last-tx-key (last (for [tx-ops txs] (xt/submit-tx node tx-ops)))]
-           (tu/then-await-tx last-tx-key node (Duration/ofSeconds 2)))
+        (let [last-tx-key (last (for [tx-ops txs] (xt/submit-tx node tx-ops)))]
+          (tu/then-await-tx last-tx-key node (Duration/ofSeconds 2)))
 
-         (tu/finish-chunk! node)
+        (tu/finish-chunk! node)
 
-         (t/is (= ["tables/foo/chunks/leaf-c00.arrow" "tables/foo/chunks/trie-c00.arrow"]
-                  (.listObjects os "tables/foo/chunks"))))
+        (t/is (= ["tables/foo/chunks/leaf-c00.arrow" "tables/foo/chunks/trie-c00.arrow"]
+                 (.listObjects os "tables/foo/chunks"))))
 
-       (tj/check-json (.toPath (io/as-file (io/resource "xtdb/indexer-test/can-build-live-index")))
-                      (.resolve node-dir "objects"))))))
+      (tj/check-json (.toPath (io/as-file (io/resource "xtdb/indexer-test/can-build-live-index")))
+                     (.resolve node-dir "objects")))))

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -41,8 +41,8 @@
       (util/with-open [live-idx-tx (.startTx live-index (xtp/->TransactionInstant 0 (.toInstant #inst "2000")))
                        live-table-tx (.liveTable live-idx-tx "my-table")]
         (let [wp (IVectorPosition/build)]
-          (doseq [iid iids]
-            (.logPut live-table-tx (util/uuid->bytes iid) 0 0
+          (doseq [^UUID iid iids]
+            (.logPut live-table-tx (util/uuid->bytes iid) (.getMostSignificantBits iid) 0 0
                      #(.getPositionAndIncrement wp))))
 
         (.commit live-idx-tx)

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -35,7 +35,7 @@
            xtdb.object_store.ObjectStore
            (xtdb.watermark IWatermark IWatermarkSource)))
 
-(t/use-fixtures :once tu/with-allocator)
+(t/use-fixtures :once tu/no-tries tu/with-allocator)
 
 (def txs
   [[[:put :device-info

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -200,7 +200,7 @@
                  :xt/valid-from (util/->zdt tt)
                  :xt/valid-to (util/->zdt util/end-of-time)
                  :xt/system-from (util/->zdt tt)
-                 :xt/system-to (util/->zdt util/end-of-time)}]
+                 :xt/system-to nil}]
                (tu/query-ra '[:scan {:table xt_docs}
                               [xt/id version
                                xt/valid-from, xt/valid-to

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -16,7 +16,6 @@
             [xtdb.test-json :as tj]
             [xtdb.test-util :as tu]
             [xtdb.ts-devices :as ts]
-            [xtdb.types :as ty]
             [xtdb.util :as util]
             [xtdb.vector.reader :as vr]
             xtdb.watermark)
@@ -35,7 +34,7 @@
            xtdb.object_store.ObjectStore
            (xtdb.watermark IWatermark IWatermarkSource)))
 
-(t/use-fixtures :once tu/no-tries tu/with-allocator)
+(t/use-fixtures :once tu/with-allocator)
 
 (def txs
   [[[:put :device-info

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -4,7 +4,7 @@
             [xtdb.test-util :as tu]))
 
 (t/use-fixtures :each tu/with-node)
-(t/use-fixtures :once tu/no-tries tu/with-allocator)
+(t/use-fixtures :once tu/with-allocator)
 
 (t/deftest test-param-metadata-error-310
   (let [tx1 (xt/submit-tx tu/*node*

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -4,7 +4,7 @@
             [xtdb.test-util :as tu]))
 
 (t/use-fixtures :each tu/with-node)
-(t/use-fixtures :once tu/with-allocator)
+(t/use-fixtures :once tu/no-tries tu/with-allocator)
 
 (t/deftest test-param-metadata-error-310
   (let [tx1 (xt/submit-tx tu/*node*

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -56,34 +56,36 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
              (q "posts2")))))
 
 (t/deftest test-dml-sees-in-tx-docs
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)"]
-                           [:sql "UPDATE foo SET v = 1"]])
+  (tu/without-tries
+   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)"]
+                            [:sql "UPDATE foo SET v = 1"]])
 
-  (t/is (= [{:xt$id "foo", :v 1}]
-           (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo"))))
+   (t/is (= [{:xt$id "foo", :v 1}]
+            (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo")))))
 
 (t/deftest test-delete-without-search-315
-  (letfn [(q []
-            (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                  {:default-all-valid-time? true}))]
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES ('foo')"]])
+  (tu/without-tries
+   (letfn [(q []
+             (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                   {:default-all-valid-time? true}))]
+     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES ('foo')"]])
 
-    (t/is (= [{:xt$id "foo",
-               :xt$valid_from (util/->zdt #inst "2020")
-               :xt$valid_to (util/->zdt util/end-of-time)}]
-             (q)))
+     (t/is (= [{:xt$id "foo",
+                :xt$valid_from (util/->zdt #inst "2020")
+                :xt$valid_to (util/->zdt util/end-of-time)}]
+              (q)))
 
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]])
+     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]])
 
-    (t/is (= [{:xt$id "foo"
-               :xt$valid_from (util/->zdt #inst "2020")
-               :xt$valid_to (util/->zdt #inst "2020-01-02")}]
-             (q)))
+     (t/is (= [{:xt$id "foo"
+                :xt$valid_from (util/->zdt #inst "2020")
+                :xt$valid_to (util/->zdt #inst "2020-01-02")}]
+              (q)))
 
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]]
-                  {:default-all-valid-time? true})
+     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]]
+                   {:default-all-valid-time? true})
 
-    (t/is (= [] (q)))))
+     (t/is (= [] (q))))))
 
 (t/deftest test-update-set-field-from-param-328
   (xt/submit-tx tu/*node* [[:sql ["INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)"
@@ -99,25 +101,26 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
                 (into #{} (map (juxt :first_name :last_name :xt$valid_from :xt$valid_to)))))))
 
 (t/deftest test-can-submit-same-id-into-multiple-tables-338
-  (let [tx1 (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')"]
-                                     [:sql "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')"]])
-        tx2 (xt/submit-tx tu/*node* [[:sql "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'"]])]
+  (tu/without-tries
+   (let [tx1 (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')"]
+                                      [:sql "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')"]])
+         tx2 (xt/submit-tx tu/*node* [[:sql "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'"]])]
 
-    (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
-             (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
-                   {:basis {:tx tx1}})))
+     (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
+              (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
+                    {:basis {:tx tx1}})))
 
-    (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
-             (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
-                   {:basis {:tx tx2}})))
+     (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
+              (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
+                    {:basis {:tx tx2}})))
 
-    (t/is (= [{:xt$id "thing", :foo "t2-foo"}]
-             (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
-                   {:basis {:tx tx1}})))
+     (t/is (= [{:xt$id "thing", :foo "t2-foo"}]
+              (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
+                    {:basis {:tx tx1}})))
 
-    (t/is (= [{:xt$id "thing", :foo "t2-foo-v2"}]
-             (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
-                   {:basis {:tx tx2}, :default-all-valid-time? false})))))
+     (t/is (= [{:xt$id "thing", :foo "t2-foo-v2"}]
+              (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
+                    {:basis {:tx tx2}, :default-all-valid-time? false}))))))
 
 (t/deftest test-put-delete-with-implicit-tables-338
   (letfn [(foos []
@@ -183,87 +186,89 @@ SELECT foo.xt$id, foo.v,
 FROM foo FOR ALL SYSTEM_TIME FOR ALL VALID_TIME"))))
 
 (t/deftest test-current-timestamp-in-temporal-constraint-409
-  (xt/submit-tx tu/*node* [[:sql "
+  (tu/without-tries
+   (xt/submit-tx tu/*node* [[:sql "
 INSERT INTO foo (xt$id, v)
 VALUES (1, 1)"]])
 
-  (t/is (= [{:xt$id 1, :v 1,
-             :xt$valid_from (util/->zdt #inst "2020")
-             :xt$valid_to (util/->zdt util/end-of-time)}]
-           (xt/q tu/*node* "SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
+   (t/is (= [{:xt$id 1, :v 1,
+              :xt$valid_from (util/->zdt #inst "2020")
+              :xt$valid_to (util/->zdt util/end-of-time)}]
+            (xt/q tu/*node* "SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
 
-  (t/is (= []
-           (xt/q tu/*node* "
+   (t/is (= []
+            (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo FOR VALID_TIME AS OF DATE '1999-01-01'"
-                 {:basis {:current-time (util/->instant #inst "1999")}})))
+                  {:basis {:current-time (util/->instant #inst "1999")}})))
 
-  (t/is (= []
-           (xt/q tu/*node* "
+   (t/is (= []
+            (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo FOR VALID_TIME AS OF CURRENT_TIMESTAMP"
-                 {:basis {:current-time (util/->instant #inst "1999")}}))))
+                  {:basis {:current-time (util/->instant #inst "1999")}})))))
 
 (t/deftest test-repeated-row-id-scan-bug-also-409
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES (1, 1)"]])
+  (tu/without-tries
+   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES (1, 1)"]])
 
-  (let [tx1 (xt/submit-tx tu/*node* [[:sql "
+   (let [tx1 (xt/submit-tx tu/*node* [[:sql "
 UPDATE foo
 FOR PORTION OF VALID_TIME FROM DATE '2022-01-01' TO DATE '2024-01-01'
 SET v = 2
 WHERE foo.xt$id = 1"]])
 
-        tx2 (xt/submit-tx tu/*node* [[:sql "
+         tx2 (xt/submit-tx tu/*node* [[:sql "
 DELETE FROM foo
 FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01'
 WHERE foo.xt$id = 1"]])]
 
-    (letfn [(q1 [opts]
-              (xt/q tu/*node* "
+     (letfn [(q1 [opts]
+               (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo
 ORDER BY foo.xt$valid_from"
-                    opts))
-            (q2 [opts]
-              (frequencies
-               (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo" opts)))]
+                     opts))
+             (q2 [opts]
+               (frequencies
+                (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo" opts)))]
 
-      (t/is (= [{:xt$id 1, :v 1
-                 :xt$valid_from (util/->zdt #inst "2020")
-                 :xt$valid_to (util/->zdt #inst "2022")}
-                {:xt$id 1, :v 2
-                 :xt$valid_from (util/->zdt #inst "2022")
-                 :xt$valid_to (util/->zdt #inst "2024")}
-                {:xt$id 1, :v 1
-                 :xt$valid_from (util/->zdt #inst "2024")
-                 :xt$valid_to (util/->zdt util/end-of-time)}]
+       (t/is (= [{:xt$id 1, :v 1
+                  :xt$valid_from (util/->zdt #inst "2020")
+                  :xt$valid_to (util/->zdt #inst "2022")}
+                 {:xt$id 1, :v 2
+                  :xt$valid_from (util/->zdt #inst "2022")
+                  :xt$valid_to (util/->zdt #inst "2024")}
+                 {:xt$id 1, :v 1
+                  :xt$valid_from (util/->zdt #inst "2024")
+                  :xt$valid_to (util/->zdt util/end-of-time)}]
 
-               (q1 {:basis {:tx tx1}, :default-all-valid-time? true})))
+                (q1 {:basis {:tx tx1}, :default-all-valid-time? true})))
 
-      (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
-               (q2 {:basis {:tx tx1}, :default-all-valid-time? true})))
+       (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
+                (q2 {:basis {:tx tx1}, :default-all-valid-time? true})))
 
-      (t/is (= [{:xt$id 1, :v 1
-                 :xt$valid_from (util/->zdt #inst "2020")
-                 :xt$valid_to (util/->zdt #inst "2022")}
-                {:xt$id 1, :v 2
-                 :xt$valid_from (util/->zdt #inst "2022")
-                 :xt$valid_to (util/->zdt #inst "2023")}
-                {:xt$id 1, :v 1
-                 :xt$valid_from (util/->zdt #inst "2025")
-                 :xt$valid_to (util/->zdt util/end-of-time)}]
+       (t/is (= [{:xt$id 1, :v 1
+                  :xt$valid_from (util/->zdt #inst "2020")
+                  :xt$valid_to (util/->zdt #inst "2022")}
+                 {:xt$id 1, :v 2
+                  :xt$valid_from (util/->zdt #inst "2022")
+                  :xt$valid_to (util/->zdt #inst "2023")}
+                 {:xt$id 1, :v 1
+                  :xt$valid_from (util/->zdt #inst "2025")
+                  :xt$valid_to (util/->zdt util/end-of-time)}]
 
-               (q1 {:basis {:tx tx2}, :default-all-valid-time? true})))
+                (q1 {:basis {:tx tx2}, :default-all-valid-time? true})))
 
-      (t/is (= [{:xt$id 1, :v 1
-                 :xt$valid_from (util/->zdt #inst "2025")
-                 :xt$valid_to (util/->zdt util/end-of-time)}]
+       (t/is (= [{:xt$id 1, :v 1
+                  :xt$valid_from (util/->zdt #inst "2025")
+                  :xt$valid_to (util/->zdt util/end-of-time)}]
 
-               (q1 {:basis {:tx tx2, :current-time (util/->instant #inst "2026")}
-                    :default-all-valid-time? false})))
+                (q1 {:basis {:tx tx2, :current-time (util/->instant #inst "2026")}
+                     :default-all-valid-time? false})))
 
-      (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
-               (q2 {:basis {:tx tx2}, :default-all-valid-time? true}))))))
+       (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
+                (q2 {:basis {:tx tx2}, :default-all-valid-time? true})))))))
 
 (t/deftest test-error-handling-inserting-strings-into-app-time-cols-397
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, xt$valid_from) VALUES (1, '2018-01-01')"]])
@@ -336,14 +341,14 @@ ORDER BY foo.xt$valid_from"
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1(xt$id, data) VALUES (1, [2, 3])"]
                            [:sql "INSERT INTO t1(xt$id, data) VALUES (2, [5, 6, 7])"]])
 
-  (t/is (= [{:data [2 3]} {:data [5 6 7]}]
-           (xt/q tu/*node* "SELECT t1.data FROM t1")))
+  (t/is (= #{{:data [2 3]} {:data [5 6 7]}}
+           (set (xt/q tu/*node* "SELECT t1.data FROM t1"))))
 
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO t2(xt$id, data) VALUES (1, [2, 3])"]
                            [:sql "INSERT INTO t2(xt$id, data) VALUES (2, ['dog', 'cat'])"]])
 
-  (t/is (= [{:data [2 3]} {:data ["dog" "cat"]}]
-           (xt/q tu/*node* "SELECT t2.data FROM t2"))))
+  (t/is (= #{{:data [2 3]} {:data ["dog" "cat"]}}
+           (set (xt/q tu/*node* "SELECT t2.data FROM t2")))))
 
 (t/deftest test-cross-join-ioobe-547
   (xt/submit-tx tu/*node* [[:sql "
@@ -359,41 +364,42 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
            (xt/q tu/*node* "SELECT t2.data t2d, t1.data t1d FROM t2, t1"))))
 
 (t/deftest test-txs-table-485
-  (tu/with-log-level 'xtdb.indexer :error
-    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])
-    (xt/submit-tx tu/*node* [[:abort]])
-    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :bar}]])
-    (xt/submit-tx tu/*node* [[:put-fn :tx-fn-fail
-                              '(fn []
-                                 (throw (Exception. "boom")))]
-                             [:call :tx-fn-fail]])
+  (tu/without-tries
+   (tu/with-log-level 'xtdb.indexer :error
+     (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])
+     (xt/submit-tx tu/*node* [[:abort]])
+     (xt/submit-tx tu/*node* [[:put :docs {:xt/id :bar}]])
+     (xt/submit-tx tu/*node* [[:put-fn :tx-fn-fail
+                               '(fn []
+                                  (throw (Exception. "boom")))]
+                              [:call :tx-fn-fail]])
 
-    (t/is (= [{:tx-id 0, :tx-time (util/->zdt #inst "2020-01-01"), :committed? true}
-              {:tx-id 1, :tx-time (util/->zdt #inst "2020-01-02"), :committed? false}
-              {:tx-id 2, :tx-time (util/->zdt #inst "2020-01-03"), :committed? true}
-              {:tx-id 3, :tx-time (util/->zdt #inst "2020-01-04"), :committed? false}]
-             (xt/q tu/*node*
-                   '{:find [tx-id tx-time committed?]
-                     :where [($ :xt/txs {:xt/id tx-id, :xt/tx-time tx-time, :xt/committed? committed?})]})))
+     (t/is (= [{:tx-id 0, :tx-time (util/->zdt #inst "2020-01-01"), :committed? true}
+               {:tx-id 1, :tx-time (util/->zdt #inst "2020-01-02"), :committed? false}
+               {:tx-id 2, :tx-time (util/->zdt #inst "2020-01-03"), :committed? true}
+               {:tx-id 3, :tx-time (util/->zdt #inst "2020-01-04"), :committed? false}]
+              (xt/q tu/*node*
+                    '{:find [tx-id tx-time committed?]
+                      :where [($ :xt/txs {:xt/id tx-id, :xt/tx-time tx-time, :xt/committed? committed?})]})))
 
-    (t/is (= [{:committed? false}]
-             (xt/q tu/*node*
-                   ['{:find [committed?]
-                      :in [tx-id]
-                      :where [($ :xt/txs {:xt/id tx-id, :xt/committed? committed?})]}
-                    1])))
+     (t/is (= [{:committed? false}]
+              (xt/q tu/*node*
+                    ['{:find [committed?]
+                       :in [tx-id]
+                       :where [($ :xt/txs {:xt/id tx-id, :xt/committed? committed?})]}
+                     1])))
 
-    (t/is (thrown-with-msg?
-           RuntimeException
-           #":xtdb\.call/error-evaluating-tx-fn"
+     (t/is (thrown-with-msg?
+            RuntimeException
+            #":xtdb\.call/error-evaluating-tx-fn"
 
-           (throw (-> (xt/q tu/*node*
-                            ['{:find [err]
-                               :in [tx-id]
-                               :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
-                             3])
-                      first
-                      :err :form))))))
+            (throw (-> (xt/q tu/*node*
+                             ['{:find [err]
+                                :in [tx-id]
+                                :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
+                              3])
+                       first
+                       :err :form)))))))
 
 (t/deftest test-indexer-cleans-up-aborted-transactions-2489
   (t/testing "INSERT"
@@ -425,66 +431,68 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
                  [:sql "INSERT INTO bar (xt$id, a) VALUES (1, 3)"]
                  [:sql "INSERT INTO bar (xt$id, b) VALUES (2, 4)"]])
 
-  (t/is (= [{:a 1, :xt$id 1} {:b 2, :xt$id 2}]
-           (xt/q tu/*node* "SELECT * FROM foo")))
+  (t/is (= #{{:a 1, :xt$id 1} {:b 2, :xt$id 2}}
+           (set (xt/q tu/*node* "SELECT * FROM foo"))))
 
   (t/is (=
-         [{:a 1, :xt$id 1, :a:1 3, :xt$id:1 1}
-          {:a 1, :xt$id 1, :b:1 4, :xt$id:1 2}
-          {:b 2, :xt$id 2, :a:1 3, :xt$id:1 1}
-          {:b 2, :xt$id 2, :b:1 4, :xt$id:1 2}]
-         (xt/q tu/*node* "SELECT * FROM foo, bar")))
+         #{{:a 1, :xt$id 1, :a:1 3, :xt$id:1 1}
+           {:a 1, :xt$id 1, :b:1 4, :xt$id:1 2}
+           {:b 2, :xt$id 2, :a:1 3, :xt$id:1 1}
+           {:b 2, :xt$id 2, :b:1 4, :xt$id:1 2}}
+         (set (xt/q tu/*node* "SELECT * FROM foo, bar"))))
 
   (t/is (=
-         [{:xt$id 1, :a 3, :xt$id:1 1, :a:1 1}
-          {:xt$id 2, :b 4, :xt$id:1 1, :a:1 1}
-          {:xt$id 1, :a 3, :xt$id:1 2, :b:1 2}
-          {:xt$id 2, :b 4, :xt$id:1 2, :b:1 2}]
-         (xt/q tu/*node* "SELECT bar.*, foo.* FROM foo, bar")))
+         #{{:xt$id 1, :a 3, :xt$id:1 1, :a:1 1}
+           {:xt$id 2, :b 4, :xt$id:1 1, :a:1 1}
+           {:xt$id 1, :a 3, :xt$id:1 2, :b:1 2}
+           {:xt$id 2, :b 4, :xt$id:1 2, :b:1 2}}
+         (set (xt/q tu/*node* "SELECT bar.*, foo.* FROM foo, bar"))))
 
   (t/is (=
-         [{:a 1, :xt$id 1, :a:1 3, :xt$id:1 1}
-          {:a 1, :xt$id 1, :b:1 4, :xt$id:1 2}
-          {:b 2, :xt$id 2, :a:1 3, :xt$id:1 1}
-          {:b 2, :xt$id 2, :b:1 4, :xt$id:1 2}]
-         (xt/q tu/*node* "SELECT * FROM (SELECT * FROM foo, bar) AS baz")))
+         #{{:a 1, :xt$id 1, :a:1 3, :xt$id:1 1}
+           {:a 1, :xt$id 1, :b:1 4, :xt$id:1 2}
+           {:b 2, :xt$id 2, :a:1 3, :xt$id:1 1}
+           {:b 2, :xt$id 2, :b:1 4, :xt$id:1 2}}
+         (set (xt/q tu/*node* "SELECT * FROM (SELECT * FROM foo, bar) AS baz"))))
 
   (xt/submit-tx tu/*node*
                 [[:sql "INSERT INTO bing (SELECT * FROM foo)"]])
 
-  (t/is (= [{:a 1, :xt$id 1} {:b 2, :xt$id 2}]
-           (xt/q tu/*node* "SELECT * FROM bing"))))
+  (t/is (= #{{:a 1, :xt$id 1} {:b 2, :xt$id 2}}
+           (set (xt/q tu/*node* "SELECT * FROM bing")))))
 
 (deftest test-scan-all-table-col-names
-  (t/testing "testing scan.allTableColNames combines table info from both live and past chunks"
-    (-> (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo1" :a 1}]
-                                 [:put :bar {:xt/id "bar1"}]
-                                 [:put :bar {:xt/id "bar2" :b 2}]])
-        (tu/then-await-tx tu/*node*))
+  (tu/without-tries
+   (t/testing "testing scan.allTableColNames combines table info from both live and past chunks"
+     (-> (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo1" :a 1}]
+                                  [:put :bar {:xt/id "bar1"}]
+                                  [:put :bar {:xt/id "bar2" :b 2}]])
+         (tu/then-await-tx tu/*node*))
 
-      (tu/finish-chunk! tu/*node*)
+     (tu/finish-chunk! tu/*node*)
 
-      (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
-                               [:put :baz {:xt/id "foo1" :a 4}]])
+     (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
+                              [:put :baz {:xt/id "foo1" :a 4}]])
 
-      (t/is (= [{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}]
-               (xt/q tu/*node* "SELECT * FROM foo")))
-      (t/is (= [{:xt$id "bar1"} {:b 2, :xt$id "bar2"}]
-               (xt/q tu/*node* "SELECT * FROM bar")))
-      (t/is (= [{:a 4, :xt$id "foo1"}]
-               (xt/q tu/*node* "SELECT * FROM baz")))))
+     (t/is (= [{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}]
+              (xt/q tu/*node* "SELECT * FROM foo")))
+     (t/is (= [{:xt$id "bar1"} {:b 2, :xt$id "bar2"}]
+              (xt/q tu/*node* "SELECT * FROM bar")))
+     (t/is (= [{:a 4, :xt$id "foo1"}]
+              (xt/q tu/*node* "SELECT * FROM baz"))))))
 
 (deftest test-erase-after-delete-2607
-  (t/testing "general case"
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (1, 1)"]])
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.xt$id = 1"]])
-    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 1"]])
-    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
-    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))
-  (t/testing "zero width case"
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 1)"]
-                             [:sql "DELETE FROM foo WHERE foo.xt$id = 2"]])
-    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]])
-    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
-    ;; TODO if it doesn't show up in valid-time it won't get deleted
-    #_(t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME")))))
+  (tu/without-tries
+   (t/testing "general case"
+     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (1, 1)"]])
+     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.xt$id = 1"]])
+     (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 1"]])
+     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
+     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))
+   (t/testing "zero width case"
+     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 1)"]
+                              [:sql "DELETE FROM foo WHERE foo.xt$id = 2"]])
+     (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]])
+     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
+     ;; TODO if it doesn't show up in valid-time it won't get deleted
+     #_(t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -56,36 +56,34 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
              (q "posts2")))))
 
 (t/deftest test-dml-sees-in-tx-docs
-  (tu/without-tries
-   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)"]
-                            [:sql "UPDATE foo SET v = 1"]])
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)"]
+                           [:sql "UPDATE foo SET v = 1"]])
 
-   (t/is (= [{:xt$id "foo", :v 1}]
-            (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo")))))
+  (t/is (= [{:xt$id "foo", :v 1}]
+           (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo"))))
 
 (t/deftest test-delete-without-search-315
-  (tu/without-tries
-   (letfn [(q []
-             (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo"
-                   {:default-all-valid-time? true}))]
-     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES ('foo')"]])
+  (letfn [(q []
+            (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo"
+                  {:default-all-valid-time? true}))]
+    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES ('foo')"]])
 
-     (t/is (= [{:xt$id "foo",
-                :xt$valid_from (util/->zdt #inst "2020")
-                :xt$valid_to (util/->zdt util/end-of-time)}]
-              (q)))
+    (t/is (= [{:xt$id "foo",
+               :xt$valid_from (util/->zdt #inst "2020")
+               :xt$valid_to (util/->zdt util/end-of-time)}]
+             (q)))
 
-     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]])
+    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]])
 
-     (t/is (= [{:xt$id "foo"
-                :xt$valid_from (util/->zdt #inst "2020")
-                :xt$valid_to (util/->zdt #inst "2020-01-02")}]
-              (q)))
+    (t/is (= [{:xt$id "foo"
+               :xt$valid_from (util/->zdt #inst "2020")
+               :xt$valid_to (util/->zdt #inst "2020-01-02")}]
+             (q)))
 
-     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]]
-                   {:default-all-valid-time? true})
+    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]]
+                  {:default-all-valid-time? true})
 
-     (t/is (= [] (q))))))
+    (t/is (= [] (q)))))
 
 (t/deftest test-update-set-field-from-param-328
   (xt/submit-tx tu/*node* [[:sql ["INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)"
@@ -101,26 +99,25 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
                 (into #{} (map (juxt :first_name :last_name :xt$valid_from :xt$valid_to)))))))
 
 (t/deftest test-can-submit-same-id-into-multiple-tables-338
-  (tu/without-tries
-   (let [tx1 (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')"]
-                                      [:sql "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')"]])
-         tx2 (xt/submit-tx tu/*node* [[:sql "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'"]])]
+  (let [tx1 (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')"]
+                                     [:sql "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')"]])
+        tx2 (xt/submit-tx tu/*node* [[:sql "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'"]])]
 
-     (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
-              (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
-                    {:basis {:tx tx1}})))
+    (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
+             (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
+                   {:basis {:tx tx1}})))
 
-     (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
-              (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
-                    {:basis {:tx tx2}})))
+    (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
+             (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
+                   {:basis {:tx tx2}})))
 
-     (t/is (= [{:xt$id "thing", :foo "t2-foo"}]
-              (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
-                    {:basis {:tx tx1}})))
+    (t/is (= [{:xt$id "thing", :foo "t2-foo"}]
+             (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
+                   {:basis {:tx tx1}})))
 
-     (t/is (= [{:xt$id "thing", :foo "t2-foo-v2"}]
-              (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
-                    {:basis {:tx tx2}, :default-all-valid-time? false}))))))
+    (t/is (= [{:xt$id "thing", :foo "t2-foo-v2"}]
+             (xt/q tu/*node* "SELECT t2.xt$id, t2.foo FROM t2"
+                   {:basis {:tx tx2}, :default-all-valid-time? false})))))
 
 (t/deftest test-put-delete-with-implicit-tables-338
   (letfn [(foos []
@@ -186,89 +183,87 @@ SELECT foo.xt$id, foo.v,
 FROM foo FOR ALL SYSTEM_TIME FOR ALL VALID_TIME"))))
 
 (t/deftest test-current-timestamp-in-temporal-constraint-409
-  (tu/without-tries
-   (xt/submit-tx tu/*node* [[:sql "
+  (xt/submit-tx tu/*node* [[:sql "
 INSERT INTO foo (xt$id, v)
 VALUES (1, 1)"]])
 
-   (t/is (= [{:xt$id 1, :v 1,
-              :xt$valid_from (util/->zdt #inst "2020")
-              :xt$valid_to (util/->zdt util/end-of-time)}]
-            (xt/q tu/*node* "SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
+  (t/is (= [{:xt$id 1, :v 1,
+             :xt$valid_from (util/->zdt #inst "2020")
+             :xt$valid_to (util/->zdt util/end-of-time)}]
+           (xt/q tu/*node* "SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
 
-   (t/is (= []
-            (xt/q tu/*node* "
+  (t/is (= []
+           (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo FOR VALID_TIME AS OF DATE '1999-01-01'"
-                  {:basis {:current-time (util/->instant #inst "1999")}})))
+                 {:basis {:current-time (util/->instant #inst "1999")}})))
 
-   (t/is (= []
-            (xt/q tu/*node* "
+  (t/is (= []
+           (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo FOR VALID_TIME AS OF CURRENT_TIMESTAMP"
-                  {:basis {:current-time (util/->instant #inst "1999")}})))))
+                 {:basis {:current-time (util/->instant #inst "1999")}}))))
 
 (t/deftest test-repeated-row-id-scan-bug-also-409
-  (tu/without-tries
-   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES (1, 1)"]])
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES (1, 1)"]])
 
-   (let [tx1 (xt/submit-tx tu/*node* [[:sql "
+  (let [tx1 (xt/submit-tx tu/*node* [[:sql "
 UPDATE foo
 FOR PORTION OF VALID_TIME FROM DATE '2022-01-01' TO DATE '2024-01-01'
 SET v = 2
 WHERE foo.xt$id = 1"]])
 
-         tx2 (xt/submit-tx tu/*node* [[:sql "
+        tx2 (xt/submit-tx tu/*node* [[:sql "
 DELETE FROM foo
 FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01'
 WHERE foo.xt$id = 1"]])]
 
-     (letfn [(q1 [opts]
-               (xt/q tu/*node* "
+    (letfn [(q1 [opts]
+              (xt/q tu/*node* "
 SELECT foo.xt$id, foo.v, foo.xt$valid_from, foo.xt$valid_to
 FROM foo
 ORDER BY foo.xt$valid_from"
-                     opts))
-             (q2 [opts]
-               (frequencies
-                (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo" opts)))]
+                    opts))
+            (q2 [opts]
+              (frequencies
+               (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo" opts)))]
 
-       (t/is (= [{:xt$id 1, :v 1
-                  :xt$valid_from (util/->zdt #inst "2020")
-                  :xt$valid_to (util/->zdt #inst "2022")}
-                 {:xt$id 1, :v 2
-                  :xt$valid_from (util/->zdt #inst "2022")
-                  :xt$valid_to (util/->zdt #inst "2024")}
-                 {:xt$id 1, :v 1
-                  :xt$valid_from (util/->zdt #inst "2024")
-                  :xt$valid_to (util/->zdt util/end-of-time)}]
+      (t/is (= [{:xt$id 1, :v 1
+                 :xt$valid_from (util/->zdt #inst "2020")
+                 :xt$valid_to (util/->zdt #inst "2022")}
+                {:xt$id 1, :v 2
+                 :xt$valid_from (util/->zdt #inst "2022")
+                 :xt$valid_to (util/->zdt #inst "2024")}
+                {:xt$id 1, :v 1
+                 :xt$valid_from (util/->zdt #inst "2024")
+                 :xt$valid_to (util/->zdt util/end-of-time)}]
 
-                (q1 {:basis {:tx tx1}, :default-all-valid-time? true})))
+               (q1 {:basis {:tx tx1}, :default-all-valid-time? true})))
 
-       (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
-                (q2 {:basis {:tx tx1}, :default-all-valid-time? true})))
+      (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
+               (q2 {:basis {:tx tx1}, :default-all-valid-time? true})))
 
-       (t/is (= [{:xt$id 1, :v 1
-                  :xt$valid_from (util/->zdt #inst "2020")
-                  :xt$valid_to (util/->zdt #inst "2022")}
-                 {:xt$id 1, :v 2
-                  :xt$valid_from (util/->zdt #inst "2022")
-                  :xt$valid_to (util/->zdt #inst "2023")}
-                 {:xt$id 1, :v 1
-                  :xt$valid_from (util/->zdt #inst "2025")
-                  :xt$valid_to (util/->zdt util/end-of-time)}]
+      (t/is (= [{:xt$id 1, :v 1
+                 :xt$valid_from (util/->zdt #inst "2020")
+                 :xt$valid_to (util/->zdt #inst "2022")}
+                {:xt$id 1, :v 2
+                 :xt$valid_from (util/->zdt #inst "2022")
+                 :xt$valid_to (util/->zdt #inst "2023")}
+                {:xt$id 1, :v 1
+                 :xt$valid_from (util/->zdt #inst "2025")
+                 :xt$valid_to (util/->zdt util/end-of-time)}]
 
-                (q1 {:basis {:tx tx2}, :default-all-valid-time? true})))
+               (q1 {:basis {:tx tx2}, :default-all-valid-time? true})))
 
-       (t/is (= [{:xt$id 1, :v 1
-                  :xt$valid_from (util/->zdt #inst "2025")
-                  :xt$valid_to (util/->zdt util/end-of-time)}]
+      (t/is (= [{:xt$id 1, :v 1
+                 :xt$valid_from (util/->zdt #inst "2025")
+                 :xt$valid_to (util/->zdt util/end-of-time)}]
 
-                (q1 {:basis {:tx tx2, :current-time (util/->instant #inst "2026")}
-                     :default-all-valid-time? false})))
+               (q1 {:basis {:tx tx2, :current-time (util/->instant #inst "2026")}
+                    :default-all-valid-time? false})))
 
-       (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
-                (q2 {:basis {:tx tx2}, :default-all-valid-time? true})))))))
+      (t/is (= {{:xt$id 1, :v 1} 2, {:xt$id 1, :v 2} 1}
+               (q2 {:basis {:tx tx2}, :default-all-valid-time? true}))))))
 
 (t/deftest test-error-handling-inserting-strings-into-app-time-cols-397
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, xt$valid_from) VALUES (1, '2018-01-01')"]])
@@ -364,42 +359,41 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
            (xt/q tu/*node* "SELECT t2.data t2d, t1.data t1d FROM t2, t1"))))
 
 (t/deftest test-txs-table-485
-  (tu/without-tries
-   (tu/with-log-level 'xtdb.indexer :error
-     (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])
-     (xt/submit-tx tu/*node* [[:abort]])
-     (xt/submit-tx tu/*node* [[:put :docs {:xt/id :bar}]])
-     (xt/submit-tx tu/*node* [[:put-fn :tx-fn-fail
-                               '(fn []
-                                  (throw (Exception. "boom")))]
-                              [:call :tx-fn-fail]])
+  (tu/with-log-level 'xtdb.indexer :error
+    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])
+    (xt/submit-tx tu/*node* [[:abort]])
+    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :bar}]])
+    (xt/submit-tx tu/*node* [[:put-fn :tx-fn-fail
+                              '(fn []
+                                 (throw (Exception. "boom")))]
+                             [:call :tx-fn-fail]])
 
-     (t/is (= [{:tx-id 0, :tx-time (util/->zdt #inst "2020-01-01"), :committed? true}
+    (t/is (= #{{:tx-id 0, :tx-time (util/->zdt #inst "2020-01-01"), :committed? true}
                {:tx-id 1, :tx-time (util/->zdt #inst "2020-01-02"), :committed? false}
                {:tx-id 2, :tx-time (util/->zdt #inst "2020-01-03"), :committed? true}
-               {:tx-id 3, :tx-time (util/->zdt #inst "2020-01-04"), :committed? false}]
-              (xt/q tu/*node*
-                    '{:find [tx-id tx-time committed?]
-                      :where [($ :xt/txs {:xt/id tx-id, :xt/tx-time tx-time, :xt/committed? committed?})]})))
+               {:tx-id 3, :tx-time (util/->zdt #inst "2020-01-04"), :committed? false}}
+             (set (xt/q tu/*node*
+                        '{:find [tx-id tx-time committed?]
+                          :where [($ :xt/txs {:xt/id tx-id, :xt/tx-time tx-time, :xt/committed? committed?})]}))))
 
-     (t/is (= [{:committed? false}]
-              (xt/q tu/*node*
-                    ['{:find [committed?]
-                       :in [tx-id]
-                       :where [($ :xt/txs {:xt/id tx-id, :xt/committed? committed?})]}
-                     1])))
+    (t/is (= [{:committed? false}]
+             (xt/q tu/*node*
+                   ['{:find [committed?]
+                      :in [tx-id]
+                      :where [($ :xt/txs {:xt/id tx-id, :xt/committed? committed?})]}
+                    1])))
 
-     (t/is (thrown-with-msg?
-            RuntimeException
-            #":xtdb\.call/error-evaluating-tx-fn"
+    (t/is (thrown-with-msg?
+           RuntimeException
+           #":xtdb\.call/error-evaluating-tx-fn"
 
-            (throw (-> (xt/q tu/*node*
-                             ['{:find [err]
-                                :in [tx-id]
-                                :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
-                              3])
-                       first
-                       :err :form)))))))
+           (throw (-> (xt/q tu/*node*
+                            ['{:find [err]
+                               :in [tx-id]
+                               :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
+                             3])
+                      first
+                      :err :form))))))
 
 (t/deftest test-indexer-cleans-up-aborted-transactions-2489
   (t/testing "INSERT"
@@ -462,37 +456,35 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
            (set (xt/q tu/*node* "SELECT * FROM bing")))))
 
 (deftest test-scan-all-table-col-names
-  (tu/without-tries
-   (t/testing "testing scan.allTableColNames combines table info from both live and past chunks"
-     (-> (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo1" :a 1}]
-                                  [:put :bar {:xt/id "bar1"}]
-                                  [:put :bar {:xt/id "bar2" :b 2}]])
-         (tu/then-await-tx tu/*node*))
+  (t/testing "testing scan.allTableColNames combines table info from both live and past chunks"
+    (-> (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo1" :a 1}]
+                                 [:put :bar {:xt/id "bar1"}]
+                                 [:put :bar {:xt/id "bar2" :b 2}]])
+        (tu/then-await-tx tu/*node*))
 
-     (tu/finish-chunk! tu/*node*)
+    (tu/finish-chunk! tu/*node*)
 
-     (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
-                              [:put :baz {:xt/id "foo1" :a 4}]])
+    (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
+                             [:put :baz {:xt/id "foo1" :a 4}]])
 
-     (t/is (= [{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}]
-              (xt/q tu/*node* "SELECT * FROM foo")))
-     (t/is (= [{:xt$id "bar1"} {:b 2, :xt$id "bar2"}]
-              (xt/q tu/*node* "SELECT * FROM bar")))
-     (t/is (= [{:a 4, :xt$id "foo1"}]
-              (xt/q tu/*node* "SELECT * FROM baz"))))))
+    (t/is (= [{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}]
+             (xt/q tu/*node* "SELECT * FROM foo")))
+    (t/is (= [{:xt$id "bar1"} {:b 2, :xt$id "bar2"}]
+             (xt/q tu/*node* "SELECT * FROM bar")))
+    (t/is (= [{:a 4, :xt$id "foo1"}]
+             (xt/q tu/*node* "SELECT * FROM baz")))))
 
 (deftest test-erase-after-delete-2607
-  (tu/without-tries
-   (t/testing "general case"
-     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (1, 1)"]])
-     (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.xt$id = 1"]])
-     (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 1"]])
-     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
-     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))
-   (t/testing "zero width case"
-     (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 1)"]
-                              [:sql "DELETE FROM foo WHERE foo.xt$id = 2"]])
-     (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]])
-     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
-     ;; TODO if it doesn't show up in valid-time it won't get deleted
-     #_(t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))))
+  (t/testing "general case"
+    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (1, 1)"]])
+    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.xt$id = 1"]])
+    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 1"]])
+    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
+    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))
+  (t/testing "zero width case"
+    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 1)"]
+                             [:sql "DELETE FROM foo WHERE foo.xt$id = 2"]])
+    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]])
+    (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
+    ;; TODO if it doesn't show up in valid-time it won't get deleted
+    #_(t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME")))))

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -9,7 +9,7 @@
            (java.time LocalTime)
            (org.roaringbitmap RoaringBitmap)))
 
-(t/use-fixtures :once tu/no-tries tu/with-allocator)
+(t/use-fixtures :once tu/with-allocator)
 
 (t/deftest test-find-gt-ivan
   (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 2, :rows-per-chunk 10}})]

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -9,7 +9,7 @@
            (java.time LocalTime)
            (org.roaringbitmap RoaringBitmap)))
 
-(t/use-fixtures :once tu/with-allocator)
+(t/use-fixtures :once tu/no-tries tu/with-allocator)
 
 (t/deftest test-find-gt-ivan
   (with-open [node (node/start-node {:xtdb/live-chunk {:rows-per-block 2, :rows-per-chunk 10}})]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1229,26 +1229,25 @@
       (is (= [{:xt$id 42}, {:xt$id 43}] (q conn ["SELECT foo.xt$id from foo"]))))))
 
 (deftest set-app-time-defaults-test
-  (tu/without-tries
-   (with-open [conn (jdbc-conn)]
-     (let [sql #(q conn [%])]
-       (sql "SET valid_time_defaults TO as_of_now")
+  (with-open [conn (jdbc-conn)]
+    (let [sql #(q conn [%])]
+      (sql "SET valid_time_defaults TO as_of_now")
 
-       (sql "START TRANSACTION READ WRITE")
-       (sql "INSERT INTO foo (xt$id, version) VALUES ('foo', 0)")
-       (sql "COMMIT")
+      (sql "START TRANSACTION READ WRITE")
+      (sql "INSERT INTO foo (xt$id, version) VALUES ('foo', 0)")
+      (sql "COMMIT")
 
-       (sql "START TRANSACTION READ WRITE")
-       (sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")
-       (sql "COMMIT")
+      (sql "START TRANSACTION READ WRITE")
+      (sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")
+      (sql "COMMIT")
 
-       (is (= [{:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}]
-              (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))
+      (is (= [{:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}]
+             (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))
 
-       (sql "SET valid_time_defaults iso_standard")
-       (is (= (set [{:version 0, :xt$valid_from "2020-01-01T00:00Z", :xt$valid_to "2020-01-02T00:00Z"}
-                    {:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}])
-              (set (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"]))))))))
+      (sql "SET valid_time_defaults iso_standard")
+      (is (= (set [{:version 0, :xt$valid_from "2020-01-01T00:00Z", :xt$valid_to "2020-01-02T00:00Z"}
+                   {:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}])
+             (set (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))))))
 
 ;; this demonstrates that session / set variables do not change the next statement
 ;; its undefined - but we can say what it is _not_.

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1229,25 +1229,26 @@
       (is (= [{:xt$id 42}, {:xt$id 43}] (q conn ["SELECT foo.xt$id from foo"]))))))
 
 (deftest set-app-time-defaults-test
-  (with-open [conn (jdbc-conn)]
-    (let [sql #(q conn [%])]
-      (sql "SET valid_time_defaults TO as_of_now")
+  (tu/without-tries
+   (with-open [conn (jdbc-conn)]
+     (let [sql #(q conn [%])]
+       (sql "SET valid_time_defaults TO as_of_now")
 
-      (sql "START TRANSACTION READ WRITE")
-      (sql "INSERT INTO foo (xt$id, version) VALUES ('foo', 0)")
-      (sql "COMMIT")
+       (sql "START TRANSACTION READ WRITE")
+       (sql "INSERT INTO foo (xt$id, version) VALUES ('foo', 0)")
+       (sql "COMMIT")
 
-      (sql "START TRANSACTION READ WRITE")
-      (sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")
-      (sql "COMMIT")
+       (sql "START TRANSACTION READ WRITE")
+       (sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")
+       (sql "COMMIT")
 
-      (is (= [{:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}]
-             (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))
+       (is (= [{:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}]
+              (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))
 
-      (sql "SET valid_time_defaults iso_standard")
-      (is (= (set [{:version 0, :xt$valid_from "2020-01-01T00:00Z", :xt$valid_to "2020-01-02T00:00Z"}
-                   {:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}])
-             (set (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"])))))))
+       (sql "SET valid_time_defaults iso_standard")
+       (is (= (set [{:version 0, :xt$valid_from "2020-01-01T00:00Z", :xt$valid_to "2020-01-02T00:00Z"}
+                    {:version 1, :xt$valid_from "2020-01-02T00:00Z", :xt$valid_to "9999-12-31T23:59:59.999999Z"}])
+              (set (q conn ["SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"]))))))))
 
 ;; this demonstrates that session / set variables do not change the next statement
 ;; its undefined - but we can say what it is _not_.

--- a/src/test/clojure/xtdb/sql/logic_test/direct_sql_test.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/direct_sql_test.clj
@@ -1,5 +1,9 @@
 (ns xtdb.sql.logic-test.direct-sql-test
-  (:require [xtdb.sql.logic-test.runner :as slt]))
+  (:require [xtdb.sql.logic-test.runner :as slt]
+            [clojure.test :as t]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :once tu/no-tries)
 
 (slt/def-slt-test direct-sql--dml {:direct-sql true})
 (slt/def-slt-test direct-sql--gcse-statistics {:direct-sql true})

--- a/src/test/clojure/xtdb/sql/logic_test/direct_sql_test.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/direct_sql_test.clj
@@ -1,9 +1,6 @@
 (ns xtdb.sql.logic-test.direct-sql-test
   (:require [xtdb.sql.logic-test.runner :as slt]
-            [clojure.test :as t]
-            [xtdb.test-util :as tu]))
-
-(t/use-fixtures :once tu/no-tries)
+            [clojure.test :as t]))
 
 (slt/def-slt-test direct-sql--dml {:direct-sql true})
 (slt/def-slt-test direct-sql--gcse-statistics {:direct-sql true})

--- a/src/test/clojure/xtdb/sql/logic_test/runner.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/runner.clj
@@ -428,11 +428,10 @@
                                         (assoc results :time (math/round (/ (double (- ^long (. System (nanoTime)) start-time)) 1000000.0)))))]]
           (println "Running " script-name)
           (case db
-            "xtdb" (tu/without-tries
-                    (tu/with-mock-clock
-                      (fn []
-                        (tu/with-node
-                          #(with-xtdb f)))))
+            "xtdb" (tu/with-mock-clock
+                     (fn []
+                       (tu/with-node
+                         #(with-xtdb f))))
             "sqlite" (with-sqlite f)
             (with-jdbc db f)))))
     (let [{:keys [failure error] :or {failure 0 error 0} :as total-results} (reduce (partial merge-with +) (vals @results))]

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -3,7 +3,6 @@
             [xtdb.api :as xt]
             [xtdb.test-util :as tu]))
 
-(use-fixtures :once tu/no-tries)
 (use-fixtures :each tu/with-node)
 
 (defn query-at-tx [query tx]

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -203,7 +203,8 @@
           {:tx-id 2, :committed? false}]
          (xt/q tu/*node* '{:find [tx-id committed?]
                            :where [($ :xt/txs {:xt/id tx-id,
-                                               :xt/committed? committed?})]})))
+                                               :xt/committed? committed?})]
+                           :order-by [[tx-id]]})))
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (3)"]])
   (xt/submit-tx tu/*node* [[:sql ["UPDATE xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? SET foo = 'bar' WHERE xt_docs.xt$id = 3"
                                   #inst "2011"]]])

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -3,6 +3,7 @@
             [xtdb.api :as xt]
             [xtdb.test-util :as tu]))
 
+(use-fixtures :once tu/no-tries)
 (use-fixtures :each tu/with-node)
 
 (defn query-at-tx [query tx]

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -198,13 +198,12 @@
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (2)"]])
   (xt/submit-tx tu/*node* [[:sql ["DELETE FROM xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? WHERE xt_docs.xt$id = 2"
                                   #inst "2011"]]])
-  (is (= [{:tx-id 0, :committed? false}
-          {:tx-id 1, :committed? true}
-          {:tx-id 2, :committed? false}]
-         (xt/q tu/*node* '{:find [tx-id committed?]
-                           :where [($ :xt/txs {:xt/id tx-id,
-                                               :xt/committed? committed?})]
-                           :order-by [[tx-id]]})))
+  (is (= #{{:tx-id 0, :committed? false}
+           {:tx-id 1, :committed? true}
+           {:tx-id 2, :committed? false}}
+         (set (xt/q tu/*node* '{:find [tx-id committed?]
+                                :where [($ :xt/txs {:xt/id tx-id,
+                                                    :xt/committed? committed?})]}))))
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (3)"]])
   (xt/submit-tx tu/*node* [[:sql ["UPDATE xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? SET foo = 'bar' WHERE xt_docs.xt$id = 3"
                                   #inst "2011"]]])

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -12,8 +12,6 @@
             [xtdb.operator.scan :as scan])
   (:import (java.nio.file Path)))
 
-(t/use-fixtures :once tu/no-tries)
-
 (def ^:dynamic *node* nil)
 
 ;; (slurp (io/resource (format "io/airlift/tpch/queries/q%d.sql" 1)))

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -8,8 +8,11 @@
             [xtdb.datasets.tpch.ra :as tpch-ra]
             xtdb.sql-test
             [xtdb.test-util :as tu]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [xtdb.operator.scan :as scan])
   (:import (java.nio.file Path)))
+
+(t/use-fixtures :once tu/no-tries)
 
 (def ^:dynamic *node* nil)
 

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_info/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -179,6 +188,11 @@
       "count" : 2,
       "VALIDITY" : [1,1],
       "DATA" : ["248daaa010bf702848523e4fa63f996c","ef4f71005524e9af20ffaca545cde6e1"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : ["216172782113783808","0"]
     },{
       "name" : "xt$system_from",
       "count" : 2,

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/device_readings/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -333,6 +342,11 @@
       "count" : 2,
       "VALIDITY" : [1,1],
       "DATA" : ["58941814a63f68d05acf4177ec17d3ba","6bd5602dd9300d63410ca07b677f0041"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 2,
+      "VALIDITY" : [1,1],
+      "DATA" : ["72057594037927936","288230376151711744"]
     },{
       "name" : "xt$system_from",
       "count" : 2,

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -68,79 +68,40 @@
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "foo",
+            "name" : "xt$tx_time",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
             },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "bar",
+            "name" : "xt$committed?",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "bool"
             },
-            "children" : [{
-              "name" : "utf8",
-              "nullable" : false,
-              "type" : {
-                "name" : "utf8"
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "baz",
-            "nullable" : false,
+            "name" : "xt$error",
+            "nullable" : true,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "ClojureFormType"
             },
-            "children" : [{
-              "name" : "f64",
-              "nullable" : false,
-              "type" : {
-                "name" : "floatingpoint",
-                "precision" : "DOUBLE"
-              },
-              "children" : [ ]
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
             },{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -185,17 +146,17 @@
       "name" : "xt$iid",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["4cd9b7672d7fbee8fb51fb1e049f6903","a4e167a76a05add8a8654c169b07b044"]
+      "DATA" : ["6b2c5e88c38aa669787f711205999504","a4e167a76a05add8a8654c169b07b044"]
     },{
       "name" : "xt$legacy_iid",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["72057594037927936","0"]
+      "DATA" : ["360287970189639680","144115188075855872"]
     },{
       "name" : "xt$system_from",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : [1577836800000000,1577836800000000]
+      "DATA" : [1577923200000000,1577836800000000]
     },{
       "name" : "op",
       "count" : 2,
@@ -209,7 +170,7 @@
           "name" : "xt$valid_from",
           "count" : 2,
           "VALIDITY" : [1,1],
-          "DATA" : [1577836800000000,1577836800000000]
+          "DATA" : [1577923200000000,1577836800000000]
         },{
           "name" : "xt$valid_to",
           "count" : 2,
@@ -222,53 +183,24 @@
           "children" : [{
             "name" : "xt$id",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "i64",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["1","0"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : ["8165","0"]
           },{
-            "name" : "foo",
+            "name" : "xt$tx_time",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "i64",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["1","2"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : [1577923200000000,1577836800000000]
           },{
-            "name" : "bar",
+            "name" : "xt$committed?",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "utf8",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "OFFSET" : [0,5,10],
-              "DATA" : ["world","hello"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : [1,1]
           },{
-            "name" : "baz",
+            "name" : "xt$error",
             "count" : 2,
-            "TYPE_ID" : [0,1],
-            "OFFSET" : [0,0],
-            "children" : [{
-              "name" : "f64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : [3.3]
-            },{
-              "name" : "i64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["12"]
-            }]
+            "VALIDITY" : [0,0],
+            "OFFSET" : [0,0,0],
+            "DATA" : ["",""]
           }]
         }]
       },{

--- a/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-chunk-as-arrow-ipc-file-format/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/foo/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/foo/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -165,6 +174,11 @@
       "count" : 5,
       "VALIDITY" : [1,1,1,1,1],
       "DATA" : ["420fce314175df402adbeae3cfbbb856","420fce314175df402adbeae3cfbbb856","4cd9b7672d7fbee8fb51fb1e049f6903","4cd9b7672d7fbee8fb51fb1e049f6903","4cd9b7672d7fbee8fb51fb1e049f6903"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 5,
+      "VALIDITY" : [1,1,1,1,1],
+      "DATA" : ["792633534417207296","792633534417207296","576460752303423488","576460752303423488","576460752303423488"]
     },{
       "name" : "xt$system_from",
       "count" : 5,

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -65,45 +65,43 @@
             "name" : "struct"
           },
           "children" : [{
-            "name" : "b",
-            "nullable" : false,
-            "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
-            },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
-          },{
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "uuid",
-              "nullable" : false,
-              "type" : {
-                "name" : "UuidType"
-              },
-              "children" : [ ],
-              "metadata" : [{
-                "value" : "uuid",
-                "key" : "ARROW:extension:name"
-              },{
-                "value" : "",
-                "key" : "ARROW:extension:metadata"
-              }]
+            "children" : [ ]
+          },{
+            "name" : "xt$tx_time",
+            "nullable" : false,
+            "type" : {
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$committed?",
+            "nullable" : false,
+            "type" : {
+              "name" : "bool"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$error",
+            "nullable" : true,
+            "type" : {
+              "name" : "ClojureFormType"
+            },
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
+            },{
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -143,67 +141,66 @@
     }]
   },
   "batches" : [{
-    "count" : 3,
+    "count" : 6,
     "columns" : [{
       "name" : "xt$iid",
-      "count" : 3,
-      "VALIDITY" : [1,1,1],
-      "DATA" : ["424f5622c8264deda5dbe2144d665c38","424f5622c8264deda5dbe2144d665c38","424f5622c8264deda5dbe2144d665c38"]
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["2d9400fe884f154caa33862ea52eac95","4f109710492db95684cceb0d4f906c4a","657188d6a2a8753f6a2ef42bee7c12d8","88a681ae37728a5dd25693aaf1a8808e","a4e167a76a05add8a8654c169b07b044","d088c719d195af87f0012cb3a60c804c"]
     },{
       "name" : "xt$legacy_iid",
-      "count" : 3,
-      "VALIDITY" : [1,1,1],
-      "DATA" : ["72057594037927936","72057594037927936","72057594037927936"]
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["864691128455135232","936748722493063168","504403158265495552","360287970189639680","144115188075855872","1008806316530991104"]
     },{
       "name" : "xt$system_from",
-      "count" : 3,
-      "VALIDITY" : [1,1,1],
-      "DATA" : [1578009600000000,1577923200000000,1577836800000000]
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : [1578096000000000,1578182400000000,1578009600000000,1577923200000000,1577836800000000,1578268800000000]
     },{
       "name" : "op",
-      "count" : 3,
-      "TYPE_ID" : [2,0,0],
-      "OFFSET" : [0,0,1],
+      "count" : 6,
+      "TYPE_ID" : [0,0,0,0,0,0],
+      "OFFSET" : [0,1,2,3,4,5],
       "children" : [{
         "name" : "put",
-        "count" : 2,
-        "VALIDITY" : [1,1],
+        "count" : 6,
+        "VALIDITY" : [1,1,1,1,1,1],
         "children" : [{
           "name" : "xt$valid_from",
-          "count" : 2,
-          "VALIDITY" : [1,1],
-          "DATA" : [1577923200000000,1577836800000000]
+          "count" : 6,
+          "VALIDITY" : [1,1,1,1,1,1],
+          "DATA" : [1578096000000000,1578182400000000,1578009600000000,1577923200000000,1577836800000000,1578268800000000]
         },{
           "name" : "xt$valid_to",
-          "count" : 2,
-          "VALIDITY" : [1,1],
-          "DATA" : [253402300799999999,253402300799999999]
+          "count" : 6,
+          "VALIDITY" : [1,1,1,1,1,1],
+          "DATA" : [253402300799999999,253402300799999999,253402300799999999,253402300799999999,253402300799999999,253402300799999999]
         },{
           "name" : "xt$doc",
-          "count" : 2,
-          "VALIDITY" : [1,1],
+          "count" : 6,
+          "VALIDITY" : [1,1,1,1,1,1],
           "children" : [{
-            "name" : "b",
-            "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "i64",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["3","2"]
-            }]
-          },{
             "name" : "xt$id",
-            "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "uuid",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["424f5622c8264deda5dbe2144d665c38","424f5622c8264deda5dbe2144d665c38"]
-            }]
+            "count" : 6,
+            "VALIDITY" : [1,1,1,1,1,1],
+            "DATA" : ["11831","15076","8538","4461","0","18145"]
+          },{
+            "name" : "xt$tx_time",
+            "count" : 6,
+            "VALIDITY" : [1,1,1,1,1,1],
+            "DATA" : [1578096000000000,1578182400000000,1578009600000000,1577923200000000,1577836800000000,1578268800000000]
+          },{
+            "name" : "xt$committed?",
+            "count" : 6,
+            "VALIDITY" : [1,1,1,1,1,1],
+            "DATA" : [1,1,1,1,1,0]
+          },{
+            "name" : "xt$error",
+            "count" : 6,
+            "VALIDITY" : [0,0,0,0,0,1],
+            "OFFSET" : [0,0,0,0,0,0,284],
+            "DATA" : ["","","","","","#xt/runtime-err {:xtdb.error/error-type :runtime-error, :xtdb.error/error-key :xtdb.indexer/invalid-valid-times, :xtdb.error/message \"Runtime error: ':xtdb.indexer/invalid-valid-times'\", :valid-from #time/instant \"2020-01-01T00:00:00Z\", :valid-to #time/instant \"2019-01-01T00:00:00Z\"}"]
           }]
         }]
       },{
@@ -223,7 +220,7 @@
         }]
       },{
         "name" : "evict",
-        "count" : 1
+        "count" : 0
       }]
     }]
   }]

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -65,45 +65,43 @@
             "name" : "struct"
           },
           "children" : [{
-            "name" : "a",
-            "nullable" : false,
-            "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
-            },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
-          },{
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "uuid",
-              "nullable" : false,
-              "type" : {
-                "name" : "UuidType"
-              },
-              "children" : [ ],
-              "metadata" : [{
-                "value" : "uuid",
-                "key" : "ARROW:extension:name"
-              },{
-                "value" : "",
-                "key" : "ARROW:extension:metadata"
-              }]
+            "children" : [ ]
+          },{
+            "name" : "xt$tx_time",
+            "nullable" : false,
+            "type" : {
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$committed?",
+            "nullable" : false,
+            "type" : {
+              "name" : "bool"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$error",
+            "nullable" : true,
+            "type" : {
+              "name" : "ClojureFormType"
+            },
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
+            },{
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -143,27 +141,27 @@
     }]
   },
   "batches" : [{
-    "count" : 2,
+    "count" : 1,
     "columns" : [{
       "name" : "xt$iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d","cb8815ee85f74c61a8032ea1c949cf8d"]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["a4e167a76a05add8a8654c169b07b044"]
     },{
       "name" : "xt$legacy_iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["0","0"]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["432345564227567616"]
     },{
       "name" : "xt$system_from",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : [1577923200000000,1577836800000000]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
     },{
       "name" : "op",
-      "count" : 2,
-      "TYPE_ID" : [1,0],
-      "OFFSET" : [0,0],
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
       "children" : [{
         "name" : "put",
         "count" : 1,
@@ -183,43 +181,42 @@
           "count" : 1,
           "VALIDITY" : [1],
           "children" : [{
-            "name" : "a",
-            "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "i64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["1"]
-            }]
-          },{
             "name" : "xt$id",
             "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "uuid",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d"]
-            }]
+            "VALIDITY" : [1],
+            "DATA" : ["0"]
+          },{
+            "name" : "xt$tx_time",
+            "count" : 1,
+            "VALIDITY" : [1],
+            "DATA" : [1577836800000000]
+          },{
+            "name" : "xt$committed?",
+            "count" : 1,
+            "VALIDITY" : [1],
+            "DATA" : [1]
+          },{
+            "name" : "xt$error",
+            "count" : 1,
+            "VALIDITY" : [0],
+            "OFFSET" : [0,0],
+            "DATA" : [""]
           }]
         }]
       },{
         "name" : "delete",
-        "count" : 1,
-        "VALIDITY" : [1],
+        "count" : 0,
+        "VALIDITY" : [ ],
         "children" : [{
           "name" : "xt$valid_from",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [1577923200000000]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         },{
           "name" : "xt$valid_to",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [253402300799999999]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         }]
       },{
         "name" : "evict",

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/tables/xt_docs/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -323,6 +332,11 @@
       "count" : 6,
       "VALIDITY" : [1,1,1,1,1,1],
       "DATA" : ["55bfc78e47207dc5125af00a5f52d66c","64b0cf833d08d23b08185c18bb7a0ef2","9e3f856e68998313827ff18dd4d88e78","bfc55eb61f526d86de90b2bb2e648a89","d9c7fae2a04e047164936265ba33cf80","fbfa9e45ee9bd2f827b8dde9e41d3814"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["288230376151711744","72057594037927936","144115188075855872","216172782113783808","0","360287970189639680"]
     },{
       "name" : "xt$system_from",
       "count" : 6,

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -65,45 +65,43 @@
             "name" : "struct"
           },
           "children" : [{
-            "name" : "a",
-            "nullable" : false,
-            "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
-            },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
-          },{
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "uuid",
-              "nullable" : false,
-              "type" : {
-                "name" : "UuidType"
-              },
-              "children" : [ ],
-              "metadata" : [{
-                "value" : "uuid",
-                "key" : "ARROW:extension:name"
-              },{
-                "value" : "",
-                "key" : "ARROW:extension:metadata"
-              }]
+            "children" : [ ]
+          },{
+            "name" : "xt$tx_time",
+            "nullable" : false,
+            "type" : {
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$committed?",
+            "nullable" : false,
+            "type" : {
+              "name" : "bool"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$error",
+            "nullable" : true,
+            "type" : {
+              "name" : "ClojureFormType"
+            },
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
+            },{
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -143,27 +141,27 @@
     }]
   },
   "batches" : [{
-    "count" : 2,
+    "count" : 1,
     "columns" : [{
       "name" : "xt$iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d","cb8815ee85f74c61a8032ea1c949cf8d"]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["a4e167a76a05add8a8654c169b07b044"]
     },{
       "name" : "xt$legacy_iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["0","0"]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["144115188075855872"]
     },{
       "name" : "xt$system_from",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : [1577923200000000,1577836800000000]
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
     },{
       "name" : "op",
-      "count" : 2,
-      "TYPE_ID" : [1,0],
-      "OFFSET" : [0,0],
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
       "children" : [{
         "name" : "put",
         "count" : 1,
@@ -183,43 +181,42 @@
           "count" : 1,
           "VALIDITY" : [1],
           "children" : [{
-            "name" : "a",
-            "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "i64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["1"]
-            }]
-          },{
             "name" : "xt$id",
             "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "uuid",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d"]
-            }]
+            "VALIDITY" : [1],
+            "DATA" : ["0"]
+          },{
+            "name" : "xt$tx_time",
+            "count" : 1,
+            "VALIDITY" : [1],
+            "DATA" : [1577836800000000]
+          },{
+            "name" : "xt$committed?",
+            "count" : 1,
+            "VALIDITY" : [1],
+            "DATA" : [1]
+          },{
+            "name" : "xt$error",
+            "count" : 1,
+            "VALIDITY" : [0],
+            "OFFSET" : [0,0],
+            "DATA" : [""]
           }]
         }]
       },{
         "name" : "delete",
-        "count" : 1,
-        "VALIDITY" : [1],
+        "count" : 0,
+        "VALIDITY" : [ ],
         "children" : [{
           "name" : "xt$valid_from",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [1577923200000000]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         },{
           "name" : "xt$valid_to",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [253402300799999999]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         }]
       },{
         "name" : "evict",

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -68,79 +68,40 @@
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "foo",
+            "name" : "xt$tx_time",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
             },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "bar",
+            "name" : "xt$committed?",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "bool"
             },
-            "children" : [{
-              "name" : "utf8",
-              "nullable" : false,
-              "type" : {
-                "name" : "utf8"
-              },
-              "children" : [ ]
-            }]
+            "children" : [ ]
           },{
-            "name" : "baz",
-            "nullable" : false,
+            "name" : "xt$error",
+            "nullable" : true,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "ClojureFormType"
             },
-            "children" : [{
-              "name" : "f64",
-              "nullable" : false,
-              "type" : {
-                "name" : "floatingpoint",
-                "precision" : "DOUBLE"
-              },
-              "children" : [ ]
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
             },{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -185,17 +146,17 @@
       "name" : "xt$iid",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["4cd9b7672d7fbee8fb51fb1e049f6903","a4e167a76a05add8a8654c169b07b044"]
+      "DATA" : ["659fa87d49ccd11c201a9454d9336063","a4e167a76a05add8a8654c169b07b044"]
     },{
       "name" : "xt$legacy_iid",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["72057594037927936","0"]
+      "DATA" : ["504403158265495552","288230376151711744"]
     },{
       "name" : "xt$system_from",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : [1577836800000000,1577836800000000]
+      "DATA" : [1577923200000000,1577836800000000]
     },{
       "name" : "op",
       "count" : 2,
@@ -209,7 +170,7 @@
           "name" : "xt$valid_from",
           "count" : 2,
           "VALIDITY" : [1,1],
-          "DATA" : [1577836800000000,1577836800000000]
+          "DATA" : [1577923200000000,1577836800000000]
         },{
           "name" : "xt$valid_to",
           "count" : 2,
@@ -222,53 +183,24 @@
           "children" : [{
             "name" : "xt$id",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "i64",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["1","0"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : ["5845","0"]
           },{
-            "name" : "foo",
+            "name" : "xt$tx_time",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "i64",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "DATA" : ["1","2"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : [1577923200000000,1577836800000000]
           },{
-            "name" : "bar",
+            "name" : "xt$committed?",
             "count" : 2,
-            "TYPE_ID" : [0,0],
-            "OFFSET" : [0,1],
-            "children" : [{
-              "name" : "utf8",
-              "count" : 2,
-              "VALIDITY" : [1,1],
-              "OFFSET" : [0,5,10],
-              "DATA" : ["world","hello"]
-            }]
+            "VALIDITY" : [1,1],
+            "DATA" : [1,1]
           },{
-            "name" : "baz",
+            "name" : "xt$error",
             "count" : 2,
-            "TYPE_ID" : [0,1],
-            "OFFSET" : [0,0],
-            "children" : [{
-              "name" : "f64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : [3.3]
-            },{
-              "name" : "i64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["12"]
-            }]
+            "VALIDITY" : [0,0],
+            "OFFSET" : [0,0,0],
+            "DATA" : ["",""]
           }]
         }]
       },{

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/tables/xt_docs/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -318,6 +327,11 @@
       "count" : 6,
       "VALIDITY" : [1,1,1,1,1,1],
       "DATA" : ["47a6245d9effb01c6b67db10b5d9aaa8","55bfc78e47207dc5125af00a5f52d66c","64b0cf833d08d23b08185c18bb7a0ef2","d9c7fae2a04e047164936265ba33cf80","f4f7e2b0aae952281ff649b14ba5a6dc","fbfa9e45ee9bd2f827b8dde9e41d3814"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 6,
+      "VALIDITY" : [1,1,1,1,1,1],
+      "DATA" : ["144115188075855872","360287970189639680","216172782113783808","0","72057594037927936","432345564227567616"]
     },{
       "name" : "xt$system_from",
       "count" : 6,

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt$txs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt$txs/chunks/leaf-c00.arrow.json
@@ -65,45 +65,43 @@
             "name" : "struct"
           },
           "children" : [{
-            "name" : "a",
-            "nullable" : false,
-            "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
-            },
-            "children" : [{
-              "name" : "i64",
-              "nullable" : false,
-              "type" : {
-                "name" : "int",
-                "bitWidth" : 64,
-                "isSigned" : true
-              },
-              "children" : [ ]
-            }]
-          },{
             "name" : "xt$id",
             "nullable" : false,
             "type" : {
-              "name" : "union",
-              "mode" : "Dense",
-              "typeIds" : [ ]
+              "name" : "int",
+              "bitWidth" : 64,
+              "isSigned" : true
             },
-            "children" : [{
-              "name" : "uuid",
-              "nullable" : false,
-              "type" : {
-                "name" : "UuidType"
-              },
-              "children" : [ ],
-              "metadata" : [{
-                "value" : "uuid",
-                "key" : "ARROW:extension:name"
-              },{
-                "value" : "",
-                "key" : "ARROW:extension:metadata"
-              }]
+            "children" : [ ]
+          },{
+            "name" : "xt$tx_time",
+            "nullable" : false,
+            "type" : {
+              "name" : "timestamp",
+              "unit" : "MICROSECOND",
+              "timezone" : "UTC"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$committed?",
+            "nullable" : false,
+            "type" : {
+              "name" : "bool"
+            },
+            "children" : [ ]
+          },{
+            "name" : "xt$error",
+            "nullable" : true,
+            "type" : {
+              "name" : "ClojureFormType"
+            },
+            "children" : [ ],
+            "metadata" : [{
+              "value" : "xt/clj-form",
+              "key" : "ARROW:extension:name"
+            },{
+              "value" : "",
+              "key" : "ARROW:extension:metadata"
             }]
           }]
         }]
@@ -143,83 +141,82 @@
     }]
   },
   "batches" : [{
-    "count" : 2,
+    "count" : 3,
     "columns" : [{
       "name" : "xt$iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d","cb8815ee85f74c61a8032ea1c949cf8d"]
+      "count" : 3,
+      "VALIDITY" : [1,1,1],
+      "DATA" : ["1ef6a989c60d8dc721fc8b54fb3bc0fe","4a2474f0c7afe8df22b2da22ac73e818","a4e167a76a05add8a8654c169b07b044"]
     },{
       "name" : "xt$legacy_iid",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : ["0","0"]
+      "count" : 3,
+      "VALIDITY" : [1,1,1],
+      "DATA" : ["432345564227567616","216172782113783808","144115188075855872"]
     },{
       "name" : "xt$system_from",
-      "count" : 2,
-      "VALIDITY" : [1,1],
-      "DATA" : [1577923200000000,1577836800000000]
+      "count" : 3,
+      "VALIDITY" : [1,1,1],
+      "DATA" : [1578009600000000,1577923200000000,1577836800000000]
     },{
       "name" : "op",
-      "count" : 2,
-      "TYPE_ID" : [1,0],
-      "OFFSET" : [0,0],
+      "count" : 3,
+      "TYPE_ID" : [0,0,0],
+      "OFFSET" : [0,1,2],
       "children" : [{
         "name" : "put",
-        "count" : 1,
-        "VALIDITY" : [1],
+        "count" : 3,
+        "VALIDITY" : [1,1,1],
         "children" : [{
           "name" : "xt$valid_from",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [1577836800000000]
+          "count" : 3,
+          "VALIDITY" : [1,1,1],
+          "DATA" : [1578009600000000,1577923200000000,1577836800000000]
         },{
           "name" : "xt$valid_to",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [253402300799999999]
+          "count" : 3,
+          "VALIDITY" : [1,1,1],
+          "DATA" : [253402300799999999,253402300799999999,253402300799999999]
         },{
           "name" : "xt$doc",
-          "count" : 1,
-          "VALIDITY" : [1],
+          "count" : 3,
+          "VALIDITY" : [1,1,1],
           "children" : [{
-            "name" : "a",
-            "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "i64",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["1"]
-            }]
-          },{
             "name" : "xt$id",
-            "count" : 1,
-            "TYPE_ID" : [0],
-            "OFFSET" : [0],
-            "children" : [{
-              "name" : "uuid",
-              "count" : 1,
-              "VALIDITY" : [1],
-              "DATA" : ["cb8815ee85f74c61a8032ea1c949cf8d"]
-            }]
+            "count" : 3,
+            "VALIDITY" : [1,1,1],
+            "DATA" : ["6554","3421","0"]
+          },{
+            "name" : "xt$tx_time",
+            "count" : 3,
+            "VALIDITY" : [1,1,1],
+            "DATA" : [1578009600000000,1577923200000000,1577836800000000]
+          },{
+            "name" : "xt$committed?",
+            "count" : 3,
+            "VALIDITY" : [1,1,1],
+            "DATA" : [1,0,1]
+          },{
+            "name" : "xt$error",
+            "count" : 3,
+            "VALIDITY" : [0,1,0],
+            "OFFSET" : [0,0,284,284],
+            "DATA" : ["","#xt/runtime-err {:xtdb.error/error-type :runtime-error, :xtdb.error/error-key :xtdb.indexer/invalid-valid-times, :xtdb.error/message \"Runtime error: ':xtdb.indexer/invalid-valid-times'\", :valid-from #time/instant \"2020-01-01T00:00:00Z\", :valid-to #time/instant \"2019-01-01T00:00:00Z\"}",""]
           }]
         }]
       },{
         "name" : "delete",
-        "count" : 1,
-        "VALIDITY" : [1],
+        "count" : 0,
+        "VALIDITY" : [ ],
         "children" : [{
           "name" : "xt$valid_from",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [1577923200000000]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         },{
           "name" : "xt$valid_to",
-          "count" : 1,
-          "VALIDITY" : [1],
-          "DATA" : [253402300799999999]
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
         }]
       },{
         "name" : "evict",

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt$txs/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt$txs/chunks/trie-c00.arrow.json
@@ -1,0 +1,87 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [0,1,2]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/chunks/leaf-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/tables/xt_docs/chunks/leaf-c00.arrow.json
@@ -9,6 +9,15 @@
       },
       "children" : [ ]
     },{
+      "name" : "xt$legacy_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "int",
+        "bitWidth" : 64,
+        "isSigned" : true
+      },
+      "children" : [ ]
+    },{
       "name" : "xt$system_from",
       "nullable" : false,
       "type" : {
@@ -145,6 +154,11 @@
       "count" : 4,
       "VALIDITY" : [1,1,1,1],
       "DATA" : ["9e3f856e68998313827ff18dd4d88e78","9e3f856e68998313827ff18dd4d88e78","d9c7fae2a04e047164936265ba33cf80","d9c7fae2a04e047164936265ba33cf80"]
+    },{
+      "name" : "xt$legacy_iid",
+      "count" : 4,
+      "VALIDITY" : [1,1,1,1],
+      "DATA" : ["72057594037927936","72057594037927936","0","0"]
     },{
       "name" : "xt$system_from",
       "count" : 4,

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
@@ -22,7 +22,7 @@ SELECT *
 1998-01-10T00:00Z[UTC]
 9999-12-31T23:59:59.999999Z[UTC]
 2020-01-01T00:00Z[UTC]
-9999-12-31T23:59:59.999999Z[UTC]
+NULL
 
 statement ok
 INSERT INTO Prop_Owner (xt$id, customer_number, property_number, xt$valid_from)
@@ -44,7 +44,7 @@ SELECT *
 1998-01-15T00:00Z[UTC]
 9999-12-31T23:59:59.999999Z[UTC]
 2020-01-02T00:00Z[UTC]
-9999-12-31T23:59:59.999999Z[UTC]
+NULL
 
 query IIITTTT nosort
 SELECT *
@@ -576,7 +576,7 @@ SELECT *
 ----
 827
 2020-01-06T00:00Z[UTC]
-9999-12-31T23:59:59.999999Z[UTC]
+NULL
 
 statement ok
 INSERT INTO Prop_Owner (xt$id, customer_number, property_number, xt$valid_from)


### PR DESCRIPTION
First part of #2574.

TODO:

* [x] Temporal filtering - filter out data that is not temporally valid.
* [x] Scan operator to figure out whether there are completed chunks, and not use the trie scan operator if so.
* [x] Scan operator to reliably figure out whether the query is a point/point query, and not use the trie scan operator if not.
* [x] Remove `tu/without-tries`/`scan/*use-tries?*` et al.
* [x] projecting out `xt/valid-to` and `xt/valid-from` (prefer a next commit)

Implementation notes:
- When we receive a point/point query and there are no finished chunks we now use a cursor that iterates over live-trie data.
- There are 4 code paths:
   - valid-time point / sys-time now
   - valid-time point / sys-time point
   - valid-time point / sys-time now with projection of valid-time columns
   - valid-time point / sys-time point with projection of valid-time columns
- The different code paths are mainly there because you need to do more work going top to bottom.
- These code paths share a lot code, but I didn't want to spend a lot of time on how to best refactor this, as it will change very likely a lot more in the near future.
- Currently eot for sys-time is projected out as `null` and eot for valid-time is still `9999`. When things stabilize we need to address this inconsistency.