### PR TITLE
Move clearing of live-idx tables to explicit nextChunk step

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -613,7 +613,9 @@
     (set! (.-latest_completed_chunk_tx this) latest-completed-tx)
 
     (let [wm-lock-stamp (.writeLock wm-lock)]
+
       (try
+        (.nextChunk live-idx)
         (when-let [^IWatermark shared-wm (.shared-wm this)]
           (set! (.shared-wm this) nil)
           (.close shared-wm))

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -49,6 +49,7 @@
   (^xtdb.indexer.live_index.ILiveIndexTx startTx [^xtdb.api.protocols.TransactionInstant txKey])
   (^xtdb.watermark.ILiveIndexWatermark openWatermark [])
   (^java.util.Map finishChunk [^long chunkIdx])
+  (^void nextChunk [])
   (^void close []))
 
 (defprotocol TestLiveTable
@@ -287,11 +288,12 @@
 
       @(CompletableFuture/allOf futs)
 
-      (util/close tables)
-      (.clear tables)
-
       (-> (into {} (keep deref) futs)
           (util/rethrowing-cause))))
+
+  (nextChunk [_]
+    (util/close tables)
+    (.clear tables))
 
   AutoCloseable
   (close [_]


### PR DESCRIPTION
Remove unnecessary locking from live-table