### PR TITLE
Give system components child allocators

### DIFF
--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -22,7 +22,8 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 (defmethod ig/init-key :xtdb/allocator [_ _] (RootAllocator.))
-(defmethod ig/halt-key! :xtdb/allocator [_ ^BufferAllocator a] (.close a))
+(defmethod ig/halt-key! :xtdb/allocator [_ ^BufferAllocator a]
+  (util/close a))
 
 (defmethod ig/prep-key :xtdb/default-tz [_ default-tz]
   (cond

--- a/core/src/main/clojure/xtdb/operator.clj
+++ b/core/src/main/clojure/xtdb/operator.clj
@@ -132,7 +132,7 @@
                  (.acquire ref-ctr)
                  (let [^BufferAllocator allocator
                        (if allocator
-                         (.newChildAllocator allocator "BoundQuery/openCursor" AllocationListener/NOOP 0 Long/MAX_VALUE)
+                         (util/->child-allocator allocator "BoundQuery/openCursor")
                          (RootAllocator.))
                        wm (some-> wm-src (.openWatermark wm-tx))]
                    (try

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -712,3 +712,5 @@
 (defn normal-form-str->datalog-form-str ^String [^String s]
   (NormalForm/datalogForm s))
 
+(defn ->child-allocator [^BufferAllocator allocator name]
+  (.newChildAllocator allocator name (.getInitReservation allocator) (.getLimit allocator)))


### PR DESCRIPTION
Now every component closes it's own allocator. Narrowing down memory leaks now becomes a lot more efficient. 
The LiveIndex now needs to wait for it's watermarks to go out of scope before closing.