### PR TITLE
Make more use of the iid blooms

### DIFF
--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -4,9 +4,10 @@
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie])
   (:import (clojure.lang MapEntry)
+           (org.apache.arrow.memory RootAllocator)
            (org.roaringbitmap RoaringBitmap)
-           (xtdb.trie ArrowHashTrie)
-           (org.apache.arrow.memory RootAllocator)))
+           (org.roaringbitmap.buffer MutableRoaringBitmap)
+           (xtdb.trie ArrowHashTrie)))
 
 (deftest test-merge-plan-with-nil-nodes-2700
   (with-open [al (RootAllocator.)
@@ -16,21 +17,25 @@
     (let [trie-page-idxs [(RoaringBitmap.)
                           (RoaringBitmap/bitmapOf (int-array '(0 1 2 3)))
                           (RoaringBitmap/bitmapOf (int-array '(0)))
-                          (RoaringBitmap/bitmapOf (int-array '(0 1)))]]
-      (t/is (= {:path [],
-                :node [:branch
-                       [{:path [0],
-                         :node [:branch
-                                [{:path [0 0], :node [:leaf [nil nil {:page-idx 0} nil]]}
-                                 {:path [0 1], :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]}
-                                 {:path [0 2], :node [:leaf [nil nil {:page-idx 0} nil]]}
-                                 {:path [0 3], :node [:leaf [nil {:page-idx 1} {:page-idx 0} nil]]}]]}
-                        {:path [1], :node [:leaf [nil {:page-idx 2} {:page-idx 0} nil]]}
-                        {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
-                        {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
-               (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
-                                       trie-page-idxs)
-                    (walk/postwalk (fn [x]
-                                     (if (and (map-entry? x) (= :path (key x)))
-                                       (MapEntry/create :path (into [] (val x)))
-                                       x)))))))))
+                          (RoaringBitmap/bitmapOf (int-array '(0 1)))]
+          constant-iid-bloom-bitmap (.toImmutableRoaringBitmap (MutableRoaringBitmap/bitmapOf (int-array '(1000 1001 1002))))]
+      (letfn [(iid-bloom-bitmap [_ordinal _page-idx]
+                constant-iid-bloom-bitmap)]
+        (t/is (= {:path [],
+                  :node [:branch
+                         [{:path [0],
+                           :node [:branch
+                                  [{:path [0 0], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                   {:path [0 1], :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]}
+                                   {:path [0 2], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                   {:path [0 3], :node [:leaf [nil {:page-idx 1} {:page-idx 0} nil]]}]]}
+                          {:path [1], :node [:leaf [nil {:page-idx 2} {:page-idx 0} nil]]}
+                          {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
+                          {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
+                 (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
+                                         trie-page-idxs
+                                         iid-bloom-bitmap)
+                      (walk/postwalk (fn [x]
+                                       (if (and (map-entry? x) (= :path (key x)))
+                                         (MapEntry/create :path (into [] (val x)))
+                                         x))))))))))


### PR DESCRIPTION
This PR brings in an optimisation of metadata usage. When the metadata filters have been applied one has a set of pages in hand which match the metadata predicates. Normally one has to replay any pages from subsequent tries that could affect the matching metadata pages to get correct temporal resolution. The optimisation this PR proposes is to only take subsequent page if there is some overlap in IIDs (making use of the iid blooms). One issue with that is that for certain iids (that were just included because of some other IID overlap) we might do incorrect temporal resolution. The assumption here is that the column predicates will filter out those results anyway.

I couldn't particularly see any improvements in 0.01 TPCH runs. So maybe reworth checking if this is actually an improvement.

TODO:
- [x] assure that we are not missing anything with regards to incorrect temporal resolution
- [x] update `merge-leaf` test of xtdb.trie