### PR TITLE
Avoid using spec/conform in submit-tx, #2744

### DIFF
--- a/api/src/main/clojure/xtdb/api/protocols.clj
+++ b/api/src/main/clojure/xtdb/api/protocols.clj
@@ -1,6 +1,7 @@
 (ns ^{:clojure.tools.namespace.repl/load false, :clojure.tools.namespace.repl/unload false} xtdb.api.protocols
   (:import java.io.Writer
-           java.time.Instant))
+           java.time.Instant
+           xtdb.types.ClojureForm))
 
 (defrecord TransactionInstant [^long tx-id, ^Instant system-time]
   Comparable
@@ -14,11 +15,12 @@
 (defmethod print-method TransactionInstant [tx-key w]
   (print-dup tx-key w))
 
-(defrecord ClojureForm [form])
+(defn ->ClojureForm [form]
+  (ClojureForm. form))
 
-(defmethod print-dup ClojureForm [{:keys [form]} ^Writer w]
+(defmethod print-dup ClojureForm [^ClojureForm clj-form ^Writer w]
   (.write w "#xt/clj-form ")
-  (print-method form w))
+  (print-method (.form clj-form) w))
 
 (defmethod print-method ClojureForm [clj-form w]
   (print-dup clj-form w))

--- a/api/src/main/java/xtdb/tx/Ops.java
+++ b/api/src/main/java/xtdb/tx/Ops.java
@@ -1,0 +1,270 @@
+package xtdb.tx;
+
+import clojure.lang.Keyword;
+import xtdb.types.ClojureForm;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("StaticInitializerReferencesSubClass")
+public sealed class Ops {
+    private Ops() {
+    }
+
+    public static Sql sql(String sql) {
+        return new Sql(sql);
+    }
+
+    public static Sql sql(String sql, List<?> paramRow) {
+        return new Sql(sql, List.of(paramRow));
+    }
+
+    public static Sql sqlBatch(String sql, List<List<?>> paramGroupRows) {
+        return new Sql(sql, paramGroupRows);
+    }
+
+    public static Sql sqlBatch(String sql, ByteBuffer paramGroupBytes) {
+        return new Sql(sql, paramGroupBytes);
+    }
+
+    public static Sql sqlBatch(String sql, byte[] paramGroupBytes) {
+        return sqlBatch(sql, ByteBuffer.wrap(paramGroupBytes));
+    }
+
+    public static final class Sql extends Ops {
+        private final String sql;
+        private final List<List<?>> paramGroupRows;
+        private final ByteBuffer paramGroupBytes;
+
+        public Sql(String sql) {
+            this.sql = sql;
+            this.paramGroupRows = null;
+            this.paramGroupBytes = null;
+        }
+
+        private Sql(String sql, ByteBuffer paramGroupBytes) {
+            this.sql = sql;
+            this.paramGroupBytes = paramGroupBytes;
+            this.paramGroupRows = null;
+        }
+
+        public Sql(String sql, List<List<?>> paramGroupRows) {
+            this.sql = sql;
+            this.paramGroupRows = paramGroupRows;
+            this.paramGroupBytes = null;
+        }
+
+        public String sql() {
+            return sql;
+        }
+
+        public ByteBuffer paramGroupBytes() {
+            return paramGroupBytes;
+        }
+
+        public List<List<?>> paramGroupRows() {
+            return paramGroupRows;
+        }
+
+        @Override
+        public String toString() {
+            return "[:sql '%s' {:paramGroupRows=%s, :paramGroupBytes=%s}]".formatted(sql, paramGroupRows, paramGroupBytes);
+        }
+    }
+
+    public static Put put(Keyword tableName, Map<Keyword, Object> doc) {
+        return new Put(tableName, doc);
+    }
+
+    private static final Keyword XT_TXS = Keyword.intern("xt", "tx-fns");
+    private static final Keyword XT_ID = Keyword.intern("xt", "id");
+    private static final Keyword XT_FN = Keyword.intern("xt", "fn");
+
+    public static Put putFn(Object fnId, Object fnForm) {
+        return put(XT_TXS, Map.of(XT_ID, fnId, XT_FN, new ClojureForm(fnForm)));
+    }
+
+    public static final class Put extends Ops {
+
+        private final Keyword tableName;
+        private final Map<Keyword, Object> doc;
+        private Instant validFrom;
+        private Instant validTo;
+
+        private Put(Keyword tableName, Map<Keyword, Object> doc) {
+            this.tableName = tableName;
+            this.doc = doc;
+        }
+
+        public Keyword tableName() {
+            return tableName;
+        }
+
+        public Map<Keyword, Object> doc() {
+            return doc;
+        }
+
+        public Instant validFrom() {
+            return validFrom;
+        }
+
+        public Put validFrom(Instant validFrom) {
+            this.validFrom = validFrom;
+            return this;
+        }
+
+        public Put validFrom(Date validFrom) {
+            this.validFrom = validFrom.toInstant();
+            return this;
+        }
+
+        public Instant validTo() {
+            return validTo;
+        }
+
+        public Put validTo(Instant validTo) {
+            this.validTo = validTo;
+            return this;
+        }
+
+        public Put validTo(Date validTo) {
+            this.validTo = validTo.toInstant();
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "[:put {tableName=%s, doc=%s, validFrom=%s, validTo=%s}]".formatted(tableName, doc, validFrom, validTo);
+        }
+    }
+
+    public static Delete delete(Keyword tableName, Object entityId) {
+        return new Delete(tableName, entityId);
+    }
+
+    public static final class Delete extends Ops {
+
+        private final Keyword tableName;
+        private final Object entityId;
+        private Instant validFrom;
+        private Instant validTo;
+
+        private Delete(Keyword tableName, Object entityId) {
+            this.tableName = tableName;
+            this.entityId = entityId;
+        }
+
+        public Keyword tableName() {
+            return tableName;
+        }
+
+        public Object entityId() {
+            return entityId;
+        }
+
+        public Instant validFrom() {
+            return validFrom;
+        }
+
+        public Delete validFrom(Instant validFrom) {
+            this.validFrom = validFrom;
+            return this;
+        }
+
+        public Delete validFrom(Date validFrom) {
+            this.validFrom = validFrom.toInstant();
+            return this;
+        }
+
+        public Instant validTo() {
+            return validTo;
+        }
+
+        public Delete validTo(Instant validTo) {
+            this.validTo = validTo;
+            return this;
+        }
+
+        public Delete validTo(Date validTo) {
+            this.validTo = validTo.toInstant();
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "[:delete %s %s {validFrom=%s, validTo=%s}]".formatted(tableName, entityId, validFrom, validTo);
+        }
+    }
+
+    public static Evict evict(Keyword tableName, Object entityId) {
+        return new Evict(tableName, entityId);
+    }
+
+    public static final class Evict extends Ops {
+
+        private final Keyword tableName;
+        private final Object entityId;
+
+        private Evict(Keyword tableName, Object entityId) {
+            this.tableName = tableName;
+            this.entityId = entityId;
+        }
+
+        public Keyword tableName() {
+            return tableName;
+        }
+
+        public Object entityId() {
+            return entityId;
+        }
+
+        @Override
+        public String toString() {
+            return "[:evict {tableName=%s, entityId=%s}]".formatted(tableName, entityId);
+        }
+    }
+
+    public static Call call(Object fnId, Object... args) {
+        return new Call(fnId, args);
+    }
+
+    public static final class Call extends Ops {
+
+        private final Object fnId;
+        private final Object[] args;
+
+        public Call(Object fnId, Object[] args) {
+            this.fnId = fnId;
+            this.args = args;
+        }
+
+        public Object fnId() {
+            return fnId;
+        }
+
+        public Object[] args() {
+            return args;
+        }
+
+        @Override
+        public String toString() {
+            return "[:call %s %s]".formatted(fnId, Arrays.toString(args));
+        }
+    }
+
+    public static final Abort ABORT = new Abort();
+
+    public static final class Abort extends Ops {
+        private Abort() {
+        }
+
+        @Override
+        public String toString() {
+            return "[:abort]";
+        }
+    }
+}

--- a/api/src/main/java/xtdb/types/ClojureForm.java
+++ b/api/src/main/java/xtdb/types/ClojureForm.java
@@ -1,0 +1,4 @@
+package xtdb.types;
+
+public record ClojureForm(Object form) {
+}

--- a/api/src/main/java/xtdb/types/IntervalDayTime.java
+++ b/api/src/main/java/xtdb/types/IntervalDayTime.java
@@ -2,33 +2,15 @@ package xtdb.types;
 
 import java.time.Duration;
 import java.time.Period;
-import java.util.Objects;
+
 import clojure.lang.PersistentHashMap;
 
-public final class IntervalDayTime {
-    public final Period period;
-    public final Duration duration;
-
-    public IntervalDayTime(Period period, Duration duration) {
-        if ( period.getYears() != 0 || period.getMonths() != 0)
+public record IntervalDayTime(Period period, Duration duration) {
+    public IntervalDayTime {
+        if (period.getYears() != 0 || period.getMonths() != 0)
             throw new xtdb.IllegalArgumentException("Period can not contain years or months!",
-                                                    PersistentHashMap.EMPTY,
-                                                    null);
-        this.period = period;
-        this.duration = duration;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        IntervalDayTime that = (IntervalDayTime) o;
-        return period.equals(that.period) && duration.equals(that.duration);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(period, duration);
+                    PersistentHashMap.EMPTY,
+                    null);
     }
 
     @Override

--- a/api/src/main/java/xtdb/types/IntervalMonthDayNano.java
+++ b/api/src/main/java/xtdb/types/IntervalMonthDayNano.java
@@ -2,29 +2,8 @@ package xtdb.types;
 
 import java.time.Duration;
 import java.time.Period;
-import java.util.Objects;
 
-public final class IntervalMonthDayNano {
-    public final Period period;
-    public final Duration duration;
-
-    public IntervalMonthDayNano(Period period, Duration duration) {
-        this.period = period;
-        this.duration = duration;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        IntervalMonthDayNano that = (IntervalMonthDayNano) o;
-        return period.equals(that.period) && duration.equals(that.duration);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(period, duration);
-    }
+public record IntervalMonthDayNano(Period period, Duration duration) {
 
     @Override
     public String toString() {

--- a/api/src/main/java/xtdb/types/IntervalYearMonth.java
+++ b/api/src/main/java/xtdb/types/IntervalYearMonth.java
@@ -1,27 +1,8 @@
 package xtdb.types;
 
 import java.time.Period;
-import java.util.Objects;
 
-public final class IntervalYearMonth {
-    public final Period period;
-
-    public IntervalYearMonth(Period period) {
-        this.period = period;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        IntervalYearMonth that = (IntervalYearMonth) o;
-        return period.equals(that.period);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(period);
-    }
+public record IntervalYearMonth(Period period) {
 
     @Override
     public String toString() {

--- a/api/src/main/java/xtdb/util/NormalForm.java
+++ b/api/src/main/java/xtdb/util/NormalForm.java
@@ -1,0 +1,64 @@
+package xtdb.util;
+
+import clojure.lang.Keyword;
+import clojure.lang.Symbol;
+
+import java.util.Locale;
+
+public class NormalForm {
+    private NormalForm() {
+    }
+
+    // TODO we could cache these? guessing they're probably not free.
+    
+    private static String normalise(String s) {
+        return s.toLowerCase(Locale.ROOT)
+                .replace('.', '$')
+                .replace('-', '_');
+    }
+
+    private static String unnormalise(String s) {
+        return s.replace('_', '-')
+                .replace('$', '.');
+    }
+
+    public static String normalForm(String s) {
+        var i = s.lastIndexOf('/');
+        if (i < 0) {
+            return normalise(s);
+        } else {
+            return "%s$%s".formatted(normalise(s.substring(0, i)), normalise(s.substring(i + 1)));
+        }
+    }
+
+    public static String datalogForm(String s) {
+        var i = s.lastIndexOf('$');
+        if (i < 0) {
+            return unnormalise(s);
+        } else {
+            return "%s/%s".formatted(s.substring(0, i), s.substring(i + 1));
+        }
+    }
+
+    public static Keyword normalForm(Keyword k) {
+        return Keyword.intern(normalForm(k.sym));
+    }
+
+    public static Keyword datalogForm(Keyword normalFormKeyword) {
+        var k = normalFormKeyword.getName();
+        var i = k.lastIndexOf('$');
+        if (i < 0) {
+            return Keyword.intern(unnormalise(k));
+        } else {
+            return Keyword.intern(unnormalise(k.substring(0, i)), unnormalise(k.substring(i + 1)));
+        }
+    }
+
+    public static Symbol normalForm(Symbol sym) {
+        if (sym.getNamespace() != null) {
+            return Symbol.intern("%s$%s".formatted(normalise(sym.getNamespace()), normalise(sym.getName())));
+        } else {
+            return Symbol.intern(normalise(sym.getName()));
+        }
+    }
+}

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -32,7 +32,8 @@
            (org.apache.arrow.vector BitVector)
            (org.apache.arrow.vector.complex DenseUnionVector ListVector)
            (org.apache.arrow.vector.ipc ArrowStreamReader)
-           (xtdb.api.protocols ClojureForm TransactionInstant)
+           (xtdb.api.protocols TransactionInstant)
+           xtdb.types.ClojureForm
            (xtdb.indexer.live_index ILiveIndex ILiveIndexTx ILiveTableTx)
            xtdb.metadata.IMetadataManager
            xtdb.object_store.ObjectStore
@@ -181,7 +182,7 @@
           (when-not (instance? ClojureForm fn-body)
             (throw (err/illegal-arg :xtdb.call/invalid-tx-fn {:fn-doc fn-doc})))
 
-          (let [fn-form (:form fn-body)]
+          (let [fn-form (.form ^ClojureForm fn-body)]
             (try
               (sci/eval-form sci-ctx fn-form)
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -24,7 +24,7 @@
            (org.apache.arrow.memory BufferAllocator)
            [org.apache.arrow.memory.util ArrowBufPointer]
            [org.roaringbitmap RoaringBitmap]
-           [org.roaringbitmap.buffer ImmutableRoaringBitmap MutableRoaringBitmap]
+           [org.roaringbitmap.buffer MutableRoaringBitmap]
            xtdb.api.protocols.TransactionInstant
            xtdb.buffer_pool.IBufferPool
            xtdb.ICursor

--- a/core/src/main/clojure/xtdb/tx_producer.clj
+++ b/core/src/main/clojure/xtdb/tx_producer.clj
@@ -1,7 +1,6 @@
 (ns xtdb.tx-producer
   (:require [clojure.spec.alpha :as s]
             [juxt.clojars-mirrors.integrant.core :as ig]
-            [xtdb.api.protocols :as xtp]
             [xtdb.error :as err]
             xtdb.log
             [xtdb.rewrite :refer [zmatch]]
@@ -14,9 +13,10 @@
            (java.util ArrayList HashMap)
            org.apache.arrow.memory.BufferAllocator
            (org.apache.arrow.vector VectorSchemaRoot)
-           org.apache.arrow.vector.types.UnionMode
            (org.apache.arrow.vector.types.pojo ArrowType$Union Schema)
+           org.apache.arrow.vector.types.UnionMode
            (xtdb.log Log LogRecord)
+           xtdb.types.ClojureForm
            xtdb.vector.IValueWriter))
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
@@ -286,7 +286,7 @@
           :put (write-put! tx-op)
           :put-fn (let [{:keys [id tx-fn app-time-opts]} tx-op]
                     (write-put! {:table :xt$tx_fns
-                                 :doc {:xt$id id, :xt$fn (xtp/->ClojureForm tx-fn)}
+                                 :doc {:xt$id id, :xt$fn (ClojureForm. tx-fn)}
                                  :app-time-opts app-time-opts}))
           :delete (write-delete! tx-op)
           :evict (write-evict! tx-op)

--- a/core/src/main/clojure/xtdb/vector.clj
+++ b/core/src/main/clojure/xtdb/vector.clj
@@ -159,7 +159,7 @@
         (valueCount [_] (.getValueCount arrow-vec))
         (readObject [_ idx]
           (let [^IntervalDayTime idt (.getObject vec-rdr idx)]
-            (PeriodDuration. (.-period idt) (.-duration idt)))))))
+            (PeriodDuration. (.period idt) (.duration idt)))))))
 
   IntervalMonthDayNanoVector
   (->mono-reader [arrow-vec _col-type]
@@ -168,7 +168,7 @@
         (valueCount [_] (.getValueCount arrow-vec))
         (readObject [_ idx]
           (let [^IntervalMonthDayNano imdn (.getObject vec-rdr idx)]
-            (PeriodDuration. (.-period imdn) (.-duration imdn))))))))
+            (PeriodDuration. (.period imdn) (.duration imdn))))))))
 
 (extend-protocol MonoFactory
   ListVector

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -1,6 +1,5 @@
 (ns xtdb.vector.writer
-  (:require [clojure.set :as set]
-            [xtdb.error :as err]
+  (:require [xtdb.error :as err]
             [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector :as vec]
@@ -18,7 +17,7 @@
            (org.apache.arrow.vector BigIntVector BitVector DecimalVector DateDayVector DateMilliVector DurationVector ExtensionTypeVector FixedSizeBinaryVector Float4Vector Float8Vector IntVector IntervalDayVector IntervalMonthDayNanoVector IntervalYearVector NullVector PeriodDuration SmallIntVector TimeMicroVector TimeMilliVector TimeNanoVector TimeSecVector TimeStampVector TinyIntVector ValueVector VarBinaryVector VarCharVector VectorSchemaRoot)
            (org.apache.arrow.vector.complex DenseUnionVector ListVector StructVector)
            (org.apache.arrow.vector.types.pojo ArrowType$List ArrowType$Struct ArrowType$Union Field FieldType)
-           xtdb.api.protocols.ClojureForm
+           xtdb.types.ClojureForm
            (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
            (xtdb.vector IRelationWriter RelationReader IRowCopier IVectorReader IVectorWriter IVectorPosition)
            (xtdb.vector.extensions SetType)))
@@ -314,7 +313,7 @@
 
   IntervalYearMonth
   (value->col-type [_] [:interval :year-month])
-  (write-value! [v ^IVectorWriter w] (.writeInt w (.toTotalMonths (.-period v))))
+  (write-value! [v ^IVectorWriter w] (.writeInt w (.toTotalMonths (.period v))))
 
   IntervalDayTime
   (value->col-type [_] [:interval :day-time])
@@ -845,8 +844,8 @@
 
   ClojureForm
   (value->col-type [_] :clj-form)
-  (write-value! [{:keys [form]} ^IVectorWriter w]
-    (write-value! (pr-str form) w)))
+  (write-value! [clj-form ^IVectorWriter w]
+    (write-value! (pr-str (.form clj-form)) w)))
 
 (defn write-vec! [^ValueVector v, vs]
   (.clear v)

--- a/core/src/main/java/xtdb/vector/extensions/ClojureFormVector.java
+++ b/core/src/main/java/xtdb/vector/extensions/ClojureFormVector.java
@@ -6,11 +6,11 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import xtdb.types.ClojureForm;
 
 public class ClojureFormVector extends XtExtensionVector<VarCharVector> {
 
     private static final IFn READ_STRING = Clojure.var("clojure.core", "read-string");
-    private static final IFn TO_CLJ_FORM = Clojure.var("xtdb.api.protocols", "->ClojureForm");
 
     public ClojureFormVector(String name, BufferAllocator allocator, FieldType fieldType) {
         super(name, allocator, fieldType, new VarCharVector(name, allocator));
@@ -22,6 +22,6 @@ public class ClojureFormVector extends XtExtensionVector<VarCharVector> {
 
     @Override
     public Object getObject(int index) {
-        return TO_CLJ_FORM.invoke(READ_STRING.invoke(getUnderlyingVector().getObject(index).toString()));
+        return new ClojureForm(READ_STRING.invoke(getUnderlyingVector().getObject(index).toString()));
     }
 }

--- a/http-server/src/main/clojure/xtdb/server.clj
+++ b/http-server/src/main/clojure/xtdb/server.clj
@@ -6,7 +6,6 @@
             [juxt.clojars-mirrors.integrant.core :as ig]
             [muuntaja.core :as m]
             [muuntaja.format.core :as mf]
-            [muuntaja.format.json :as mj]
             [reitit.coercion :as r.coercion]
             [reitit.coercion.spec :as rc.spec]
             [reitit.core :as r]
@@ -20,10 +19,8 @@
             [reitit.swagger :as r.swagger]
             [ring.adapter.jetty9 :as j]
             [spec-tools.core :as st]
-            [xtdb.api :as xt]
             [xtdb.api.protocols :as xtp]
             [xtdb.error :as err]
-            [xtdb.node :as node]
             [xtdb.transit :as xt.transit]
             [xtdb.util :as util])
   (:import java.io.OutputStream

--- a/modules/c1-import/src/main/clojure/xtdb/c1_import.clj
+++ b/modules/c1-import/src/main/clojure/xtdb/c1_import.clj
@@ -3,7 +3,6 @@
             [clojure.spec.alpha :as s]
             [clojure.tools.logging :as log]
             [cognitect.transit :as transit]
-            [xtdb.api.protocols :as xtp]
             [xtdb.cli :as cli]
             xtdb.log
             [xtdb.node :as node]
@@ -12,7 +11,8 @@
   (:import clojure.lang.MapEntry
            java.lang.AutoCloseable
            (java.nio.file ClosedWatchServiceException Files OpenOption Path StandardOpenOption StandardWatchEventKinds WatchEvent WatchEvent$Kind)
-           java.util.HashSet))
+           java.util.HashSet
+           xtdb.types.ClojureForm))
 
 (defmethod ig/prep-key :xtdb/c1-import [_ opts]
   (into {:tx-producer (ig/ref :xtdb.tx-producer/tx-producer)}
@@ -35,7 +35,7 @@
                         (MapEntry/create k
                                          (cond-> v
                                            (and (list? v) (= (first v) 'fn))
-                                           (xtp/->ClojureForm)))))))))
+                                           (ClojureForm.)))))))))
 
 (defn- submit-file! [^xtdb.tx_producer.TxProducer tx-producer, ^Path log-file]
   (with-open [is (Files/newInputStream log-file (into-array OpenOption #{StandardOpenOption/READ}))]
@@ -135,11 +135,11 @@
     (shutdown-agents)))
 
 (comment
-  (require '[xtdb.api.protocols :as xt])
+  (require '[xtdb.api.protocols :as xtp])
 
   (with-open [node (node/start-node {:xtdb/c1-import {:export-log-path "/tmp/tpch"}})]
     (try
-      (xt/datalog-query node (-> '{:find [?cust ?nkey ?n_name]
+      (xtp/datalog-query node (-> '{:find [?cust ?nkey ?n_name]
                                    :where [[?cust :c_nationkey ?nkey]
                                            [?nkey :n_name ?n_name]]
                                    :limit 10}

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -6,7 +6,8 @@
             [xtdb.test-util :as tu :refer [*node*]]
             [xtdb.util :as util]
             [xtdb.error :as err])
-  (:import (java.time Duration ZoneId)))
+  (:import (java.time Duration ZoneId)
+           xtdb.types.ClojureForm))
 
 (t/use-fixtures :each
   (tu/with-each-api-implementation
@@ -156,7 +157,7 @@
              (->> (xt/q *node*
                         '{:find [tx-id tx-time committed? err]
                           :where [($ :xt/txs {:xt/id tx-id, :xt/tx-time tx-time, :xt/committed? committed? :xt/error err})]})
-                  (into #{} (map #(update % :err (comp ex-data :form)))))))))
+                  (into #{} (map #(update % :err (comp ex-data (fn [^ClojureForm clj-form] (some-> clj-form .form)))))))))))
 
 (def ^:private devs
   '[[:put :users {:xt/id :jms, :name "James"}]

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util]))
+            [xtdb.util :as util])
+  (:import xtdb.types.ClojureForm))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
@@ -377,13 +378,14 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
            RuntimeException
            #":xtdb\.call/error-evaluating-tx-fn"
 
-           (throw (-> (xt/q tu/*node*
-                            ['{:find [err]
-                               :in [tx-id]
-                               :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
-                             3])
-                      first
-                      :err :form))))))
+           (throw (let [^ClojureForm clj-form (-> (xt/q tu/*node*
+                                                        ['{:find [err]
+                                                           :in [tx-id]
+                                                           :where [($ :xt/txs {:xt/id tx-id, :xt/error err})]}
+                                                         3])
+                                                  first
+                                                  :err)]
+                    (.form clj-form)))))))
 
 (t/deftest test-indexer-cleans-up-aborted-transactions-2489
   (t/testing "INSERT"

--- a/src/test/clojure/xtdb/tx_fn_test.clj
+++ b/src/test/clojure/xtdb/tx_fn_test.clj
@@ -152,7 +152,7 @@
                                 [:call :assoc-version :fail]])
       (t/is (= 0 (foo-version)))
 
-      (t/is (thrown-with-msg? IllegalArgumentException #"Invalid tx op"
+      (t/is (thrown-with-msg? IllegalArgumentException #"invalid-tx-op"
                               (some-> (idx/reset-tx-fn-error!) throw))))
 
     (t/testing "no :fn"

--- a/wire-formats/src/main/clojure/xtdb/edn.clj
+++ b/wire-formats/src/main/clojure/xtdb/edn.clj
@@ -1,7 +1,7 @@
 (ns ^{:clojure.tools.namespace.repl/load false}
   xtdb.edn
   (:require [time-literals.read-write :as time-literals])
-  (:import (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
+  (:import (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
            java.io.Writer
            [java.time Duration Period]
            [org.apache.arrow.vector PeriodDuration]))
@@ -23,7 +23,7 @@
   (IntervalYearMonth. (Period/parse p)))
 
 (defmethod print-dup IntervalYearMonth [^IntervalYearMonth i, ^Writer w]
-  (.write w (format "#xt/interval-ym %s" (pr-str (str (.-period i))))))
+  (.write w (format "#xt/interval-ym %s" (pr-str (str (.period i))))))
 
 (defmethod print-method IntervalYearMonth [i ^Writer w]
   (print-dup i w))
@@ -32,7 +32,7 @@
   (IntervalDayTime. (Period/parse p) (Duration/parse d)))
 
 (defmethod print-dup IntervalDayTime [^IntervalDayTime i, ^Writer w]
-  (.write w (format "#xt/interval-dt %s" (pr-str [(str (.-period i)) (str (.-duration i))]))))
+  (.write w (format "#xt/interval-dt %s" (pr-str [(str (.period i)) (str (.duration i))]))))
 
 (defmethod print-method IntervalDayTime [i ^Writer w]
   (print-dup i w))
@@ -41,7 +41,7 @@
   (IntervalMonthDayNano. (Period/parse p) (Duration/parse d)))
 
 (defmethod print-dup IntervalMonthDayNano [^IntervalMonthDayNano i, ^Writer w]
-  (.write w (format "#xt/interval-mdn %s" (pr-str [(str (.-period i)) (str (.-duration i))]))))
+  (.write w (format "#xt/interval-mdn %s" (pr-str [(str (.period i)) (str (.duration i))]))))
 
 (defmethod print-method IntervalMonthDayNano [i ^Writer w]
   (print-dup i w))


### PR DESCRIPTION
resolves #2744 - unscientifically, this cuts down TPC-H 0.05 tx submission by ~60%.

* Essentially, this is hand-rolling a parser for our tx-ops - see `txp/parse-tx-op`.
* I've also written some Java beans to hold the parsed data structures - these could later form the start of a statically-typed Java client transaction DSL should we wish.