### PR TITLE
Add multipart support to Azure Object Store

### DIFF
--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -7,8 +7,7 @@
             [xtdb.azure.object-store :as os]
             [xtdb.azure.file-watch :as azure-file-watch]
             [xtdb.log :as xtdb-log]
-            [xtdb.util :as util]
-            [clojure.reflect :as reflect])
+            [xtdb.util :as util])
   (:import (com.azure.core.credential TokenCredential)
            (com.azure.core.management AzureEnvironment)
            (com.azure.core.management.profile AzureProfile)

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -4,14 +4,15 @@
             [xtdb.util :as util])
   (:import [com.azure.core.util BinaryData]
            [com.azure.storage.blob BlobContainerClient]
+           [com.azure.storage.blob.specialized BlockBlobClient]
            [com.azure.storage.blob.models BlobRange BlobStorageException DownloadRetryOptions]
            [java.io ByteArrayOutputStream Closeable]
            [java.lang AutoCloseable]
            [java.nio ByteBuffer]
-           [java.util NavigableSet]
+           [java.util NavigableSet ArrayList List Base64 Base64$Encoder]
            [java.util.concurrent CompletableFuture]
            [java.util.function Supplier]
-           [xtdb.object_store ObjectStore]))
+           [xtdb.object_store ObjectStore SupportsMultipart IMultipartUpload]))
 
 (defn- get-blob [^BlobContainerClient blob-container-client blob-name]
   (try
@@ -53,7 +54,44 @@
 (defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
   (-> (.getBlobClient blob-container-client blob-name)
       (.deleteIfExists)))
-(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix ^NavigableSet file-name-cache ^AutoCloseable file-list-watcher]
+
+(def ^Base64$Encoder base-64-encoder (Base64/getEncoder))
+
+(defn block-number->base64-block-id [block-number]
+  (.encodeToString base-64-encoder (.getBytes (str block-number))))
+
+(defrecord MultipartUpload [^BlockBlobClient block-blob-client on-complete ^List !staged-block-ids]
+  IMultipartUpload
+  (uploadPart [_  buf]
+    (CompletableFuture/completedFuture
+     (let [block-number (inc (count !staged-block-ids))
+           block-id (block-number->base64-block-id block-number)
+           binary-data (BinaryData/fromByteBuffer buf)]
+       (.stageBlock block-blob-client block-id binary-data)
+       (.add !staged-block-ids block-id))))
+
+  (complete [_]
+    (CompletableFuture/completedFuture
+     (do
+       (.commitBlockList block-blob-client !staged-block-ids)
+       ;; Run passed in on-complete function (adds the key to the filename cache)
+       (on-complete))))
+  
+  (abort [_]
+    (CompletableFuture/completedFuture
+     (do
+       ;; Commit an empty blocklist removes all staged & uncomitted files
+       (.commitBlockList block-blob-client [])
+       ;; Delete the empty blob
+       (.deleteIfExists block-blob-client)))))
+
+(defn- start-multipart [^BlobContainerClient blob-container-client blob-name on-complete-fn]
+  (let [block-blob-client (-> blob-container-client 
+                              (.getBlobClient blob-name) 
+                              (.getBlockBlobClient))]
+    (->MultipartUpload block-blob-client on-complete-fn (ArrayList.))))
+
+(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix minimum-part-size ^NavigableSet file-name-cache ^AutoCloseable file-list-watcher]
   ObjectStore
   (getObject [_ k]
     (CompletableFuture/completedFuture
@@ -87,6 +125,13 @@
     (.remove file-name-cache k)
     (delete-blob blob-container-client (str prefix k))
     (CompletableFuture/completedFuture nil))
+  
+  SupportsMultipart
+  (startMultipart [_ k]
+    (CompletableFuture/completedFuture
+     (start-multipart blob-container-client
+                      (str prefix k)
+                      (fn [] (.add file-name-cache k)))))
 
   Closeable
   (close [_]

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -91,7 +91,7 @@
                               (.getBlockBlobClient))]
     (->MultipartUpload block-blob-client on-complete-fn (ArrayList.))))
 
-(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix minimum-part-size ^NavigableSet file-name-cache ^AutoCloseable file-list-watcher]
+(defrecord AzureBlobObjectStore [^BlobContainerClient blob-container-client prefix multipart-minimum-part-size ^NavigableSet file-name-cache ^AutoCloseable file-list-watcher]
   ObjectStore
   (getObject [_ k]
     (CompletableFuture/completedFuture

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -121,7 +121,7 @@
                                                    (.setRetrieveUncommittedBlobs true))))]
     (set/difference all-blobs comitted-blobs)))
 
-(t/deftest ^:s3 multipart-start-and-cancel
+(t/deftest ^:azure multipart-start-and-cancel
   (with-open [os (object-store (random-uuid))]
     (let [blob-container-client (:blob-container-client os)
           prefix (:prefix os)]
@@ -138,7 +138,7 @@
             (let [uncomitted-blobs (fetch-uncomitted-blobs blob-container-client prefix)]
               (= #{} uncomitted-blobs))))))))
 
-(t/deftest ^:s3 multipart-put-test
+(t/deftest ^:azure multipart-put-test
   (with-open [os (object-store (random-uuid))]
     (let [blob-container-client (:blob-container-client os)
           prefix (:prefix os)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -6,10 +6,14 @@
             [xtdb.azure :as azure]
             [xtdb.object-store-test :as os-test]
             [xtdb.node :as node]
-            [clojure.tools.logging :as log])
-  (:import java.util.UUID
-           java.io.Closeable
-           xtdb.object_store.ObjectStore))
+            [clojure.tools.logging :as log]
+            [clojure.set :as set])
+  (:import [java.util UUID]
+           [java.io Closeable]
+           [java.nio ByteBuffer]
+           [com.azure.storage.blob.models ListBlobsOptions BlobListDetails BlobItem]
+           [com.azure.storage.blob BlobContainerClient]
+           [xtdb.object_store ObjectStore SupportsMultipart IMultipartUpload]))
 
 (def resource-group-name "azure-modules-test")
 (def storage-account "xtdbteststorageaccount")
@@ -97,3 +101,64 @@
     (t/is (= [{:id :foo}]
              (xt/q node '{:find [id]
                           :where [($ :xt_docs [{:xt/id id}])]})))))
+
+(defn list-filenames [^BlobContainerClient blob-container-client prefix ^ListBlobsOptions list-opts]
+  (->> (.listBlobs blob-container-client list-opts nil)
+       (.iterator)
+       (iterator-seq)
+       (mapv (fn [^BlobItem blob-item]
+               (subs (.getName blob-item) (count prefix))))
+       (set)))
+
+(defn fetch-uncomitted-blobs [^BlobContainerClient blob-container-client prefix]
+  (let [base-opts (-> (ListBlobsOptions.)
+                      (.setPrefix prefix))
+        comitted-blobs (list-filenames blob-container-client prefix base-opts)
+        all-blobs (list-filenames blob-container-client
+                                  prefix
+                                  (.setDetails base-opts
+                                               (-> (BlobListDetails.)
+                                                   (.setRetrieveUncommittedBlobs true))))]
+    (set/difference all-blobs comitted-blobs)))
+
+(t/deftest ^:s3 multipart-start-and-cancel
+  (with-open [os (object-store (random-uuid))]
+    (let [blob-container-client (:blob-container-client os)
+          prefix (:prefix os)]
+      (t/testing "Call to start multipart should work/return an object"
+        (let [multipart-upload ^IMultipartUpload  @(.startMultipart ^SupportsMultipart os "test-multi-created")]
+          (t/is multipart-upload)
+
+          (t/testing "Uploading a part should create an uncomitted blob"
+            (let [uncomitted-blobs (fetch-uncomitted-blobs blob-container-client prefix)]
+              (= #{"test-multi-created"} uncomitted-blobs)))
+
+          (t/testing "Call to abort a multipart upload should work - uncomitted blob removed"
+            @(.abort multipart-upload)
+            (let [uncomitted-blobs (fetch-uncomitted-blobs blob-container-client prefix)]
+              (= #{} uncomitted-blobs))))))))
+
+(t/deftest ^:s3 multipart-put-test
+  (with-open [os (object-store (random-uuid))]
+    (let [blob-container-client (:blob-container-client os)
+          prefix (:prefix os)
+          multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os "test-multi-put")
+          part-size 500
+          file-part-1 ^ByteBuffer (os-test/generate-random-byte-buffer part-size)
+          file-part-2 ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
+
+      ;; Uploading parts to multipart upload
+      @(.uploadPart multipart-upload (.flip file-part-1))
+      @(.uploadPart multipart-upload (.flip file-part-2))
+
+      (t/testing "Call to complete a multipart upload should work - should be removed from the uncomitted list"
+        @(.complete multipart-upload)
+        (let [uncomitted-blobs (fetch-uncomitted-blobs blob-container-client prefix)]
+          (t/is (= #{} uncomitted-blobs))))
+
+      (t/testing "Multipart upload works correctly - file present and contents correct"
+        (t/is (= ["test-multi-put"] (.listObjects ^ObjectStore os)))
+
+        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os "test-multi-put")]
+          (t/testing "capacity should be equal to total of 2 parts"
+            (t/is (= (* 2 part-size) (.capacity uploaded-buffer)))))))))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -39,6 +39,17 @@
 (defn get-bytes [^ObjectStore obj-store k start len]
   (byte-buf->bytes @(.getObjectRange obj-store k start len)))
 
+;; Generates a byte buffer of random characters
+(defn generate-random-byte-buffer [buffer-size]
+  (let [random         (java.util.Random.)
+        byte-buffer    (ByteBuffer/allocate buffer-size)]
+    (loop [i 0]
+      (if (< i buffer-size)
+        (do
+          (.put byte-buffer (byte (.nextInt random 128)))
+          (recur (inc i)))
+        byte-buffer))))
+
 (deftype InMemoryObjectStore [^NavigableMap os]
   ObjectStore
   (getObject [_this k]

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -87,23 +87,12 @@
               uploads (.uploads ^ListMultipartUploadsResponse list-multipart-uploads-response)]
           (t/is (= [] uploads) "uploads should be empty"))))))
 
-;; Generates a byte buffer of random characters
-(defn generate-random-byte-buffer [buffer-size]
-  (let [random         (java.util.Random.)
-        byte-buffer    (ByteBuffer/allocate buffer-size)]
-    (loop [i 0]
-      (if (< i buffer-size)
-        (do
-          (.put byte-buffer (byte (.nextInt random 128)))
-          (recur (inc i)))
-        byte-buffer))))
-
 (t/deftest ^:s3 multipart-put-test
   (with-open [os (object-store (random-uuid))]
     (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os "test-multi-put")
           part-size (* 5 1024 1024)
-          file-part-1 (generate-random-byte-buffer part-size)
-          file-part-2 (generate-random-byte-buffer part-size)]
+          file-part-1 (os-test/generate-random-byte-buffer part-size)
+          file-part-2 (os-test/generate-random-byte-buffer part-size)]
 
       ;; Uploading parts to multipart upload
       @(.uploadPart multipart-upload file-part-1)


### PR DESCRIPTION
Resolves #2838 

## In this PR

Implements `SupportsMultipart` interface in the Azure Object store - using [**Azure's BlockBlobs**](https://learn.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs)
- Implement the interface within the `azure` object store:
  - `startMultipart` calls to create a BlockBlobClient, which is passed into the azure defrecord of `MultipartUpload` (which implements `IMultipartUpload`).
  - Multipart upload acts on the BlockBlobClient:
    - `uploadPart` stages a new block at a Base64 ID made from the 'part number', and stores the staged blocks ids in a list
    - `complete` calls to `commitBlockList` on the object with the above IDs, which will write out a file consisting of the blocks onto Azure.
    - `abort` calls to `commitBlockList` on the object with an empty list - creating an empty object and removing all staged blocks. We then delete the subsequent file (if it exists).   
  - On completing an upload, calls a `complete-fn` passed from the object store. This adds the initial key to the filename cache. 
- Adds the `multipart-minimum-part-size` field to the object store -  useful for callers to decide part boundaries.
  - This is set to 0 for Azure as there is no minimum block size. 
- Test all of the above for azure - starting a multipart, aborting a multipart, uploading parts, verifying parts are uploaded as expected. 