### PR TITLE
First pass at metadata support for new trees

### DIFF
--- a/core/src/main/clojure/xtdb/bloom.clj
+++ b/core/src/main/clojure/xtdb/bloom.clj
@@ -36,15 +36,15 @@
   (^double [^long n ^long k ^long m]
    (Math/pow (- 1 (Math/exp (/ (- k) (double (/ m n))))) k)))
 
-(defn bloom->bitmap ^org.roaringbitmap.buffer.ImmutableRoaringBitmap [^VarBinaryVector bloom-vec ^long idx]
-  (let [pointer (.getDataPointer bloom-vec idx)
+(defn bloom->bitmap ^org.roaringbitmap.buffer.ImmutableRoaringBitmap [^IVectorReader bloom-rdr ^long idx]
+  (let [pointer (.getPointer bloom-rdr idx)
         nio-buffer (.nioBuffer (.getBuf pointer) (.getOffset pointer) (.getLength pointer))]
     (ImmutableRoaringBitmap. nio-buffer)))
 
-(defn bloom-contains? [^VarBinaryVector bloom-vec
+(defn bloom-contains? [^IVectorReader bloom-rdr
                        ^long idx
                        ^ints hashes]
-  (let [^ImmutableRoaringBitmap bloom (bloom->bitmap bloom-vec idx)]
+  (let [^ImmutableRoaringBitmap bloom (bloom->bitmap bloom-rdr idx)]
     (loop [n 0]
       (if (= n (alength hashes))
         true

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -547,7 +547,7 @@
 
             tx-key)))
 
-          (await/notify-tx tx-key awaiters)
+      (await/notify-tx tx-key awaiters)
 
       (catch Throwable t
         (set! (.indexer-error this) t)

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -167,7 +167,7 @@
       (when (pos? (.rowCount live-rel-rdr))
         (let [bufs (trie/live-trie->bufs allocator live-trie live-rel-rdr)
               chunk-idx-str (util/->lex-hex-string chunk-idx)
-              !fut (trie/write-trie-bufs! obj-store (format "tables/%s/chunks" table-name) chunk-idx-str bufs)
+              !fut (trie/write-trie-bufs! obj-store table-name chunk-idx-str bufs)
               table-metadata (MapEntry/create table-name
                                               {:col-types (live-rel->col-types live-rel-rdr)
                                                :row-count (.rowCount live-rel-rdr)})]

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -20,11 +20,11 @@
            java.time.temporal.ChronoUnit
            (java.util ArrayList Collections Date Iterator LinkedHashMap LinkedList Map Queue UUID WeakHashMap)
            (java.util.concurrent CompletableFuture ExecutionException ExecutorService Executors ThreadFactory TimeUnit)
-           (java.util.function Consumer Function Supplier)
+           (java.util.function BiFunction Consumer Function Supplier)
            (org.apache.arrow.compression CommonsCompressionFactory)
            (org.apache.arrow.flatbuf Footer Message RecordBatch)
            (org.apache.arrow.memory AllocationManager ArrowBuf BufferAllocator)
-           (org.apache.arrow.memory.util ArrowBufPointer ByteFunctionHelpers MemoryUtil)
+           (org.apache.arrow.memory.util ByteFunctionHelpers MemoryUtil)
            (org.apache.arrow.vector ValueVector VectorLoader VectorSchemaRoot)
            (org.apache.arrow.vector.ipc ArrowFileWriter ArrowStreamWriter ArrowWriter)
            (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter ArrowRecordBatch MessageSerializer)
@@ -343,6 +343,11 @@
   (reify Function
     (apply [_ v]
       (f v))))
+
+(defn ->jbifn {:style/indent :defn} ^java.util.function.BiFunction [f]
+  (reify BiFunction
+    (apply [_ a b]
+      (f a b))))
 
 (defn then-apply {:style/indent :defn}
   ^java.util.concurrent.CompletableFuture

--- a/core/src/main/java/xtdb/trie/LeafMergeQueue.java
+++ b/core/src/main/java/xtdb/trie/LeafMergeQueue.java
@@ -53,7 +53,7 @@ public class LeafMergeQueue {
         });
 
         pq.addAll(lps.stream().filter(Objects::nonNull).filter(this::isValid).toList());
-}
+    }
 
     private ArrowBufPointer getPointer(LeafPointer lp, ArrowBufPointer ptr) {
         return rdrs[lp.ordinal].getPointer(lp.index, ptr);

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -342,3 +342,6 @@
       (.syncRowCount trie-wtr))
 
     trie-root))
+
+(defn byte-buffer->path [^java.nio.ByteBuffer bb]
+  (mapcat (fn [b] [(mod (bit-shift-right b 4) 16) (mod (bit-and b (dec (bit-shift-left 1 4))) 16)]) (.array bb)))

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -4,53 +4,34 @@
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie])
   (:import (clojure.lang MapEntry)
+           (org.roaringbitmap RoaringBitmap)
            (xtdb.trie ArrowHashTrie)
            (org.apache.arrow.memory RootAllocator)))
 
 (deftest test-merge-plan-with-nil-nodes-2700
   (with-open [al (RootAllocator.)
-              t1-root (tu/open-arrow-hash-trie-root al [[nil 1 nil 2] 1 nil 3])
-              log-root (tu/open-arrow-hash-trie-root al 1)
-              log2-root (tu/open-arrow-hash-trie-root al [nil nil 1 2])]
-    (t/is (= {:path [],
-              :node [:branch
-                     [{:path [0],
-                       :node [:branch
-                              [{:path [0 0],
-                                :node [:leaf [nil nil {:ordinal 2, :trie-leaf {:page-idx 1}} nil]]}
-
-                               {:path [0 1],
-                                :node [:leaf [nil
-                                              {:ordinal 1, :trie-leaf {:page-idx 1}}
-                                              {:ordinal 2, :trie-leaf {:page-idx 1}}
-                                              nil]]}
-
-                               {:path [0 2],
-                                :node [:leaf [nil nil {:ordinal 2, :trie-leaf {:page-idx 1}} nil]]}
-
-                               {:path [0 3],
-                                :node [:leaf [nil
-                                              {:ordinal 1, :trie-leaf {:page-idx 2}}
-                                              {:ordinal 2, :trie-leaf {:page-idx 1}}
-                                              nil]]}]]}
-                      {:path [1],
-                       :node [:leaf [nil
-                                     {:ordinal 1, :trie-leaf {:page-idx 1}}
-                                     {:ordinal 2, :trie-leaf {:page-idx 1}}
-                                     nil]]}
-                      {:path [2],
-                       :node [:leaf [nil
-                                     nil
-                                     {:ordinal 2, :trie-leaf {:page-idx 1}}
-                                     {:ordinal 3, :trie-leaf {:page-idx 1}}]]}
-                      {:path [3],
-                       :node [:leaf [nil
-                                     {:ordinal 1, :trie-leaf {:page-idx 3}}
-                                     {:ordinal 2, :trie-leaf {:page-idx 1}}
-                                     {:ordinal 3, :trie-leaf {:page-idx 2}}]]}]]}
-
-             (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)] nil)
-                  (walk/postwalk (fn [x]
-                                   (if (and (map-entry? x) (= :path (key x)))
-                                     (MapEntry/create :path (into [] (val x)))
-                                     x))))))))
+              t1-root (tu/open-arrow-hash-trie-root al [[nil 0 nil 1] 2 nil 3])
+              log-root (tu/open-arrow-hash-trie-root al 0)
+              log2-root (tu/open-arrow-hash-trie-root al [nil nil 0 1])]
+    (let [trie-page-idxs [(RoaringBitmap.)
+                          (RoaringBitmap/bitmapOf (int-array '(0 1 2 3)))
+                          (RoaringBitmap/bitmapOf (int-array '(0)))
+                          (RoaringBitmap/bitmapOf (int-array '(0 1)))]]
+      (t/is (= {:path [],
+                :node [:branch
+                       [{:path [0],
+                         :node [:branch
+                                [{:path [0 0], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                 {:path [0 1], :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]}
+                                 {:path [0 2], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                 {:path [0 3], :node [:leaf [nil {:page-idx 1} {:page-idx 0} nil]]}]]}
+                        {:path [1], :node [:leaf [nil {:page-idx 2} {:page-idx 0} nil]]}
+                        {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
+                        {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
+               (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
+                                       trie-page-idxs
+                                       nil)
+                    (walk/postwalk (fn [x]
+                                     (if (and (map-entry? x) (= :path (key x)))
+                                       (MapEntry/create :path (into [] (val x)))
+                                       x)))))))))

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/hello/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/hello/chunks/trie-c00.arrow.json
@@ -148,9 +148,37 @@
                 "name" : "uuid",
                 "nullable" : true,
                 "type" : {
-                  "name" : "bool"
+                  "name" : "struct"
                 },
-                "children" : [ ]
+                "children" : [{
+                  "name" : "min",
+                  "nullable" : true,
+                  "type" : {
+                    "name" : "UuidType"
+                  },
+                  "children" : [ ],
+                  "metadata" : [{
+                    "value" : "uuid",
+                    "key" : "ARROW:extension:name"
+                  },{
+                    "value" : "",
+                    "key" : "ARROW:extension:metadata"
+                  }]
+                },{
+                  "name" : "max",
+                  "nullable" : true,
+                  "type" : {
+                    "name" : "UuidType"
+                  },
+                  "children" : [ ],
+                  "metadata" : [{
+                    "value" : "uuid",
+                    "key" : "ARROW:extension:name"
+                  },{
+                    "value" : "",
+                    "key" : "ARROW:extension:metadata"
+                  }]
+                }]
               }]
             },{
               "name" : "bloom",
@@ -263,7 +291,17 @@
                 "name" : "uuid",
                 "count" : 6,
                 "VALIDITY" : [0,0,0,0,0,1],
-                "DATA" : [0,0,0,0,0,1]
+                "children" : [{
+                  "name" : "min",
+                  "count" : 6,
+                  "VALIDITY" : [0,0,0,0,0,1],
+                  "DATA" : ["00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","cb8815ee85f74c61a8032ea1c949cf8d"]
+                },{
+                  "name" : "max",
+                  "count" : 6,
+                  "VALIDITY" : [0,0,0,0,0,1],
+                  "DATA" : ["00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","cb8815ee85f74c61a8032ea1c949cf8d"]
+                }]
               }]
             },{
               "name" : "bloom",

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/world/chunks/trie-c00.arrow.json
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/tables/world/chunks/trie-c00.arrow.json
@@ -148,9 +148,37 @@
                 "name" : "uuid",
                 "nullable" : true,
                 "type" : {
-                  "name" : "bool"
+                  "name" : "struct"
                 },
-                "children" : [ ]
+                "children" : [{
+                  "name" : "min",
+                  "nullable" : true,
+                  "type" : {
+                    "name" : "UuidType"
+                  },
+                  "children" : [ ],
+                  "metadata" : [{
+                    "value" : "uuid",
+                    "key" : "ARROW:extension:name"
+                  },{
+                    "value" : "",
+                    "key" : "ARROW:extension:metadata"
+                  }]
+                },{
+                  "name" : "max",
+                  "nullable" : true,
+                  "type" : {
+                    "name" : "UuidType"
+                  },
+                  "children" : [ ],
+                  "metadata" : [{
+                    "value" : "uuid",
+                    "key" : "ARROW:extension:name"
+                  },{
+                    "value" : "",
+                    "key" : "ARROW:extension:metadata"
+                  }]
+                }]
               }]
             },{
               "name" : "bloom",
@@ -263,7 +291,17 @@
                 "name" : "uuid",
                 "count" : 6,
                 "VALIDITY" : [0,0,0,0,0,1],
-                "DATA" : [0,0,0,0,0,1]
+                "children" : [{
+                  "name" : "min",
+                  "count" : 6,
+                  "VALIDITY" : [0,0,0,0,0,1],
+                  "DATA" : ["00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","424f5622c8264deda5dbe2144d665c38"]
+                },{
+                  "name" : "max",
+                  "count" : 6,
+                  "VALIDITY" : [0,0,0,0,0,1],
+                  "DATA" : ["00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","00000000000000000000000000000000","424f5622c8264deda5dbe2144d665c38"]
+                }]
               }]
             },{
               "name" : "bloom",


### PR DESCRIPTION
This takes a first pass at metadata support for the new trees. No pushdown blooms for now.

Open question:
- [x] Should the metadata expression namespace be updated for boolean metadata? Moved to it's own ticket #2717 
- [x] ~Good naming for `chunk-idx/trie-idx`~