### PR TITLE
Switch `file-name-cache` to work with `java.nio.Path` #2482 #2483

### DIFF
--- a/core/src/main/clojure/xtdb/file_list.clj
+++ b/core/src/main/clojure/xtdb/file_list.clj
@@ -1,8 +1,29 @@
 (ns xtdb.file-list
-  (:require [clojure.string :as string])
-  (:import java.util.NavigableSet))
+  (:require [clojure.java.io :as io])
+  (:import [java.nio.file Path]
+           [java.util NavigableSet]))
+
+(defn file-name->path [^String file-name]
+  (.toPath (io/file file-name)))
+
+(defn add-filename [^NavigableSet file-name-cache ^String file-name]
+  (.add file-name-cache (file-name->path file-name)))
+
+(defn add-filename-list [^NavigableSet file-name-cache file-name-list]
+  (.addAll file-name-cache (mapv file-name->path file-name-list)))
+
+(defn remove-filename [^NavigableSet file-name-cache ^String file-name]
+  (.remove file-name-cache (file-name->path file-name)))
+
+(defn list-files [^NavigableSet file-name-cache]
+  (mapv str file-name-cache))
 
 (defn list-files-under-prefix [^NavigableSet file-name-cache prefix]
-  (->> (.tailSet ^NavigableSet file-name-cache prefix)
-       (take-while #(string/starts-with? % prefix))
-       (into [])))
+  (let [prefix-path ^Path (file-name->path prefix)
+        prefix-depth (.getNameCount prefix-path)]
+    (->> (.tailSet ^NavigableSet file-name-cache prefix-path)
+         (take-while #(.startsWith ^Path % prefix-path))
+         (keep (fn [^Path path]
+                 (when (> (.getNameCount path) prefix-depth)
+                   (str (.subpath path 0 (inc prefix-depth))))))
+         (distinct))))

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -111,18 +111,18 @@
      (get-blob-range blob-container-client (str prefix k) start len)))
 
   (putObject [_ k buf]
-    (.add file-name-cache k)
+    (file-list/add-filename file-name-cache k)
     (put-blob blob-container-client (str prefix k) buf)
     (CompletableFuture/completedFuture nil))
 
   (listObjects [_this]
-    (into [] file-name-cache))
+    (file-list/list-files file-name-cache))
 
   (listObjects [_this dir]
     (file-list/list-files-under-prefix file-name-cache dir))
 
   (deleteObject [_ k]
-    (.remove file-name-cache k)
+    (file-list/remove-filename file-name-cache k)
     (delete-blob blob-container-client (str prefix k))
     (CompletableFuture/completedFuture nil))
   
@@ -131,7 +131,7 @@
     (CompletableFuture/completedFuture
      (start-multipart blob-container-client
                       (str prefix k)
-                      (fn [] (.add file-name-cache k)))))
+                      (fn [] (file-list/add-filename file-name-cache k)))))
 
   Closeable
   (close [_]

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
@@ -81,18 +81,18 @@
      (get-blob-range this k start len)))
 
   (putObject [this k buf]
-    (.add file-name-cache k)
+    (file-list/add-filename file-name-cache k)
     (put-blob this k buf)
     (CompletableFuture/completedFuture nil))
 
   (listObjects [_this]
-    (into [] file-name-cache))
+    (file-list/list-files file-name-cache))
 
   (listObjects [_this dir]
     (file-list/list-files-under-prefix file-name-cache dir))
 
   (deleteObject [this k]
-    (.remove file-name-cache k)
+    (file-list/remove-filename file-name-cache k)
     (delete-blob this k)
     (CompletableFuture/completedFuture nil))
 

--- a/modules/s3/src/main/clojure/xtdb/s3.clj
+++ b/modules/s3/src/main/clojure/xtdb/s3.clj
@@ -143,16 +143,16 @@
         (util/then-apply (fn [_]
                            ;; Add file name to the local cache as the last thing we do (ie - if PUT
                            ;; fails, shouldnt add filename to the cache)
-                           (.add file-name-cache k)))))
+                           (file-list/add-filename file-name-cache k)))))
 
   (listObjects [_this]
-    (into [] file-name-cache))
+    (file-list/list-files file-name-cache))
 
   (listObjects [_this dir]
     (file-list/list-files-under-prefix file-name-cache dir))
 
   (deleteObject [_ k]
-    (.remove file-name-cache k)
+    (file-list/remove-filename file-name-cache k)
     (.deleteObject client
                    (-> (DeleteObjectRequest/builder)
                        (.bucket bucket)
@@ -175,7 +175,7 @@
                                                 (.uploadId initiate-response)
                                                 (fn [k]
                                                   ;; On complete - add filename to cache
-                                                  (.add file-name-cache k))
+                                                  (file-list/add-filename file-name-cache k))
                                                 (ArrayList.)))))))
 
   Closeable

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -134,14 +134,25 @@
   (put-edn obj-store "foo/alan" :alan)
   (put-edn obj-store "bar/bob" :bob)
   (put-edn obj-store "bar/baz/dan" :dan)
+  (put-edn obj-store "bar/baza/james" :james)
 
-  (t/is (= ["bar/alice" "bar/baz/dan" "bar/bob" "foo/alan"] (.listObjects obj-store)))
-  (t/is (= ["bar/alice" "bar/baz" "bar/bob" ] (.listObjects obj-store "bar")))
+  (t/is (= ["bar/alice" "bar/baz/dan" "bar/baza/james" "bar/bob" "foo/alan"] (.listObjects obj-store)))
+  (t/is (= ["foo/alan"] (.listObjects obj-store "foo")))
+  
+  (t/testing "call listObjects with a prefix ended with a slash - should work the same"
+    (t/is (= ["foo/alan"] (.listObjects obj-store "foo/"))))
+  
+  (t/testing "calling listObjects with prefix on directory with subdirectories - should only return top level keys"
+    (t/is (= ["bar/alice" "bar/baz" "bar/baza" "bar/bob"] (.listObjects obj-store "bar"))))
+  
+  (t/testing "calling listObjects with prefix with common prefix - should only return that which is a complete match against a directory "
+    (t/is (= ["bar/baz/dan"] (.listObjects obj-store "bar/baz"))))
 
+  
      ;; Delete an object
   @(.deleteObject obj-store "bar/alice")
 
-  (t/is (= ["bar/baz" "bar/bob"] (.listObjects obj-store "bar"))))
+  (t/is (= ["bar/baz" "bar/baza" "bar/bob"] (.listObjects obj-store "bar"))))
 
 (defn test-range [^ObjectStore obj-store]
 

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -133,14 +133,15 @@
   (put-edn obj-store "bar/alice" :alice)
   (put-edn obj-store "foo/alan" :alan)
   (put-edn obj-store "bar/bob" :bob)
+  (put-edn obj-store "bar/baz/dan" :dan)
 
-  (t/is (= ["bar/alice" "bar/bob" "foo/alan"] (.listObjects obj-store)))
-  (t/is (= ["bar/alice" "bar/bob"] (.listObjects obj-store "bar")))
+  (t/is (= ["bar/alice" "bar/baz/dan" "bar/bob" "foo/alan"] (.listObjects obj-store)))
+  (t/is (= ["bar/alice" "bar/baz" "bar/bob" ] (.listObjects obj-store "bar")))
 
      ;; Delete an object
   @(.deleteObject obj-store "bar/alice")
 
-  (t/is (= ["bar/bob"] (.listObjects obj-store "bar"))))
+  (t/is (= ["bar/baz" "bar/bob"] (.listObjects obj-store "bar"))))
 
 (defn test-range [^ObjectStore obj-store]
 


### PR DESCRIPTION
Resolves #2842 and Resolves #2843

- Updates the `xtdb.file-list` namespace to add a set of functions which handle adding, removing and listing the `file-name-cache` using `java.nio.Path` objects. 
- Updates all usages of the `file-name-cache` to use these functions, so everywhere we use the cache we are handling `Path` objects for the sake of consistency. 
- Add some tests for the "list with prefix" behaviour - should work as explained below (and in line with #2842)

A benefit to switching over the usages of `file-name-cache` to all work with functions defined in `file-list` is that we can change the representation of the `file-name-cache` however we want under the hood - all that callers need to know is that they pass in and get back out strings representing the file-name/object key.

## Impacted object stores

This change will impact all object stores that use the `file-name-cache` for listing objects - this is currently:
- S3 Object Store
- Azure Object Store
- Google Cloud Object Store

Have tested these with their test suites (particularly the various list tests, including the new tests for prefix behaviour and the `multiple-object-store-list-test` to ensure that the `file_watch` functions are adding/removing stuff correctly).

## Expected prefix behaviour

Given a set of filenames with the following structure:

```
foo
  foo/example1
  foo/example2
  foo/bar/example3
  foo/bar/example4
  foo/baz/example5
```  

Previoius behaviour of calling `listObjects` with prefix `foo` on object stores that were using `list-files-under-prefix` would return the full nested list, ie:
```
foo/example1 foo/example2 foo/bar/example3 foo/bar/example4 foo/baz/example5
```

What we now return is a shallow list - only returning files and directories at foo level, ie:
```
foo/example1 foo/example2 foo/bar foo/baz
```