### PR TITLE
Lazy trie writing, #2652 pt 1

### DIFF
--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -164,8 +164,9 @@
 
   (finishChunk [_ chunk-idx]
     (let [live-rel-rdr (vw/rel-wtr->rdr live-rel)]
-      (when-let [bufs (trie/live-trie->bufs allocator (-> live-trie (.compactLogs)) live-rel-rdr)]
-        (let [chunk-idx-str (util/->lex-hex-string chunk-idx)
+      (when (pos? (.rowCount live-rel-rdr))
+        (let [bufs (trie/live-trie->bufs allocator live-trie live-rel-rdr)
+              chunk-idx-str (util/->lex-hex-string chunk-idx)
               !fut (trie/write-trie-bufs! obj-store (format "tables/%s/chunks" table-name) chunk-idx-str bufs)
               table-metadata (MapEntry/create table-name
                                               {:col-types (live-rel->col-types live-rel-rdr)

--- a/core/src/main/clojure/xtdb/indexer/rrrr.clj
+++ b/core/src/main/clojure/xtdb/indexer/rrrr.clj
@@ -66,4 +66,4 @@
               t1-root (open-arrow-hash-trie-root al [[nil 1 nil 3] 1 nil 3])
               log-root (open-arrow-hash-trie-root al 1)
               log2-root (open-arrow-hash-trie-root al [nil nil 3 4])]
-    (trie/trie-merge-tasks [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)])))
+    (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)])))

--- a/core/src/main/java/xtdb/util/WritableByteBufferChannel.java
+++ b/core/src/main/java/xtdb/util/WritableByteBufferChannel.java
@@ -1,0 +1,36 @@
+package xtdb.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+public class WritableByteBufferChannel implements AutoCloseable {
+    private final ByteArrayOutputStream baos;
+    private final WritableByteChannel ch;
+
+    private WritableByteBufferChannel(ByteArrayOutputStream baos, WritableByteChannel ch) {
+        this.baos = baos;
+        this.ch = ch;
+    }
+
+    public ByteBuffer getAsByteBuffer() {
+        return ByteBuffer.wrap(baos.toByteArray());
+    }
+
+    public WritableByteChannel getChannel() {
+        return ch;
+    }
+
+    public static WritableByteBufferChannel open() {
+        var baos = new ByteArrayOutputStream();
+        var ch = Channels.newChannel(baos);
+        return new WritableByteBufferChannel(baos, ch);
+    }
+
+    @Override
+    public void close() throws IOException {
+        ch.close();
+    }
+}

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -7,8 +7,7 @@
             [xtdb.object-store :as os]
             [xtdb.test-json :as tj]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util]
-            [xtdb.vector.reader :as vr])
+            [xtdb.util :as util])
   (:import [java.nio ByteBuffer]
            java.time.Duration
            [java.util Random UUID]


### PR DESCRIPTION
Initial merge as part of #2652, mostly so that we can write tries without needing to keep the whole trie in memory.

* We also turn the merge-tasks into a tree - a 'merge plan' - so that we have the original structure when trying to merge log tries.