### PR TITLE
[Show] EventResolver + unit tests

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -206,9 +206,9 @@
   (^void nextIid []))
 
 (defn event-resolver
-  ([range-range?] (event-resolver range-range? (LinkedList.)))
+  (^xtdb.operator.scan.EventResolver [range-range?] (event-resolver range-range? (LinkedList.)))
 
-  ([range-range?, ^List !ranges]
+  (^xtdb.operator.scan.EventResolver [range-range?, ^List !ranges]
    (let [!overlapping-ranges (LinkedList.)]
      (reify EventResolver
        (nextIid [_]

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -386,11 +386,14 @@
 (t/deftest test-correct-rectangle-cutting
   (with-open [node (node/start-node {})]
     (letfn [(q [id]
-              (-> (xt/q node {:find '[v vf vt]
-                              :where [(list 'match :xt_docs
-                                            ['v {:xt/id id :xt/valid-from 'vf :xt/valid-to 'vt}]
-                                            {:for-valid-time :all-time})]})
-                  frequencies))]
+              (frequencies
+               (xt/q node
+                     ['{:find [v vf vt]
+                        :in [id]
+                        :where [(match :xt_docs
+                                  [v {:xt/id id :xt/valid-from vf :xt/valid-to vt}]
+                                  {:for-valid-time :all-time})]}
+                      id])))]
       (t/testing "period starts before and does NOT overlap"
         (xt/submit-tx node [[:put :xt_docs {:xt/id 1, :v 1} {:for-valid-time [:in #inst "2010" #inst "2020"]}]])
         (xt/submit-tx node [[:put :xt_docs {:xt/id 1, :v 2} {:for-valid-time [:in #inst "2005" #inst "2009"]}]])


### PR DESCRIPTION
@jarohen and me extracted the temporal resolution logic into it's own little interfaces. This is probably a good example of how to make things more testable and separate the logic into smaller components that capture less state. In this example we went for 
```clj
(definterface RowConsumer
  (^void accept [^int idx, ^long validFrom, ^long validTo, ^long systemFrom, ^long systemTo]))

(definterface EventResolver
  (^void resolveEvent [^int idx, ^long validFrom, ^long validTo, ^long systemFrom
                       ^xtdb.operator.scan.RowConsumer rowConsumer])
  (^void nextIid []))
  ```
  The `RowConsumer` interface is what actually writes/selects the data for the scan. When testing this can be as simple as concatenating the incoming data to some state that can be asserted against. The `EventResolver` in this case closes over a little state which contains the previous seen events for the currently being processed `IID` (hence also the `nextIid` call which clears that state). 
Some temporal resolution test then becomes 
```clj
(t/deftest test-correct-rectangle-cutting
  (letfn [(test-er [& events]
            (let [!state (atom [])
                  rc (reify RowConsumer
                       (accept [_ idx valid-from valid-to sys-from sys-to]
                         (swap! !state conj [idx valid-from valid-to sys-from sys-to])))
                  er (scan/event-resolver false (LinkedList.))]
              (doseq [[idx valid-from valid-to sys-from] events]
                (.resolveEvent er idx valid-from valid-to sys-from rc))
              @!state))]

    (t/is (= [[1 2005 2009 1 util/end-of-time-μs] [0 2010 2020 0 util/end-of-time-μs]]
             (test-er [1 2005 2009 1]
                      [0 2010 2020 0]))
          "period starts before and does NOT overlap")))
 ```
 The `test-er` then sets up two objects that implement our interfaces respectively. We went for interfaces here mainly to avoid boxing. With "normal" objects pretty much the same performance could have been achieved with normal Clojure functions. The nice thing about this setup is that it does not at all involve any calls to namespaces higher up the db stack.