### PR TITLE
Skip calculating scan-col-types if there are no scan-cols

### DIFF
--- a/core/src/main/clojure/xtdb/operator.clj
+++ b/core/src/main/clojure/xtdb/operator.clj
@@ -110,7 +110,7 @@
                  wm-tx (or tx after-tx)
                  clock (Clock/fixed current-time default-tz)
                  {:keys [col-types ->cursor]} (.computeIfAbsent cache
-                                                                {:scan-col-types (when scan-emitter
+                                                                {:scan-col-types (when (and (seq scan-cols) scan-emitter)
                                                                                    (with-open [wm (.openWatermark wm-src wm-tx)]
                                                                                      (.scanColTypes scan-emitter wm scan-cols)))
                                                                  :param-types (expr/->param-types params)


### PR DESCRIPTION
Cost of computing the cache key for scan-col-types here is significant due to having to take a watermark out. Assumption is that if there are no scan-cols then their types are irrelevant and therefore its valid to skip this check.