### PR TITLE
Auctionmark automation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,6 +210,55 @@ if (hasProperty("fin")) {
     }
 }
 
+fun addToArgsIfExistent(propertyName: String, args: MutableList<String>){
+    if (project.hasProperty(propertyName)) {
+        project.property(propertyName)?.toString()?.let { property ->
+            args.add("--" + propertyName)
+            args.add(property)
+        }
+    }
+}
+
+tasks.create("run-auctionmark", JavaExec::class) {
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+    val args = mutableListOf<String>(
+        "-m", "xtdb.bench2.xtdb2"
+    )
+
+    addToArgsIfExistent("output-file", args)
+    addToArgsIfExistent("load-phase" , args)
+    addToArgsIfExistent("duration", args)
+
+    this.args = args
+}
+
+tasks.create("create-reports", JavaExec::class) {
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs)
+    val args = mutableListOf<String>(
+        "-m", "xtdb.bench2.report"
+    )
+
+    if (project.hasProperty("report0")) {
+        project.property("report0")?.toString()?.let { report ->
+            args.add("--report")
+            args.add(report)
+        }
+    }
+
+    if (project.hasProperty("report1")) {
+        project.property("report1")?.toString()?.let { report ->
+            args.add("--report")
+            args.add(report)
+        }
+    }
+
+    this.args = args
+}
+
 fun createSltTask(
     taskName: String,
     maxFailures: Long = 0,

--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -6,6 +6,15 @@ Auctionmark runs in some capacity currently, this guide describes the requiremen
 - Run AWS_PROFILE=<profile_name_containing_above_creds> bin/download-dataset.sh --auctionmark (skip)
 - See comments at bottom of xtdb.bench2.xtdb.clj for further instructions.
 
+=== Creating a C1 vs C2 comparison report
+
+The following setup assumes that you have `2.x` checked out and another directory at `../xtdb` which can checkout the `auctionmark` branch of C1.
+Make sure there is nothing to be stashed on your (presumably C1) working branch.
+The following script will first run a C1 auctionmark on your machine followed by a C2 run and finally creates a report for comparison. It assumes you are placed at the root of the `modules/bench` directory.
+`./bin/auctionmark-compare.clj --load-phase true --run-duration "PT30S"`
+For subsequent runs one can potentially skip the load-phase.
+
+
 = (Deprecated) Bench
 
 A rudimentary bench adapted from XTDB 1.x. It currently only runs TPC-H, and only runs it ad-hoc (on Fargate) - it doesn't have any of the daily scheduling.

--- a/modules/bench/bin/auctionmark-compare.clj
+++ b/modules/bench/bin/auctionmark-compare.clj
@@ -1,0 +1,52 @@
+#!/usr/bin/env bb
+
+(require '[babashka.cli :as cli]
+         '[babashka.process :as p]
+         '[clojure.tools.logging :as log]
+         '[taoensso.timbre :as timbre])
+
+(timbre/set-level! :debug)
+
+(def cli-opts {:coerce {:load-phase :boolean :duration :string}})
+(def opts (cli/parse-opts *command-line-args* cli-opts))
+
+(log/debug "Given options: " opts)
+
+(def c1-auctionmark-file "/tmp/auctionmark-c1-run.edn")
+(def c2-auctionmark-file "/tmp/auctionmark-c2-run.edn")
+(def jvm-args ["-Xmx2g", "-Xms2g", "-XX:MaxDirectMemorySize=3g", "-XX:MaxMetaspaceSize=1g"])
+
+(log/info "Checking out C1 auctionmark branch")
+(p/shell {:dir "../../../xtdb/"} "git checkout auctionmark")
+
+(log/info "Running auctionmark on C1")
+(log/debug "C1 process result:"
+           @(p/process {:inherit true
+                        :shutdown p/destroy-tree
+                        :extra-env {"MALLOC_ARENA_MAX" "2"
+                                    "JVM_OPTS" (->> jvm-args (interpose " ") (apply str))}
+                        :dir "../../../xtdb/bench/"}
+                       (cond-> (str "lein run -m xtdb.bench2.core1 --output-file " c1-auctionmark-file " ")
+                         (not (nil? (:load-phase opts))) (str "--load-phase " (:load-phase opts) " ")
+                         (:duration opts) (str "--duration " (:duration opts)))))
+
+(log/info "Running auctionmark on C2")
+(let [args (cond-> (str "-Poutput-file=" c2-auctionmark-file " ")
+             (not (nil? (:load-phase opts))) (str "-Pload-phase=" (:load-phase opts) " ")
+             (:duration opts) (str "-Pduration=" (:duration opts))
+             true (str "'"))]
+
+  (log/debug "C2 process result:"
+             @(p/process {:inherit true
+                          :shutdown p/destroy-tree
+                          :dir "../../"}
+                         (str "./gradlew run-auctionmark " args))))
+
+(log/info "Generating comparison report")
+(log/debug "Generating reports process result:"
+           @(p/process {:inherit true
+                        :shutdown p/destroy-tree
+                        :dir "../../"}
+                       (str "./gradlew create-reports "
+                            "-Preport0=[core1," c1-auctionmark-file "] "
+                            "-Preport1=[core2," c2-auctionmark-file "]")))

--- a/modules/bench/src/main/clojure/xtdb/bench2/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/auctionmark.clj
@@ -609,8 +609,11 @@
            [{:t :do
              :stage :setup-worker
              :tasks [{:t :call, :f (fn [_] (log/info "setting up worker with stats"))}
-                     ;; wait for node to come up
-                     {:t :call, :f (fn [_] (when-not load-phase (Thread/sleep 1000)))}
+                     ;; wait for node to catch up
+                     {:t :call, :f #(when-not load-phase
+                                      ;; otherwise nothing has come through the log yet
+                                      (Thread/sleep 1000)
+                                      #_(tu/then-await-tx (:sut %)))}
                      {:t :call, :f load-stats-into-worker}
                      {:t :call, :f log-stats}
                      {:t :call, :f (fn [_] (log/info "finished setting up worker with stats"))}]}

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -1,19 +1,22 @@
 (ns xtdb.bench2.xtdb2
   (:require [clojure.java.io :as io]
+            [clojure.tools.cli :as cli]
+            [clojure.tools.logging :as log]
             [xtdb.api :as xt]
             [xtdb.api.protocols :as xtp]
             [xtdb.bench2 :as b]
             [xtdb.bench2.measurement :as bm]
             [xtdb.node :as node]
-            [xtdb.test-util :as tu])
-  (:import (xtdb InstantSource)
-           (io.micrometer.core.instrument MeterRegistry Timer)
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import (io.micrometer.core.instrument MeterRegistry Timer)
            (java.io Closeable File)
            (java.nio.file Path)
            (java.time Clock Duration)
            (java.util Random)
            (java.util.concurrent ConcurrentHashMap)
-           (java.util.concurrent.atomic AtomicLong)))
+           (java.util.concurrent.atomic AtomicLong)
+           (xtdb InstantSource)))
 
 (set! *warn-on-reflection* false)
 
@@ -192,6 +195,46 @@
         worker (b/->Worker node root-random domain-state custom-state clock reports)]
     worker))
 
+(defn- only-oltp-stage [report]
+  (let [stage-filter #(filter (comp #{:oltp} :stage) %)]
+    (-> report
+        (update :stages stage-filter)
+        (update :metrics stage-filter))))
+
+(defn run-auctionmark [{:keys [output-file node-dir load-phase duration]
+                        :or {node-dir "dev/auctionmark-run"
+                             duration "PT30S"} :as opts}]
+  (let [output-file (or output-file (str "auctionmark-" duration ".edn"))
+        node-dir (.toPath (io/file node-dir))]
+    (when load-phase
+      (util/delete-dir node-dir))
+    (let [report (-> (run-benchmark
+                      {:node-opts {:node-dir node-dir
+                                   :instant-src InstantSource/SYSTEM}
+                       :benchmark-type :auctionmark
+                       :benchmark-opts (assoc opts :sync true)})
+                     only-oltp-stage)]
+      (spit (io/file output-file) report))))
+
+(def cli-options
+  [[nil "--load-phase LOAD-PHASE" :parse-fn #(not (or (= % "false") (= % "nil")))]
+   [nil "--output-file OUTPUT-FILE"]
+   [nil "--node-dir NODE-DIR"]
+   [nil "--duration DURATION" :validate [#(try (Duration/parse %) true (catch Throwable _t false))
+                                         "Incorrect duration period"]]
+   [nil "--threads THREADS" :parse-fn #(Long/parseLong %)]
+   [nil "--scale-factor" :parse-fn #(Double/parseDouble %)]])
+
+(defn -main [& args]
+  (let [{:keys [options _arguments errors]} (cli/parse-opts args cli-options)]
+    (log/debug "Auctionmark run opts:" options)
+    (if (seq errors)
+      (binding [*out* *err*]
+        (doseq [error errors]
+          (println error))
+        (System/exit 1))
+      (run-auctionmark options))))
+
 (comment
 
   ;; ======
@@ -207,8 +250,8 @@
   (def node-dir (io/file "dev/dev-node"))
   (delete-directory-recursive node-dir)
 
-  ;; comment out the different phases in auctionmark.clj
-  ;; load phase is the only one required if testing single point queries
+  ;; The load-phase is essentially required once to setup some initial data,
+  ;; but can be ignored on subsequent runs.
   ;; run-benchmark clears up the node it creates (but not the data),
   ;; hence needing to create a new one to test single point queries
 
@@ -217,8 +260,8 @@
      {:node-opts {:node-dir (.toPath node-dir)
                   :instant-src InstantSource/SYSTEM}
       :benchmark-type :auctionmark
-      :benchmark-opts {:duration run-duration
-                       :scale-factor 0.1 :threads 8}}))
+      :benchmark-opts {:duration run-duration :load-phase true
+                       :scale-factor 0.1 :threads 1}}))
 
   ;;;;;;;;;;;;;
   ;; Viewing Reports

--- a/src/test/clojure/xtdb/bench2/auctionmark_test.clj
+++ b/src/test/clojure/xtdb/bench2/auctionmark_test.clj
@@ -107,7 +107,8 @@
       (am/load-categories-tsv worker)
       (bxt2/generate worker :category am/generate-category 1)
       (bxt2/generate worker :item am/generate-item 1)
-
+      ;; to wait for indexing
+      (Thread/sleep 10)
       (t/is (= "i_0" (-> (am/proc-get-item worker) first :i_id))))))
 
 (t/deftest proc-new-user-test


### PR DESCRIPTION
This PR adds a script and a couple of gradle tasks that should help creating an Auctionmark report more easily.
Being in the `modules/bench` directory, one should (big  emphasis on "should") now be able to create a comparison report with just one command.
```
./bin/auctionmark-compare.clj --load-phase false --duration "PT30S"
```

TODO:
- [x] some small issues with the gradle task to be sorted out