### PR TITLE
Buffer pool tightening + concurrent node tests

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -10,7 +10,6 @@
            [java.util Map UUID]
            java.util.concurrent.CompletableFuture
            java.util.concurrent.locks.StampedLock
-           java.util.function.BiPredicate
            (java.util.concurrent.atomic AtomicLong)
            [org.apache.arrow.memory ArrowBuf BufferAllocator]
            (org.apache.arrow.vector VectorSchemaRoot)
@@ -55,7 +54,7 @@
   (let [stamp (.writeLock buffers-lock)
         hit (.containsKey ^Map buffers k)]
     (try
-      (let [arrow-buf (.computeIfAbsent buffers k (util/->jfn (fn [_] (f))))]
+      (let [arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
         (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
         [hit arrow-buf])
       (finally

--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -24,12 +24,9 @@
 
 (defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
 
-(defn- cache-get ^ArrowBuf [^Map buffers ^StampedLock buffers-lock k]
-  (let [stamp (.readLock buffers-lock)]
-    (try
-      (some-> (.get buffers k) retain)
-      (finally
-        (.unlock buffers-lock stamp)))))
+(defn- cache-get ^ArrowBuf [^Map buffers k]
+  (locking buffers
+    (some-> (.get buffers k) retain)))
 
 (def ^AtomicLong cache-miss-byte-counter (AtomicLong.))
 (def ^AtomicLong cache-hit-byte-counter (AtomicLong.))
@@ -52,24 +49,19 @@
 (defn- cache-compute
   "Returns a pair [hit-or-miss, buf] computing the cached ArrowBuf from (f) if needed.
   `hit-or-miss` is true if the buffer was found, false if the object was added as part of this call."
-  [^Map buffers ^StampedLock buffers-lock k f]
-  (let [stamp (.writeLock buffers-lock)
-        hit (.containsKey ^Map buffers k)]
-    (try
-      (let [arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
-        (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
-        [hit (retain arrow-buf)])
-      (finally
-        (.unlock buffers-lock stamp)))))
+  [^Map buffers k f]
+  (locking buffers
+    (let [hit (.containsKey ^Map buffers k)
+          arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
+      (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
+      [hit (retain arrow-buf)])))
 
-
-(deftype BufferPool [^BufferAllocator allocator ^ObjectStore object-store ^Map buffers ^StampedLock buffers-lock
-                     ^Path cache-path]
+(deftype BufferPool [^BufferAllocator allocator ^ObjectStore object-store ^Map buffers ^Path cache-path]
   IBufferPool
   (getBuffer [_ k]
     (if (nil? k)
       (CompletableFuture/completedFuture nil)
-      (let [cached-buffer (cache-get buffers buffers-lock k)]
+      (let [cached-buffer (cache-get buffers k)]
         (cond
           cached-buffer
           (do
@@ -86,7 +78,7 @@
                       (try
                         (let [nio-buffer (util/->mmap-path buffer-path)
                               create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer cleanup-file)
-                              [hit buf] (cache-compute buffers buffers-lock k create-arrow-buf)]
+                              [hit buf] (cache-compute buffers k create-arrow-buf)]
                           (when hit (cleanup-file))
                           buf)
                         (catch Throwable t
@@ -100,17 +92,17 @@
                   (fn [nio-buffer]
                     (record-io-wait start-ns)
                     (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-                          [_ buf] (cache-compute buffers buffers-lock k create-arrow-buf)]
+                          [_ buf] (cache-compute buffers k create-arrow-buf)]
                       buf)))))))))
 
   (getRangeBuffer [_ k start len]
     (object-store/ensure-shared-range-oob-behaviour start len)
     (if (nil? k)
       (CompletableFuture/completedFuture nil)
-      (let [cached-full-buffer (cache-get buffers buffers-lock k)
+      (let [cached-full-buffer (cache-get buffers k)
 
             cached-buffer
-            (or (cache-get buffers buffers-lock [k start len])
+            (or (cache-get buffers [k start len])
                 (when ^ArrowBuf cached-full-buffer
                   (.slice cached-full-buffer start len)))]
 
@@ -124,30 +116,24 @@
                   (fn [nio-buffer]
                     (record-io-wait start-ns)
                     (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-                          [_ buf] (cache-compute buffers buffers-lock [k start len] create-arrow-buf)]
+                          [_ buf] (cache-compute buffers [k start len] create-arrow-buf)]
                       buf)))))))))
 
   (evictBuffer [_ k]
-    (if-let [buffer (let [stamp (.writeLock buffers-lock)]
-                      (try
-                        (.remove buffers k)
-                        (finally
-                          (.unlock buffers-lock stamp))))]
+    (if-let [buffer (locking buffers
+                      (.remove buffers k))]
       (do (util/close buffer)
           true)
       false))
 
   Closeable
   (close [_]
-    (let [write-stamp (.writeLock buffers-lock)]
-      (try
-        (let [i (.iterator (.values buffers))]
-          (while (.hasNext i)
-            (util/close (.next i))
-            (.remove i)))
-        (util/close allocator)
-        (finally
-          (.unlock buffers-lock write-stamp))))))
+    (locking buffers
+      (let [i (.iterator (.values buffers))]
+        (while (.hasNext i)
+          (util/close (.next i))
+          (.remove i)))
+      (util/close allocator))))
 
 (defn- ->buffer-cache [^long cache-entries-size ^long cache-bytes-size]
   (ArrowBufLRU. 16 cache-entries-size cache-bytes-size))
@@ -165,8 +151,7 @@
   (when (and cache-path (not (util/path-exists cache-path)))
     (util/mkdirs cache-path))
   (util/with-close-on-catch [allocator (util/->child-allocator allocator "buffer-pool")]
-    (->BufferPool  allocator object-store
-                   (->buffer-cache cache-entries-size cache-bytes-size) (StampedLock.) cache-path)))
+    (->BufferPool  allocator object-store (->buffer-cache cache-entries-size cache-bytes-size) cache-path)))
 
 (defmethod ig/halt-key! ::buffer-pool [_ ^BufferPool buffer-pool]
   (.close buffer-pool))

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -1,0 +1,77 @@
+(ns xtdb.concurrent-node-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.buffer-pool :as bp]
+            [xtdb.object-store :as os]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import (org.apache.arrow.memory ArrowBuf)
+           (xtdb.buffer_pool IBufferPool)
+           (xtdb.object_store ObjectStore)
+           (xtdb InstantSource)))
+
+(defn- random-maps [n]
+  (let [nb-ks 5
+        ks [:foo :bar :baz :foobar :barfoo]]
+    (->> (repeatedly n #(zipmap ks (map str (repeatedly nb-ks random-uuid))))
+         (map-indexed #(assoc %2 :xt/id %1)))))
+
+(defn q-now [node q+args]
+  (xt/q node q+args
+        {:basis {:after-tx (:latest-completed-tx (xt/status node))}}))
+
+(def ^java.io.File node-dir (io/file "dev/concurrent-node-test"))
+(def node-opts {:node-dir (.toPath node-dir)
+                :instant-src InstantSource/SYSTEM})
+
+(defn- populate-node [{:keys [node-dir] :as node-opts}]
+  (when-not (util/path-exists node-dir)
+    (with-open [node (tu/->local-node node-opts)]
+      (doseq [tx (->> (random-maps 400000)
+                      (map #(vector :put :docs %))
+                      (partition-all 1024))]
+        (xt/submit-tx node tx))
+      (tu/finish-chunk! node))))
+
+(comment
+  (util/delete-dir (.toPath node-dir))
+  (populate-node node-opts))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(deftest ^:integration concurrent-buffer-pool-test
+  (populate-node node-opts)
+  (tu/with-system {:xtdb/allocator {}
+                   :xtdb.buffer-pool/buffer-pool {:cache-path (.resolve (.toPath node-dir) "buffers")}
+                   :xtdb.object-store/file-system-object-store {:root-path (.resolve (.toPath node-dir) "objects")}}
+    (fn []
+      (let [^IBufferPool buffer-pool (::bp/buffer-pool tu/*sys*)
+            ^ObjectStore object-store (::os/file-system-object-store tu/*sys*)
+            objs (.listObjects object-store)
+            get-item #(with-open [^ArrowBuf _buf (deref (.getBuffer buffer-pool (rand-nth objs)))]
+                        (Thread/sleep 10))
+            f-call #(future
+                      (dotimes [_ 300]
+                        (get-item)))
+
+            fs (doall (repeatedly 3 f-call))]
+        (t/is (not (nil? object-store)))
+        (mapv deref fs)))))
+
+(deftest ^:integration concurrent-node-test
+  (populate-node node-opts)
+  (with-open [node (tu/->local-node node-opts)]
+    (let [open-ids (->> (xt/q node '{:find [id] :where [(match :docs {:xt/id id})]})
+                        (mapv :id))
+          q '{:find [id foo bar baz foobar barfoo]
+              :in [id]
+              :where [(match :docs [{:xt/id id} foo bar baz foobar barfoo])]}
+          get-item #(q-now node [q (rand-nth open-ids)])
+          f-call #(future
+                    (dotimes [_ 100]
+                      (get-item)))
+          fs (doall (repeatedly 3 f-call))]
+      (mapv deref fs)
+      ;; just so deftest doesn't complain about no assertions
+      (t/is (true? true)))))


### PR DESCRIPTION
This tightens some stuff around the buffer pool and adds some concurrent node tests.
I moved the `retain` logic inside the buffer pool lock and also used `syncronized` locking instead of an explict lock. I don't know why the explicit lock results in memory leaks (probably something good to understand) before merging this. I also addressed the issue of #2802 with a simple quickfix. As @wotbrew is looking at the buffer pool anyways pretty soon, I suspect that a lot of this will change.