### PR TITLE
ArrowBufLRU

### DIFF
--- a/core/src/main/java/xtdb/util/ArrowBufLRU.java
+++ b/core/src/main/java/xtdb/util/ArrowBufLRU.java
@@ -1,0 +1,42 @@
+package xtdb.util;
+
+import org.apache.arrow.memory.ArrowBuf;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiPredicate;
+
+public class ArrowBufLRU<K, ArrowBuf> extends LinkedHashMap<K, ArrowBuf> {
+    private static final long serialVersionUID = 1L;
+
+    private long byteSize;
+    private final BiPredicate<Map<K, ArrowBuf>, Entry<K, ArrowBuf>> removeEldestEntryFn;
+
+    @Override
+    public ArrowBuf put(K key, ArrowBuf buf) {
+        byteSize += ((org.apache.arrow.memory.ArrowBuf) buf).capacity();
+        return super.put(key, (ArrowBuf) buf);
+    }
+
+    public ArrowBufLRU(int initialSize, int maxSize, long maxByteSize) {
+        super(initialSize, 0.75f, true);
+        this.byteSize = 0;
+        this.removeEldestEntryFn = new BiPredicate<Map<K, ArrowBuf>, Entry<K, ArrowBuf>>() {
+            @Override
+            public boolean test(Map<K, ArrowBuf> m, Entry<K, ArrowBuf> entry) {
+                if(maxSize < m.size() || maxByteSize < byteSize){
+                    ((org.apache.arrow.memory.ArrowBuf) entry.getValue()).close();
+                    return  true;
+                }
+                return false;
+            }
+        };
+    }
+
+    public boolean removeEldestEntry(Map.Entry<K, ArrowBuf> entry) {
+        var res = this.removeEldestEntryFn.test(this, entry);
+        if (res) byteSize -= ((org.apache.arrow.memory.ArrowBuf) entry.getValue()).capacity();
+        return res;
+    }
+}


### PR DESCRIPTION
The buffer-pool was calculating the total size in bytes of the cache by iterating through all the entries every time an item was added. The calculation of this total size in bytes was showing up in the profiler. This specialization of an LRU cache does so by  keeping track of the total size in bytes of the cache and updating things as they come into and leaf the cache. It's quite a specialized class so if there is a more generic solution with the same characteristics I am all for it. 