### PR TITLE
Indexer uses new :bytes-per-chunk option

### DIFF
--- a/core/src/main/clojure/xtdb/log/watcher.clj
+++ b/core/src/main/clojure/xtdb/log/watcher.clj
@@ -42,7 +42,7 @@
 
                       (condp = (Byte/toUnsignedInt (.get ^ByteBuffer (.-record record) 0))
                         xt-log/hb-user-arrow-transaction
-                        (with-open [tx-ops-ch (util/->seekable-byte-channel (.record record))
+                        (with-open [tx-ops-ch (util/->seekable-byte-channel (.-record record))
                                     sr (ArrowStreamReader. tx-ops-ch allocator)
                                     tx-root (.getVectorSchemaRoot sr)]
                           (.loadNextBatch sr)
@@ -52,7 +52,7 @@
                                                              (not (.isNull system-time-vec 0))
                                                              (assoc :system-time (-> (.get system-time-vec 0) (util/micros->instant))))]
 
-                            (.indexTx indexer tx-key tx-root)))
+                            (.indexTx indexer tx-key tx-root (.limit (.-record record)))))
 
                         xt-log/hb-flush-chunk
                         (let [expected-chunk-tx-id (get-bb-long (:record record) 1 -1)]

--- a/core/src/main/java/xtdb/util/RowCounter.java
+++ b/core/src/main/java/xtdb/util/RowCounter.java
@@ -1,8 +1,15 @@
 package xtdb.util;
 
 public class RowCounter {
+    /**
+     * An approximation of the chunk-size overhead added for a single row, regardless of contents.
+     * This number is a parameter to the deterministic indexing, so it is not something we can change.
+     */
+    private static final long ROW_BYTE_COUNT_APPROX_OVERHEAD = 48;
+
     private long chunkIdx;
     private long chunkRowCount;
+    private long chunkApproxByteCount;
 
     public RowCounter(long chunkIdx) {
         this.chunkIdx = chunkIdx;
@@ -11,11 +18,14 @@ public class RowCounter {
     public void nextChunk() {
         chunkIdx += chunkRowCount;
         chunkRowCount = 0;
+        chunkApproxByteCount = 0;
     }
 
     public void addRows(int rowCount) {
         chunkRowCount += rowCount;
+        chunkApproxByteCount += ROW_BYTE_COUNT_APPROX_OVERHEAD * rowCount;
     }
+    public void addTxBytes(int txByteCount) { chunkApproxByteCount += txByteCount; }
 
     public long getChunkRowCount() {
         return chunkRowCount;
@@ -23,5 +33,9 @@ public class RowCounter {
 
     public long getChunkIdx() {
         return chunkIdx;
+    }
+
+    public long getChunkByteCount() {
+        return chunkApproxByteCount;
     }
 }


### PR DESCRIPTION
This helps limit memory usage when row widths are unpredictable. 

Progress toward #2816

Experimentation might be useful to try to estimate how closely the limit approximates actual memory usage for the live tree etc, right now it should correlate somewhat but is likely quite inaccurate.

I want to look at using .getBufferSizeFor to get a more accurate estimate, discovered https://github.com/apache/arrow/issues/38242. 