### PR TITLE
Fix LeafMergeQueue for non-consecutive ordinals

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -570,10 +570,10 @@
                                                                      (.select rel-rdr (.select iid-pred allocator rel-rdr params))))))
                 merge-q (->merge-queue loaded-leaves merge-task)
                 ^"[Ljava.util.function.IntConsumer;"
-                row-pickers (into-array IntConsumer
-                                        (for [{:keys [rel-rdr]} loaded-leaves]
-                                          (range-range-row-picker out-rel rel-rdr col-names temporal-timestamps picker-state)))]
-
+                row-pickers (make-array IntConsumer (count leaves))]
+            (doseq [{:keys [^LeafMergeQueue$LeafPointer leaf-ptr rel-rdr]} loaded-leaves]
+              (aset row-pickers (.getOrdinal leaf-ptr)
+                    (range-range-row-picker out-rel rel-rdr col-names temporal-timestamps picker-state)))
             (loop []
               (when-let [lp (.poll merge-q)]
                 (.accept ^IntConsumer (aget row-pickers (.getOrdinal lp)) (.getIndex lp))


### PR DESCRIPTION
A leaf merge task might contain ordinals (the log tries participating in the merge task)  that are not consecutive. Say for example log-tries with ordinals 1 and 3 are participating in the merge task. This would create issues with the indexing into the readers in the `LeafMergeQueue`. This PR addresses that.