### PR TITLE
Reorganize trie loading

### DIFF
--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -8,8 +8,7 @@
             [xtdb.datasets.tpch.ra :as tpch-ra]
             xtdb.sql-test
             [xtdb.test-util :as tu]
-            [xtdb.util :as util]
-            [xtdb.operator.scan :as scan])
+            [xtdb.util :as util])
   (:import (java.nio.file Path)))
 
 (def ^:dynamic *node* nil)

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -2,46 +2,69 @@
   (:require [clojure.test :as t :refer [deftest]]
             [clojure.walk :as walk]
             [xtdb.test-util :as tu]
-            [xtdb.trie :as trie])
+            [xtdb.trie :as trie]
+            [xtdb.util :as util])
   (:import (clojure.lang MapEntry)
+           (java.util.function IntPredicate)
            (org.apache.arrow.memory RootAllocator)
+           (org.apache.arrow.memory.util ArrowBufPointer)
            (org.roaringbitmap RoaringBitmap)
            (org.roaringbitmap.buffer MutableRoaringBitmap)
-           (xtdb.trie ArrowHashTrie)))
+           (xtdb.trie HashTrie ArrowHashTrie)))
 
 (deftest test-merge-plan-with-nil-nodes-2700
-  (with-open [al (RootAllocator.)
-              t1-root (tu/open-arrow-hash-trie-root al [[nil 0 nil 1] 2 nil 3])
-              log-root (tu/open-arrow-hash-trie-root al 0)
-              log2-root (tu/open-arrow-hash-trie-root al [nil nil 0 1])]
-    (let [page-idxs [(RoaringBitmap.)
-                     (RoaringBitmap/bitmapOf (int-array '(0 1 2 3)))
-                     (RoaringBitmap/bitmapOf (int-array '(0)))
-                     (RoaringBitmap/bitmapOf (int-array '(0 1)))]
-          constant-iid-bloom-bitmap (.toImmutableRoaringBitmap (MutableRoaringBitmap/bitmapOf (int-array '(1000 1001 1002))))]
-      (letfn [(page-idx-pred [ordinal ^long page-idx]
-                (when-let [^RoaringBitmap page-idxs (nth page-idxs ordinal)]
-                  (.contains page-idxs page-idx)))
-              (iid-bloom-bitmap [_ordinal _page-idx]
-                constant-iid-bloom-bitmap)]
-        (t/is (= {:path [],
-                  :node [:branch
-                         [{:path [0],
-                           :node [:branch
-                                  [{:path [0 0], :node [:leaf [nil nil {:page-idx 0} nil]]}
-                                   {:path [0 1], :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]}
-                                   {:path [0 2], :node [:leaf [nil nil {:page-idx 0} nil]]}
-                                   {:path [0 3], :node [:leaf [nil {:page-idx 1} {:page-idx 0} nil]]}]]}
-                          {:path [1], :node [:leaf [nil {:page-idx 2} {:page-idx 0} nil]]}
-                          {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
-                          {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
-                 (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
-                                         page-idx-pred
-                                         iid-bloom-bitmap)
-                      (walk/postwalk (fn [x]
-                                       (if (and (map-entry? x) (= :path (key x)))
-                                         (MapEntry/create :path (into [] (val x)))
-                                         x))))))))))
+  (let [iid-bb (trie/->iid #uuid "01000000-0000-0000-0000-000000000000")]
+    (with-open [al (RootAllocator.)
+                t1-root (tu/open-arrow-hash-trie-root al [[nil 0 nil 1] 2 nil 3])
+                log-root (tu/open-arrow-hash-trie-root al 0)
+                log2-root (tu/open-arrow-hash-trie-root al [nil nil 0 1])
+                iid-arrow-buf (util/->arrow-buf-view al iid-bb)]
+      (let [page-idxs [(RoaringBitmap.)
+                       (RoaringBitmap/bitmapOf (int-array '(0 1 2 3)))
+                       (RoaringBitmap/bitmapOf (int-array '(0)))
+                       (RoaringBitmap/bitmapOf (int-array '(0 1)))]
+            page-idx-preds (mapv #(reify IntPredicate
+                                    (test [_ page-idx]
+                                      (.contains ^RoaringBitmap % page-idx))) page-idxs)
+            constant-iid-bloom-bitmap (.toImmutableRoaringBitmap (MutableRoaringBitmap/bitmapOf (int-array '(1000 1001 1002))))]
+        (letfn [(iid-bloom-bitmap [_page-idx]
+                  constant-iid-bloom-bitmap)]
+          (t/is (= {:path [],
+                    :node [:branch
+                           [{:path [0],
+                             :node [:branch
+                                    [{:path [0 0], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                     {:path [0 1], :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]}
+                                     {:path [0 2], :node [:leaf [nil nil {:page-idx 0} nil]]}
+                                     {:path [0 3], :node [:leaf [nil {:page-idx 1} {:page-idx 0} nil]]}]]}
+                            {:path [1], :node [:leaf [nil {:page-idx 2} {:page-idx 0} nil]]}
+                            {:path [2], :node [:leaf [nil nil {:page-idx 0} {:page-idx 0}]]}
+                            {:path [3], :node [:leaf [nil {:page-idx 3} {:page-idx 0} {:page-idx 1}]]}]]}
+                   (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
+                                           (constantly true)
+                                           page-idx-preds
+                                           (repeat 4 iid-bloom-bitmap))
+                        (walk/postwalk (fn [x]
+                                         (if (and (map-entry? x) (= :path (key x)))
+                                           (MapEntry/create :path (into [] (val x)))
+                                           x)))))
+                "testing general case")
+          (t/is (= {:path [],
+                    :node [:branch
+                           [{:path [0],
+                             :node [:branch
+                                    [nil {:path [0 1],
+                                          :node [:leaf [nil {:page-idx 0} {:page-idx 0} nil]]} nil nil]]} nil nil nil]]}
+                   (->> (trie/->merge-plan [nil (ArrowHashTrie/from t1-root) (ArrowHashTrie/from log-root) (ArrowHashTrie/from log2-root)]
+                                           (let [iid-ptr (ArrowBufPointer. iid-arrow-buf 0 (.capacity iid-bb))]
+                                             #(zero? (HashTrie/compareToPath iid-ptr %)))
+                                           page-idx-preds
+                                           (repeat 4 iid-bloom-bitmap))
+                        (walk/postwalk (fn [x]
+                                         (if (and (map-entry? x) (= :path (key x)))
+                                           (MapEntry/create :path (into [] (val x)))
+                                           x)))))
+                "testing iid fast path case"))))))
 
 (t/deftest test-selects-current-tries
   (letfn [(f [table-tries]


### PR DESCRIPTION
This is solves #2736 and puts iid page selection in front of metadata checking. We are also slimming down the MetadataManager (related ticket #2752) by essentially it mainly acting as a cache. The metadata checking also gets moved to `->merge-plan`. We are mainly trying to delay any checks so we can decide whether or not we actually need to do a check. 
The iid fast path now works as follows:
- We get an iid from the query
- We construct a path predicate 
- When calculating the merge plan we first check the path predicate to prune the trie as much as possible.
- If we get to a leaf we do the metadata checks (reason for for delaying the metadata checks).
- If everything passes one gets one merge-task.

The general case is similar except that there is no pruning happening and the `path-predicate` will always return true.

TODO:
- [ ] Worth checking if for non-selective scans this makes things slower.