### PR TITLE
Reinstate pushdown blooms

### DIFF
--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -15,8 +15,8 @@
            java.lang.AutoCloseable
            java.nio.ByteBuffer
            (java.util HashMap HashSet Map NavigableMap Set TreeMap)
-           (java.util.concurrent ConcurrentHashMap CompletableFuture)
-           (java.util.function BiFunction Consumer Function)
+           (java.util.concurrent ConcurrentHashMap)
+           (java.util.function BiFunction Function)
            (java.util.stream IntStream)
            (org.apache.arrow.memory ArrowBuf)
            (org.apache.arrow.vector FieldVector VectorLoader VectorSchemaRoot)

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -289,8 +289,8 @@
     (util/try-close recursive-cursor)
     (util/try-close base-cursor)))
 
-(def ^:dynamic ^:private *relation-variable->col-types* {})
-(def ^:dynamic ^:private *relation-variable->cursor-factory* {})
+(def ^:dynamic *relation-variable->col-types* {})
+(def ^:dynamic *relation-variable->cursor-factory* {})
 
 (defmethod lp/emit-expr :relation [{:keys [relation]} _opts]
   (let [col-types (*relation-variable->col-types* relation)]

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -12,7 +12,7 @@
            xtdb.operator.IRelationSelector
            (xtdb.operator.scan RowConsumer)))
 
-(t/use-fixtures :each tu/with-mock-clock tu/with-allocator)
+(t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
 
 (t/deftest test-simple-scan
   (with-open [node (node/start-node {})]
@@ -623,3 +623,25 @@
     (t/is (= (into #{} (map #(hash-map :xt/id %)) (range 20))
              (set (tu/query-ra '[:scan {:table xt_docs} [xt/id]]
                                {:node node}))))))
+
+(deftest test-pushdown-blooms
+  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id :foo, :col "foo"}]
+                           [:put :xt-docs {:xt/id :bar, :col "bar"}]])
+  (tu/finish-chunk! tu/*node*)
+  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id :toto, :col "toto"}]])
+  (tu/finish-chunk! tu/*node*)
+
+  (let [!page-idxs-cnt (atom 0)
+        old-filter-trie-match scan/filter-trie-match]
+    (with-redefs [scan/filter-trie-match (fn [& args]
+                                           (let [res (apply old-filter-trie-match args)]
+                                             (when res (swap! !page-idxs-cnt inc))
+                                             res))]
+      (t/is (= [{:col "toto"}]
+               (tu/query-ra
+                '[:join [{col col}]
+                  [:scan {:table xt_docs} [col {col (= col "toto")}]]
+                  [:scan {:table xt_docs} [col]]]
+                {:node tu/*node*})))
+      ;; one page for the left side, one page for the right side
+      (t/is (= 2 @!page-idxs-cnt)))))


### PR DESCRIPTION
This PR reinstates the pushdown blooms. There are also some changes to the join operators. We now create the RHS (probe side) lazily. The main reason for the move to lazy is so that `scan` can use the pushdown blooms when creating the cursor. We also need to pass down as state some dynamic vars which will no longer be bound when doing things lazily. The dynamic vars will be removed in a later step.