### PR TITLE
Stop compacting logs when taking out wm, move to scan

### DIFF
--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -145,7 +145,7 @@
           (locking this-table
             (let [wm-live-rel (open-wm-live-rel live-rel retain?)
                   col-types (live-rel->col-types wm-live-rel)
-                  wm-live-trie (.compactLogs ^LiveHashTrie @!transient-trie)]
+                  wm-live-trie @!transient-trie]
               (reify ILiveTableWatermark
                 (columnTypes [_] col-types)
                 (liveRelation [_] wm-live-rel)
@@ -177,7 +177,7 @@
     (locking this
       (let [wm-live-rel (open-wm-live-rel live-rel retain?)
             col-types (live-rel->col-types wm-live-rel)
-            wm-live-trie (.compactLogs live-trie)]
+            wm-live-trie live-trie]
 
         (reify ILiveTableWatermark
           (columnTypes [_] col-types)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -508,7 +508,7 @@
                   (.load loader record-batch)
                   (.add trie-roots root)))))
           (let [hash-tries (cond-> (mapv #(ArrowHashTrie/from %) trie-roots)
-                             live-table-wm (conj (.liveTrie live-table-wm)))]
+                             live-table-wm (conj (.compactLogs (.liveTrie live-table-wm))))]
 
             {:arrow-leaves (mapv (fn [{:keys [leaf-buf leaf-root]}]
                                    (reify AutoCloseable


### PR DESCRIPTION
Reduces tpch 0.001 load time (SQL DML) by roughly ~40% (7s -> 4s)