### PR TITLE
Use mergeSort for logs instead of compacting the whole trie in scan

### DIFF
--- a/core/src/main/java/xtdb/trie/LiveHashTrie.java
+++ b/core/src/main/java/xtdb/trie/LiveHashTrie.java
@@ -139,6 +139,10 @@ public record LiveHashTrie(Node rootNode, IVectorReader iidReader) implements Ha
             return null;
         }
 
+        public int [] mergeSort (LiveHashTrie trie) {
+            return this.mergeSort(trie, data, sortLog(trie, log, logCount), logCount);
+        }
+
         private int[] mergeSort(LiveHashTrie trie, int[] data, int[] log, int logCount) {
             int dataCount = data.length;
 


### PR DESCRIPTION
This merge sorts the logs into the remaining data on per leaf basis. Should preform better in most cases but especially for sparse queries. One could potentially think about ways to only sort this data once and make use of that work for subsequent queries or the next compacting call in the indexer.