### PR TITLE
LocalObjectStore interface

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -22,10 +22,12 @@
   (^java.util.concurrent.CompletableFuture getRangeBuffer [^String k ^int start ^int len])
   (^boolean evictBuffer [^String k]))
 
+(defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
+
 (defn- cache-get ^ArrowBuf [^Map buffers ^StampedLock buffers-lock k]
   (let [stamp (.readLock buffers-lock)]
     (try
-      (.get buffers k)
+      (some-> (.get buffers k) retain)
       (finally
         (.unlock buffers-lock stamp)))))
 
@@ -56,11 +58,10 @@
     (try
       (let [arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
         (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
-        [hit arrow-buf])
+        [hit (retain arrow-buf)])
       (finally
         (.unlock buffers-lock stamp)))))
 
-(defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
 
 (deftype BufferPool [^BufferAllocator allocator ^ObjectStore object-store ^Map buffers ^StampedLock buffers-lock
                      ^Path cache-path]
@@ -73,7 +74,7 @@
           cached-buffer
           (do
             (record-cache-hit cached-buffer)
-            (CompletableFuture/completedFuture (retain cached-buffer)))
+            (CompletableFuture/completedFuture cached-buffer))
 
           cache-path
           (let [start-ns (System/nanoTime)]
@@ -87,7 +88,7 @@
                               create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer cleanup-file)
                               [hit buf] (cache-compute buffers buffers-lock k create-arrow-buf)]
                           (when hit (cleanup-file))
-                          (retain buf))
+                          buf)
                         (catch Throwable t
                           (try (cleanup-file) (catch Throwable t1 (log/error t1 "Error caught cleaning up file during exception handling")))
                           (throw t))))))))
@@ -100,7 +101,7 @@
                     (record-io-wait start-ns)
                     (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
                           [_ buf] (cache-compute buffers buffers-lock k create-arrow-buf)]
-                      (retain buf))))))))))
+                      buf)))))))))
 
   (getRangeBuffer [_ k start len]
     (object-store/ensure-shared-range-oob-behaviour start len)
@@ -124,7 +125,7 @@
                     (record-io-wait start-ns)
                     (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
                           [_ buf] (cache-compute buffers buffers-lock [k start len] create-arrow-buf)]
-                      (retain buf))))))))))
+                      buf)))))))))
 
   (evictBuffer [_ k]
     (if-let [buffer (let [stamp (.writeLock buffers-lock)]
@@ -138,15 +139,15 @@
 
   Closeable
   (close [_]
-    (let [stamp (.writeLock buffers-lock)]
+    (let [write-stamp (.writeLock buffers-lock)]
       (try
         (let [i (.iterator (.values buffers))]
           (while (.hasNext i)
             (util/close (.next i))
             (.remove i)))
+        (util/close allocator)
         (finally
-          (.unlock buffers-lock stamp)))
-      (util/close allocator))))
+          (.unlock buffers-lock write-stamp))))))
 
 (defn- ->buffer-cache [^long cache-entries-size ^long cache-bytes-size]
   (ArrowBufLRU. 16 cache-entries-size cache-bytes-size))

--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -10,7 +10,6 @@
            [java.util Map UUID]
            java.util.concurrent.CompletableFuture
            java.util.concurrent.locks.StampedLock
-           java.util.function.BiPredicate
            (java.util.concurrent.atomic AtomicLong)
            [org.apache.arrow.memory ArrowBuf BufferAllocator]
            (org.apache.arrow.vector VectorSchemaRoot)
@@ -55,7 +54,7 @@
   (let [stamp (.writeLock buffers-lock)
         hit (.containsKey ^Map buffers k)]
     (try
-      (let [arrow-buf (.computeIfAbsent buffers k (util/->jfn (fn [_] (f))))]
+      (let [arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
         (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
         [hit arrow-buf])
       (finally

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -1,0 +1,80 @@
+(ns xtdb.concurrent-node-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.buffer-pool :as bp]
+            [xtdb.object-store :as os]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import (org.apache.arrow.memory ArrowBuf)
+           (xtdb.buffer_pool IBufferPool)
+           (xtdb.object_store ObjectStore)
+           (xtdb InstantSource)))
+
+(defn- random-maps [n]
+  (let [nb-ks 5
+        ks [:foo :bar :baz :foobar :barfoo]]
+    (->> (repeatedly n #(zipmap ks (map str (repeatedly nb-ks random-uuid))))
+         (map-indexed #(assoc %2 :xt/id %1)))))
+
+(defn q-now [node q+args]
+  (xt/q node q+args
+        {:basis {:after-tx (:latest-completed-tx (xt/status node))}}))
+
+(def ^java.io.File node-dir (io/file "dev/concurrent-node-test"))
+(def node-opts {:node-dir (.toPath node-dir)
+                :instant-src InstantSource/SYSTEM})
+
+(comment
+  (util/delete-dir (.toPath node-dir)))
+
+(defn- populate-node [{:keys [node-dir] :as node-opts}]
+  (when-not (util/path-exists node-dir)
+    (with-open [node (tu/->local-node node-opts)]
+
+      (doseq [tx (->> (random-maps 1000000)
+                      (map #(vector :put :docs %))
+                      (partition-all 1024))]
+        (xt/submit-tx node tx))
+      (tu/finish-chunk! node))))
+
+(comment
+  (populate-node node-opts))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(deftest concurrent-buffer-pool-test
+  (populate-node node-opts)
+  (tu/with-system {:xtdb/allocator {}
+                   :xtdb.buffer-pool/buffer-pool {:cache-path (.resolve (.toPath node-dir) "buffers")}
+                   :xtdb.object-store/file-system-object-store {:root-path (.resolve (.toPath node-dir) "objects")}}
+    (fn []
+      (let [^IBufferPool buffer-pool (::bp/buffer-pool tu/*sys*)
+            ^ObjectStore object-store (::os/file-system-object-store tu/*sys*)
+            objs (.listObjects object-store)
+            get-item #(with-open [^ArrowBuf _buf (deref (.getBuffer buffer-pool (rand-nth objs)))]
+                        (Thread/sleep 10))
+            f-call #(future
+                      (dotimes [_ 300]
+                        (get-item)))
+
+            fs (doall (repeatedly 3 f-call))]
+        (t/is (not (nil? object-store)))
+        (mapv deref fs)))))
+
+(deftest concurrent-node-test
+  (populate-node node-opts)
+  (with-open [node (tu/->local-node node-opts)]
+    (let [open-ids (->> (xt/q node '{:find [id] :where [(match :docs {:xt/id id})]})
+                        (mapv :id))
+          q '{:find [id foo bar baz foobar barfoo]
+              :in [id]
+              :where [(match :docs [{:xt/id id} foo bar baz foobar barfoo])]}
+          get-item #(q-now node [q (rand-nth open-ids)])
+          f-call #(future
+                    (dotimes [_ 10]
+                      (get-item)))
+          fs (doall (repeatedly 3 f-call))]
+      (mapv deref fs)
+      ;; just so deftest doesn't complain about no assertions
+      (t/is (true? true)))))


### PR DESCRIPTION
This resolves #2772. The problem is that the object store interface was created with a remote object store in mind. So that a call like `(.getObject object-store k cache-path)` would actually copy the object from remote storage to the machine. When working with the file-system object store this just does unnecessary copies locally which show up in the profiler. The PR tries to avoid the unnecessary copying by introducing a temporary solution for the case described above. @wotbrew mentioned that these interfaces will change significantly with his IO work and that the case of a local file system object store might then completely be dealt with by the buffer-pool. 