### PR TITLE
IID fast path

### DIFF
--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -176,3 +176,29 @@
                                              {:ordinal ordinal, :leaf node})))))}])))]
 
     (vec (trie-merge-tasks* (map #(some-> ^HashTrie % (.rootNode)) tries) []))))
+
+(defn- bucket-for [^bytes iid level]
+  (let [level-offset-bits (* HashTrie/LEVEL_BITS (inc level))
+        level-offset-bytes (/ (- level-offset-bits HashTrie/LEVEL_BITS) Byte/SIZE)]
+    (bit-and (bit-shift-right (get iid level-offset-bytes) (mod level-offset-bits Byte/SIZE)) HashTrie/LEVEL_MASK)))
+
+(defn iid-trie-merge-task [tries ^bytes iid]
+  (letfn [(trie-merge-tasks* [nodes path level]
+            (let [bucket-idx (bucket-for iid level)
+                  trie-children (mapv #(some-> ^HashTrie$Node % (.children)) nodes)]
+              (if (some identity trie-children)
+                (trie-merge-tasks* (mapv (fn [node ^objects node-children]
+                                           (if node-children
+                                             (aget node-children bucket-idx)
+                                             node))
+                                         nodes trie-children)
+                                   (conj path bucket-idx)
+                                   (inc level))
+                {:path (byte-array path)
+                 :leaves (->> nodes
+                              (into [] (keep-indexed
+                                        (fn [ordinal ^HashTrie$Node node]
+                                          (when node
+                                            {:ordinal ordinal, :leaf node})))))})))]
+
+    (trie-merge-tasks* (map #(some-> ^HashTrie % (.rootNode)) tries) [] 0)))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -24,7 +24,7 @@
            (org.apache.arrow.compression CommonsCompressionFactory)
            (org.apache.arrow.flatbuf Footer Message RecordBatch)
            (org.apache.arrow.memory AllocationManager ArrowBuf BufferAllocator)
-           (org.apache.arrow.memory.util ByteFunctionHelpers MemoryUtil)
+           (org.apache.arrow.memory.util ArrowBufPointer ByteFunctionHelpers MemoryUtil)
            (org.apache.arrow.vector ValueVector VectorLoader VectorSchemaRoot)
            (org.apache.arrow.vector.ipc ArrowFileWriter ArrowStreamWriter ArrowWriter)
            (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter ArrowRecordBatch MessageSerializer)
@@ -116,6 +116,9 @@
              (.putLong (.getLeastSignificantBits uuid)))]
     (.position bb 0)
     bb))
+
+(defn byte-buffer->uuid [^ByteBuffer bb]
+  (UUID. (.getLong bb 0) (.getLong bb 1)))
 
 (defn ->lex-hex-string
   "Turn a long into a lexicographically-sortable hex string by prepending the length"


### PR DESCRIPTION
This PR adds a fast path option for `scan` which contains an equal iid predicte (ie ` {xt/id (= xt/id #uuid "f83b7a34-ab34-47e4-ae98-ea8ec5339332")}`. We first find the leaves that potentially could contain that iid and then binary search the start of the iid runs in the leaves. We do a selection of the iid runs before passing them to the `LeafMergeQueue`. In this PR we are only doing literals, we will revisit for in params.

One potential improvement which is not done here is to not at all use a `LeafMergeQueue`. As the iid runs come from different tries we could essentially just consume them newest to oldest leaf. 

- [x] better boundaries between temporal resolution logic and trie walking
- [x] correctly check for iid predicates
- [x] how to do `ByteBuffer` and `ArrowBufPointer` comparison
