### PR TITLE
Storing col-types on vector-writers

### DIFF
--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -172,6 +172,14 @@
   (^org.apache.arrow.vector.types.pojo.Field [col-type] (col-type->field (col-type->field-name col-type) col-type))
   (^org.apache.arrow.vector.types.pojo.Field [col-name col-type] (col-type->field* (str col-name) false col-type)))
 
+(defn without-null [col-type]
+  (let [without-null (-> (flatten-union-types col-type)
+                         (disj :null))]
+    (case (count without-null)
+      0 :null
+      1 (first without-null)
+      without-null)))
+
 (defn col-type->leg [col-type]
   (let [head (col-type-head col-type)]
     (case head

--- a/core/src/main/java/xtdb/vector/IVectorWriter.java
+++ b/core/src/main/java/xtdb/vector/IVectorWriter.java
@@ -14,6 +14,8 @@ public interface IVectorWriter extends IValueWriter, AutoCloseable {
 
     ValueVector getVector();
 
+    Object getColType();
+
     /**
      * This method calls {@link ValueVector#setValueCount} on the underlying vector, so that all of the values written
      * become visible through the Arrow Java API - we don't call this after every write because (for composite vectors, and especially unions)

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -1,13 +1,11 @@
 (ns xtdb.indexer-test
   (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.test :as t :refer [deftest]]
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
             [xtdb.api.protocols :as xtp]
             [xtdb.buffer-pool :as bp]
-            [xtdb.expression.metadata :as expr.meta]
             [xtdb.indexer :as idx]
             [xtdb.metadata :as meta]
             [xtdb.node :as node]
@@ -16,21 +14,17 @@
             [xtdb.test-util :as tu]
             [xtdb.ts-devices :as ts]
             [xtdb.util :as util]
-            [xtdb.vector.reader :as vr]
             xtdb.watermark)
   (:import (java.nio.channels ClosedByInterruptException)
            java.nio.file.Files
            java.time.Duration
-           (java.util.function Consumer)
-           [org.apache.arrow.memory ArrowBuf BufferAllocator]
-           [org.apache.arrow.vector BigIntVector VectorLoader VectorSchemaRoot]
-           [org.apache.arrow.vector.complex ListVector StructVector]
+           [org.apache.arrow.memory BufferAllocator]
            xtdb.api.protocols.TransactionInstant
-           [xtdb.buffer_pool BufferPool IBufferPool]
+           [xtdb.buffer_pool IBufferPool]
            (xtdb.metadata IMetadataManager)
            xtdb.node.Node
            xtdb.object_store.ObjectStore
-           (xtdb.watermark IWatermark IWatermarkSource)))
+           (xtdb.watermark IWatermarkSource)))
 
 (t/use-fixtures :once tu/with-allocator)
 


### PR DESCRIPTION
... in an attempt to speed up the creation of watermarks, #2681.

* These col-types are effectively stateful for things like DUVs, structs, lists, because at any point a caller can add a type/struct key/etc - so these have to do a bit more calculation on the fly. We could potentially keep these as actual state, and update it when we know there's been a change, if this on-the-fly calculation is still too expensive.

Seems to get a quick 10% win on TPC-H SQL 0.001.