### PR TITLE
Reuse cache-path in buffer pool

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -69,8 +69,12 @@
             (CompletableFuture/completedFuture cached-buffer))
 
           cache-path
-          (let [start-ns (System/nanoTime)]
-            (-> (.getObject object-store k (.resolve cache-path (str (UUID/randomUUID))))
+          (let [start-ns (System/nanoTime)
+                buffer-cache-path (.resolve cache-path k)]
+            (-> (if (util/path-exists buffer-cache-path)
+                  (CompletableFuture/completedFuture buffer-cache-path)
+                  (do (util/create-parents buffer-cache-path)
+                      (.getObject object-store k buffer-cache-path)))
                 (util/then-apply
                   (fn [buffer-path]
                     (record-io-wait start-ns)

--- a/core/src/main/clojure/xtdb/object_store.clj
+++ b/core/src/main/clojure/xtdb/object_store.clj
@@ -156,8 +156,9 @@
            (when-not (util/path-exists from-path)
              (throw (obj-missing-exception k)))
 
-           (Files/copy from-path out-path
-                       ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0))
+           (when-not (util/path-exists out-path)
+             (Files/copy from-path out-path
+                         ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0)))
            out-path)))))
 
   (putObject [_this k buf]

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -314,6 +314,11 @@
 (defn mkdirs [^Path path]
   (Files/createDirectories path (make-array FileAttribute 0)))
 
+(defn create-parents [^Path path]
+  (let [parents (.getParent path)]
+    (when-not (path-exists parents)
+      (mkdirs parents))))
+
 (defn ->temp-file ^Path [^String prefix ^String suffix]
   (doto (Files/createTempFile prefix suffix (make-array FileAttribute 0))
     (delete-file)))


### PR DESCRIPTION
This resolves https://github.com/xtdb/xtdb/issues/2772. Instead of copying the file from the object-store every time when checking the cache it is instead copied once (also for the file-system-object-store) and then cached under the `cache-path` of the `buffer-pool`. We also don't delete the buffer pool cache-path directory on buffer pool intialization.