### PR TITLE
Remove ToString from LRUCache

### DIFF
--- a/core/src/xtdb/cache/lru.clj
+++ b/core/src/xtdb/cache/lru.clj
@@ -9,10 +9,6 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 (deftype LRUCache [^LinkedHashMap cache ^StampedLock lock ^long size]
-  Object
-  (toString [_]
-    (.toString cache))
-
   ICache
   (computeIfAbsent [this k stored-key-fn f]
     (let [v (.valAt this k ::not-found)] ; use ::not-found as values can be falsy


### PR DESCRIPTION
The cache is a detail opaque to users, we should avoid the risk of crashing REPL's etc at dev time due to realising a large cache as string.

Fixes #2597