### PR TITLE
Add functions for multipart upload for S3 object store

### DIFF
--- a/core/src/main/clojure/xtdb/object_store.clj
+++ b/core/src/main/clojure/xtdb/object_store.clj
@@ -14,14 +14,23 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
+(definterface IMultipartUpload
+  (^java.util.concurrent.CompletableFuture #_<Void> uploadPart [^java.nio.ByteBuffer buf] 
+   "Asynchonously uploads a part to the multipart request - adds to the internal completed parts list")
+  (^java.util.concurrent.CompletableFuture #_<Void> complete []
+   "Asynchonously completes the multipart-request")
+  (^java.util.concurrent.CompletableFuture #_<?> abort []
+   "Asynchonously cancels the multipart-request - useful/necessary to cleanup any parts of the multipart upload on an error"))
+
+#_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface ObjectStore
   (^java.util.concurrent.CompletableFuture #_<ByteBuffer> getObject [^String k]
-   "Asynchonously returns the given object in a ByteBuffer
+                                                                    "Asynchonously returns the given object in a ByteBuffer
     If the object doesn't exist, the CF completes with an IllegalStateException.")
 
   (^java.util.concurrent.CompletableFuture #_<ByteBuffer> getObjectRange
-    [^String k ^long start ^long len]
-    "Asynchonously returns the given len bytes starting from start (inclusive) of the object in a ByteBuffer
+   [^String k ^long start ^long len]
+   "Asynchonously returns the given len bytes starting from start (inclusive) of the object in a ByteBuffer
     If the object doesn't exist, the CF completes with an IllegalStateException.
 
     Out of bounds `start` cause the returned future to complete with an Exception, the type of which is implementation dependent.
@@ -34,10 +43,11 @@
     Behaviour for a start position at or exceeding the byte length of the object is undefined. You may or may not receive an exception.")
 
   (^java.util.concurrent.CompletableFuture #_<Path> getObject [^String k, ^java.nio.file.Path out-path]
-   "Asynchronously writes the object to the given path.
+                                                              "Asynchronously writes the object to the given path.
     If the object doesn't exist, the CF completes with an IllegalStateException.")
 
   (^java.util.concurrent.CompletableFuture #_<?> putObject [^String k, ^java.nio.ByteBuffer buf])
+  (^java.util.concurrent.CompletableFuture #_<IMultipartUpload> startMultipart [^String k])
   (^java.lang.Iterable #_<String> listObjects [])
   (^java.lang.Iterable #_<String> listObjects [^String dir])
   (^java.util.concurrent.CompletableFuture #_<?> deleteObject [^String k]))

--- a/modules/s3/cloudformation/s3-stack.yml
+++ b/modules/s3/cloudformation/s3-stack.yml
@@ -66,6 +66,8 @@ Resources:
                 - 's3:PutObject'
                 - 's3:DeleteObject'
                 - 's3:ListBucket'
+                - 's3:AbortMultipartUpload'
+                - 's3:ListBucketMultipartUploads'
               Resource:
                 -  !Join [ '', [ 'arn:aws:s3:::', !Ref S3BucketName] ]
                 -  !Join [ '', [ 'arn:aws:s3:::', !Ref S3BucketName, '/*'] ]


### PR DESCRIPTION
Resolves #2823 

## In this PR

- Add a new interface to the object store namespace, `IMultipartUpload`. This has three functions:
  - `uploadPart` to send a new part to the multipart upload.
  - `complete` to finish a mulitpart upload and verify all parts have been submitted.
  - `abort` to cancel a multipart upload. 
- Add a new method to the `ObjectStore` protocol:
  - `startMultipart`, which initiates a multipart upload and returns an instance of `IMultipartUpload`
- Implement the above within the `s3` object store:
  - `startMultipart` calls to initiate a multipart upload in S3, returns the upload id and creates an s3 defrecord `MultipartUpload` which implements `IMultipartUpload`.
  - Implements all of the functions of IMultipartUpload using corresponding functions on the S3 API - completed parts being stored/added to an `ArrayList` and part number being derived from the number of items in the list.
  - On completing an upload, calls a `complete-fn` passed from the object store. This adds the initial key to the filename cache. 
- Also adds a new field to the S3 object store -  `multipart-minimum-part-size`. This might be useful for callers to decide part boundaries.
- Test all of the above for S3 - starting a multipart, aborting a multipart, uploading parts, verifying parts are uploaded as expected. 