### PR TITLE
add ability to merge log tries and live tries in scan, #2575

### DIFF
--- a/core/src/main/java/xtdb/trie/LeafMerge.java
+++ b/core/src/main/java/xtdb/trie/LeafMerge.java
@@ -1,0 +1,61 @@
+package xtdb.trie;
+
+import org.apache.arrow.memory.util.ArrowBufPointer;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class LeafMerge {
+
+    private LeafMerge() {
+    }
+
+    public interface LeafPointer {
+        int getLeafOrdinal();
+
+        ArrowBufPointer getPointer(ArrowBufPointer reuse);
+
+        /**
+         * @return true to continue, false to terminate
+         */
+        boolean pick();
+
+        boolean isValid();
+    }
+
+    private static Comparator<LeafPointer> leafComparator() {
+        var leftBufPtr = new ArrowBufPointer();
+        var rightBufPtr = new ArrowBufPointer();
+
+        return ((Comparator<LeafPointer>) (l, r) -> l.getPointer(leftBufPtr).compareTo(r.getPointer(rightBufPtr)))
+                .thenComparing((l, r) -> Long.compare(r.getLeafOrdinal(), l.getLeafOrdinal()));
+    }
+
+    /**
+     * @param leaves ordered leaves to merge. assume leaves are sorted internally by sys-time desc,
+     *               and that every entry in leaf[n+1] is later than every entry in leaf[n],
+     *               or that the ordering doesn't matter to the result (e.g. independent tries at the same chunk - T1 and T2)
+     */
+    public static void merge(List<LeafPointer> leaves) {
+        var pq = new PriorityQueue<>(leafComparator());
+
+        for (LeafPointer leaf : leaves) {
+            if (leaf.isValid()) {
+                pq.add(leaf);
+            }
+        }
+
+        // keep taking from the PQ until we hit the end of the path
+        while (true) {
+            var leaf = pq.poll();
+            if (leaf == null) return;
+
+            if (!leaf.pick()) return;
+
+            if (leaf.isValid()) {
+                pq.add(leaf);
+            }
+        }
+    }
+}

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -16,8 +16,7 @@
             [xtdb.util :as util]
             [xtdb.vector :as vec]
             [xtdb.vector.reader :as vr]
-            [xtdb.vector.writer :as vw]
-            [xtdb.operator.scan :as scan])
+            [xtdb.vector.writer :as vw])
   (:import [ch.qos.logback.classic Level Logger]
            clojure.lang.ExceptionInfo
            java.net.ServerSocket
@@ -34,7 +33,7 @@
            xtdb.indexer.IIndexer
            xtdb.ingester.Ingester
            (xtdb.operator IRaQuerySource PreparedQuery)
-           (xtdb.vector RelationReader IVectorReader)))
+           (xtdb.vector IVectorReader RelationReader)))
 
 #_{:clj-kondo/ignore [:uninitialized-var]}
 (def ^:dynamic ^org.apache.arrow.memory.BufferAllocator *allocator*)
@@ -51,7 +50,7 @@
                      (.buffer *allocator* 10)
                      (throw (ex-info "boom!" {})))))))
 
-(def ^:dynamic ^:private *node-opts* {})
+(def ^:dynamic *node-opts* {})
 #_{:clj-kondo/ignore [:uninitialized-var]}
 (def ^:dynamic *node*)
 

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -467,12 +467,12 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
     (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
                              [:put :baz {:xt/id "foo1" :a 4}]])
 
-    (t/is (= [{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}]
-             (xt/q tu/*node* "SELECT * FROM foo")))
-    (t/is (= [{:xt$id "bar1"} {:b 2, :xt$id "bar2"}]
-             (xt/q tu/*node* "SELECT * FROM bar")))
-    (t/is (= [{:a 4, :xt$id "foo1"}]
-             (xt/q tu/*node* "SELECT * FROM baz")))))
+    (t/is (= #{{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}}
+             (set (xt/q tu/*node* "SELECT * FROM foo"))))
+    (t/is (= #{{:xt$id "bar1"} {:b 2, :xt$id "bar2"}}
+             (set (xt/q tu/*node* "SELECT * FROM bar"))))
+    (t/is (= #{{:a 4, :xt$id "foo1"}}
+             (set (xt/q tu/*node* "SELECT * FROM baz"))))))
 
 (deftest test-erase-after-delete-2607
   (t/testing "general case"


### PR DESCRIPTION
This PR adds the ability for the scan operator to merge the log tries and the live tries - this means that we can remove the 'no persisted chunks' constraint on the scan feature flag (just 'point/point' remains - see #2649)

* We add a `trie/trie-merge-tasks` function - this takes a collection of tries, and returns the trie partitions that need to be merged. e.g. if we have tries of different depths, we'll first want to merge the page with path prefix 0 of trie 0 with path 00 of trie 1, then the same page (albeit a different row subset) of trie 0 with path 01 of trie 1, etc etc. This is naturally tested using the larger scale tests (e.g. TPC-H) but could use some unit tests.
* We add a `LeafMerge` class, which is responsible for merge-sorting N applicable leaves. The caller creates a `LeafPointer` for each leaf to merge; then, for each match, `LeafMerge` calls `leafPtr.select()` - we assume that the implementation of this method yields the row as necessary

  This means that the `point-point-selection` (now `point-point-row-selector`) code now has its control inverted - it's essentially called with the index to yield rather than it iterating through the indices. As such, the implementation needs to change a little, because we're no longer in control of the iteration, so we need to keep a little more state between calls.
* We now copy the input rows in the `PointPointCursor` (rather than yielding a selection). This is for ease of implementation, for now, because we don't yet have an `IVectorReader` impl that can accept an indirection over multiple input vectors.
* The I/O for loading individual pages of each trie is all located within the `PointPointCursor` - no doubt we'll want to abstract over this, but I didn't feel like I knew enough at this stage about what we'll need later to be able to properly separate the concerns. Once we have range queries, content filtering and 4R tries, we'll be in a much better place to consider different separations.