### PR TITLE
Permit loading of trie leaf buffers batch at time

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="java-17-openjdk" project-jdk-type="JavaSDK" />
 </project>

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -48,7 +48,7 @@
                               (.writeBranch trie-wtr (int-array idxs)))
 
                     :leaf (let [loaded-leaves (trie/load-leaves leaves {:leaves node-arg})
-                                merge-q (trie/->merge-queue (mapv :rel-rdr loaded-leaves) loaded-leaves {:path path})
+                                merge-q (trie/->merge-queue (mapv :rel-rdr loaded-leaves) (mapv :leaf-ptr loaded-leaves) {:path path})
 
                                 ^"[Lxtdb.vector.IRowCopier;"
                                 row-copiers (->> (for [{:keys [rel-rdr]} loaded-leaves]

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -48,7 +48,7 @@
                               (.writeBranch trie-wtr (int-array idxs)))
 
                     :leaf (let [loaded-leaves (trie/load-leaves leaves {:leaves node-arg})
-                                merge-q (trie/->merge-queue loaded-leaves {:path path})
+                                merge-q (trie/->merge-queue (mapv :rel-rdr loaded-leaves) loaded-leaves {:path path})
 
                                 ^"[Lxtdb.vector.IRowCopier;"
                                 row-copiers (->> (for [{:keys [rel-rdr]} loaded-leaves]
@@ -85,7 +85,7 @@
       (merge-tries! allocator leaves
                     (.getChannel leaf-out-bb) (.getChannel trie-out-bb)
                     (trie/table-merge-plan (constantly true)
-                                           (meta/matching-tries metadata-mgr (mapv :trie-file table-tries) roots
+                                           (meta/matching-tries metadata-mgr table-tries roots
                                                                 (reify IMetadataPredicate
                                                                   (build [_ _table-metadata]
                                                                     (reify IntPredicate
@@ -103,7 +103,8 @@
     (log/infof "compacted '%s' -> '%s'." table-name out-trie-key)
 
     (catch Throwable t
-      (log/error t "Error running compaction job."))))
+      (log/error t "Error running compaction job.")
+      (throw t))))
 
 (defn compaction-jobs [table-name table-tries]
   (for [[level table-tries] (->> (trie/current-table-tries table-tries)

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -363,14 +363,14 @@
 (defmethod ig/halt-key! ::metadata-manager [_ mgr]
   (util/try-close mgr))
 
-(defrecord TrieMatch [^String trie-file, ^ArrowHashTrie trie, ^RelationReader trie-rdr, ^IntPredicate page-idx-pred, ^IFn iid-bloom-bitmap-fn, ^Set col-names])
+(defrecord TrieMatch [^String trie-data, ^ArrowHashTrie trie, ^RelationReader trie-rdr, ^IntPredicate page-idx-pred, ^IFn iid-bloom-bitmap-fn, ^Set col-names])
 
-(defn matching-tries [^IMetadataManager metadata-mgr, trie-files, roots, ^IMetadataPredicate metadata-pred]
-  (->> (for [[trie-file ^VectorSchemaRoot root] (mapv vector trie-files roots)
+(defn matching-tries [^IMetadataManager metadata-mgr, table-tries, roots, ^IMetadataPredicate metadata-pred]
+  (->> (for [[table-trie ^VectorSchemaRoot root] (mapv vector table-tries roots)
              :let [trie-rdr (vr/<-root root)]]
-         (let [^ITableMetadata table-metadata (.tableMetadata metadata-mgr trie-rdr trie-file)
+         (let [^ITableMetadata table-metadata (.tableMetadata metadata-mgr trie-rdr (:trie-file table-trie))
                page-idx-pred (.build metadata-pred table-metadata)]
-           (->TrieMatch trie-file (ArrowHashTrie/from root) trie-rdr
+           (->TrieMatch table-trie (ArrowHashTrie/from root) trie-rdr
                         page-idx-pred #(.iidBloomBitmap table-metadata %)
                         (.columnNames table-metadata))))
        vec))

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -403,11 +403,19 @@
                                    {:rel-rdr (.loadLeaf leaf-loader trie-leaf)
                                     :leaf-ptr (.getLeafPointer leaf-loader)})))))))
 
-(defn ->merge-queue ^xtdb.trie.LeafMergeQueue [merge-task-readers loaded-leaves {:keys [path]}]
-  (LeafMergeQueue. path
-                   (into-array IVectorReader
-                               (map (fn [^RelationReader rel-rdr]
-                                      (when rel-rdr
-                                        (.readerForName rel-rdr "xt$iid")))
-                                    merge-task-readers))
-                   (map :leaf-ptr loaded-leaves)))
+(defn ->merge-queue
+  (^xtdb.trie.LeafMergeQueue [merge-task-readers {:keys [path]}]
+   (LeafMergeQueue. path
+                    (into-array IVectorReader
+                                (map (fn [^RelationReader rel-rdr]
+                                       (when rel-rdr
+                                         (.readerForName rel-rdr "xt$iid")))
+                                     merge-task-readers))))
+  (^xtdb.trie.LeafMergeQueue [merge-task-readers leaf-ptrs {:keys [path]}]
+   (LeafMergeQueue. path
+                    (into-array IVectorReader
+                                (map (fn [^RelationReader rel-rdr]
+                                       (when rel-rdr
+                                         (.readerForName rel-rdr "xt$iid")))
+                                     merge-task-readers))
+                    leaf-ptrs)))

--- a/core/src/main/java/xtdb/trie/LeafMergeQueue.java
+++ b/core/src/main/java/xtdb/trie/LeafMergeQueue.java
@@ -34,25 +34,36 @@ public class LeafMergeQueue {
         }
     }
 
-    private final byte[] path;
-    private final IVectorReader[] rdrs;
-    private final PriorityQueue<LeafPointer> pq;
-
     private final ArrowBufPointer leftCmp = new ArrowBufPointer();
     private final ArrowBufPointer rightCmp = new ArrowBufPointer();
     private final ArrowBufPointer isValidCmp = new ArrowBufPointer();
 
+    private final byte[] path;
+    private final IVectorReader[] rdrs;
+    private final PriorityQueue<LeafPointer> pq = new PriorityQueue<>((l, r) -> {
+        int cmp = getPointer(l, leftCmp).compareTo(getPointer(r, rightCmp));
+        if (cmp != 0) return cmp;
+        return Long.compare(r.ordinal, l.ordinal);
+    });
+
     public LeafMergeQueue(byte[] path, IVectorReader[] rdrs, Collection<LeafPointer> lps) {
         this.rdrs = rdrs;
         this.path = path;
-
-        this.pq = new PriorityQueue<>((l, r) -> {
-            int cmp = getPointer(l, leftCmp).compareTo(getPointer(r, rightCmp));
-            if (cmp != 0) return cmp;
-            return Long.compare(r.ordinal, l.ordinal);
-        });
-
         pq.addAll(lps.stream().filter(Objects::nonNull).filter(this::isValid).toList());
+    }
+
+    public LeafMergeQueue(byte[] path, IVectorReader[] rdrs) {
+        this.rdrs = rdrs;
+        this.path = path;
+        for (int i = 0; i < rdrs.length; i++) {
+            var rdr = rdrs[i];
+            if (rdr != null) {
+                var lp = new LeafPointer(i);
+                if (isValid(lp)) {
+                    pq.add(lp);
+                }
+            }
+        }
     }
 
     private ArrowBufPointer getPointer(LeafPointer lp, ArrowBufPointer ptr) {

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -76,8 +76,8 @@
                                       (tu/->live-leaf-loader lt1 1)]
                       leaf-out-ch trie-out-ch
                       {:path (byte-array [])
-                       :node [:leaf [(.rootNode (.compactLogs (li/live-trie lt0)))
-                                     (.rootNode (.compactLogs (li/live-trie lt1)))]]}))
+                       :node [:leaf [{:node (.rootNode (.compactLogs (li/live-trie lt0)))}
+                                     {:node (.rootNode (.compactLogs (li/live-trie lt1)))}]]}))
 
     (tj/check-json expected-dir tmp-dir)))
 

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -131,12 +131,12 @@
           literal-selector (expr.meta/->metadata-selector '(and (< xt/id 11) (> xt/id 9)) '{xt/id :i64} {})
           trie-obj-key (trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 0 21))]
       (util/with-open [roots (trie/open-arrow-trie-files buffer-pool [{:trie-file trie-obj-key}])]
-        (let [{:keys [^IntPredicate page-idx-pred] :as res} (first (meta/matching-tries metadata-mgr [trie-obj-key] roots literal-selector))]
+        (let [{:keys [^IntPredicate page-idx-pred] :as res} (first (meta/matching-tries metadata-mgr [{:trie-file trie-obj-key}] roots literal-selector))]
 
-          (t/is (= {:trie-file trie-obj-key
+          (t/is (= {:trie-data {:trie-file trie-obj-key}
                     :col-names
                     #{"xt$iid" "xt$valid_to" "xt$valid_from" "xt$id" "xt$system_from"}}
-                   (select-keys res [:trie-file :col-names])))
+                   (select-keys res [:trie-data :col-names])))
 
           (doseq [page-idx relevant-pages]
             (t/is (true? (.test page-idx-pred page-idx)))))))))
@@ -151,10 +151,10 @@
         trie-obj-key (trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 0 2))]
 
     (util/with-open [roots (trie/open-arrow-trie-files buffer-pool [{:trie-file trie-obj-key}])]
-      (let [{:keys [^IntPredicate page-idx-pred] :as res} (first (meta/matching-tries metadata-mgr [trie-obj-key] roots true-selector))]
-        (t/is (= {:trie-file trie-obj-key,
+      (let [{:keys [^IntPredicate page-idx-pred] :as res} (first (meta/matching-tries metadata-mgr [{:trie-file trie-obj-key}] roots true-selector))]
+        (t/is (= {:trie-data {:trie-file trie-obj-key},
                   :col-names
                   #{"xt$iid" "xt$valid_to" "xt$valid_from" "xt$id" "xt$system_from" "boolean_or_int"}}
-                 (select-keys res [:trie-file :col-names])))
+                 (select-keys res [:trie-data :col-names])))
 
         (t/is (true? (.test page-idx-pred 0)))))))

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -46,17 +46,17 @@
 
           (let [trie-files [(trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 0 2))
                             (trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 2 8))]
-                table-tries (mapv #(hash-map :trie-file %) trie-files)]
+                table-tries (mapv #'trie/parse-trie-filename trie-files)]
             (util/with-open [roots (trie/open-arrow-trie-files buffer-pool table-tries)]
               (t/testing "only needs to scan chunk 1, page 1"
 
-                (let [trie-matches (meta/matching-tries metadata-mgr trie-files roots
+                (let [trie-matches (meta/matching-tries metadata-mgr table-tries roots
                                                         (expr.meta/->metadata-selector '(> name "Ivan") '{name :utf8} {}))]
                   (t/is (false? (.test ^IntPredicate (:page-idx-pred (first trie-matches)) 0)))
                   (t/is (true? (.test ^IntPredicate (:page-idx-pred (second trie-matches)) 0))))
 
                 (with-open [params (tu/open-params {'?name "Ivan"})]
-                  (let [trie-matches (meta/matching-tries metadata-mgr trie-files roots
+                  (let [trie-matches (meta/matching-tries metadata-mgr table-tries roots
                                                           (expr.meta/->metadata-selector '(> name ?name) '{name :utf8} params))]
                     (t/is (false? (.test ^IntPredicate (:page-idx-pred (first trie-matches)) 0)))
                     (t/is (true? (.test ^IntPredicate (:page-idx-pred (second trie-matches)) 0))))))))
@@ -92,17 +92,17 @@
 
       (let [trie-files [(trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 0 4))
                         (trie/->table-trie-obj-key "xt_docs" (trie/->trie-key 0 4 7))]
-            table-tries (mapv #(hash-map :trie-file %) trie-files)]
+            table-tries (mapv #'trie/parse-trie-filename trie-files)]
         (util/with-open [roots (trie/open-arrow-trie-files buffer-pool table-tries)]
           (t/testing "only needs to scan chunk 1, page 1"
 
-            (let [trie-matches (meta/matching-tries metadata-mgr trie-files roots
+            (let [trie-matches (meta/matching-tries metadata-mgr table-tries roots
                                                     (expr.meta/->metadata-selector '(= name "Ivan") '{name :utf8} {}))]
               (t/is (true? (.test ^IntPredicate (:page-idx-pred (first trie-matches)) 0)))
               (t/is (false? (.test ^IntPredicate (:page-idx-pred (second trie-matches)) 0))))
 
             (with-open [params (tu/open-params {'?name "Ivan"})]
-              (let [trie-matches (meta/matching-tries metadata-mgr trie-files roots
+              (let [trie-matches (meta/matching-tries metadata-mgr table-tries roots
                                                       (expr.meta/->metadata-selector '(= name ?name) '{name :utf8} params))]
                 (t/is (true? (.test ^IntPredicate (:page-idx-pred (first trie-matches)) 0)))
                 (t/is (false? (.test ^IntPredicate (:page-idx-pred (second trie-matches)) 0))))))))


### PR DESCRIPTION
Provides (naive for now) buffer pool functions to get a record batch and arrow footer. These are integrated into scan such that batches can later be loaded using range requests by the buffer pool.

Note:

- For now, the ArrowLoaders still exist for compaction.
- LeafPointers are still used for the algorithmic sorting but their scope is limited they are constructed by the MergeQueue when it wraps the task readers
- there is no explicit iterator / spliterator, it turns out the memory management angle is not as expected due to management being offloaded to a cursor shared VectorSchemaRoot cache.

Surprisingly early testing shows no degradation in performance

TPCH  0.05

| Test | PR2774 | 2.X |
| - | - | - |
| HOT | 115682.257417ms | 133288.293041ms |
| COLD | 117183.607208ms | 135290.006541ms | 

Resolves #2694