### PR TITLE
Add filename caching to Azure object store

### DIFF
--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -1,11 +1,11 @@
-# Azure Module
+= Azure Module
 
 Within our XTDB node, we can make use of Azure Services for certain purposes. Currently, we can:
 
 * Use *Azure Blob Storage* as the XTDB Object Store.
 * Use *Azure Eventhubs* as the Log.
 
-### Project Dependency 
+== Project Dependency 
 
 In order to use any of the Azure services, you will need to include a dependency on the xtdb.azure module.
 
@@ -23,11 +23,11 @@ _pom.xml_
 </dependency>
 ```
 
-### Authentication
+== Authentication
 
 Authentication for the components in the module is done via the https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable[*DefaultAzureCredential*] class - you will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules.
 
-## Azure Blob Storage Object Store
+== Azure Blob Storage Object Store
 
 We can swap out the implementation of the object store with one based on Azure Blob Storage. To do so, we add the `xtdb.azure/blob-object-store` key within the integrant config for our node, alongside any config:
 ```clojure
@@ -39,7 +39,40 @@ We can swap out the implementation of the object store with one based on Azure B
 }
 ```
 
-### Parameters
+=== Azure Resource Manager Stack
+
+In order to handle the various bits of Azure infrastructure required to use Azure Blob Storage as an XTDB object store, we provide a link:azure-resource-manager/azure-stack.json[parameterized 'Azure Resource Manager' stack] to setup everything that you should need.
+
+==== Inputs to the stack
+
+The paramaterized stack expects the following to be provided:
+
+* The location to build the resources -- Defaults to the location of the resource group you're deploying the template in.
+* The name of the storage account to create -- Defaults to `xtdbstorageaccount`
+* The pricing tier/type of storage account to use -- Defaults to `Standard_LRS`
+* The name of the storage container to use as the XTDB object store (and used by associated resources) -- Defaults to `xtdb-object-store`
+* The name of the EventGrid system topic we use for container events -- Defaults to `xtdb-storage-account-system-topic`
+* The name to use for the Service Bus namespace -- Defaults to `xtdb-storage-account-eventbus`
+* The name to use for the Service Bus topic created in the namespace above -- Defaults to `xtdb-storage-bus-topic`
+* The name of the custom XTDB role to create with permissions for the created resources -- Defaults to `xtdb-role`
+
+
+==== Created Resources
+
+The Azure Resource Manager stack will create the following resources within the specified resource group in Azure:
+
+* An https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview[Azure Storage Account]
+* A https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[Storage Account Container] within said storage account to use as the object store.
+* An https://learn.microsoft.com/en-us/azure/event-grid/system-topics[EventGrid System Topic], subscribed to blob creation/deletion events on the container.
+* A `standard` tier https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces[Service Bus Namespace]:
+** A https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions[Service Bus Topic] for the Service Bus namespace.
+* An https://learn.microsoft.com/en-us/azure/event-grid/concepts#event-subscriptions[Event Subscription] on the EventGrid System Topic for the Service Bus Topic.
+* A https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role definition] for all of the necessary permissions for XTDB to use the above:
+** Using the created storage container (Get, Put, Delete and List).
+** Reading messages sent to EventGrid.
+** Creating subscriptions on the Service Bus topic.
+
+=== Parameters
 
 These are the following parameters that can be passed within the config for our `xtdb.azure/blob-object-store`:
 [cols="1,1,2,1"]
@@ -53,6 +86,16 @@ These are the following parameters that can be passed within the config for our 
 | `container`
 | String 
 | The name of the https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[container] to use an an object store
+| Yes
+
+| `Service Bus-namespace`
+| String
+| The name of the https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces[Service Bus namespace] which contains the topic collecting notifications from the container 
+| Yes
+
+| `Service Bus-topic-name`
+| String
+| The name of the https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions[Service Bus topic] which contains is collecting notifications from the container
 | Yes
 
 |`prefix`

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -27,50 +27,24 @@ _pom.xml_
 
 Authentication for the components in the module is done via the https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable[*DefaultAzureCredential*] class - you will need to setup authentication using any of the methods listed within the Azure documentation to be able to make use of the operations inside the modules.
 
+Whatever method used to authenticate, you will need to ensure it has the correct permissions. Alongside the various bits of infrastructure required for the object store, we create a custom XDTB IAM role. One can use this role to provide all necessary permissions for the object store and the resources it is using on Azure, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services.
+See the custom role definition in the link:azure-resource-manager/azure-stack.json[Resource Manager stack] for what exactly that includes.
+
 == Azure Blob Storage Object Store
 
 We can swap out the implementation of the object store with one based on Azure Blob Storage. To do so, we add the `xtdb.azure/blob-object-store` key within the integrant config for our node, alongside any config:
 ```clojure
 {
   ...
-  {:xtdb.azure/blob-object-store {:storage-account "storage-account"
-                                  :container "container"}}
+  {:xtdb.azure/blob-object-store {:storage-account "xtdbstorageaccount"
+                                  :container "xtdb-object-store"
+                                  :servicebus-namespace "xtdb-storage-account-eventbus"
+                                  :servicebus-topic-name "xtdb-storage-bus-topic"}}
   ...
 }
 ```
 
-=== Azure Resource Manager Stack
-
-In order to handle the various bits of Azure infrastructure required to use Azure Blob Storage as an XTDB object store, we provide a link:azure-resource-manager/azure-stack.json[parameterized 'Azure Resource Manager' stack] to setup everything that you should need.
-
-==== Inputs to the stack
-
-The paramaterized stack expects the following to be provided:
-
-* The location to build the resources -- Defaults to the location of the resource group you're deploying the template in.
-* The name of the storage account to create -- Defaults to `xtdbstorageaccount`
-* The pricing tier/type of storage account to use -- Defaults to `Standard_LRS`
-* The name of the storage container to use as the XTDB object store (and used by associated resources) -- Defaults to `xtdb-object-store`
-* The name of the EventGrid system topic we use for container events -- Defaults to `xtdb-storage-account-system-topic`
-* The name to use for the Service Bus namespace -- Defaults to `xtdb-storage-account-eventbus`
-* The name to use for the Service Bus topic created in the namespace above -- Defaults to `xtdb-storage-bus-topic`
-* The name of the custom XTDB role to create with permissions for the created resources -- Defaults to `xtdb-role`
-
-
-==== Created Resources
-
-The Azure Resource Manager stack will create the following resources within the specified resource group in Azure:
-
-* An https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview[Azure Storage Account]
-* A https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[Storage Account Container] within said storage account to use as the object store.
-* An https://learn.microsoft.com/en-us/azure/event-grid/system-topics[EventGrid System Topic], subscribed to blob creation/deletion events on the container.
-* A `standard` tier https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces[Service Bus Namespace]:
-** A https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions[Service Bus Topic] for the Service Bus namespace.
-* An https://learn.microsoft.com/en-us/azure/event-grid/concepts#event-subscriptions[Event Subscription] on the EventGrid System Topic for the Service Bus Topic.
-* A https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role definition] for all of the necessary permissions for XTDB to use the above:
-** Using the created storage container (Get, Put, Delete and List).
-** Reading messages sent to EventGrid.
-** Creating subscriptions on the Service Bus topic.
+Alongside the storage account container, we require an eventgrid topic and service bus topic to pass around file changes to the container, such that we can keep a local copy of files on S3, saving on expensive/lengthy operations to list objects on S3. Below follows the various parameters used by the module, and some notes around the provided <<resource-manager, Azure Resource Manager template>> which sets up all of the necessary extra infrastructure. Even if this isn't used, we will require a similar setup to track file changes on whichever storage account/container you are using, and relevant permissions to use all of the services. 
 
 === Parameters
 
@@ -88,12 +62,12 @@ These are the following parameters that can be passed within the config for our 
 | The name of the https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[container] to use an an object store
 | Yes
 
-| `Service Bus-namespace`
+| `servicebus-namespace`
 | String
 | The name of the https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces[Service Bus namespace] which contains the topic collecting notifications from the container 
 | Yes
 
-| `Service Bus-topic-name`
+| `servicebus-topic-name`
 | String
 | The name of the https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions[Service Bus topic] which contains is collecting notifications from the container
 | Yes
@@ -102,9 +76,42 @@ These are the following parameters that can be passed within the config for our 
 | String 
 | A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
 | No
-|=== 
+|===
 
-## Azure EventHub Log
+[#resource-manager]
+=== Azure Resource Manager Stack
+
+In order to handle the various bits of Azure infrastructure required to use Azure Blob Storage as an XTDB object store, we provide a link:azure-resource-manager/azure-stack.json[parameterized 'Azure Resource Manager' stack] to setup everything that you should need.
+
+==== Inputs to the stack
+
+The paramaterized stack expects the following to be provided:
+
+* The location to build the resources -- Defaults to the location of the resource group you're deploying the template in.
+* The name of the storage account to create -- Defaults to `xtdbstorageaccount`
+* The pricing tier/type of storage account to use -- Defaults to `Standard_LRS`
+* The name of the storage container to use as the XTDB object store (and used by associated resources) -- Defaults to `xtdb-object-store`
+* The name of the EventGrid system topic we use for container events -- Defaults to `xtdb-storage-account-system-topic`
+* The name to use for the Service Bus namespace -- Defaults to `xtdb-storage-account-eventbus`
+* The name to use for the Service Bus topic created in the namespace above -- Defaults to `xtdb-storage-bus-topic`
+* The name of the custom XTDB role to create with permissions for the created resources -- Defaults to `xtdb-role`
+
+==== Created Resources
+
+The Azure Resource Manager stack will create the following resources within the specified resource group in Azure:
+
+* An https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview[Azure Storage Account]
+* A https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers[Storage Account Container] within said storage account to use as the object store.
+* An https://learn.microsoft.com/en-us/azure/event-grid/system-topics[EventGrid System Topic], subscribed to blob creation/deletion events on the container.
+* A `standard` tier https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview#namespaces[Service Bus Namespace]:
+** A https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions[Service Bus Topic] for the Service Bus namespace.
+* An https://learn.microsoft.com/en-us/azure/event-grid/concepts#event-subscriptions[Event Subscription] on the EventGrid System Topic for the Service Bus Topic.
+* A https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role definition] for all of the necessary permissions for XTDB to use the above:
+** Using the created storage container (Get, Put, Delete and List).
+** Reading messages sent to EventGrid.
+** Creating subscriptions on the Service Bus topic.
+
+== Azure EventHub Log
 
 We can swap out the implementation of the log with one based on Azure Eventhubs. To do so, we add the `xtdb.azure/event-hub-log` key within the integrant config for our node, alongside any config:
 ```clojure
@@ -119,7 +126,7 @@ We can swap out the implementation of the log with one based on Azure Eventhubs.
 }
 ```
 
-### Parameters
+=== Parameters
 
 These are the following parameters that can be passed within the config for our `xtdb.azure/event-hub-log`:
 [cols="1,1,2,1"]
@@ -162,7 +169,7 @@ These are the following parameters that can be passed within the config for our 
 
 |=== 
 
-### Using Event Hubs 
+=== Using Event Hubs 
 
 Some things to note when setting up Event Hubs for XTDB:
 
@@ -176,7 +183,7 @@ When creating an eventhub manually to use as an XTDB log, there are a few proper
 * Partition count should be set to *1* - XTDB will only ever use a single partition within it's implementations of Log as they are required to be *totally ordered*.
 * The retention period is configurable - you will likely wish to set this to as high as you reasonably can given the pricing tier of your Event Hubs namespace. 
 
-#### Creating the Event Hub Automatically
+==== Creating the Event Hub Automatically
 
 If `create-event-hub?` is set to `true`, XTDB will attempt to create an Event Hub on your behalf - some notes on this:
 

--- a/modules/azure/azure-resource-manager/azure-stack.json
+++ b/modules/azure/azure-resource-manager/azure-stack.json
@@ -50,6 +50,13 @@
         "description": "Provide a name for the service bus namespace."
       }
     },
+    "serviceBusTopicName": {
+      "type": "string",
+      "defaultValue": "xtdb-storage-bus-topic",
+      "metadata": {
+        "description": "Provide a name for the service bus topic."
+      }
+    },
     "customRoleName": {
       "type": "string",
       "defaultValue": "xtdb-role",
@@ -88,6 +95,7 @@
         "publicAccess": "None"
       }
     },
+
     {
       "type": "Microsoft.EventGrid/systemTopics",
       "apiVersion": "2021-12-01",
@@ -101,52 +109,88 @@
         "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
       ]
     },
+
     {
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
       "apiVersion": "2021-01-01-preview",
       "location": "[parameters('location')]",
       "sku": {
-        "name": "Basic"
-      }
-    },
-    {
-    "name": "[variables('roleDefinitionId')]",
-    "type": "Microsoft.Authorization/roleDefinitions",
-    "apiVersion": "2022-04-01",
-    "properties": {
-      "roleName": "[parameters('customRoleName')]",
-      "description": "All the resources and access XTDB needs.",
-      "type": "customRole",
-      "assignableScopes": [ "[subscription().id]",  "[concat(subscription().id, '/resourceGroups/', resourceGroup().name)]" ],
-      "permissions": [
+        "name": "Standard"
+      },
+      "properties": {
+        "publicNetworkAccess": "false"
+      },
+      "resources": [
         {
-          "actions": [
-            "Microsoft.ServiceBus/*",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/write",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/read",
-            "Microsoft.EventGrid/systemTopics/read",
-            "Microsoft.EventGrid/systemTopics/eventSubscriptions/read",
-            "Microsoft.EventGrid/systemTopics/eventSubscriptions/write",
-            "Microsoft.EventGrid/systemTopics/eventSubscriptions/delete",
-            "Microsoft.EventGrid/systemTopics/eventSubscriptions/getFullUrl/action",
-            "Microsoft.EventGrid/systemTopics/eventSubscriptions/getDeliveryAttributes/action"
+          "apiVersion": "2021-01-01-preview",
+          "name": "[parameters('serviceBusTopicName')]",
+          "type": "Topics",
+          "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
           ],
-          "notActions": [],
-          "dataActions": [
-            "Microsoft.ServiceBus/*",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
-            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action"
-          ],
-          "notDataActions": []
+          "properties": {
+            "path": "[parameters('serviceBusTopicName')]"
+          }
         }
       ]
+    },
+
+    {
+      "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[concat(parameters('systemTopicName'), '/', parameters('serviceBusTopicName'), '-subscription')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.EventGrid/systemTopics', parameters('systemTopicName'))]",
+        "[resourceId('Microsoft.ServiceBus/namespaces/topics', parameters('serviceBusNamespaceName'), parameters('serviceBusTopicName'))]"
+      ],
+      "properties": {
+        "destination": {
+          "endpointType": "ServiceBusTopic",
+          "properties": {
+            "resourceId": "[resourceId('Microsoft.ServiceBus/namespaces/topics', parameters('serviceBusNamespaceName'), parameters('serviceBusTopicName'))]"
+          }
+        }
+      }
+    },
+
+    {
+      "name": "[variables('roleDefinitionId')]",
+      "type": "Microsoft.Authorization/roleDefinitions",
+      "apiVersion": "2022-04-01",
+      "properties": {
+        "roleName": "[parameters('customRoleName')]",
+        "description": "All the resources and access XTDB needs.",
+        "type": "customRole",
+        "assignableScopes": [ "[subscription().id]",  "[concat(subscription().id, '/resourceGroups/', resourceGroup().name)]" ],
+        "permissions": [
+          {
+            "actions": [
+              "Microsoft.ServiceBus/*",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+              "Microsoft.EventGrid/systemTopics/read",
+              "Microsoft.EventGrid/systemTopics/eventSubscriptions/read",
+              "Microsoft.EventGrid/systemTopics/eventSubscriptions/write",
+              "Microsoft.EventGrid/systemTopics/eventSubscriptions/delete",
+              "Microsoft.EventGrid/systemTopics/eventSubscriptions/getFullUrl/action",
+              "Microsoft.EventGrid/systemTopics/eventSubscriptions/getDeliveryAttributes/action"
+            ],
+            "notActions": [],
+            "dataActions": [
+              "Microsoft.ServiceBus/*",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
+              "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action"
+            ],
+            "notDataActions": []
+          }
+        ]
+      }
     }
-  }
   ],
   "outputs": {}
 }

--- a/modules/azure/azure-resource-manager/azure-stack.json
+++ b/modules/azure/azure-resource-manager/azure-stack.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Provide a location for the Blob Storage account that supports Event Grid."
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "xtdbstorageaccount",
+      "metadata": {
+        "description": "Name of the Storage Account that the XTDB Object Store will live under"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "storageContainerName": {
+      "type": "string",
+      "defaultValue": "xtdb-object-store",
+      "metadata": {
+        "description": "Name of the Storage Container that will be used as the XTDB Object Store"
+      }
+    },
+    "systemTopicName": {
+      "type": "string",
+      "defaultValue": "xtdb-storage-account-system-topic",
+      "metadata": {
+        "description": "Provide a name for the system topic."
+      }
+    },
+    "serviceBusNamespaceName": {
+      "type": "string",
+      "defaultValue": "xtdb-storage-account-eventbus",
+      "metadata": {
+        "description": "Provide a name for the service bus namespace."
+      }
+    },
+    "customRoleName": {
+      "type": "string",
+      "defaultValue": "xtdb-role",
+      "metadata": {
+        "description": "Role name for the new XTDB Custom Role Definition"
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "roleDefinitionId": "[guid(subscription().id, string(parameters('customRoleName')))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('storageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2021-04-01",
+      "tags": {
+        "displayName": "[parameters('storageAccountName')]"
+      },
+      "location": "[parameters('location')]",
+      "kind": "StorageV2",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "name": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('storageContainerName'))]",
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2021-04-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ],
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicAccess": "None"
+      }
+    },
+    {
+      "type": "Microsoft.EventGrid/systemTopics",
+      "apiVersion": "2021-12-01",
+      "name": "[parameters('systemTopicName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "source": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+        "topicType": "Microsoft.Storage.StorageAccounts"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    },
+    {
+      "name": "[parameters('serviceBusNamespaceName')]",
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2021-01-01-preview",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Basic"
+      }
+    },
+    {
+    "name": "[variables('roleDefinitionId')]",
+    "type": "Microsoft.Authorization/roleDefinitions",
+    "apiVersion": "2022-04-01",
+    "properties": {
+      "roleName": "[parameters('customRoleName')]",
+      "description": "All the resources and access XTDB needs.",
+      "type": "customRole",
+      "assignableScopes": [ "[subscription().id]",  "[concat(subscription().id, '/resourceGroups/', resourceGroup().name)]" ],
+      "permissions": [
+        {
+          "actions": [
+            "Microsoft.ServiceBus/*",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+            "Microsoft.EventGrid/systemTopics/read",
+            "Microsoft.EventGrid/systemTopics/eventSubscriptions/read",
+            "Microsoft.EventGrid/systemTopics/eventSubscriptions/write",
+            "Microsoft.EventGrid/systemTopics/eventSubscriptions/delete",
+            "Microsoft.EventGrid/systemTopics/eventSubscriptions/getFullUrl/action",
+            "Microsoft.EventGrid/systemTopics/eventSubscriptions/getDeliveryAttributes/action"
+          ],
+          "notActions": [],
+          "dataActions": [
+            "Microsoft.ServiceBus/*",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
+            "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action"
+          ],
+          "notDataActions": []
+        }
+      ]
+    }
+  }
+  ],
+  "outputs": {}
+}
+

--- a/modules/azure/bin/clear_servicebus_queues.sh
+++ b/modules/azure/bin/clear_servicebus_queues.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+results=$(az servicebus queue list -g "azure-modules-test" --namespace-name "xtdb-test-storage-account-eventbus" --query "[].{Name:name}" --output json)
+
+for row in $(echo "$results" | jq -r '.[]|"\(.Name)"')
+do
+  az servicebus queue delete -g "azure-modules-test" --namespace-name "xtdb-test-storage-account-eventbus" --name "$row"
+done

--- a/modules/azure/bin/clear_subscriptions.sh
+++ b/modules/azure/bin/clear_subscriptions.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+results=$(az eventgrid system-topic event-subscription list -g "azure-modules-test" --system-topic-name "xtdb-test-storage-account-system-topic" --query "[].{Name:name}" --output json)
+
+for row in $(echo "$results" | jq -r '.[]|"\(.Name)"')
+do
+  az eventgrid system-topic event-subscription delete -g "azure-modules-test" --system-topic-name "xtdb-test-storage-account-system-topic" --name "$row" -y &
+done

--- a/modules/azure/bin/clear_test_container.sh
+++ b/modules/azure/bin/clear_test_container.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+az storage blob delete-batch --account-name xtdbteststorageaccount --source xtdb-test-object-store

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -20,8 +20,13 @@ dependencies {
 
     api("com.azure", "azure-storage-blob", "12.22.0")
     api("com.azure", "azure-messaging-eventhubs", "5.15.0")
-    api("com.azure", "azure-messaging-servicebus", "7.14.2")
+    api("com.azure", "azure-messaging-servicebus", "7.14.2")  {
+        exclude("com.azure", "azure-core-http-netty")
+    }
     api("com.azure", "azure-identity", "1.9.0")
     api("com.azure", "azure-core-management", "1.11.1")
     api("com.azure.resourcemanager", "azure-resourcemanager-eventhubs", "2.26.0")
+
+    // doesnt pull in a problematic version of netty
+    api("com.azure", "azure-core-http-netty", "1.13.2")
 }

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -24,6 +24,4 @@ dependencies {
     api("com.azure", "azure-identity", "1.9.0")
     api("com.azure", "azure-core-management", "1.11.1")
     api("com.azure.resourcemanager", "azure-resourcemanager-eventhubs", "2.26.0")
-    api("com.azure.resourcemanager", "azure-resourcemanager-servicebus", "2.26.0")
-    api("com.azure.resourcemanager", "azure-resourcemanager-eventgrid", "1.1.0")
 }

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -20,7 +20,10 @@ dependencies {
 
     api("com.azure", "azure-storage-blob", "12.22.0")
     api("com.azure", "azure-messaging-eventhubs", "5.15.0")
+    api("com.azure", "azure-messaging-servicebus", "7.14.2")
     api("com.azure", "azure-identity", "1.9.0")
     api("com.azure", "azure-core-management", "1.11.1")
     api("com.azure.resourcemanager", "azure-resourcemanager-eventhubs", "2.26.0")
+    api("com.azure.resourcemanager", "azure-resourcemanager-servicebus", "2.26.0")
+    api("com.azure.resourcemanager", "azure-resourcemanager-eventgrid", "1.1.0")
 }

--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -49,14 +49,14 @@
         blob-client (.getBlobContainerClient blob-service-client container)
         file-name-cache (ConcurrentSkipListSet.)
         ;; Watch azure container for changes
-        azure-watch-info (azure-file-watch/file-list-watch (assoc opts
-                                                                  :blob-container-client blob-client
-                                                                  :azure-credential credential)
-                                                           file-name-cache)]
+        file-list-watcher (azure-file-watch/open-file-list-watcher (assoc opts
+                                                                          :blob-container-client blob-client
+                                                                          :azure-credential credential)
+                                                                   file-name-cache)]
     (os/->AzureBlobObjectStore blob-client
                                prefix
                                file-name-cache
-                               azure-watch-info)))
+                               file-list-watcher)))
 
 (comment
 

--- a/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
@@ -7,8 +7,9 @@
            [com.azure.messaging.servicebus.administration ServiceBusAdministrationClient ServiceBusAdministrationClientBuilder]
            [com.azure.storage.blob.models ListBlobsOptions BlobItem]
            [com.azure.storage.blob BlobContainerClient]
+           [java.lang AutoCloseable]
            [java.util NavigableSet UUID]
-           java.util.function.Consumer))
+           [java.util.function Consumer]))
 
 (defn file-list-init [{:keys [^BlobContainerClient blob-container-client prefix]}  ^NavigableSet file-name-cache]
   (let [list-blob-opts (cond-> (ListBlobsOptions.)
@@ -39,50 +40,50 @@
      :servicebus-topic-name servicebus-topic-name
      :subscription-name subscription-name}))
 
-(defn file-list-watch [{:keys [^BlobContainerClient blob-container-client ^TokenCredential azure-credential servicebus-namespace container prefix] :as opts} ^NavigableSet file-name-cache]
+(defn open-file-list-watcher [{:keys [^BlobContainerClient blob-container-client ^TokenCredential azure-credential servicebus-namespace container prefix] :as opts} ^NavigableSet file-name-cache]
   (let [;; Create queue that will subscribe to sns topic for notifications
-        {:keys [servicebus-topic-name subscription-name] :as closable-opts} (setup-topic-subscription opts)
+        {:keys [^ServiceBusAdministrationClient servicebus-admin-client servicebus-topic-name subscription-name]} (setup-topic-subscription opts)
 
         _ (log/info "Initializing filename list from container " container)
          ;; Init the filename cache with current files
         _ (file-list-init opts file-name-cache)
-        
+
         url-suffix (if prefix (str "/" prefix) "/")
         base-file-url (str (.getBlobContainerUrl blob-container-client) url-suffix)
-        processor-client (-> (ServiceBusClientBuilder.)
-                             (.fullyQualifiedNamespace (format "%s.servicebus.windows.net" servicebus-namespace))
-                             (.credential azure-credential)
-                             (.processor)
-                             (.topicName servicebus-topic-name)
-                             (.subscriptionName subscription-name)
-                             (.processMessage (reify Consumer
-                                                (accept [_ msg]
-                                                  (let [parsed-msg (json/read-str (.. ^ServiceBusReceivedMessageContext msg getMessage getBody toString) :key-fn keyword)
-                                                        msg-data (:data parsed-msg)
-                                                        event-type (get {"PutBlob" :create "DeleteBlob" :delete} (:api msg-data))
-                                                        file-url (:url msg-data)
-                                                        file (when (string/starts-with? file-url base-file-url)
-                                                              (subs file-url (count base-file-url)))]
-                                                    (log/info (format "Message received, performing %s on file %s" event-type file))
-                                                    (when (and event-type file)
-                                                      (cond
-                                                        (= event-type :create) (.add file-name-cache file)
-                                                        (= event-type :delete) (.remove file-name-cache file)))))))
-                             (.processError (reify Consumer
-                                              (accept [_ msg]
-                                                      (log/error "Error when processing message from service bus queue - " (.getException ^ServiceBusErrorContext msg)))))
-                             (.buildProcessorClient))]
+        ^ServiceBusProcessorClient processor-client (-> (ServiceBusClientBuilder.)
+                                                        (.fullyQualifiedNamespace (format "%s.servicebus.windows.net" servicebus-namespace))
+                                                        (.credential azure-credential)
+                                                        (.processor)
+                                                        (.topicName servicebus-topic-name)
+                                                        (.subscriptionName subscription-name)
+                                                        (.processMessage (reify Consumer
+                                                                           (accept [_ msg]
+                                                                             (let [parsed-msg (json/read-str (.. ^ServiceBusReceivedMessageContext msg getMessage getBody toString) :key-fn keyword)
+                                                                                   msg-data (:data parsed-msg)
+                                                                                   event-type (get {"PutBlob" :create "DeleteBlob" :delete} (:api msg-data))
+                                                                                   file-url (:url msg-data)
+                                                                                   file (when (string/starts-with? file-url base-file-url)
+                                                                                          (subs file-url (count base-file-url)))]
+                                                                               (log/info (format "Message received, performing %s on file %s" event-type file))
+                                                                               (when (and event-type file)
+                                                                                 (cond
+                                                                                   (= event-type :create) (.add file-name-cache file)
+                                                                                   (= event-type :delete) (.remove file-name-cache file)))))))
+                                                        (.processError (reify Consumer
+                                                                         (accept [_ msg]
+                                                                           (log/error "Error when processing message from service bus queue - " (.getException ^ServiceBusErrorContext msg)))))
+                                                        (.buildProcessorClient))]
 
       ;; Start processing messages from the queue
     (log/info "Watching for filechanges from container " container)
     (.start processor-client)
 
-      ;; Return all closeable opts from the function
-    (assoc closable-opts :processor-client processor-client)))
+    ;; Return an auto closeable object that clears up the processor and subscription
+    (reify 
+      AutoCloseable
+      (close [_]
+        (log/info "Stopping & closing filechange processor client")
+        (.close processor-client)
 
-(defn watcher-close-fn [{:keys [^ServiceBusAdministrationClient servicebus-admin-client ^ServiceBusProcessorClient processor-client servicebus-topic-name subscription-name]}]
-  (log/info "Stopping & closing filechange processor client")
-  (.close processor-client)
-  
-  (log/info (format "Removing subscription %s on topic %s " servicebus-topic-name subscription-name))
-  (.deleteSubscription servicebus-admin-client servicebus-topic-name subscription-name))
+        (log/info (format "Removing subscription %s on topic %s " servicebus-topic-name subscription-name))
+        (.deleteSubscription servicebus-admin-client servicebus-topic-name subscription-name)))))

--- a/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
@@ -1,0 +1,144 @@
+(ns xtdb.azure.file-watch
+  (:require [clojure.data.json :as json]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log])
+  (:import [com.azure.core.credential TokenCredential]
+           [com.azure.core.management AzureEnvironment]
+           [com.azure.core.management.profile AzureProfile]
+           [com.azure.messaging.servicebus ServiceBusClientBuilder]
+           [com.azure.messaging.servicebus.administration ServiceBusAdministrationClientBuilder]
+           [com.azure.messaging.servicebus.administration.models CreateQueueOptions]
+           [com.azure.resourcemanager.eventgrid EventGridManager]
+           [com.azure.resourcemanager.eventgrid.models ServiceBusQueueEventSubscriptionDestination EventSubscriptionProvisioningState]
+           [com.azure.resourcemanager.eventgrid.fluent.models EventSubscriptionInner]
+           [com.azure.resourcemanager.servicebus ServiceBusManager]
+           [com.azure.resourcemanager.servicebus.models EntityStatus]
+           [com.azure.storage.blob.models ListBlobsOptions BlobItem]
+           [com.azure.storage.blob BlobContainerClient]
+           [java.util NavigableSet UUID]
+           java.util.function.Consumer
+           java.time.Duration))
+
+(defn file-list-init [{:keys [^BlobContainerClient blob-container-client prefix]}  ^NavigableSet file-name-cache]
+  (let [list-blob-opts (cond-> (ListBlobsOptions.)
+                         prefix (.setPrefix prefix))
+        filename-list (->> (.listBlobs blob-container-client list-blob-opts nil)
+                           (.iterator)
+                           (iterator-seq)
+                           (mapv (fn [^BlobItem blob-item]
+                                   (subs (.getName blob-item) (count prefix)))))]
+    (.addAll file-name-cache filename-list)))
+
+(defn mk-short-uuid []
+  (subs (str (UUID/randomUUID)) 0 8))
+
+(defn successuflly-created? [subscription-info]
+  (= (.provisioningState subscription-info) EventSubscriptionProvisioningState/SUCCEEDED))
+
+(defn failed-creation? [subscription-info]
+  (= (.provisioningState subscription-info) EventSubscriptionProvisioningState/FAILED))
+
+(defn setup-notif-queue [{:keys [^TokenCredential azure-credential resource-group-name servicebus-namespace eventgrid-topic]}]
+  (let [servicebus-manager (ServiceBusManager/authenticate azure-credential (AzureProfile. (AzureEnvironment/AZURE)))
+        servicebus-admin-client (-> (ServiceBusAdministrationClientBuilder.)
+                                    (.credential (format "%s.servicebus.windows.net" servicebus-namespace)
+                                                 azure-credential)
+                                    (.buildClient))
+        eventgrid-manager (EventGridManager/authenticate azure-credential (AzureProfile. (AzureEnvironment/AZURE)))
+        queue-name (format "xtdb-object-store-container-notifs-%s" (mk-short-uuid))
+
+        _ (log/info "Creating Service Bus Queue " queue-name)
+        _ (-> servicebus-admin-client
+              (.createQueue queue-name (-> (CreateQueueOptions.)
+                                           (.setAutoDeleteOnIdle nil)
+                                           (.setDefaultMessageTimeToLive (Duration/ofHours 1)))))
+
+        _ (log/info "Fetching resource info for Service Bus Queue " queue-name)
+        queue-info (-> servicebus-manager
+                       (.serviceClient)
+                       (.getQueues)
+                       (.get resource-group-name servicebus-namespace queue-name))
+
+        _ (log/info (format "Creating subscription on %s for queue %s" eventgrid-topic queue-name))
+        subscription-info (-> eventgrid-manager
+                              (.systemTopicEventSubscriptions)
+                              (.createOrUpdate resource-group-name
+                                               eventgrid-topic
+                                               (format "%s-subscription" queue-name)
+                                               (-> (EventSubscriptionInner.)
+                                                   (.withDestination
+                                                    (-> (ServiceBusQueueEventSubscriptionDestination.)
+                                                        (.withResourceId (.id queue-info)))))))]
+
+    
+
+    ;; await successful creation of subscription
+    (while (not (successuflly-created? subscription-info))
+      (when (failed-creation? subscription-info)
+        (throw (Exception. (format "Service bus queue %s failed to be created, closing node." queue-name))))
+      (Thread/sleep 10))
+
+    {:servicebus-admin-client servicebus-admin-client
+     :eventgrid-manager eventgrid-manager
+     :subscription-name (.name subscription-info)
+     :queue-name queue-name
+     :resource-group-name resource-group-name
+     :eventgrid-topic eventgrid-topic}))
+
+(defn file-list-watch [{:keys [^BlobContainerClient blob-container-client ^TokenCredential azure-credential servicebus-namespace container prefix] :as opts} ^NavigableSet file-name-cache]
+  (let [;; Create queue that will subscribe to sns topic for notifications
+        {:keys [queue-name subscription-name] :as closable-opts} (setup-notif-queue opts)
+
+        _ (log/info "Initializing filename list from container " container)
+         ;; Init the filename cache with current files
+        _ (file-list-init opts file-name-cache)
+        
+        url-suffix (if prefix (str "/" prefix) "/")
+        base-file-url (str (.getBlobContainerUrl blob-container-client) url-suffix)
+        processor-client (-> (ServiceBusClientBuilder.)
+                             (.fullyQualifiedNamespace (format "%s.servicebus.windows.net" servicebus-namespace))
+                             (.credential azure-credential)
+                             (.processor)
+                             (.queueName queue-name)
+                             (.subscriptionName subscription-name)
+                             (.disableAutoComplete)
+                             (.processMessage (reify Consumer
+                                                (accept [_ msg]
+                                                  (let [parsed-msg (json/read-str (.. msg getMessage getBody toString) :key-fn keyword)
+                                                        msg-data (:data parsed-msg)
+                                                        event-type (get {"PutBlob" :create "DeleteBlob" :delete} (:api msg-data))
+                                                        file-url (:url msg-data)
+                                                        file (when (string/starts-with? file-url base-file-url)
+                                                              (subs file-url (count base-file-url)))]
+                                                    (log/info (format "Message received, performing %s on file %s" event-type file))
+                                                    (when (and event-type file)
+                                                      (cond
+                                                        (= event-type :create) (.add file-name-cache file)
+                                                        (= event-type :delete) (.remove file-name-cache file)))
+                                                    
+                                                    (.complete msg)))))
+                             (.processError (reify Consumer
+                                              (accept [_ msg]
+                                                      (log/error "Error when processing message from service bus queue - " (.getException msg)))))
+                             (.buildProcessorClient))]
+
+      ;; Start processing messages from the queue
+    (log/info "Watching for filechanges from container " container)
+    (.start processor-client)
+
+      ;; Return all closeable opts from the function
+    (assoc closable-opts :processor-client processor-client)))
+
+(defn watcher-close-fn [{:keys [resource-group-name eventgrid-topic servicebus-admin-client eventgrid-manager processor-client subscription-name queue-name]}]
+  (log/info "Stopping & closing filechange processor client")
+  (.close processor-client)
+  
+  (log/info "Removing queue subscription, subscription-id: " subscription-name)
+  (-> eventgrid-manager
+      (.systemTopicEventSubscriptions)
+      (.delete resource-group-name
+               eventgrid-topic
+               subscription-name))
+  
+  (log/info "Removing Service Bus Queue, queue-name: " queue-name)
+  (.deleteQueue servicebus-admin-client queue-name))

--- a/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
@@ -132,7 +132,10 @@
 (defn watcher-close-fn [{:keys [resource-group-name eventgrid-topic servicebus-admin-client eventgrid-manager processor-client subscription-name queue-name]}]
   (log/info "Stopping & closing filechange processor client")
   (.close processor-client)
-  
+
+  (log/info "Awaiting AMQP connection close")
+  (Thread/sleep 60000)
+
   (log/info "Removing queue subscription, subscription-id: " subscription-name)
   (-> eventgrid-manager
       (.systemTopicEventSubscriptions)

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -35,7 +35,11 @@
         (<= 200 status-code 299) nil
         (= 404 status-code) (throw (os/obj-missing-exception blob-name))
         :else (throw (ex-info "Blob range request failure" {:status status-code})))
-      (ByteBuffer/wrap (.toByteArray out)))))
+      (ByteBuffer/wrap (.toByteArray out)))
+    (catch BlobStorageException e
+      (if (= 404 (.getStatusCode e))
+        (throw (os/obj-missing-exception blob-name))
+        (throw e)))))
 
 (defn- put-blob [^BlobContainerClient blob-container-client blob-name blob-buffer]
   (try

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -8,12 +8,15 @@
             [xtdb.node :as node]
             [clojure.tools.logging :as log])
   (:import java.util.UUID
-           (java.io Closeable)))
+           java.io.Closeable
+           xtdb.object_store.ObjectStore))
 
 (def resource-group-name "azure-modules-test")
-(def storage-account "xtdbazureobjectstoretest")
-(def container "xtdb-test")
+(def storage-account "xtdbteststorageaccount")
+(def container "xtdb-test-object-store")
 (def eventhub-namespace "xtdbeventhublogtest")
+(def servicebus-namespace "xtdb-test-storage-account-eventbus")
+(def eventgrid-topic "xtdb-test-storage-account-system-topic")
 (def config-present? (some? (and (System/getenv "AZURE_CLIENT_ID")
                                  (System/getenv "AZURE_CLIENT_SECRET")
                                  (System/getenv "AZURE_TENANT_ID")
@@ -42,20 +45,50 @@
 (defn object-store ^Closeable [prefix]
   (->> (ig/prep-key ::azure/blob-object-store {:storage-account storage-account
                                                :container container
+                                               :resource-group-name resource-group-name
+                                               :servicebus-namespace servicebus-namespace
+                                               :eventgrid-topic eventgrid-topic
                                                :prefix (str "xtdb.azure-test." prefix)})
        (ig/init-key ::azure/blob-object-store)))
 
 (t/deftest ^:azure put-delete-test
-  (let [os (object-store (random-uuid))]
+  (with-open [os (object-store (random-uuid))]
     (os-test/test-put-delete os)))
 
 (t/deftest ^:azure range-test
-  (let [os (object-store (random-uuid))]
+  (with-open [os (object-store (random-uuid))]
     (os-test/test-range os)))
 
+(def wait-time-ms 5000)
+
 (t/deftest ^:azure list-test
-  (let [os (object-store (random-uuid))]
-    (os-test/test-list-objects os)))
+  (with-open [os (object-store (random-uuid))]
+    (os-test/test-list-objects os wait-time-ms)))
+
+(t/deftest ^:s3 list-test-with-prior-objects
+  (let [prefix (random-uuid)]
+    (with-open [os (object-store prefix)]
+      (os-test/put-edn os "alice" :alice)
+      (os-test/put-edn os "alan" :alan)
+      (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
+
+    (with-open [os (object-store prefix)]
+      (t/testing "prior objects will still be there, should be available on a list request"
+        (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
+      (t/testing "should be able to delete prior objects and have that reflected in list objects output"
+        @(.deleteObject ^ObjectStore os "alice")
+        (Thread/sleep wait-time-ms)
+        (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
+
+(t/deftest ^:s3 multiple-object-store-list-test
+  (let [prefix (random-uuid)]
+    (with-open [os-1 (object-store prefix)
+                os-2 (object-store prefix)]
+      (os-test/put-edn os-1 "alice" :alice)
+      (os-test/put-edn os-2 "alan" :alan)
+      (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-2))))))
 
 (t/deftest ^:azure test-eventhub-log
   (with-open [node (node/start-node {::azure/event-hub-log {:namespace eventhub-namespace

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -64,7 +64,7 @@
   (with-open [os (object-store (random-uuid))]
     (os-test/test-list-objects os wait-time-ms)))
 
-(t/deftest ^:s3 list-test-with-prior-objects
+(t/deftest ^:azure list-test-with-prior-objects
   (let [prefix (random-uuid)]
     (with-open [os (object-store prefix)]
       (os-test/put-edn os "alice" :alice)
@@ -80,7 +80,7 @@
         (Thread/sleep wait-time-ms)
         (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
 
-(t/deftest ^:s3 multiple-object-store-list-test
+(t/deftest ^:azure multiple-object-store-list-test
   (let [prefix (random-uuid)]
     (with-open [os-1 (object-store prefix)
                 os-2 (object-store prefix)]

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -14,9 +14,9 @@
 (def resource-group-name "azure-modules-test")
 (def storage-account "xtdbteststorageaccount")
 (def container "xtdb-test-object-store")
-(def eventhub-namespace "xtdbeventhublogtest")
+(def eventhub-namespace "xtdb-test-storage-account-eventbus")
 (def servicebus-namespace "xtdb-test-storage-account-eventbus")
-(def eventgrid-topic "xtdb-test-storage-account-system-topic")
+(def servicebus-topic-name "xtdb-test-storage-bus-topic")
 (def config-present? (some? (and (System/getenv "AZURE_CLIENT_ID")
                                  (System/getenv "AZURE_CLIENT_SECRET")
                                  (System/getenv "AZURE_TENANT_ID")
@@ -45,9 +45,8 @@
 (defn object-store ^Closeable [prefix]
   (->> (ig/prep-key ::azure/blob-object-store {:storage-account storage-account
                                                :container container
-                                               :resource-group-name resource-group-name
                                                :servicebus-namespace servicebus-namespace
-                                               :eventgrid-topic eventgrid-topic
+                                               :servicebus-topic-name servicebus-topic-name
                                                :prefix (str "xtdb.azure-test." prefix)})
        (ig/init-key ::azure/blob-object-store)))
 


### PR DESCRIPTION
# Main PR contents

Resolves #2643 

Implements local filename caching for Azure - alongside a template for all the related necessary infrastructure:
- Created a parameterized azure resource template, that sets up:
  - A new storage account
  - A container to use as the object store.
  - An event grid system topic, subscribed to blobcreate/blobdelete events on the container.
  - A `standard` tier service-bus namespace.
  - A service-bus topic for the service-bus namespace.
  - A subscription on the eventgrid system topic for the service-bus topic.
  - A custom role definition for all of the necessary permissions for XTDB to use the above.  
- Added an implementation of file listing using the cache approach:
  - Azure blob object store now expects the `servicebus-namespace` and `servicebus-topic-name` to be passed into config, and the process is expected to have all the permissions of the custom role
  - We firstly create a new subscription to the service bus topic.
  - We then do our 'init' behaviour, which uses azure list-objects to get all current bucket contents.
  - We create a service bus processor for the topic subscription - handling messages/errors. 
     - When it receives a creation event, will add the filename to the cache.
     - When it receives a removal event, removes the filename from the cache.
- Updates to the azure test to ensure that they fit new listing behaviour, and all works as expected.
- Update the Azure README with setup info


Also included is: 
- A fix to the `get-object` error behaviour to ensure that the object store throws expected errors in `get-range`.
- Pin the Azure module to a specific azure-http-netty version, to not pull in a newer transitive dependency and break other XTDB functions.

# Initial implementation and why/how it had to change

A note of the other approach I tried here, and what I had to in the end - more details below:

Initially, I wanted to set this up using _just_ [**Service Bus Queues**](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#queues) (as this would allow me to use the BASIC tier of ServiceBus, and pricing to be scale-to-zero). 
- I setup all of the required to create everything needed within the code:
  - Created a queue via the ServiceBusAdministrationClient (using a new queue name for each - suffixed with a unique short id).
  - Created a subscription to the eventgrid system topic via the EventGrid ResourceManager class.
  - Also created all of the code necessary to clean both of these up.
- The servicebus processor client pointed at the created queue.
- This would process messages fine - it worked very similarly to how it does now.

We encountered a problem, however. There was a test that did the following:
- Start an object store (1)
- Add a few things to the object store
- Query that the list function works - this always passed, could always see messages going through.
- Close object store (1).
- Start a new object store (2), same settings as before
- Call to list objects - can see the previous elements added to the previous object store.
- DELETE one of the previous elements.
- Call to list objects - should process the delete, should be one less element.

Now - that delete event never seem to came on the second object store. Even if we waited for up to a minute, it never seemed to come through. As a note, this should have been a brand new service bus queue created with a new subscription. This issue _also_ broke things _between_ tests - ie, if I ran all tests, they would fail, whereas individually they were fine.

If we waited some amount of time between closing the first object store and creating the second, all seemed to work fine! In practice, this was around a minute or so, at which case the new object store would be created, its new queue and subscription created, and it would process the delete as expected.

There's a more extended investigation/set of notes on the [thread in the JUXT slack](https://juxt.slack.com/archives/G018EA25K71/p1691075790519189), but to summarize, on looking at azure level logging, this is what I believe the problem to be:
-  Under the hood of the servicebus queue, they use the AMQP protocol - I could see the creation of AMQP connections/channels in the logs (see [**here**](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide) for more info)
- Looking at the logs, it seems like in the case where we didn't wait between creating object stores, AMQP reuses the original connection made for the first queue. I suppose it may well be a retry thing - if it temporarily gets disconnected it wants to connect.
- As such - no messages ever come in on the old queue/connection, and it simply doesn't receive anything.
- In the case where we wait between object store creation - it makes a **new** AMQP connection, which is why I believe it succeeds.

From what I can tell - there's not a lot that can be done with the AMQP setup as a high level service bus API user. The most I could do was switch to using a [different AMQP transport type](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.transporttype?view=azure-dotnet), though this had no impact from what I could tell. I also tried switching off of the [**ServiceBusProcessorClient**](https://learn.microsoft.com/en-us/java/api/com.azure.messaging.servicebus.servicebusprocessorclient?view=azure-java-stable) to using the [**ServiceBusReceiverClient**](https://learn.microsoft.com/en-us/java/api/com.azure.messaging.servicebus.servicebusreceiverclient?view=azure-java-stable) - and again, I saw no change.

What **did** fix the problem, in the end, was switching over from using Service Bus Queues to using a [**Service Bus Topic**](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions#topics-and-subscriptions) that is subscribed to the Event Grid system topic, and creating 'subscriptions' to that in the code and using those with the processor client. In THAT case, all seems to be well - at the expense of having to use the 'STANDARD' pricing tier for Service Bus.