### PR TITLE
Scan to start of iids relevant for specific merge task

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -280,10 +280,8 @@
                                                      iid-pred (.select (.select iid-pred allocator data-rdr params)))
                           data-row-ptr (ScanDataRowPointer. leaf-rdr
                                                             (-> (copy-row-consumer out-rel leaf-rdr col-names)
-                                                                (wrap-temporal-bounds temporal-bounds)))]]
-              (while (and (< (.getIndex data-row-ptr) (.rowCount data-row-ptr))
-                          (neg? (HashTrie/compareToPath (.getIidPointer data-row-ptr is-valid-ptr) path)))
-                (.nextIndex data-row-ptr))
+                                                                (wrap-temporal-bounds temporal-bounds))
+                                                            path)]]
               (when (.isValid data-row-ptr is-valid-ptr path)
                 (.add merge-q data-row-ptr)))
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -280,7 +280,10 @@
                                                      iid-pred (.select (.select iid-pred allocator data-rdr params)))
                           data-row-ptr (ScanDataRowPointer. leaf-rdr
                                                             (-> (copy-row-consumer out-rel leaf-rdr col-names)
-                                                            (wrap-temporal-bounds temporal-bounds)))]]
+                                                                (wrap-temporal-bounds temporal-bounds)))]]
+              (while (and (< (.getIndex data-row-ptr) (.rowCount data-row-ptr))
+                          (neg? (HashTrie/compareToPath (.getIidPointer data-row-ptr is-valid-ptr) path)))
+                (.nextIndex data-row-ptr))
               (when (.isValid data-row-ptr is-valid-ptr path)
                 (.add merge-q data-row-ptr)))
 

--- a/core/src/main/java/xtdb/trie/ScanDataRowPointer.java
+++ b/core/src/main/java/xtdb/trie/ScanDataRowPointer.java
@@ -26,7 +26,7 @@ public class ScanDataRowPointer implements IDataRowPointer {
     public static final Keyword PUT = Keyword.intern("put");
     public static final Keyword DELETE = Keyword.intern("delete");
 
-    public ScanDataRowPointer(RelationReader relReader, Object rowConsumer) {
+    public ScanDataRowPointer(RelationReader relReader, Object rowConsumer, byte [] path) {
         this.relReader = relReader;
 
         iidReader = relReader.readerForName("xt$iid");
@@ -42,6 +42,17 @@ public class ScanDataRowPointer implements IDataRowPointer {
         deleteValidToReader = deleteReader.structKeyReader("xt$valid_to");
 
         this.rowConsumer = rowConsumer;
+
+        ArrowBufPointer bufPointer;
+        int left = 0;
+        int right = rowCount();
+        int mid;
+        while(left < right) {
+            mid = (left + right) / 2;
+            if (HashTrie.compareToPath(iidReader.getPointer(mid), path) < 0) left = mid + 1;
+            else right = mid;
+        }
+        this.idx = left;
     }
 
     @Override


### PR DESCRIPTION
Fixes #2815. Does a binary search for the start of a potential IID run (via the `path` of a merge task) on ScanDataRowPointer initialization.