### PR TITLE
Add google cloud file watching

### DIFF
--- a/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/file_watch.clj
@@ -64,7 +64,7 @@
                                                                                    file-url (:url msg-data)
                                                                                    file (when (string/starts-with? file-url base-file-url)
                                                                                           (subs file-url (count base-file-url)))]
-                                                                               (log/info (format "Message received, performing %s on file %s" event-type file))
+                                                                               (log/debug (format "Message received, performing %s on file %s" event-type file))
                                                                                (when (and event-type file)
                                                                                  (cond
                                                                                    (= event-type :create) (.add file-name-cache file)

--- a/modules/google-cloud/README.adoc
+++ b/modules/google-cloud/README.adoc
@@ -1,10 +1,10 @@
-# Google Cloud Module
+= Google Cloud Module
 
 Within our XTDB node, we can make use of Google Cloud Services for certain purposes. Currently, we can:
 
 * Use *Google Cloud Storage* as the XTDB Object Store.
 
-### Project Dependency 
+== Project Dependency 
 
 In order to use any of the Google Cloud services, you will need to include a dependency on the `xtdb-google-cloud` module.
 
@@ -22,11 +22,14 @@ _pom.xml_
 </dependency>
 ```
 
-### Authentication
+== Authentication
 
 Authentication for both the document store and checkpoint store components within the module is handled via Google’s "Application Default Credentials" - see the https://github.com/googleapis/google-auth-library-java/blob/main/README.md#application-default-credentials[*relevant documentation*] to get set up. You will need to setup authentication using any of the methods listed within the documentation to be able to make use of the operations inside the modules. 
 
-## Google Cloud Storage Object Store
+Whatever method used to authenticate, you will need to ensure it has the correct permissions. Alongside the various bits of infrastructure required for the object store, we create a custom XDTB IAM role. One can use this role to provide all necessary permissions for the object store and the resources it is using on Google cloud, otherwise you will need to ensure whichever credentials you are using to authenticate XTDB have the same level of permissions to the miscellaneous services.
+See the custom role definition in the link:cloud-deployment-manager/xtdb-object-store-stack.jinja[Google Cloud Deployment Manager stack] for what exactly that includes.
+
+== Google Cloud Storage Object Store
 
 We can swap out the implementation of the object store with one based on Google Cloud Blob Storage. To do so, we add the `xtdb.google-cloud/blob-object-store` key within the integrant config for our node, alongside any config:
 ```clojure
@@ -37,6 +40,8 @@ We can swap out the implementation of the object store with one based on Google 
   ...
 }
 ```
+
+Alongside the Cloud Storage bucket, we require a Pub/Sub topic which receives file change notifications from the container, such that we can keep a local copy of the files that are on Google Cloud, saving on expensive/lengthy operations to list objects. Below follows the various parameters used by the module, and some notes around the provided <<deployment-manager, Google Cloud Deployment Manager configuration template>> which sets up all of the necessary extra infrastructure. Even if this isn't used, we will require a similar setup to track file changes on whichever bucket you are using, and relevant permissions to use all of the services. 
 
 ### Parameters
 
@@ -51,7 +56,12 @@ These are the following parameters that can be passed within the config for our 
 
 | `bucket`
 | String 
-| The cloud storage bucket which the documents will be stored within
+| The https://cloud.google.com/storage/docs/buckets[Cloud Storage bucket] which the documents will be stored within
+| Yes
+
+| `pubsub-topic`
+| String 
+| The name of the https://cloud.google.com/pubsub/docs/overview#core_concepts[Pub/Sub topic] which is collecting notifications from the Cloud Storage bucket
 | Yes
 
 |`prefix`
@@ -59,3 +69,59 @@ These are the following parameters that can be passed within the config for our 
 | A string to prefix all of your files with - for example, if "foo" is provided all xtdb files will be located under a "foo" directory
 | No
 |=== 
+
+[#deployment-manager]
+=== Google Cloud Deployment Manager Configuration
+
+In order to handle the various bits of Google Cloud infrastructure required to use a Cloud Storage bukcet as an XTDB object store, we provide a link:cloud-deployment-manager/xtdb-stack.yaml[Google Cloud Deployment Manager Configuration] to setup everything that you should need. Read below for more details on what's required in your Google Cloud project, what the configuration sets up and how to customize it, and how to deploy the configuration.
+
+==== Requirements in the Google Cloud Project
+
+In order to use our configuration to create the infrastructure, we will need the following APIs active within the project:
+
+* Cloud Storage API
+* Pub/Sub API
+* IAM API
+* Cloud Deployment Manager API
+
+Within the configuration, we create a custom IAM role for all of the necessary infrastructure. In order for **Cloud Deployment Manager** to create this, it will require IAM permissions to do so:
+
+* See https://cloud.google.com/iam/docs/maintain-custom-roles-deployment-manager#grant_permissions["Grant permissions to the Google APIs service account"] on how to do this, and what permissions it requires.
+
+==== Configurable Properties
+
+Within our Google Cloud Deployment Manager Configuration, we use a https://cloud.google.com/deployment-manager/docs/configuration/templates/create-basic-template[**configurable template**] that takes a set of properties. We can use these to configure the created resources. 
+
+The properties within the file are as follows:
+
+* `object_store_bucketname` (default `xtdb-object-store`) - the name of the Cloud Storage bucket that will be created and used as our XTDB object store.
+* `bucket_location_type` (default `region`) - the https://cloud.google.com/storage/docs/locations[location type] of the created bucket, this can be use either `region`, `dual-region`, or `multi-region`.
+* `bucket_location` (default `EUROPE-WEST2`) - the https://cloud.google.com/storage/docs/locations[bucket location] of the created bucket. Available values depend on the `bucket_location_type` - see https://cloud.google.com/storage/docs/locations#available-locations["Available locations"] for more info.
+* `notifications_pubsub_topic_name` (default `xtdb-object-store-notif-topic`) - the name of the Pub/Sub topic to create, that will contain the file notifications for the create bucket.
+* `custom_role_name` (default `xtdb_custom_role`) - the name of the custom XTDB role to create with all of the permissions it will need for the Cloud Storage buckets and Pub/Sub topic. 
+* `custom_role_additional_permissions`` (default `[]`) - a list of any extra IAM roles you want the custom XTDB role to have. Defaults to an empty list, and creates only the permissions we need for XTDB. 
+
+==== Created Resources
+
+Deploying configuration file will create the following resources within the specified project in Google Cloud:
+
+* A Cloud Storage bucket
+* A Pub/Sub topic, subscribed to notifications from the Cloud Storage bucket.
+* A custom role for all of the necessary permissions for XTDB to use the above:
+** Using the bucket (get, create, delete, list, and update storage objects)
+** Creating, consuming, and deleting subscriptions on PubSub topics.
+
+==== How to deploy the configuration
+
+In the following example, we deploy the Cloud Deployment Manager configuration using the `gcloud` command line tool:
+
+* See https://cloud.google.com/sdk[**here**] for more details. 
+* Ensure that you are https://cloud.google.com/sdk/gcloud/reference/auth/login[authenticated with the CLI] and have sufficient permissions to use deployment manager.
+
+Ensure you have the contents of the `cloud-deployment-manager` folder. Once you have configured the `xtdb-stack.yaml` file to your liking, run the following command:
+
+```bash
+gcloud deployment-manager deployments create <deployment-name> --config cloud-deployment-manager/xtdb-stack.yaml
+```
+
+Replace `deployment-name` with a user readable name for the deployment in Cloud Deployment Manager, such that you can easily find and update it if and when you need to.

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -18,5 +18,11 @@ dependencies {
     api(project(":api"))
     api(project(":core"))
 
-    api("com.google.cloud", "google-cloud-storage", "2.23.0")
+    api("com.google.cloud", "google-cloud-storage", "2.23.0") {
+        exclude("com.google.guava","listenablefuture")
+    }
+    api("com.google.cloud", "google-cloud-pubsub", "1.124.0") {
+        exclude("com.google.guava","listenablefuture")
+    }
+    api("com.google.guava","guava","32.1.1-jre")
 }

--- a/modules/google-cloud/cloud-deployment-manager/xtdb-object-store-stack.jinja
+++ b/modules/google-cloud/cloud-deployment-manager/xtdb-object-store-stack.jinja
@@ -1,0 +1,51 @@
+{% set TOPIC = properties["notifications_pubsub_topic_name"] %}
+{% set BUCKET = properties["object_store_bucketname"] %}
+{% set ROLE = properties["custom_role_name"] %}
+
+resources:
+- type: gcp-types/pubsub-v1:projects.topics
+  name: {{ TOPIC }} 
+  properties:
+    topic: {{ TOPIC }}
+
+- type: gcp-types/storage-v1:buckets
+  name: {{ BUCKET }}
+  properties:
+    location: {{ properties["bucket_location"] }}
+    locationType: {{ properties["bucket_location_type"] }}
+    storageClass: STANDARD
+
+- type: gcp-types/storage-v1:notifications
+  name: {{ BUCKET }}-notifications
+  properties:
+    bucket: $(ref.{{ BUCKET }}.name)
+    topic: $(ref.{{ TOPIC }}.name)
+    payload_format: JSON_API_V1
+    event_types:
+    - OBJECT_FINALIZE
+    - OBJECT_DELETE
+
+- type: gcp-types/iam-v1:projects.roles
+  name: {{ ROLE }}
+  properties:
+    parent: projects/{{ env["project"] }}
+    roleId: {{ ROLE }}
+    role:
+      title: XTDB Custom role
+      stage: GA
+      description: Custom role for XTDB - allows usage of containers and pubsub for reading container notifications.
+      includedPermissions:
+      - storage.objects.create
+      - storage.objects.delete
+      - storage.objects.get
+      - storage.objects.list
+      - storage.objects.update
+      - pubsub.subscriptions.create
+      - pubsub.subscriptions.delete
+      - pubsub.subscriptions.get
+      - pubsub.subscriptions.consume
+      - pubsub.snapshots.seek
+      - pubsub.topics.attachSubscription
+      {% for permission in properties["additionalPermission"] %}
+      - {{ permission }}
+      {% endfor %}

--- a/modules/google-cloud/cloud-deployment-manager/xtdb-stack.yaml
+++ b/modules/google-cloud/cloud-deployment-manager/xtdb-stack.yaml
@@ -1,0 +1,13 @@
+imports:
+- path: xtdb-object-store-stack.jinja
+
+resources:
+- name: xtdb-object-store-stack
+  type: xtdb-object-store-stack.jinja
+  properties:
+    object_store_bucketname: xtdb-object-store
+    bucket_location: EUROPE-WEST2
+    bucket_location_type: region
+    notifications_pubsub_topic_name: xtdb-object-store-notif-topic
+    custom_role_name: xtdb_custom_role
+    custom_role_additional_permissions: [] 

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
@@ -2,9 +2,11 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.google-cloud.file-watch :as google-file-watch]
             [xtdb.google-cloud.object-store :as os]
             [xtdb.util :as util])
-  (:import [com.google.cloud.storage StorageOptions StorageOptions$Builder]))
+  (:import [com.google.cloud.storage StorageOptions StorageOptions$Builder]
+           [java.util.concurrent ConcurrentSkipListSet]))
 
 (derive ::blob-object-store :xtdb/object-store)
 
@@ -15,6 +17,7 @@
     :else (str prefix "/")))
 
 (s/def ::project-id string?)
+(s/def ::pubsub-topic string?)
 (s/def ::bucket string?)
 (s/def ::prefix string?)
 
@@ -23,12 +26,15 @@
       (util/maybe-update :prefix parse-prefix)))
 
 (defmethod ig/pre-init-spec ::blob-object-store [_]
-  (s/keys :req-un [::project-id ::bucket]
+  (s/keys :req-un [::project-id ::bucket ::pubsub-topic]
           :opt-un [::prefix]))
 
-(defmethod ig/init-key ::blob-object-store [_ {:keys [project-id bucket prefix]}]
+(defmethod ig/init-key ::blob-object-store [_ {:keys [project-id bucket prefix] :as opts}]
   (let [storage-service (-> (StorageOptions/newBuilder)
                             ^StorageOptions$Builder (.setProjectId project-id)
                             ^StorageOptions (.build)
-                            (.getService))]
-    (os/->GoogleCloudStorageObjectStore storage-service bucket prefix)))
+                            (.getService))
+        file-name-cache (ConcurrentSkipListSet.)
+        ;; Watch cloud storage bucket for changes
+        file-list-watcher (google-file-watch/open-file-list-watcher (assoc opts :storage-service storage-service) file-name-cache)]
+    (os/->GoogleCloudStorageObjectStore storage-service bucket prefix file-name-cache file-list-watcher)))

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/file_watch.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/file_watch.clj
@@ -56,7 +56,7 @@
                                             (subs objectId (count prefix)))
 
                                           :else objectId)]
-                               (log/info (format "Message received, performing %s on file %s" event-type file))
+                               (log/debug (format "Message received, performing %s on file %s" event-type file))
                                (when (and event-type file)
                                  (cond
                                    (= event-type :create) (.add file-name-cache file)

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/file_watch.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/file_watch.clj
@@ -1,0 +1,82 @@
+(ns xtdb.google-cloud.file-watch
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as log])
+  (:import [com.google.pubsub.v1 SubscriptionName TopicName PushConfig PubsubMessage]
+           [com.google.cloud.pubsub.v1 SubscriptionAdminClient Subscriber MessageReceiver AckReplyConsumer]
+           [com.google.cloud.storage Blob Storage Storage$BlobListOption]
+           [java.lang AutoCloseable]
+           [java.util NavigableSet UUID]))
+
+(defn file-list-init [{:keys [^Storage storage-service bucket prefix]} ^NavigableSet file-name-cache]
+  (let [list-blob-opts (into-array Storage$BlobListOption
+                                   (if (not-empty prefix)
+                                     [(Storage$BlobListOption/prefix prefix)]
+                                     []))
+        filename-list (->> (.list storage-service bucket list-blob-opts)
+                           (.iterateAll)
+                           (mapv (fn [^Blob blob]
+                                   (subs (.getName blob) (count prefix)))))]
+    (.addAll file-name-cache filename-list)))
+
+(defn mk-short-uuid []
+  (subs (str (UUID/randomUUID)) 0 8))
+
+(defn setup-topic-subscription [{:keys [project-id pubsub-topic]}]
+  (let [subcription-admin-client (SubscriptionAdminClient/create)
+        topic (TopicName/of project-id pubsub-topic)
+        subscription-name (format "xtdb-notifs-subscription-%s" (mk-short-uuid))
+        subscription (SubscriptionName/of project-id subscription-name)
+
+        _ (log/info (format "Creating new subscription on Pub/Sub topic %s, subscription name %s" pubsub-topic subscription-name))
+        subscription-info (.createSubscription subcription-admin-client subscription topic (PushConfig/getDefaultInstance) 0)]
+    {:subcription-admin-client subcription-admin-client
+     :subscription-name subscription-name
+     :subscription-resource-name (.getName subscription-info)}))
+
+(defn open-file-list-watcher [{:keys [bucket prefix pubsub-topic] :as opts} ^NavigableSet file-name-cache]
+  (let [;; Create queue that will subscribe to sns topic for notifications
+        {:keys [^SubscriptionAdminClient subcription-admin-client 
+                ^String subscription-name 
+                ^String subscription-resource-name]} (setup-topic-subscription opts)
+
+        ;; Init the filename cache with current files
+        _ (log/info "Initializing filename list from bucket " bucket)
+        _ (file-list-init opts file-name-cache)
+
+        message-receiver (reify MessageReceiver
+                           (receiveMessage [_ message consumer]
+                             (let [{:strs [objectId eventType]} (.getAttributes ^PubsubMessage message)
+                                   event-type (get {"OBJECT_FINALIZE" :create "OBJECT_DELETE" :delete} eventType)
+                                   file (cond
+                                          (string/ends-with? objectId "/")
+                                          nil
+
+                                          prefix
+                                          (when (string/starts-with? objectId prefix)
+                                            (subs objectId (count prefix)))
+
+                                          :else objectId)]
+                               (log/info (format "Message received, performing %s on file %s" event-type file))
+                               (when (and event-type file)
+                                 (cond
+                                   (= event-type :create) (.add file-name-cache file)
+                                   (= event-type :delete) (.remove file-name-cache file)))
+
+                               (.ack ^AckReplyConsumer consumer))))
+        ^Subscriber subscriber (.build (Subscriber/newBuilder ^String subscription-resource-name ^MessageReceiver message-receiver))]
+
+      ;; Start processing messages with the subscriber
+    (log/info "Watching for filechanges from bucket " bucket)
+    (.startAsync subscriber)
+    (.awaitRunning subscriber)
+
+    ;; Return an auto closeable object that clears up the processor and subscription
+    (reify
+      AutoCloseable
+      (close [_]
+        (log/info "Stopping & terminate filechange subscriber client")
+        (.stopAsync subscriber)
+        (.awaitTerminated subscriber)
+
+        (log/info (format "Removing subscription %s on topic %s " subscription-name pubsub-topic))
+        (.deleteSubscription subcription-admin-client subscription-resource-name)))))

--- a/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
+++ b/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
@@ -123,6 +123,7 @@
                                                        (when (string/starts-with? filename prefix)
                                                          (subs filename (count prefix)))
                                                        filename)]
+                                            (log/debug (format "Message received, performing %s on file %s" event-type file))
                                             (when file
                                               (cond
                                                 (= event-type :create) (.add file-name-cache file)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -87,6 +87,7 @@
       (os-test/put-edn os-1 "alice" :alice)
       (os-test/put-edn os-2 "alan" :alan)
       (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-1)))
       (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-2))))))
 
 (t/deftest ^:azure test-eventhub-log

--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -5,11 +5,13 @@
             [juxt.clojars-mirrors.integrant.core :as ig]
             [xtdb.google-cloud :as google-cloud]
             [xtdb.object-store-test :as os-test])
-  (:import [java.io Closeable]
-           [com.google.cloud.storage Bucket Storage StorageOptions StorageOptions$Builder Storage$BucketGetOption Bucket$BucketSourceOption StorageException]))
+  (:import [com.google.cloud.storage Bucket Storage StorageOptions StorageOptions$Builder Storage$BucketGetOption Bucket$BucketSourceOption StorageException]
+           [java.io Closeable]
+           [xtdb.object_store ObjectStore]))
 
 (def project-id "xtdb-scratch")
-(def test-bucket "xtdb-cloud-storage-test-bucket")
+(def pubsub-topic "gcp-test-xtdb-object-store-notif-topic")
+(def test-bucket "gcp-test-xtdb-object-store")
 
 (defn config-present? []
   (try
@@ -41,6 +43,7 @@
 (defn object-store ^Closeable [prefix]
   (->> (ig/prep-key ::google-cloud/blob-object-store {:project-id project-id
                                                       :bucket test-bucket
+                                                      :pubsub-topic pubsub-topic
                                                       :prefix (str "xtdb.google-cloud-test." prefix)})
        (ig/init-key ::google-cloud/blob-object-store)))
 
@@ -53,6 +56,33 @@
   (let [os (object-store (random-uuid))]
     (os-test/test-range os)))
 
-(t/deftest ^:google-cloud list-test
-  (let [os (object-store (random-uuid))]
-    (os-test/test-list-objects os)))
+(def wait-time-ms 5000)
+
+(t/deftest ^:azure list-test
+  (with-open [os (object-store (random-uuid))]
+    (os-test/test-list-objects os wait-time-ms)))
+
+(t/deftest ^:azure list-test-with-prior-objects
+  (let [prefix (random-uuid)]
+    (with-open [os (object-store prefix)]
+      (os-test/put-edn os "alice" :alice)
+      (os-test/put-edn os "alan" :alan)
+      (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
+
+    (with-open [os (object-store prefix)]
+      (t/testing "prior objects will still be there, should be available on a list request"
+        (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
+      (t/testing "should be able to delete prior objects and have that reflected in list objects output"
+        @(.deleteObject ^ObjectStore os "alice")
+        (Thread/sleep wait-time-ms)
+        (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
+
+(t/deftest ^:azure multiple-object-store-list-test
+  (let [prefix (random-uuid)]
+    (with-open [os-1 (object-store prefix)
+                os-2 (object-store prefix)]
+      (os-test/put-edn os-1 "alice" :alice)
+      (os-test/put-edn os-2 "alan" :alan)
+      (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-2))))))

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -62,4 +62,5 @@
       (os-test/put-edn os-1 "alice" :alice)
       (os-test/put-edn os-2 "alan" :alan)
       (Thread/sleep wait-time-ms)
+      (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-1)))
       (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os-2))))))


### PR DESCRIPTION
Resolves #2677 

Implements local filename caching for Google Cloud - alongside a template for all the related necessary infrastructure (TODO):
- Added an implementation of file listing using the cache approach:
  - Google cloud object store now expects the `pubsub-topic` to be passed into config
  - We create a new subscription to the Pub/Sub topic
  - We then do our 'init' behaviour, which uses google cloud list-objects to get all current bucket contents.
  - We create a 'Subscriber' for the subscription - handling messages from the subscription. 
     - When it receives a creation event, will add the filename to the cache.
     - When it receives a removal event, removes the filename from the cache.
- Added a google deployment resource configuration file (see here https://cloud.google.com/deployment-manager/docs/configuration), using a configurable template:
  - Sets up the container 
  - Sets up the pubsub topic
  - Sets up the notifications to the pubsub topic, 
  - Setup a custom role with all relevant permissions for the above
- Update the README with setup info. 
- Updates to the google cloud test to ensure that they fit new listing behaviour, and all works as expected.
- Fix cleanup bug with subscriber/processor - ensure SubscriptionAdminClient cleaned up properly.
