### PR TITLE
Not putting tables in the committed state map until the tx actually commits

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -468,7 +468,7 @@
                      (pr-str tx-key)
                      (pr-str latest-completed-tx))
 
-          (with-open [live-idx-tx (.startTx live-idx tx-key)]
+          (let [live-idx-tx (.startTx live-idx tx-key)]
             (add-tx-row! row-counter live-idx-tx tx-key
                          (err/illegal-arg :invalid-system-time
                                           {::err/message "specified system-time older than current tx"
@@ -526,9 +526,10 @@
                   (if e
                     (do
                       (when (not= e abort-exn)
-                        (log/debug e "aborted tx"))
+                        (log/debug e "aborted tx")
+                        (.abort live-idx-tx))
 
-                      (with-open [live-idx-tx (.startTx live-idx tx-key)]
+                      (let [live-idx-tx (.startTx live-idx tx-key)]
                         (add-tx-row! row-counter live-idx-tx tx-key e)
                         (.commit live-idx-tx)))
 

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -38,8 +38,8 @@
                        (mapv (comp vec util/uuid->bytes)))]
 
     (t/testing "commit"
-      (util/with-open [live-idx-tx (.startTx live-index (xtp/->TransactionInstant 0 (.toInstant #inst "2000")))
-                       live-table-tx (.liveTable live-idx-tx "my-table")]
+      (let [live-idx-tx (.startTx live-index (xtp/->TransactionInstant 0 (.toInstant #inst "2000")))
+            live-table-tx (.liveTable live-idx-tx "my-table")]
         (let [wp (IVectorPosition/build)]
           (doseq [^UUID iid iids]
             (.logPut live-table-tx (ByteBuffer/wrap (util/uuid->bytes iid)) 0 0


### PR DESCRIPTION
Previously, for tables created for the first time within a tx, we'd eagerly add them to the committed tables map - we now only do this when the transaction commits.

* requires us explicitly aborting LiveIndexTx/LiveTableTx so that it can close the new table if the transaction does abort.