### PR TITLE
Support H2 > 2.0.202

### DIFF
--- a/modules/jdbc/project.clj
+++ b/modules/jdbc/project.clj
@@ -22,7 +22,7 @@
                  ;; Sample driver dependencies
                  [org.postgresql/postgresql "42.2.18" :scope "provided"]
                  [com.oracle.ojdbc/ojdbc8 "19.3.0.0" :scope "provided"]
-                 [com.h2database/h2 "1.4.200" :scope "provided"]
+                 [com.h2database/h2 "2.2.222" :scope "provided"]
                  [org.xerial/sqlite-jdbc "3.36.0.3" :scope "provided"]
                  [mysql/mysql-connector-java "8.0.23" :scope "provided"]
                  [com.microsoft.sqlserver/mssql-jdbc "8.2.2.jre8" :scope "provided"]]

--- a/test/project.clj
+++ b/test/project.clj
@@ -20,7 +20,7 @@
                  [com.xtdb/xtdb-lmdb]
 
                  ;; JDBC
-                 [com.h2database/h2 "1.4.200"]
+                 [com.h2database/h2 "2.2.222"]
                  [com.opentable.components/otj-pg-embedded "0.13.3"]
                  [org.xerial/sqlite-jdbc "3.36.0.3"]
                  [mysql/mysql-connector-java "8.0.23"]


### PR DESCRIPTION
Conditionally compiles slightly different date code to remain compatible with older versions of h2.

tx_events `v` column is now `VARBINARY` (this works for both versions). There is no schema migration, old h2 databases created with BINARY will have to use older versions to keep working. IIUC newer h2 jars are not compatible with older databases due to internal format changes anyway.

Fixes #2619

---

Manually tested backwards compatibility, open to automation but unsure if worth given the lower production usage of H2.