### PR TITLE
Remove special handling off iid fast path in merge plan

### DIFF
--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -470,7 +470,7 @@
         after-uuid #uuid "f0000000-0000-0000-0000-000000000000"
         uuids [before-uuid search-uuid after-uuid]
         !search-uuid-versions (atom [])]
-    (with-open [node (node/start-node {:xtdb/indexer {:rows-per-chunk 20}})]
+    (with-open [node (node/start-node {:xtdb/indexer {:rows-per-chunk 20 :page-limit 16}})]
       (->> (for [i (range 110)]
              (let [uuid (rand-nth uuids)]
                (when (= uuid search-uuid)

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -29,8 +29,7 @@
                         {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
                         {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
                (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
-                                       trie-page-idxs
-                                       nil)
+                                       trie-page-idxs)
                     (walk/postwalk (fn [x]
                                      (if (and (map-entry? x) (= :path (key x)))
                                        (MapEntry/create :path (into [] (val x)))


### PR DESCRIPTION
There is still a special treatment with an iid-selector that finds the start of the iid run on the given page.