### PR TITLE
Locally cache file names against XTDB object

### DIFF
--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -45,6 +45,37 @@ You do not need to install Gradle to develop XT2 - there is a Gradle https://doc
 ** `./gradlew jdbc-test` / `./gradlew kafka-test`
 ** `docker-compose down`
 
+=== Auth for testing cloud based resources 
+
+.*S3* (ensure all of the below are done on a consistent region):
+* Need to ensure the `s3-stack` is setup via CloudFormation
+** See the README for more info here.
+* Need to log in to the AWS CLI - using `aws configure sso` 
+* Need to assume the role on the CLI - `aws sts assume-role --role-arn <ARN of XTDBIamRole> --role-session-name <session-name> --profile <SSO profile>`
+* Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` & `AWS_SESSION_TOKEN` from the output 
+  of the above, then set AWS_REGION=<region for the cloudformation>
+* Start the Gradle REPL and connect to it, to have all of the AWS creds available.
+
+.*Azure*
+* Ensure the Azure stack, `azure-resource-manager/azure-stack.json` stack is setup via the Azure deployment manager.
+** See the README for more info here.
+* Ensure a user/app registration is created with the create `xtdb-custom-role`.
+* Create an access token for said user/app registration.
+* Set `AZURE_CLIENT_ID` & `AZURE_CLIENT_SECRET` from the created access token. 
+* Set `AZURE_TENANT_ID` based on the tenant id on which you created the user/app registration/  
+* Set `AZURE_SUBSCRIPTION_ID` based on whichever subscription you created the stack on.
+* Start the Gradle REPL and connect to it, to have all of the Azure creds available.
+
+.*Google Cloud*
+* Ensure the Google Cloud deployment, `cloud-deployment-manager/xtdb-object-store-stack.jinja`, is setup on the XTDB google cloud account.
+** See the README for more info here.
+* Ensure a https://console.cloud.google.com/iam-admin/serviceaccounts[Service Account] has been created for tests.
+** Ensure the Service Account has the XTDB Custom Role created by the deployment above.
+* Create a private key for the service account, saving a copy of the JSON credential file locally.
+* Authenticate as the service account, using `gcloud auth activate-service-account <example-service-account@domain.com> --key-file <private-key.json>`
+* Start the Gradle REPL and connect to it, to have all of the google cloud creds available.
+
+
 == Profiling
 
 To attach YourKit:

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -73,6 +73,7 @@
      (get-blob-range blob-container-client (str prefix k) start len)))
 
   (putObject [_ k buf]
+    (.add file-name-cache k)
     (put-blob blob-container-client (str prefix k) buf)
     (CompletableFuture/completedFuture nil))
 
@@ -83,6 +84,7 @@
     (file-list/list-files-under-prefix file-name-cache dir))
 
   (deleteObject [_ k]
+    (.remove file-name-cache k)
     (delete-blob blob-container-client (str prefix k))
     (CompletableFuture/completedFuture nil))
 

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
@@ -81,6 +81,7 @@
      (get-blob-range this k start len)))
 
   (putObject [this k buf]
+    (.add file-name-cache k)
     (put-blob this k buf)
     (CompletableFuture/completedFuture nil))
 
@@ -91,6 +92,7 @@
     (file-list/list-files-under-prefix file-name-cache dir))
 
   (deleteObject [this k]
+    (.remove file-name-cache k)
     (delete-blob this k)
     (CompletableFuture/completedFuture nil))
 

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -58,18 +58,15 @@
   (with-open [os (object-store (random-uuid))]
     (os-test/test-range os)))
 
-(def wait-time-ms 5000)
-
 (t/deftest ^:azure list-test
   (with-open [os (object-store (random-uuid))]
-    (os-test/test-list-objects os wait-time-ms)))
+    (os-test/test-list-objects os)))
 
 (t/deftest ^:azure list-test-with-prior-objects
   (let [prefix (random-uuid)]
     (with-open [os (object-store prefix)]
       (os-test/put-edn os "alice" :alice)
       (os-test/put-edn os "alan" :alan)
-      (Thread/sleep wait-time-ms)
       (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
     (with-open [os (object-store prefix)]
@@ -77,11 +74,11 @@
         (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
       (t/testing "should be able to delete prior objects and have that reflected in list objects output"
         @(.deleteObject ^ObjectStore os "alice")
-        (Thread/sleep wait-time-ms)
         (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
 
 (t/deftest ^:azure multiple-object-store-list-test
-  (let [prefix (random-uuid)]
+  (let [prefix (random-uuid)
+        wait-time-ms 5000]
     (with-open [os-1 (object-store prefix)
                 os-2 (object-store prefix)]
       (os-test/put-edn os-1 "alice" :alice)

--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -62,18 +62,15 @@
   (let [os (object-store (random-uuid))]
     (os-test/test-range os)))
 
-(def wait-time-ms 5000)
-
 (t/deftest ^:google-cloud list-test
   (with-open [os (object-store (random-uuid))]
-    (os-test/test-list-objects os wait-time-ms)))
+    (os-test/test-list-objects os)))
 
 (t/deftest ^:google-cloud list-test-with-prior-objects
   (let [prefix (random-uuid)]
     (with-open [os (object-store prefix)]
       (os-test/put-edn os "alice" :alice)
       (os-test/put-edn os "alan" :alan)
-      (Thread/sleep wait-time-ms)
       (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
 
     (with-open [os (object-store prefix)]
@@ -81,11 +78,11 @@
         (t/is (= ["alan" "alice"] (.listObjects ^ObjectStore os))))
       (t/testing "should be able to delete prior objects and have that reflected in list objects output"
         @(.deleteObject ^ObjectStore os "alice")
-        (Thread/sleep wait-time-ms)
         (t/is (= ["alan"] (.listObjects ^ObjectStore os)))))))
 
 (t/deftest ^:google-cloud multiple-object-store-list-test
-  (let [prefix (random-uuid)]
+  (let [prefix (random-uuid)
+        wait-time-ms 5000]
     (with-open [os-1 (object-store prefix)
                 os-2 (object-store prefix)]
       (os-test/put-edn os-1 "alice" :alice)

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -65,25 +65,19 @@
 
     (t/is (thrown? IllegalStateException (get-edn obj-store :alice)))))
 
-(defn test-list-objects 
-  ([^ObjectStore obj-store]
-   (test-list-objects obj-store 1000))
-  ([^ObjectStore obj-store wait-time-ms]
-   (put-edn obj-store "bar/alice" :alice)
-   (put-edn obj-store "foo/alan" :alan)
-   (put-edn obj-store "bar/bob" :bob)
+(defn test-list-objects
+  [^ObjectStore obj-store]
+  (put-edn obj-store "bar/alice" :alice)
+  (put-edn obj-store "foo/alan" :alan)
+  (put-edn obj-store "bar/bob" :bob)
 
-  ;; Allow some time for files to get processed and added to the list
-   (Thread/sleep wait-time-ms)
+  (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
+  (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar")))
 
-   (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
-   (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar")))
+     ;; Delete an object
+  @(.deleteObject obj-store "bar/alice")
 
-   ;; Delete an object
-   @(.deleteObject obj-store "bar/alice")
-   (Thread/sleep wait-time-ms)
-   
-   (t/is (= ["bar/bob"] (.listObjects obj-store "bar")))))
+  (t/is (= ["bar/bob"] (.listObjects obj-store "bar"))))
 
 (defn test-range [^ObjectStore obj-store]
 


### PR DESCRIPTION
Addresses #2783 

# In this PR

Removes the lag between writes/reads of file names on remote object stores by writing to the local filename cache as soon as we PUT/DELETE an object. This will ensure the filename is available locally on the java object immediately.

Done in this PR:
- Add a set of notes to the dev README to do auth for tests on remote object store implementations.
- Add/remove to cache within put/delete calls of remote object stores:
  - Done for S3 object store
  - Done for Azure object store
  - Done for Google Cloud object store.
- Update object store tests to remove unnecessary calls to wait (keeping it when testing with multiple object stores - ie, where the filename list will be impacted by the file watching)
  - Updated S3 tests with this behaviour.
  - Update Azure tests with this behaviour.
  - Update Google Cloud tests with this behaviour.

## Concerns around operation duplication

The current way of handling this re-uses the existing filename cache to add/remove files. How this works:
- When an object is put on/deleted from the remote object store, it will firstly be added/removed to the local filename cache.
- The object will be put on/deleted from the remote object store - this will trigger a notification to be sent which will be handled by the individual file watchers.
- The file watcher will add/remove from the local filename cache upon receipt of a notification.

What this means is that there will be duplication of adds/removes for a local object - ie, the call to **add** to the local filename cache will happen twice - first when the call to PUT is made, secondly when the notification for the PUT operation is handled by the file watcher. The same will happen for removals. 
- Generally speaking, this will not do anything - ie, adding a filename twice will be a no-op on the second call.
- There is, however, a certain side case:
  - If a file is **removed** from the local cache before the remote PUT operation is handled, there may be a case where a file is removed from the local filename cache and then re-added.
  - This would then get removed from the filename cache as the DELETE operation propagates through the system.
- This may well be an acceptable situation? By my understanding, it would be pretty odd to immediately remove an object after writing it. \In general, it would be good to understand when an object gets removed. Usual handling of remote operations should be fairly quick, so this would likely be in the magnitude of a few seconds? It is, however, one to keep in mind.
