### PR TITLE
Splitting the buffer-pool into in-memory, local and remote

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -1,26 +1,21 @@
 (ns xtdb.buffer-pool
-  (:require [xtdb.object-store :as object-store]
-            [xtdb.util :as util]
+  (:require [clojure.tools.logging :as log]
             [juxt.clojars-mirrors.integrant.core :as ig]
-            [clojure.tools.logging :as log])
-  (:import xtdb.util.ArrowBufLRU
-           xtdb.object_store.ObjectStore
-           java.io.Closeable
+            [xtdb.object-store :as object-store]
+            [xtdb.util :as util])
+  (:import java.io.Closeable
            java.nio.file.Path
-           [java.util Map UUID]
-           java.util.concurrent.CompletableFuture
-           java.util.concurrent.locks.StampedLock
+           [java.util Map]
            (java.util.concurrent.atomic AtomicLong)
+           java.util.concurrent.CompletableFuture
            [org.apache.arrow.memory ArrowBuf BufferAllocator]
            (org.apache.arrow.vector VectorSchemaRoot)
-           (org.apache.arrow.vector.ipc.message ArrowFooter ArrowRecordBatch)))
+           (org.apache.arrow.vector.ipc.message ArrowFooter ArrowRecordBatch)
+           xtdb.IBufferPool
+           xtdb.object_store.ObjectStore
+           xtdb.util.ArrowBufLRU))
 
 (set! *unchecked-math* :warn-on-boxed)
-
-(definterface IBufferPool
-  (^java.util.concurrent.CompletableFuture getBuffer [^String k])
-  (^java.util.concurrent.CompletableFuture getRangeBuffer [^String k ^int start ^int len])
-  (^boolean evictBuffer [^String k]))
 
 (defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
 

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -15,7 +15,6 @@
            org.apache.arrow.vector.types.pojo.Field
            org.apache.arrow.vector.VectorSchemaRoot
            xtdb.IBufferPool
-           xtdb.object_store.ObjectStore
            (xtdb.trie EventRowPointer IDataRel LiveHashTrie)
            xtdb.util.WritableByteBufferChannel
            xtdb.vector.IRowCopier))
@@ -76,7 +75,7 @@
           (trie/postwalk-merge-plan tries merge-nodes!)
           (.end meta-wtr))))))
 
-(defn exec-compaction-job! [^BufferAllocator allocator, ^ObjectStore obj-store, ^IBufferPool buffer-pool,
+(defn exec-compaction-job! [^BufferAllocator allocator, ^IBufferPool buffer-pool,
                             {:keys [table-name trie-keys out-trie-key]}]
   (try
     (log/infof "compacting '%s' '%s' -> '%s'..." table-name trie-keys out-trie-key)
@@ -94,9 +93,9 @@
 
       (log/debugf "uploading '%s' '%s'..." table-name out-trie-key)
 
-      @(.putObject obj-store (trie/->table-data-file-name table-name out-trie-key)
+      @(.putObject buffer-pool (trie/->table-data-file-name table-name out-trie-key)
                    (.getAsByteBuffer data-out-bb))
-      @(.putObject obj-store (trie/->table-meta-file-name table-name out-trie-key)
+      @(.putObject buffer-pool (trie/->table-meta-file-name table-name out-trie-key)
                    (.getAsByteBuffer meta-out-bb)))
 
     (log/infof "compacted '%s' -> '%s'." table-name out-trie-key)
@@ -118,25 +117,24 @@
 
 (defmethod ig/prep-key :xtdb/compactor [_ opts]
   (into {:allocator (ig/ref :xtdb/allocator)
-         :obj-store (ig/ref :xtdb/object-store)
-         :buffer-pool (ig/ref :xtdb.buffer-pool/buffer-pool)}
+         :buffer-pool (ig/ref :xtdb/buffer-pool)}
         opts))
 
-(defmethod ig/init-key :xtdb/compactor [_ {:keys [allocator ^ObjectStore obj-store buffer-pool]}]
+(defmethod ig/init-key :xtdb/compactor [_ {:keys [allocator ^IBufferPool buffer-pool]}]
   (util/with-close-on-catch [allocator (util/->child-allocator allocator "compactor")]
     (reify ICompactor
       (compactAll [_]
         (log/info "compact-all")
         (loop []
-          (let [jobs (for [table-name (->> (.listObjects obj-store "tables")
+          (let [jobs (for [table-name (->> (.listObjects buffer-pool "tables")
                                            ;; TODO should obj-store listObjects only return keys from the current level?
                                            (into #{} (keep #(second (re-find #"^tables/([^/]+)" %)))))
-                           job (compaction-jobs table-name (trie/list-meta-files obj-store table-name))]
+                           job (compaction-jobs table-name (trie/list-meta-files buffer-pool table-name))]
                        job)
                 jobs? (boolean (seq jobs))]
 
             (doseq [job jobs]
-              (exec-compaction-job! allocator obj-store buffer-pool job))
+              (exec-compaction-job! allocator buffer-pool job))
 
             (when jobs?
               (recur)))))

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -14,7 +14,7 @@
            [org.apache.arrow.memory.util ArrowBufPointer]
            org.apache.arrow.vector.types.pojo.Field
            org.apache.arrow.vector.VectorSchemaRoot
-           xtdb.buffer_pool.IBufferPool
+           xtdb.IBufferPool
            xtdb.object_store.ObjectStore
            (xtdb.trie EventRowPointer IDataRel LiveHashTrie)
            xtdb.util.WritableByteBufferChannel

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -20,7 +20,7 @@
            (org.apache.arrow.memory ArrowBuf)
            (org.apache.arrow.vector FieldVector)
            (org.apache.arrow.vector.types.pojo ArrowType$Union)
-           xtdb.buffer_pool.IBufferPool
+           xtdb.IBufferPool
            xtdb.object_store.ObjectStore
            (xtdb.vector IVectorReader IVectorWriter)))
 

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -5,7 +5,6 @@
             xtdb.buffer-pool
             [xtdb.expression.comparator :as expr.comp]
             xtdb.expression.temporal
-            xtdb.object-store
             [xtdb.transit :as xt.transit]
             [xtdb.types :as types]
             [xtdb.util :as util]
@@ -21,7 +20,6 @@
            (org.apache.arrow.vector FieldVector)
            (org.apache.arrow.vector.types.pojo ArrowType$Union)
            xtdb.IBufferPool
-           xtdb.object_store.ObjectStore
            (xtdb.vector IVectorReader IVectorWriter)))
 
 (set! *unchecked-math* :warn-on-boxed)

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -128,7 +128,6 @@
              :xtdb.indexer/live-index {}
              :xtdb.log/watcher {}
              :xtdb.metadata/metadata-manager {}
-             :xtdb/buffer-pool {}
              :xtdb.operator.scan/scan-emitter {}
              :xtdb.operator/ra-query-source {}
              ::txp/tx-producer {}
@@ -137,7 +136,7 @@
             opts)
       (doto ig/load-namespaces)
       (with-default-impl :xtdb/log :xtdb.log/memory-log)
-      (with-default-impl :xtdb/object-store :xtdb.object-store/memory-object-store)
+      (with-default-impl :xtdb/buffer-pool :xtdb.buffer-pool/in-memory)
       (doto ig/load-namespaces)))
 
 (defn start-node ^xtdb.node.Node [opts]

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -128,7 +128,7 @@
              :xtdb.indexer/live-index {}
              :xtdb.log/watcher {}
              :xtdb.metadata/metadata-manager {}
-             :xtdb.buffer-pool/buffer-pool {}
+             :xtdb/buffer-pool {}
              :xtdb.operator.scan/scan-emitter {}
              :xtdb.operator/ra-query-source {}
              ::txp/tx-producer {}

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -29,7 +29,7 @@
            [org.roaringbitmap.buffer MutableRoaringBitmap]
            xtdb.api.protocols.TransactionInstant
            (xtdb.bitemporal EventResolver RowConsumer)
-           xtdb.buffer_pool.IBufferPool
+           xtdb.IBufferPool
            xtdb.ICursor
            (xtdb.metadata IMetadataManager ITableMetadata)
            xtdb.object_store.ObjectStore

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -397,10 +397,9 @@
 (defmethod ig/prep-key ::scan-emitter [_ opts]
   (merge opts
          {:metadata-mgr (ig/ref ::meta/metadata-manager)
-          :buffer-pool (ig/ref ::bp/buffer-pool)
-          :object-store (ig/ref :xtdb/object-store)}))
+          :buffer-pool (ig/ref :xtdb/buffer-pool)}))
 
-(defmethod ig/init-key ::scan-emitter [_ {:keys [^ObjectStore object-store ^IMetadataManager metadata-mgr, ^IBufferPool buffer-pool]}]
+(defmethod ig/init-key ::scan-emitter [_ {:keys [^IMetadataManager metadata-mgr, ^IBufferPool buffer-pool]}]
   (reify IScanEmitter
     (tableColNames [_ wm table-name]
       (let [normalized-table (util/str->normal-form-str table-name)]
@@ -482,7 +481,7 @@
                                                  (fn [fvt]
                                                    (or fvt (if default-all-valid-time? [:all-time] [:at [:now :now]])))))
                            ^ILiveTableWatermark live-table-wm (some-> (.liveIndex watermark) (.liveTable normalized-table-name))
-                           current-meta-files (->> (trie/list-meta-files object-store normalized-table-name)
+                           current-meta-files (->> (trie/list-meta-files buffer-pool normalized-table-name)
                                                    (trie/current-trie-files))]
 
                        (util/with-open [iid-arrow-buf (when iid-bb (util/->arrow-buf-view allocator iid-bb))]

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -54,8 +54,8 @@
 (defn ->table-meta-file-name [table-name trie-key]
   (format "tables/%s/meta/%s.arrow" table-name trie-key))
 
-(defn list-meta-files [^ObjectStore obj-store, table-name]
-  (vec (sort (.listObjects obj-store (format "tables/%s/meta/" table-name)))))
+(defn list-meta-files [^IBufferPool buffer-pool, table-name]
+  (vec (sort (.listObjects buffer-pool (format "tables/%s/meta/" table-name)))))
 
 (def ^org.apache.arrow.vector.types.pojo.Schema meta-rel-schema
   (Schema. [(types/->field "nodes" (ArrowType$Union. UnionMode/Dense (int-array (range 3))) false
@@ -216,12 +216,12 @@
     {:data-buf (.getAsByteBuffer data-bb-ch)
      :meta-buf (.getAsByteBuffer meta-bb-ch)}))
 
-(defn write-trie-bufs! [^ObjectStore obj-store, ^String table-name, trie-key
+(defn write-trie-bufs! [^IBufferPool buffer-pool, ^String table-name, trie-key
                         {:keys [^ByteBuffer data-buf ^ByteBuffer meta-buf]}]
-  (-> (.putObject obj-store (->table-data-file-name table-name trie-key) data-buf)
+  (-> (.putObject buffer-pool (->table-data-file-name table-name trie-key) data-buf)
       (util/then-compose
         (fn [_]
-          (.putObject obj-store (->table-meta-file-name table-name trie-key) meta-buf)))))
+          (.putObject buffer-pool (->table-meta-file-name table-name trie-key) meta-buf)))))
 
 (defn parse-trie-file-name [file-name]
   (when-let [[_ trie-key level-str row-from-str next-row-str] (re-find #"/(log-l(\p{XDigit}+)-rf(\p{XDigit}+)-nr(\p{XDigit}+)+?)\.arrow$" file-name)]

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -19,7 +19,7 @@
            [org.apache.arrow.vector.ipc ArrowFileWriter]
            (org.apache.arrow.vector.types.pojo ArrowType$Union Schema)
            org.apache.arrow.vector.types.UnionMode
-           xtdb.buffer_pool.IBufferPool
+           xtdb.IBufferPool
            (xtdb.object_store ObjectStore)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$Leaf HashTrie HashTrie$Node LiveHashTrie LiveHashTrie$Leaf)
            (xtdb.util WritableByteBufferChannel)

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -4,6 +4,7 @@
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [juxt.clojars-mirrors.integrant.core :as ig]
             [xtdb.api.protocols]
             [xtdb.error :as err])
   (:import [clojure.lang Keyword MapEntry Symbol]
@@ -230,8 +231,8 @@
 (def ^{:tag 'long} end-of-time-μs
   (instant->micros end-of-time))
 
-(defn component
-  ([node k] (get (:system node) k)))
+(defn component [node k]
+  (some-> (:system node) (ig/find-derived k) first val))
 
 ;;; IO
 

--- a/core/src/main/java/xtdb/IBufferPool.java
+++ b/core/src/main/java/xtdb/IBufferPool.java
@@ -10,8 +10,6 @@ public interface IBufferPool extends AutoCloseable {
 
     CompletableFuture<ArrowBuf> getRangeBuffer(String key, int start, int len);
 
-    boolean evictBuffer(String key);
-
     CompletableFuture<?> putObject(String k, ByteBuffer buffer);
 
     Iterable<String> listObjects();

--- a/core/src/main/java/xtdb/IBufferPool.java
+++ b/core/src/main/java/xtdb/IBufferPool.java
@@ -2,10 +2,19 @@ package xtdb;
 
 import org.apache.arrow.memory.ArrowBuf;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
-public interface IBufferPool {
+public interface IBufferPool extends AutoCloseable {
     CompletableFuture<ArrowBuf> getBuffer(String key);
+
     CompletableFuture<ArrowBuf> getRangeBuffer(String key, int start, int len);
+
     boolean evictBuffer(String key);
+
+    CompletableFuture<?> putObject(String k, ByteBuffer buffer);
+
+    Iterable<String> listObjects();
+
+    Iterable<String> listObjects(String dir);
 }

--- a/core/src/main/java/xtdb/IBufferPool.java
+++ b/core/src/main/java/xtdb/IBufferPool.java
@@ -1,0 +1,11 @@
+package xtdb;
+
+import org.apache.arrow.memory.ArrowBuf;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface IBufferPool {
+    CompletableFuture<ArrowBuf> getBuffer(String key);
+    CompletableFuture<ArrowBuf> getRangeBuffer(String key, int start, int len);
+    boolean evictBuffer(String key);
+}

--- a/docker/xtdb.edn
+++ b/docker/xtdb.edn
@@ -1,5 +1,5 @@
 {:xtdb.log/local-directory-log {:root-path "/var/lib/xtdb/log"}
- :xtdb.buffer-pool/buffer-pool {:cache-path "/var/lib/xtdb/buffers"}
+ :xtdb/buffer-pool {:cache-path "/var/lib/xtdb/buffers"}
  :xtdb.object-store/file-system-object-store {:root-path "/var/lib/xtdb/objects"}
  :xtdb/server {:port 3000}
  :xtdb/pgwire {:port 5432}

--- a/docker/xtdb.edn
+++ b/docker/xtdb.edn
@@ -1,6 +1,5 @@
 {:xtdb.log/local-directory-log {:root-path "/var/lib/xtdb/log"}
- :xtdb/buffer-pool {:cache-path "/var/lib/xtdb/buffers"}
- :xtdb.object-store/file-system-object-store {:root-path "/var/lib/xtdb/objects"}
+ :xtdb.buffer-pool/local {:path "/var/lib/xtdb/buffers"}
  :xtdb/server {:port 3000}
  :xtdb/pgwire {:port 5432}
  :xtdb.flight-sql/server {:host "0.0.0.0", :port 9832}}

--- a/modules/bench/src/main/clojure/xtdb/bench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench.clj
@@ -51,9 +51,10 @@
    (node/start-node (case node-type
                       :in-memory {}
                       :local-fs {:xtdb.log/local-directory-log {:root-path (.resolve node-tmp-dir "log")}
-                                 ::os/file-system-object-store {:root-path (.resolve node-tmp-dir "objects")}}
+                                 :xtdb.buffer-pool/local {:path (.resolve node-tmp-dir "objects")}}
                       :kafka-s3 {::k/log {:bootstrap-servers "localhost:9092"
                                           :topic-name (str "bench-log-" node-id)}
+                                 :xtdb.buffer-pool/remote {}
                                  ::s3/object-store {:bucket "core2-bench"
                                                     :prefix (str "node." node-id)}}))))
 

--- a/modules/bench/src/main/clojure/xtdb/bench/multinode_tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/multinode_tpch.clj
@@ -57,7 +57,7 @@
 (comment
   (let [node-dir (Files/createTempDirectory "multinode-0.1" (make-array FileAttribute 0))
         node-opts {:xtdb.log/local-directory-log {:root-path (.resolve node-dir "log")}
-                   :xtdb.object-store/file-system-object-store {:root-path (.resolve node-dir "objects")}}]
+                   :xtdb.buffer-pool/local {:path (.resolve node-dir "objects")}}]
     (run-multinode {:scale-factor 0.1, :sleep-ms 60000}
                    (fn []
                      (node/start-node node-opts)))))

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -180,7 +180,7 @@
   (let [^Path path (.toPath node-dir)]
     {:xtdb.log/local-directory-log {:root-path (.resolve path "log")}
      :xtdb.tx-producer/tx-producer {}
-     :xtdb.buffer-pool/buffer-pool {:cache-path (.resolve path "buffers")}
+     :xtdb/buffer-pool {:cache-path (.resolve path "buffers")}
      :xtdb.object-store/file-system-object-store {:root-path (.resolve path "objects")}}))
 
 (defn- ->worker [node]

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -180,8 +180,7 @@
   (let [^Path path (.toPath node-dir)]
     {:xtdb.log/local-directory-log {:root-path (.resolve path "log")}
      :xtdb.tx-producer/tx-producer {}
-     :xtdb/buffer-pool {:cache-path (.resolve path "buffers")}
-     :xtdb.object-store/file-system-object-store {:root-path (.resolve path "objects")}}))
+     :xtdb.buffer-pool/local {:path (.resolve path "objects")}}))
 
 (defn- ->worker [node]
   (let [clock (Clock/systemUTC)

--- a/src/dev/clojure/azure_testing.clj
+++ b/src/dev/clojure/azure_testing.clj
@@ -26,12 +26,12 @@
 
 (def azure-object-store
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
-                       :xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                       :xtdb/buffer-pool {:cache-path (io/file dev-node-dir "objects")}
                        ::azure/blob-object-store {:storage-account storage-account
                                                   :container container}}}})
 
 (def azure-log
-  {::xtdb {:node-opts {:xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+  {::xtdb {:node-opts {:xtdb/buffer-pool {:cache-path (io/file dev-node-dir "objects")}
                        ::azure/event-hub-log {:fully-qualified-namespace fully-qualified-namespace
                                               :event-hub-name eventhub
                                               :max-wait-time "PT1S"}}}})

--- a/src/dev/clojure/azure_testing.clj
+++ b/src/dev/clojure/azure_testing.clj
@@ -26,12 +26,12 @@
 
 (def azure-object-store
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
-                       :xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                       :xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
                        ::azure/blob-object-store {:storage-account storage-account
                                                   :container container}}}})
 
 (def azure-log
-  {::xtdb {:node-opts {:xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+  {::xtdb {:node-opts {:xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
                        ::azure/event-hub-log {:fully-qualified-namespace fully-qualified-namespace
                                               :event-hub-name eventhub
                                               :max-wait-time "PT1S"}}}})

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -29,11 +29,10 @@
 
 (def standalone-config
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
-                        :xtdb.buffer-pool/remote {:cache-path (io/file dev-node-dir "buffers")}
-                        :xtdb.object-store/file-system-object-store {:root-path (io/file dev-node-dir "objects")}
-                        :xtdb/server {}
-                        :xtdb/pgwire {:port 5433}
-                        :xtdb.flight-sql/server {:port 52358}}}})
+                       :xtdb.buffer-pool/local {:path (io/file dev-node-dir "objects")}
+                       :xtdb/server {}
+                       :xtdb/pgwire {:port 5433}
+                       :xtdb.flight-sql/server {:port 52358}}}})
 
 (ir/set-prep! (fn [] standalone-config))
 

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -29,7 +29,7 @@
 
 (def standalone-config
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
-                        :xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                        :xtdb.buffer-pool/remote {:cache-path (io/file dev-node-dir "buffers")}
                         :xtdb.object-store/file-system-object-store {:root-path (io/file dev-node-dir "objects")}
                         :xtdb/server {}
                         :xtdb/pgwire {:port 5433}

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -29,7 +29,7 @@
 
 (def standalone-config
   {::xtdb {:node-opts {:xtdb.log/local-directory-log {:root-path (io/file dev-node-dir "log")}
-                        :xtdb.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
+                        :xtdb/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
                         :xtdb.object-store/file-system-object-store {:root-path (io/file dev-node-dir "objects")}
                         :xtdb/server {}
                         :xtdb/pgwire {:port 5433}

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -245,13 +245,12 @@
 
 (defn ->local-node ^java.lang.AutoCloseable [{:keys [^Path node-dir ^String buffers-dir
                                                      rows-per-chunk log-limit page-limit instant-src]
-                                              :or {buffers-dir "buffers"}}]
+                                              :or {buffers-dir "objects"}}]
   (let [instant-src (or instant-src (->mock-clock))]
     (node/start-node {:xtdb.log/local-directory-log {:root-path (.resolve node-dir "log")
                                                      :instant-src instant-src}
                       :xtdb.tx-producer/tx-producer {:instant-src instant-src}
-                      :xtdb.buffer-pool/remote {:cache-path (.resolve node-dir buffers-dir)}
-                      :xtdb.object-store/file-system-object-store {:root-path (.resolve node-dir "objects")}
+                      :xtdb.buffer-pool/local {:path (.resolve node-dir buffers-dir)}
                       :xtdb/indexer (->> {:rows-per-chunk rows-per-chunk}
                                          (into {} (filter val)))
                       :xtdb.indexer/live-index (->> {:log-limit log-limit :page-limit page-limit}

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -250,7 +250,7 @@
     (node/start-node {:xtdb.log/local-directory-log {:root-path (.resolve node-dir "log")
                                                      :instant-src instant-src}
                       :xtdb.tx-producer/tx-producer {:instant-src instant-src}
-                      :xtdb/buffer-pool {:cache-path (.resolve node-dir buffers-dir)}
+                      :xtdb.buffer-pool/remote {:cache-path (.resolve node-dir buffers-dir)}
                       :xtdb.object-store/file-system-object-store {:root-path (.resolve node-dir "objects")}
                       :xtdb/indexer (->> {:rows-per-chunk rows-per-chunk}
                                          (into {} (filter val)))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -250,7 +250,7 @@
     (node/start-node {:xtdb.log/local-directory-log {:root-path (.resolve node-dir "log")
                                                      :instant-src instant-src}
                       :xtdb.tx-producer/tx-producer {:instant-src instant-src}
-                      :xtdb.buffer-pool/buffer-pool {:cache-path (.resolve node-dir buffers-dir)}
+                      :xtdb/buffer-pool {:cache-path (.resolve node-dir buffers-dir)}
                       :xtdb.object-store/file-system-object-store {:root-path (.resolve node-dir "objects")}
                       :xtdb/indexer (->> {:rows-per-chunk rows-per-chunk}
                                          (into {} (filter val)))

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -17,14 +17,14 @@
 (defn buffer-sys []
   (-> {:xtdb/allocator {}
        :xtdb.object-store/memory-object-store {}
-       ::bp/buffer-pool {:object-store (ig/ref :xtdb.object-store/memory-object-store)}}
+       :xtdb/buffer-pool {:object-store (ig/ref :xtdb.object-store/memory-object-store)}}
       (doto ig/load-namespaces)
       ig/prep
       ig/init))
 
 (defn object-store ^ObjectStore [sys] (:xtdb.object-store/memory-object-store sys))
 
-(defn buffer-pool ^IBufferPool [sys] (::bp/buffer-pool sys))
+(defn buffer-pool ^IBufferPool [sys] (:xtdb/buffer-pool sys))
 
 (defn byte-seq [^ArrowBuf buf]
   (let [arr (byte-array (.capacity buf))]

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -23,11 +23,16 @@
   (fn with-each-bp [f]
     (t/testing "memory"
       (binding [*bp-type* :memory]
-        (with-bp {:xtdb.buffer-pool/in-memory {}} f)))
+        (with-bp {::bp/in-memory {}} f)))
+
+    (t/testing "local"
+      (tu/with-tmp-dirs #{path}
+        (binding [*bp-type* :local]
+          (with-bp {::bp/local {:path path}} f))))
 
     (t/testing "remote"
       (binding [*bp-type* :remote]
-        (with-bp {:xtdb.buffer-pool/remote {}
+        (with-bp {::bp/remote {}
                   ::ost/memory-object-store {}}
           f)))))
 
@@ -88,7 +93,7 @@
                  (t/is (thrown? Exception (rq 10 0))))))))))
 
 (t/deftest cache-counter-test
-  (when-not (= *bp-type* :memory)
+  (when (= *bp-type* :remote)
     (bp/clear-cache-counters)
     (t/is (= 0 (.get bp/cache-hit-byte-counter)))
     (t/is (= 0 (.get bp/cache-miss-byte-counter)))

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -5,7 +5,7 @@
             [xtdb.util :as util])
   (:import (java.nio ByteBuffer)
            (org.apache.arrow.memory ArrowBuf RootAllocator)
-           (xtdb.buffer_pool IBufferPool)
+           xtdb.IBufferPool
            (xtdb.object_store ObjectStore)
            (xtdb.util ArrowBufLRU)))
 

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -7,7 +7,7 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import (org.apache.arrow.memory ArrowBuf)
-           (xtdb.buffer_pool IBufferPool)
+           xtdb.IBufferPool
            (xtdb.object_store ObjectStore)
            (xtdb InstantSource)))
 

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -2,14 +2,11 @@
   (:require [clojure.java.io :as io]
             [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
-            [xtdb.buffer-pool :as bp]
-            [xtdb.object-store :as os]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import (org.apache.arrow.memory ArrowBuf)
-           xtdb.IBufferPool
-           (xtdb.object_store ObjectStore)
-           (xtdb InstantSource)))
+           (xtdb InstantSource)
+           xtdb.IBufferPool))
 
 (defn- random-maps [n]
   (let [nb-ks 5
@@ -43,10 +40,9 @@
 (deftest ^:integration concurrent-buffer-pool-test
   (populate-node node-opts)
   (tu/with-system {:xtdb/allocator {}
-                   :xtdb/buffer-pool {:cache-path (.resolve (.toPath node-dir) "buffers")}
-                   :xtdb.object-store/file-system-object-store {:root-path (.resolve (.toPath node-dir) "objects")}}
+                   :xtdb.buffer-pool/local {:path (.resolve (.toPath node-dir) "objects")}}
     (fn []
-      (let [^IBufferPool buffer-pool (:xtdb/buffer-pool tu/*sys*)
+      (let [^IBufferPool buffer-pool (:xtdb.buffer-pool/local tu/*sys*)
             objs (.listObjects buffer-pool)
             get-item #(with-open [^ArrowBuf _buf (deref (.getBuffer buffer-pool (rand-nth objs)))]
                         (Thread/sleep 10))

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -43,12 +43,11 @@
 (deftest ^:integration concurrent-buffer-pool-test
   (populate-node node-opts)
   (tu/with-system {:xtdb/allocator {}
-                   :xtdb.buffer-pool/buffer-pool {:cache-path (.resolve (.toPath node-dir) "buffers")}
+                   :xtdb/buffer-pool {:cache-path (.resolve (.toPath node-dir) "buffers")}
                    :xtdb.object-store/file-system-object-store {:root-path (.resolve (.toPath node-dir) "objects")}}
     (fn []
-      (let [^IBufferPool buffer-pool (::bp/buffer-pool tu/*sys*)
-            ^ObjectStore object-store (::os/file-system-object-store tu/*sys*)
-            objs (.listObjects object-store)
+      (let [^IBufferPool buffer-pool (:xtdb/buffer-pool tu/*sys*)
+            objs (.listObjects buffer-pool)
             get-item #(with-open [^ArrowBuf _buf (deref (.getBuffer buffer-pool (rand-nth objs)))]
                         (Thread/sleep 10))
             f-call #(future
@@ -56,7 +55,6 @@
                         (get-item)))
 
             fs (doall (repeatedly 3 f-call))]
-        (t/is (not (nil? object-store)))
         (mapv deref fs)))))
 
 (deftest ^:integration concurrent-node-test

--- a/src/test/clojure/xtdb/docker_test.clj
+++ b/src/test/clojure/xtdb/docker_test.clj
@@ -189,8 +189,7 @@
 
     ;; put data in to the tmp host dir to test the data mount
     (with-open [node (->> {:xtdb.log/local-directory-log {:root-path (io/file hostdir "log")}
-                           :xtdb/buffer-pool {:cache-path (io/file hostdir "buffers")}
-                           :xtdb.object-store/file-system-object-store {:root-path (io/file hostdir "objects")}}
+                           :xtdb.buffer-pool/local {:path (io/file hostdir "objects")}}
                           (node/start-node))]
       (-> (node/snapshot-async node (xt/submit-tx node [[:put {:xt/id 42, :greeting "Hello, world!"}]]))
           (.orTimeout 5 TimeUnit/SECONDS)

--- a/src/test/clojure/xtdb/docker_test.clj
+++ b/src/test/clojure/xtdb/docker_test.clj
@@ -189,7 +189,7 @@
 
     ;; put data in to the tmp host dir to test the data mount
     (with-open [node (->> {:xtdb.log/local-directory-log {:root-path (io/file hostdir "log")}
-                           :xtdb.buffer-pool/buffer-pool {:cache-path (io/file hostdir "buffers")}
+                           :xtdb/buffer-pool {:cache-path (io/file hostdir "buffers")}
                            :xtdb.object-store/file-system-object-store {:root-path (io/file hostdir "objects")}}
                           (node/start-node))]
       (-> (node/snapshot-async node (xt/submit-tx node [[:put {:xt/id 42, :greeting "Hello, world!"}]]))

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -114,7 +114,7 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
-      (let [^ObjectStore os (tu/component node ::os/file-system-object-store)]
+      (let [^IBufferPool bp (tu/component node :xtdb/buffer-pool)]
 
         (let [last-tx-key (last (for [tx-ops txs] (xt/submit-tx node tx-ops)))]
           (tu/then-await-tx last-tx-key node (Duration/ofSeconds 2)))
@@ -122,10 +122,10 @@
         (tu/finish-chunk! node)
 
         (t/is (= ["tables/foo/data/log-l00-rf00-nr110.arrow"]
-                 (.listObjects os "tables/foo/data")))
+                 (.listObjects bp "tables/foo/data")))
 
         (t/is (= ["tables/foo/meta/log-l00-rf00-nr110.arrow"]
-                 (.listObjects os "tables/foo/meta"))))
+                 (.listObjects bp "tables/foo/meta"))))
 
       (tj/check-json (.toPath (io/as-file (io/resource "xtdb/indexer-test/can-build-live-index")))
                      (.resolve node-dir "objects")))))

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -22,7 +22,8 @@
 (def with-live-index
   (partial tu/with-system {:xtdb/allocator {}
                            :xtdb.indexer/live-index {}
-                           :xtdb.object-store/memory-object-store {}}))
+                           :xtdb.object-store/memory-object-store {}
+                           :xtdb/buffer-pool {}}))
 
 (t/use-fixtures :each tu/with-allocator with-live-index)
 

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -161,14 +161,7 @@
             (let [size (.getSize (.getReferenceManager ^ArrowBuf buffer))]
               (t/is (= size (.getAccountedSize (.getReferenceManager ^ArrowBuf buffer))))
               (.close buffer)
-              (t/is (= 1 (.getRefCount (.getReferenceManager ^ArrowBuf buffer))))
-
-              (t/is (true? (.evictBuffer bp buffer-name)))
-              (t/is (false? (.evictBuffer bp buffer-name)))
-              (t/is (zero? (.getRefCount (.getReferenceManager ^ArrowBuf buffer))))
-              (t/is (= size (.getSize (.getReferenceManager ^ArrowBuf buffer))))
-              (t/is (zero? (.getAccountedSize (.getReferenceManager ^ArrowBuf buffer))))
-              (t/is (= 0 (count (.buffers ^BufferPool bp)))))))))))
+              (t/is (= 1 (.getRefCount (.getReferenceManager ^ArrowBuf buffer)))))))))))
 
 (t/deftest temporal-watermark-is-immutable-567
   (with-open [node (node/start-node {})]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -20,7 +20,7 @@
            java.time.Duration
            [org.apache.arrow.memory BufferAllocator]
            xtdb.api.protocols.TransactionInstant
-           [xtdb.buffer_pool IBufferPool]
+           xtdb.IBufferPool
            (xtdb.metadata IMetadataManager)
            xtdb.node.Node
            xtdb.object_store.ObjectStore

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -141,7 +141,7 @@
           (doseq [page-idx relevant-pages]
             (t/is (true? (.test page-idx-pred page-idx)))))))))
 
-(deftest test-boolean-metadata
+(t/deftest test-boolean-metadata
   (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :boolean-or-int true}]])
   (tu/finish-chunk! tu/*node*)
 

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -12,7 +12,7 @@
   (:import (clojure.lang MapEntry)
            (java.util.function IntPredicate)
            [org.apache.arrow.vector VectorSchemaRoot]
-           (xtdb.buffer_pool IBufferPool)
+           xtdb.IBufferPool
            (xtdb.metadata IMetadataManager IMetadataPredicate)))
 
 (t/use-fixtures :each tu/with-node)

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -112,7 +112,7 @@
 
     (tu/finish-chunk! node)
 
-    (let [^IBufferPool buffer-pool (tu/component node ::bp/buffer-pool)
+    (let [^IBufferPool buffer-pool (tu/component node :xtdb/buffer-pool)
           first-buckets (map (comp first tu/byte-buffer->path trie/->iid) (range 20))
           bucket->page-idx (->> (into (sorted-set) first-buckets)
                                 (map-indexed #(MapEntry/create %2 %1))
@@ -146,7 +146,7 @@
   (tu/finish-chunk! tu/*node*)
 
   (let [^IMetadataManager metadata-mgr (tu/component tu/*node* ::meta/metadata-manager)
-        ^IBufferPool buffer-pool (tu/component tu/*node* ::bp/buffer-pool)
+        ^IBufferPool buffer-pool (tu/component tu/*node* :xtdb/buffer-pool)
         true-selector (expr.meta/->metadata-selector '(= boolean-or-int true) '{boolean-or-int :bool} {})
         file-name (trie/->table-meta-file-name "xt_docs" (trie/->log-trie-key 0 0 2))]
 

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -9,7 +9,7 @@
             [xtdb.trie :as trie]
             [xtdb.util :as util])
   (:import (java.time LocalTime)
-           (xtdb.buffer_pool IBufferPool)
+           xtdb.IBufferPool
            (xtdb.metadata IMetadataManager ITableMetadata)))
 
 (t/use-fixtures :once tu/with-allocator)

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -15,7 +15,7 @@
 (t/use-fixtures :once tu/with-allocator)
 
 (defn with-table-metadata [node meta-file-name f]
-  (let [^IBufferPool buffer-pool (tu/component node ::bp/buffer-pool)
+  (let [^IBufferPool buffer-pool (tu/component node :xtdb/buffer-pool)
         ^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)]
     (util/with-open [{meta-rdr :rdr} (trie/open-meta-file buffer-pool meta-file-name)]
       (f (.tableMetadata metadata-mgr meta-rdr meta-file-name)))))

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -1,7 +1,6 @@
 (ns xtdb.operator-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
-            [xtdb.buffer-pool :as bp]
             [xtdb.expression.metadata :as expr.meta]
             [xtdb.metadata :as meta]
             [xtdb.node :as node]

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -67,7 +67,7 @@
 
 (t/deftest ^:s3 multipart-start-and-cancel
   (with-open [os (object-store (random-uuid))]
-    (let [multipart-upload ^IMultipartUpload  @(.startMultipart os "test-multi-created")
+    (let [multipart-upload ^IMultipartUpload  @(.startMultipart ^ObjectStore os "test-multi-created")
           prefixed-key (str (:prefix os) "test-multi-created")]
       (t/testing "Call to start a multipart upload should work and be visible in multipart upload list"
         (let [list-multipart-uploads-response @(.listMultipartUploads ^S3AsyncClient (:client os)

--- a/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
+++ b/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
@@ -11,9 +11,9 @@
            (java.util.concurrent Semaphore)
            (org.apache.arrow.memory BufferAllocator)
            (org.apache.arrow.vector.ipc ArrowStreamReader)
+           xtdb.IBufferPool
            (xtdb.indexer IIndexer)
-           (xtdb.log Log)
-           (xtdb.object_store ObjectStore)))
+           (xtdb.log Log)))
 
 (defonce log-level :error)
 
@@ -162,8 +162,8 @@
             (t/is (check-count-remains 4))))))))
 
 (defn chunk-path-seq [node]
-  (let [obj (tu/component node :xtdb.object-store/memory-object-store)]
-    (filter #(re-matches #"tables/foo/meta/log-(.*)" %) (.listObjects ^ObjectStore obj))))
+  (let [pool (tu/component node :xtdb/buffer-pool)]
+    (filter #(re-matches #"tables/foo/meta/log-(.*)" %) (.listObjects ^IBufferPool pool))))
 
 (t/deftest indexer-flushes-block-and-chunk-if-flush-op-test
   (with-open [node (start-node #time/duration "PT0.001S")]


### PR DESCRIPTION
The algorithm for buffer-pooling differs significantly depending on whether the object are stored in-memory, local or remote - we've already seen issues like #2772 where treating a local object-store (OS) like a remote object-store leads to performance issues in the former.

This PR splits the buffer pool (BP) into in-memory, local and remote implementations. 

* The in-memory essentially inlines the in-memory OS (with the latter being relegated to a test fixture now); local does the same but with the file-system store, and the current BP implementation becomes the remote one. 
* The remote BP is the only one that requires an object-store implementation. i.e. the user configures one of the following:
  * in-memory BP (default)
  * local BP (specifying a path)
  * remote BP (additionally configuring an object store)
* All put/list requests now go to the BP - nothing hits the OS directly apart from the BP.
* I removed `evictBuffer` as the behaviour would now be unclear between the various BPs (and nothing was calling it anyway). At some point we'll want to reintroduce this, but at that point I'd like to be clear that it's effectively the same as `deleteObject` (i.e. irretrievable).