### PR TITLE
Use field accessor for latest-completed-tx to get dynamic ref

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -590,11 +590,11 @@
   (latestCompletedTx [_] latest-completed-tx)
   (latestCompletedChunkTx [_] latest-completed-chunk-tx)
 
-  (awaitTxAsync [_ tx timeout]
+  (awaitTxAsync [this tx timeout]
     (-> (if tx
           (await/await-tx-async tx
                                 #(or (some-> indexer-error throw)
-                                     latest-completed-tx)
+                                     (.-latest-completed-tx this))
                                 awaiters)
           (CompletableFuture/completedFuture latest-completed-tx))
         (cond-> timeout (.orTimeout (.toMillis timeout) TimeUnit/MILLISECONDS))))


### PR DESCRIPTION
Closing over the symbol for a volatile-mutable field captures the static value of that mutable field at the point the closure constructed. Instead use of the field accessor delays resolving the value until the accessor is invoked.

This fixes a concurrency bug in which latest->completed-tx could be updated while await-tx-async was running. However because it has static reference to the old value, it would create a future but fail to see that the awaited transaction had subsequently been completed. This would result in .awaitTxAsync blocking indefinately for a future that never completes.