### PR TITLE
Channelled writers for the buffer pool, objects

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -1,32 +1,43 @@
 (ns xtdb.buffer-pool
   (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
             [juxt.clojars-mirrors.integrant.core :as ig]
-            [xtdb.object-store :as object-store]
+            [xtdb.object-store]
             [xtdb.util :as util]
             [xtdb.object-store :as os])
   (:import java.io.Closeable
+           (clojure.lang PersistentQueue)
            (java.nio ByteBuffer)
-           (java.nio.channels FileChannel$MapMode)
-           [java.nio.file FileSystems FileVisitOption Files LinkOption Path]
-           [java.util Map NavigableMap]
-           [java.util.concurrent CompletableFuture ConcurrentSkipListMap]
+           (java.nio.channels FileChannel WritableByteChannel)
+           [java.nio.file FileVisitOption Files LinkOption Path StandardOpenOption]
+           (java.nio.file.attribute FileAttribute)
+           [java.util Map NavigableMap TreeMap]
+           [java.util.concurrent CompletableFuture]
            (java.util.concurrent.atomic AtomicLong)
            java.util.NavigableMap
            [org.apache.arrow.memory ArrowBuf BufferAllocator]
            (org.apache.arrow.vector VectorSchemaRoot)
-           (org.apache.arrow.vector.ipc.message ArrowFooter ArrowRecordBatch)
-           xtdb.IBufferPool
+           (org.apache.arrow.vector.ipc ArrowFileWriter)
+           (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter ArrowRecordBatch)
            xtdb.object_store.ObjectStore
-           xtdb.util.ArrowBufLRU))
+           xtdb.util.ArrowBufLRU
+           (xtdb IBufferPool)
+           (xtdb.object_store IMultipartUpload SupportsMultipart)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
+(def ^:private min-multipart-part-size (* 5 1024 1024))
+(def ^:private max-multipart-per-upload-concurrency 4)
+
+(defn- free-memory [^Map memory-store]
+  (locking memory-store
+    (run! util/close (.values memory-store))
+    (.clear memory-store)))
+
 (defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
 
-(defn- cache-get ^ArrowBuf [^Map buffers k]
-  (locking buffers
-    (some-> (.get buffers k) retain)))
+(defn- cache-get ^ArrowBuf [^Map memory-store k]
+  (locking memory-store
+    (some-> (.get memory-store k) retain)))
 
 (def ^AtomicLong cache-miss-byte-counter (AtomicLong.))
 (def ^AtomicLong cache-hit-byte-counter (AtomicLong.))
@@ -37,292 +48,416 @@
   (.set cache-hit-byte-counter 0)
   (reset! io-wait-nanos-counter 0N))
 
-(defn record-cache-miss [^ArrowBuf arrow-buf]
+(defn- record-cache-miss [^ArrowBuf arrow-buf]
   (.addAndGet cache-miss-byte-counter (.capacity arrow-buf)))
 
-(defn record-cache-hit [^ArrowBuf arrow-buf]
+(defn- record-cache-hit [^ArrowBuf arrow-buf]
   (.addAndGet cache-hit-byte-counter (.capacity arrow-buf)))
 
-(defn record-io-wait [^long start-ns]
+(defn- record-io-wait [^long start-ns]
   (swap! io-wait-nanos-counter +' (- (System/nanoTime) start-ns)))
 
 (defn- cache-compute
   "Returns a pair [hit-or-miss, buf] computing the cached ArrowBuf from (f) if needed.
   `hit-or-miss` is true if the buffer was found, false if the object was added as part of this call."
-  [^Map buffers k f]
-  (locking buffers
-    (let [hit (.containsKey ^Map buffers k)
-          arrow-buf (if hit (.get buffers k) (let [buf (f)] (.put buffers k buf) buf))]
+  [^Map memory-store k f]
+  (locking memory-store
+    (let [hit (.containsKey memory-store k)
+          arrow-buf (if hit (.get memory-store k) (let [buf (f)] (.put memory-store k buf) buf))]
       (if hit (record-cache-hit arrow-buf) (record-cache-miss arrow-buf))
       [hit (retain arrow-buf)])))
 
-(deftype MemoryBufferPool [^BufferAllocator allocator ^NavigableMap buffers]
-  IBufferPool
-  (getBuffer [_ k]
-    (CompletableFuture/completedFuture
-     (when k
-       (when-let [cached-buffer (cache-get buffers k)]
-         (record-cache-hit cached-buffer)
-         cached-buffer))))
+(defn- upload-multipart-buffers [object-store k nio-buffers]
+  (let [^IMultipartUpload upload @(.startMultipart ^SupportsMultipart object-store k)]
+    (try
 
-  (getRangeBuffer [_ k start len]
-    (object-store/ensure-shared-range-oob-behaviour start len)
-    (CompletableFuture/completedFuture
-     (when k
-       (when-let [buffer (when-let [^ArrowBuf full-buffer (cache-get buffers k)]
-                           (.slice full-buffer start len))]
-         (record-cache-hit buffer)
-         buffer))))
-
-  (putObject [_ k buf]
-    (.put buffers k (util/->arrow-buf-view allocator buf))
-    (CompletableFuture/completedFuture nil))
-
-  (listObjects [_] (vec (.keySet buffers)))
-
-  ;; TODO #2740
-  (listObjects [_ prefix]
-    (->> (.keySet (.tailMap buffers prefix))
-         (into [] (take-while #(str/starts-with? % prefix)))))
-
-  Closeable
-  (close [_]
-    (locking buffers
-      (let [i (.iterator (.values buffers))]
-        (while (.hasNext i)
-          (util/close (.next i))
-          (.remove i)))
-      (util/close allocator))))
-
-(defmethod ig/prep-key ::in-memory [_ opts]
-  (into {:allocator (ig/ref :xtdb/allocator)}
-        opts))
-
-(defmethod ig/init-key ::in-memory [_ {:keys [^BufferAllocator allocator]}]
-  (util/with-close-on-catch [allocator (util/->child-allocator allocator "buffer-pool")]
-    (->MemoryBufferPool allocator (ConcurrentSkipListMap.))))
-
-(defmethod ig/halt-key! ::in-memory [_ buffer-pool]
-  (util/close buffer-pool))
-
-(derive ::in-memory :xtdb/buffer-pool)
-
-(defn get-path ^ByteBuffer [^Path root-path, ^String k]
-  (let [from-path (.resolve root-path k)]
-    (when-not (util/path-exists from-path)
-      (throw (os/obj-missing-exception k)))
-
-    (util/->mmap-path from-path)))
-
-(defn get-path-range ^ByteBuffer [^Path root-path, ^String k, ^long start, ^long len]
-  (os/ensure-shared-range-oob-behaviour start len)
-
-  (let [from-path (.resolve root-path k)]
-    (when-not (util/path-exists from-path)
-      (throw (os/obj-missing-exception k)))
-
-    (with-open [in (util/->file-channel from-path #{:read})]
-      (.map in FileChannel$MapMode/READ_ONLY start (max 1 (min (- (.size in) start) len))))))
-
-(defn put-path [^Path root-path, ^String k, ^ByteBuffer buf]
-  (let [buf (.duplicate buf)
-        to-path (.resolve root-path k)]
-    (util/mkdirs (.getParent to-path))
-
-    (if (identical? (FileSystems/getDefault) (.getFileSystem to-path))
-      (if (util/path-exists to-path)
-        to-path
-        (util/write-buffer-to-path-atomically buf root-path to-path))
-
-      (util/write-buffer-to-path buf to-path))))
-
-(defn list-path
-  ([^Path root-path]
-   (with-open [dir-stream (Files/walk root-path (make-array FileVisitOption 0))]
-     (vec (sort (for [^Path path (iterator-seq (.iterator dir-stream))
-                      :when (Files/isRegularFile path (make-array LinkOption 0))]
-                  (str (.relativize root-path path)))))))
-
-  ([^Path root-path, ^String dir]
-   (let [dir (.resolve root-path dir)]
-     (when (Files/exists dir (make-array LinkOption 0))
-       (with-open [dir-stream (Files/newDirectoryStream dir)]
-         (vec (sort (for [^Path path dir-stream]
-                      (str (.relativize root-path path))))))))))
-
-(deftype LocalBufferPool [^BufferAllocator allocator, ^Map buffers, ^Path root-path]
-  IBufferPool
-  (getBuffer [_ k]
-    (CompletableFuture/completedFuture
-     (when k
-       (if-let [cached-buffer (cache-get buffers k)]
-         (do
-           (record-cache-hit cached-buffer)
-           cached-buffer)
-
-         (let [nio-buffer (get-path root-path k)
-               create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-               [_ buf] (cache-compute buffers k create-arrow-buf)]
-           buf)))))
-
-  (getRangeBuffer [_ k start len]
-    (object-store/ensure-shared-range-oob-behaviour start len)
-
-    (CompletableFuture/completedFuture
-     (when k
-       (if-let [cached-buffer (or (cache-get buffers [k start len])
-                                  (when-let [^ArrowBuf cached-full-buffer (cache-get buffers k)]
-                                    (.slice cached-full-buffer start len)))]
-         (do
-           (record-cache-hit cached-buffer)
-           cached-buffer)
-
-         (let [nio-buffer (get-path-range root-path k start len)
-               create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-               [_ buf] (cache-compute buffers [k start len] create-arrow-buf)]
-           buf)))))
-
-  (putObject [_ k buf] (CompletableFuture/completedFuture (put-path root-path k buf)))
-  (listObjects [_this] (list-path root-path))
-  (listObjects [_this dir] (list-path root-path dir))
-
-  Closeable
-  (close [_]
-    (locking buffers
-      (let [i (.iterator (.values buffers))]
-        (while (.hasNext i)
-          (util/close (.next i))
-          (.remove i)))
-      (util/close allocator))))
-
-(defn- ->buffer-cache [^long cache-entries-size ^long cache-bytes-size]
-  (ArrowBufLRU. 16 cache-entries-size cache-bytes-size))
-
-(defmethod ig/prep-key ::local [_ opts]
-  (-> (merge {:cache-entries-size 1024
-              :cache-bytes-size 536870912
-              :allocator (ig/ref :xtdb/allocator)}
-             opts)
-      (util/maybe-update :path util/->path)))
-
-(defmethod ig/init-key ::local [_ {:keys [^Path path, ^BufferAllocator allocator,
-                                           ^long cache-entries-size, ^long cache-bytes-size]}]
-  (when-not (util/path-exists path)
-    (util/mkdirs path))
-
-  (util/with-close-on-catch [allocator (util/->child-allocator allocator "buffer-pool")]
-    (->LocalBufferPool allocator (->buffer-cache cache-entries-size cache-bytes-size) path)))
-
-(defmethod ig/halt-key! ::local [_ buffer-pool]
-  (util/close buffer-pool))
-
-(derive ::local :xtdb/buffer-pool)
-
-(deftype RemoteBufferPool [^BufferAllocator allocator ^ObjectStore object-store ^Map buffers ^Path cache-path]
-  IBufferPool
-  (getBuffer [_ k]
-    (if (nil? k)
-      (CompletableFuture/completedFuture nil)
-      (let [cached-buffer (cache-get buffers k)]
+      (loop [part-queue (into PersistentQueue/EMPTY nio-buffers)
+             waiting-parts []]
         (cond
-          cached-buffer
-          (do
-            (record-cache-hit cached-buffer)
-            (CompletableFuture/completedFuture cached-buffer))
+          (empty? part-queue) @(CompletableFuture/allOf (into-array CompletableFuture waiting-parts))
 
-          cache-path
-          (let [start-ns (System/nanoTime)
-                buffer-cache-path (.resolve cache-path k)]
-            (-> (if (util/path-exists buffer-cache-path)
-                  (CompletableFuture/completedFuture buffer-cache-path)
-                  (do (util/create-parents buffer-cache-path)
-                      (.getObject object-store k buffer-cache-path)))
-                (util/then-apply
-                  (fn [buffer-path]
-                    (record-io-wait start-ns)
-                    (let [cleanup-file #(util/delete-file buffer-path)]
-                      (try
-                        (let [nio-buffer (util/->mmap-path buffer-path)
-                              create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer cleanup-file)
-                              [_ buf] (cache-compute buffers k create-arrow-buf)]
-                          buf)
-                        (catch Throwable t
-                          (try (cleanup-file) (catch Throwable t1 (log/error t1 "Error caught cleaning up file during exception handling")))
-                          (throw t))))))))
+          (< (count waiting-parts) (int max-multipart-per-upload-concurrency))
+          (recur (pop part-queue) (conj waiting-parts (.uploadPart upload ^ByteBuffer (peek part-queue))))
 
           :else
-          (let [start-ns (System/nanoTime)]
-            (-> (.getObject object-store k)
-                (util/then-apply
-                  (fn [nio-buffer]
-                    (record-io-wait start-ns)
-                    (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-                          [_ buf] (cache-compute buffers k create-arrow-buf)]
-                      buf)))))))))
+          (do @(CompletableFuture/anyOf (into-array CompletableFuture waiting-parts))
+              (recur part-queue (vec (remove future-done? waiting-parts))))))
 
-  (getRangeBuffer [_ k start len]
-    (object-store/ensure-shared-range-oob-behaviour start len)
-    (if (nil? k)
-      (CompletableFuture/completedFuture nil)
-      (let [cached-full-buffer (cache-get buffers k)
+      @(.complete upload)
 
-            cached-buffer
-            (or (cache-get buffers [k start len])
-                (when ^ArrowBuf cached-full-buffer
-                  (.slice cached-full-buffer start len)))]
+      (catch Throwable upload-loop-t
+        (try
+          @(.abort upload)
+          (catch Throwable abort-t
+            (.addSuppressed upload-loop-t abort-t)))
+        (throw upload-loop-t)))))
 
-        (if cached-buffer
-          (do
-            (record-cache-hit cached-buffer)
-            (CompletableFuture/completedFuture cached-buffer))
-          (let [start-ns (System/nanoTime)]
-            (-> (.getObjectRange object-store k start len)
-                (util/then-apply
-                  (fn [nio-buffer]
-                    (record-io-wait start-ns)
-                    (let [create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
-                          [_ buf] (cache-compute buffers [k start len] create-arrow-buf)]
-                      buf)))))))))
+(defn- put-object [^IBufferPool bp k ^ByteBuffer buffer]
+  (try
+    (let [buffer (.duplicate buffer)]
+      (with-open [ch (.openChannel bp k)]
+        (while (.hasRemaining buffer)
+          (.write ch buffer)))
+      (CompletableFuture/completedFuture nil))
+    (catch Throwable t
+      (CompletableFuture/failedFuture t))))
 
-  (putObject [_ k buf] (.putObject object-store k buf))
-  (listObjects [_] (.listObjects object-store))
-  (listObjects [_ dir] (.listObjects object-store dir))
+(deftype InMemoryWritableChannel
+  [allocator
+   memory-store
+   ^:volatile-mutable ^ByteBuffer buffer
+   k
+   ^:volatile-mutable open]
+  WritableByteChannel
+  (isOpen [_] open)
+  (close [this]
+    (let [create-arrow-buf #(util/->arrow-buf-view allocator (.flip buffer))
+          [_ arrow-buf] (cache-compute memory-store k create-arrow-buf)]
+      ;; cache-compute returns the buffer, so must increment its reference count
+      ;; we are not interested in doing work with the buffer (just to putting it in the cache), hence util/close.
+      (util/close arrow-buf)
+      (set! (.-open this) false)))
+  (write [this src]
+    (let [remaining (.remaining src)]
+      (loop [src src]
+        (let [^ByteBuffer buffer (.-buffer this)]
+          (if (<= (.remaining src) (.remaining buffer))
+            (.put buffer src)
+            (let [new-buffer (ByteBuffer/allocateDirect (* 2 (.capacity buffer)))]
+              (.put new-buffer (.flip buffer))
+              (set! (.-buffer this) new-buffer)
+              (recur src)))))
+      remaining)))
 
+(defrecord InMemoryBufferPool
+  [allocator
+   ^NavigableMap memory-store]
   Closeable
   (close [_]
-    (locking buffers
-      (let [i (.iterator (.values buffers))]
-        (while (.hasNext i)
-          (util/close (.next i))
-          (.remove i)))
-      (util/close allocator))))
+    (free-memory memory-store)
+    (util/close allocator))
+  IBufferPool
+  (getBuffer [_ k]
+    (let [cached-buffer (cache-get memory-store k)]
+      (cond
+        (nil? k)
+        (CompletableFuture/completedFuture nil)
+
+        cached-buffer
+        (do (record-cache-hit cached-buffer)
+            (CompletableFuture/completedFuture cached-buffer))
+
+        :else
+        (CompletableFuture/failedFuture (os/obj-missing-exception k)))))
+  (listObjects [_]
+    (locking memory-store (vec (.keySet ^NavigableMap memory-store))))
+  (listObjects [_ dir]
+    (locking memory-store
+      (->> (.keySet (.tailMap ^NavigableMap memory-store dir))
+           (into [] (take-while #(str/starts-with? % dir)))
+           (vec))))
+  (openChannel [this k] (->InMemoryWritableChannel allocator memory-store (ByteBuffer/allocateDirect 32) k true))
+  (openArrowFileWriter [this k vsr] (ArrowFileWriter. vsr nil (.openChannel this k)))
+  (putObject [this k buffer] (put-object this k buffer)))
+
+(deftype DiskOnlyWritableChannel
+  [^IBufferPool bp
+   allocator
+   memory-store
+   ^Path disk-store
+   ^FileChannel file-channel
+   tmp-path
+   ^String k]
+  WritableByteChannel
+  (isOpen [_] (.isOpen file-channel))
+  (close [this]
+    (.close file-channel)
+    (let [file-path (.resolve disk-store k)]
+      (util/create-parents file-path)
+      ;; see #2847
+      (util/atomic-move tmp-path file-path)
+      (util/then-apply (.getBuffer bp k) util/close)))
+  (write [_ src] (.write file-channel src)))
+
+(defrecord DiskOnlyBufferPool
+  [allocator
+   ^ArrowBufLRU memory-store
+   ^Path disk-store]
+  Closeable
+  (close [_]
+    (free-memory memory-store)
+    (util/close allocator))
+  IBufferPool
+  (getBuffer [_ k]
+    (let [cached-buffer (cache-get memory-store k)]
+      (cond
+        (nil? k)
+        (CompletableFuture/completedFuture nil)
+
+        cached-buffer
+        (do (record-cache-hit cached-buffer)
+            (CompletableFuture/completedFuture cached-buffer))
+
+        :else
+        (let [buffer-cache-path (.resolve disk-store (str k))]
+          (-> (if (util/path-exists buffer-cache-path)
+                ;; todo could this not race with eviction? e.g exists for this cond, but is evicted before we can map the file into the cache?
+                (CompletableFuture/completedFuture buffer-cache-path)
+                (CompletableFuture/failedFuture (os/obj-missing-exception k)))
+              (util/then-apply
+                (fn [path]
+                  (let [nio-buffer (util/->mmap-path path)
+                        create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer)
+                        [_ buf] (cache-compute memory-store k create-arrow-buf)]
+                    buf))))))))
+  (listObjects [_]
+    (with-open [dir-stream (Files/walk disk-store (make-array FileVisitOption 0))]
+      (vec (sort (for [^Path path (iterator-seq (.iterator dir-stream))
+                       :when (Files/isRegularFile path (make-array LinkOption 0))]
+                   (str (.relativize disk-store path)))))))
+  (listObjects [_ dir]
+    (let [dir (.resolve disk-store dir)]
+      (when (Files/exists dir (make-array LinkOption 0))
+        (with-open [dir-stream (Files/newDirectoryStream dir)]
+          (vec (sort (for [^Path path dir-stream]
+                       (str (.relativize disk-store path)))))))))
+  (openChannel [this k]
+    (let [tmp-path (Files/createTempFile "bp-channel" ".arrow" (make-array FileAttribute 0))]
+      (->DiskOnlyWritableChannel this allocator memory-store disk-store (util/->file-channel tmp-path [StandardOpenOption/APPEND]) tmp-path k)))
+  (openArrowFileWriter [this k vsr]
+    (ArrowFileWriter. vsr nil (.openChannel this k)))
+  (putObject [this k buffer] (put-object this k buffer)))
+
+(deftype RemoteWritableChannel
+  [^IBufferPool bp
+   allocator
+   memory-store
+   ^Path disk-store
+   ^ObjectStore remote-store
+   ^FileChannel file-channel
+   tmp-path
+   ^String k
+   allow-file-deletion]
+  WritableByteChannel
+  (isOpen [_] (.isOpen file-channel))
+  (close [_]
+    (.close file-channel)
+    (let [mmap-buffer (util/->mmap-path tmp-path)]
+      (cond
+        (not (instance? SupportsMultipart remote-store))
+        @(.putObject remote-store k mmap-buffer)
+
+        (<= (.remaining mmap-buffer) (int min-multipart-part-size))
+        @(.putObject remote-store k mmap-buffer)
+
+        :else
+        (->> (range (.position mmap-buffer) (.limit mmap-buffer) min-multipart-part-size)
+             (map (fn [n] (.slice mmap-buffer (int n) (min (int min-multipart-part-size) (- (.limit mmap-buffer) (int n))))))
+             (upload-multipart-buffers remote-store k))))
+    (let [file-path (.resolve disk-store k)]
+      (util/create-parents file-path)
+      ;; see #2847
+      (util/atomic-move tmp-path file-path)
+      (util/then-apply (.getBuffer bp k) util/close)))
+  (write [_ src] (.write file-channel src)))
+
+(deftype RemoteArrowFileChannel
+  [^IBufferPool bp
+   allocator
+   memory-store
+   ^Path disk-store
+   ^ObjectStore remote-store
+   ^FileChannel file-channel
+   tmp-path
+   ^String k]
+  WritableByteChannel
+  (isOpen [_] (.isOpen file-channel))
+  (close [_]
+    (.close file-channel)
+    (let [mmap-buffer (util/->mmap-path tmp-path)]
+      (cond
+        (not (instance? SupportsMultipart remote-store))
+        @(.putObject remote-store k mmap-buffer)
+
+        (<= (.remaining mmap-buffer) (int min-multipart-part-size))
+        @(.putObject remote-store k mmap-buffer)
+
+        :else
+        (with-open [arrow-buf (util/->arrow-buf-view allocator mmap-buffer)]
+          (let [cuts
+                (loop [cuts []
+                       prev-cut (int 0)
+                       cut (int 0)
+                       blocks (.getRecordBatches (util/read-arrow-footer arrow-buf))]
+                  (if-some [[^ArrowBlock block & blocks] (seq blocks)]
+                    (let [offset (.getOffset block)
+                          offset-delta (- offset cut)
+                          metadata-length (.getMetadataLength block)
+                          body-length (.getBodyLength block)
+                          total-length (+ offset-delta metadata-length body-length)
+                          new-cut (+ cut total-length)
+                          cut-len (- new-cut prev-cut)]
+                      (if (<= (int min-multipart-part-size) cut-len)
+                        (recur (conj cuts new-cut) cut new-cut blocks)
+                        (recur cuts prev-cut new-cut blocks)))
+                    cuts))
+
+                part-buffers
+                (loop [part-buffers []
+                       prev-cut (int 0)
+                       cuts cuts]
+                  (if-some [[cut & cuts] (seq cuts)]
+                    (recur (conj part-buffers (.nioBuffer arrow-buf prev-cut (- (int cut) prev-cut))) (int cut) cuts)
+                    (let [final-part (.nioBuffer arrow-buf prev-cut (- (.capacity arrow-buf) prev-cut))]
+                      (conj part-buffers final-part))))]
+
+            (upload-multipart-buffers remote-store k part-buffers)
+
+            nil))))
+    (let [file-path (.resolve disk-store k)]
+      (util/create-parents file-path)
+      ;; see #2847
+      (util/atomic-move tmp-path file-path)
+      (util/then-apply (.getBuffer bp k) util/close)))
+  (write [_ src] (.write file-channel src)))
+
+(defrecord RemoteBufferPool
+  [allocator
+   ^ArrowBufLRU memory-store
+   ^Path disk-store
+   ^ObjectStore remote-store
+   allow-file-deletion]
+  Closeable
+  (close [_]
+    (free-memory memory-store)
+    (util/close allocator))
+  IBufferPool
+  (getBuffer [_ k]
+    (let [cached-buffer (cache-get memory-store k)]
+      (cond
+        (nil? k)
+        (CompletableFuture/completedFuture nil)
+
+        cached-buffer
+        (do (record-cache-hit cached-buffer)
+            (CompletableFuture/completedFuture cached-buffer))
+
+        :else
+        (let [buffer-cache-path (.resolve disk-store (str k))
+              start-ns (System/nanoTime)]
+          (-> (if (util/path-exists buffer-cache-path)
+                ;; todo could this not race with eviction? e.g exists for this cond, but is evicted before we can map the file into the cache?
+                (CompletableFuture/completedFuture buffer-cache-path)
+                (do (util/create-parents buffer-cache-path)
+                    (-> (.getObject remote-store k buffer-cache-path)
+                        (util/then-apply (fn [path] (record-io-wait start-ns) path)))))
+              (util/then-apply
+                (fn [path]
+                  (let [nio-buffer (util/->mmap-path path)
+                        buf-close-fn (if allow-file-deletion util/delete-file (constantly nil))
+                        create-arrow-buf #(util/->arrow-buf-view allocator nio-buffer buf-close-fn)
+                        [_ buf] (cache-compute memory-store k create-arrow-buf)]
+                    buf))))))))
+  (listObjects [_] (.listObjects remote-store))
+  (listObjects [_ dir] (.listObjects remote-store dir))
+  (openChannel [this k]
+    (let [tmp-path (Files/createTempFile "bp-channel" ".arrow" (make-array FileAttribute 0))
+          file-channel (util/->file-channel tmp-path [StandardOpenOption/APPEND])]
+      (->RemoteWritableChannel
+        this
+        allocator
+        memory-store
+        disk-store
+        remote-store
+        file-channel
+        tmp-path
+        k
+        allow-file-deletion)))
+  (openArrowFileWriter [this k vsr]
+    (let [tmp-path (Files/createTempFile "bp-channel" ".arrow" (make-array FileAttribute 0))
+          file-channel (util/->file-channel tmp-path [StandardOpenOption/APPEND])
+          ch (->RemoteArrowFileChannel
+               this
+               allocator
+               memory-store
+               disk-store
+               remote-store
+               file-channel
+               tmp-path
+               k)]
+      (ArrowFileWriter. vsr nil ch)))
+  (putObject [this k buffer] (put-object this k buffer)))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn ->remote [{:keys [^BufferAllocator allocator
+                        object-store
+                        data-dir
+                        allow-file-deletion
+                        max-cache-bytes
+                        max-cache-entries]
+                 :or {max-cache-entries 1024
+                      max-cache-bytes 536870912
+                      allow-file-deletion false}}]
+  (map->RemoteBufferPool
+    {:allocator (.newChildAllocator allocator "buffer-pool" 0 Long/MAX_VALUE)
+     :memory-store (ArrowBufLRU. 16 max-cache-entries max-cache-bytes)
+     :disk-store data-dir
+     :allow-file-deletion allow-file-deletion
+     :remote-store object-store}))
 
 (defmethod ig/prep-key ::remote [_ opts]
-  (-> (merge {:cache-entries-size 1024
-              :cache-bytes-size 536870912
-              :allocator (ig/ref :xtdb/allocator)
+  (-> (merge {:allocator (ig/ref :xtdb/allocator)
               :object-store (ig/ref :xtdb/object-store)}
              opts)
-      (util/maybe-update :cache-path util/->path)))
+      (util/maybe-update :disk-store util/->path)))
 
-(defmethod ig/init-key ::remote
-  [_ {:keys [^Path cache-path ^BufferAllocator allocator ^ObjectStore object-store ^long cache-entries-size ^long cache-bytes-size]}]
-  (when (and cache-path (not (util/path-exists cache-path)))
-    (util/mkdirs cache-path))
-  (util/with-close-on-catch [allocator (util/->child-allocator allocator "buffer-pool")]
-    (->RemoteBufferPool allocator object-store (->buffer-cache cache-entries-size cache-bytes-size) cache-path)))
+(defmethod ig/init-key ::remote [_ opts] (->remote opts))
 
-(defmethod ig/halt-key! ::remote [_ buffer-pool]
-  (util/close buffer-pool))
+(defmethod ig/halt-key! ::remote [_ bp] (util/close bp))
 
 (derive ::remote :xtdb/buffer-pool)
 
-(defn get-footer ^ArrowFooter [^IBufferPool bp path]
-  (with-open [^ArrowBuf arrow-buf @(.getBuffer bp (str path))]
+(defn ->local [{:keys [^BufferAllocator allocator,
+                       ^Path data-dir
+                       max-cache-bytes
+                       max-cache-entries]
+                :or {max-cache-entries 1024
+                     max-cache-bytes 536870912}}]
+  (map->DiskOnlyBufferPool
+    {:allocator (.newChildAllocator allocator "buffer-pool" 0 Long/MAX_VALUE)
+     :memory-store (ArrowBufLRU. 16 max-cache-entries max-cache-bytes)
+     :disk-store data-dir}))
+
+(defmethod ig/prep-key ::local [_ opts]
+  (-> (merge {:allocator (ig/ref :xtdb/allocator)} opts)
+      (util/maybe-update :data-dir util/->path)))
+
+(defmethod ig/init-key ::local [_ opts] (->local opts))
+
+(defmethod ig/halt-key! ::local [_ bp] (util/close bp))
+
+(derive ::local :xtdb/buffer-pool)
+
+(defn ->in-memory [{:keys [^BufferAllocator allocator]}]
+  (map->InMemoryBufferPool
+    {:allocator (.newChildAllocator allocator "buffer-pool" 0 Long/MAX_VALUE)
+     :memory-store (TreeMap.)}))
+
+(defmethod ig/prep-key ::in-memory [_ opts] (merge {:allocator (ig/ref :xtdb/allocator)} opts))
+
+(defmethod ig/init-key ::in-memory [_ opts] (->in-memory opts))
+
+(defmethod ig/halt-key! ::in-memory [_ bp] (util/close bp))
+
+(derive ::in-memory :xtdb/buffer-pool)
+
+(defn get-footer ^ArrowFooter [^IBufferPool bp k]
+  (with-open [^ArrowBuf arrow-buf @(.getBuffer bp (str k))]
     (util/read-arrow-footer arrow-buf)))
 
-(defn open-record-batch ^ArrowRecordBatch [^IBufferPool bp path block-idx]
-  (with-open [^ArrowBuf arrow-buf @(.getBuffer bp (str path))]
+(defn open-record-batch ^ArrowRecordBatch [^IBufferPool bp k block-idx]
+  (with-open [^ArrowBuf arrow-buf @(.getBuffer bp (str k))]
     (let [footer (util/read-arrow-footer arrow-buf)
           blocks (.getRecordBatches footer)
           block (nth blocks block-idx nil)]
@@ -330,7 +465,7 @@
         (throw (IndexOutOfBoundsException. "Record batch index out of bounds of arrow file"))
         (util/->arrow-record-batch-view block arrow-buf)))))
 
-(defn open-vsr ^VectorSchemaRoot [bp path allocator]
-  (let [footer (get-footer bp path)
+(defn open-vsr ^VectorSchemaRoot [bp k allocator]
+  (let [footer (get-footer bp k)
         schema (.getSchema footer)]
     (VectorSchemaRoot/create schema allocator)))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -496,13 +496,13 @@
   (^org.apache.arrow.memory.ArrowBuf [^BufferAllocator allocator ^ByteBuffer nio-buffer]
    (->arrow-buf-view allocator nio-buffer nil))
   (^org.apache.arrow.memory.ArrowBuf [^BufferAllocator allocator ^ByteBuffer nio-buffer on-close-fn]
-   (let [nio-buffer (if (.isDirect nio-buffer)
+   (let [nio-buffer (if (and (.isDirect nio-buffer) (zero? (.position nio-buffer)))
                       nio-buffer
-                      (-> (ByteBuffer/allocateDirect (.capacity nio-buffer))
+                      (-> (ByteBuffer/allocateDirect (.remaining nio-buffer))
                           (.put (.duplicate nio-buffer))
                           (.clear)))
          address (MemoryUtil/getByteBufferAddress nio-buffer)
-         size (.capacity nio-buffer)
+         size (.remaining nio-buffer)
          allocation-manager (proxy [AllocationManager] [allocator]
                               (getSize [] size)
                               (memoryAddress [] address)

--- a/core/src/main/java/xtdb/IBufferPool.java
+++ b/core/src/main/java/xtdb/IBufferPool.java
@@ -1,8 +1,11 @@
 package xtdb;
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
 
 import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.CompletableFuture;
 
 public interface IBufferPool extends AutoCloseable {
@@ -13,4 +16,8 @@ public interface IBufferPool extends AutoCloseable {
     Iterable<String> listObjects();
 
     Iterable<String> listObjects(String dir);
+
+    WritableByteChannel openChannel(String k);
+
+    ArrowFileWriter openArrowFileWriter(String k, VectorSchemaRoot vsr);
 }

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -246,7 +246,7 @@
     (node/start-node {:xtdb.log/local-directory-log {:root-path (.resolve node-dir "log")
                                                      :instant-src instant-src}
                       :xtdb.tx-producer/tx-producer {:instant-src instant-src}
-                      :xtdb.buffer-pool/local {:path (.resolve node-dir buffers-dir)}
+                      :xtdb.buffer-pool/local {:data-dir (.resolve node-dir buffers-dir)}
                       :xtdb/indexer (->> {:rows-per-chunk rows-per-chunk}
                                          (into {} (filter val)))
                       :xtdb.indexer/live-index (->> {:log-limit log-limit :page-limit page-limit}

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -1,40 +1,45 @@
 (ns xtdb.buffer-pool-test
-  (:require [clojure.test :as t]
-            [juxt.clojars-mirrors.integrant.core :as ig]
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t]
             [xtdb.buffer-pool :as bp]
             xtdb.node
-            [xtdb.object-store-test :as ost]
+            [xtdb.object-store :as os]
+            [xtdb.object-store-test :as os-test]
             [xtdb.test-util :as tu]
+            [xtdb.types :as types]
             [xtdb.util :as util])
-  (:import (java.nio ByteBuffer)
-           (org.apache.arrow.memory ArrowBuf RootAllocator)
+  (:import (clojure.lang IDeref)
+           (java.io Closeable)
+           (java.nio ByteBuffer)
+           (java.nio.file Files Path)
+           (java.nio.file.attribute FileAttribute)
+           (java.util Map TreeMap)
+           (java.util.concurrent CompletableFuture)
+           (org.apache.arrow.memory ArrowBuf)
+           (org.apache.arrow.vector IntVector VectorSchemaRoot)
+           (org.apache.arrow.vector.types.pojo Schema)
+           (xtdb.object_store IMultipartUpload ObjectStore SupportsMultipart)
            (xtdb.util ArrowBufLRU)))
 
-(def ^:dynamic *bp-type* nil)
-(def ^:dynamic ^xtdb.IBufferPool *buffer-pool* nil)
+(set! *warn-on-reflection* false)
 
-(defn- with-bp [opts f]
-  (tu/with-system (into {:xtdb/allocator {}} opts)
-    (fn []
-      (binding [*buffer-pool* (some-> (ig/find-derived tu/*sys* :xtdb/buffer-pool) first val)]
-        (f)))))
+(defn closeable [x close-fn] (reify IDeref (deref [_] x) Closeable (close [_] (close-fn x))))
 
-(t/use-fixtures :each
-  (fn with-each-bp [f]
-    (t/testing "memory"
-      (binding [*bp-type* :memory]
-        (with-bp {::bp/in-memory {}} f)))
+(defonce tmp-dirs (atom []))
 
-    (t/testing "local"
-      (tu/with-tmp-dirs #{path}
-        (binding [*bp-type* :local]
-          (with-bp {::bp/local {:path path}} f))))
+(defn create-tmp-dir [] (peek (swap! tmp-dirs conj (Files/createTempDirectory "bp-test" (make-array FileAttribute 0)))))
 
-    (t/testing "remote"
-      (binding [*bp-type* :remote]
-        (with-bp {::bp/remote {}
-                  ::ost/memory-object-store {}}
-          f)))))
+(defn each-fixture [f]
+  (try
+    (f)
+    (finally
+      (run! util/delete-dir @tmp-dirs)
+      (reset! tmp-dirs []))))
+
+(defn once-fixture [f] (tu/with-allocator f))
+
+(t/use-fixtures :each #'each-fixture)
+(t/use-fixtures :once #'once-fixture)
 
 (defn byte-seq [^ArrowBuf buf]
   (let [arr (byte-array (.capacity buf))]
@@ -42,20 +47,24 @@
     (seq arr)))
 
 (t/deftest cache-counter-test
-  (when (= *bp-type* :remote)
+  (with-open [os (os-test/->InMemoryObjectStore (TreeMap.))
+              bp (bp/->remote {:allocator tu/*allocator*
+                               :object-store os
+                               :data-dir (create-tmp-dir)})]
     (bp/clear-cache-counters)
     (t/is (= 0 (.get bp/cache-hit-byte-counter)))
     (t/is (= 0 (.get bp/cache-miss-byte-counter)))
     (t/is (= 0N @bp/io-wait-nanos-counter))
 
-    @(.putObject *buffer-pool* "foo" (ByteBuffer/wrap (.getBytes "hello")))
-    (with-open [^ArrowBuf _buf @(.getBuffer *buffer-pool* "foo")])
+    @(.putObject ^ObjectStore os "foo" (ByteBuffer/wrap (.getBytes "hello")))
+
+    (with-open [^ArrowBuf _buf @(.getBuffer bp "foo")])
 
     (t/is (pos? (.get bp/cache-miss-byte-counter)))
     (t/is (= 0 (.get bp/cache-hit-byte-counter)))
     (t/is (pos? @bp/io-wait-nanos-counter))
 
-    (with-open [^ArrowBuf _buf @(.getBuffer *buffer-pool* "foo")])
+    (with-open [^ArrowBuf _buf @(.getBuffer bp "foo")])
 
     (t/is (pos? (.get bp/cache-hit-byte-counter)))
     (t/is (= (.get bp/cache-hit-byte-counter) (.get bp/cache-miss-byte-counter)))
@@ -68,29 +77,176 @@
 
 (t/deftest arrow-buf-lru-test
   (t/testing "max size restriction"
-    (let [allocator (RootAllocator.)
-          lru (ArrowBufLRU. 1 2 128)
-          buf1 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))
-          buf2 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))
-          buf3 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))]
-      (.put lru "buf1" buf1)
-      (.put lru "buf2" buf2)
-      (t/is (= buf1 (.get lru "buf1")))
-      (t/is (= buf2 (.get lru "buf2")))
-      (.put lru "buf3" buf3)
-      (t/is (nil? (.get lru "buf1")))
-      (t/is (= buf3 (.get lru "buf3")))))
+    (with-open [lru (closeable (ArrowBufLRU. 1 2 128) #'bp/free-memory)]
+      (let [^Map lru @lru
+            buf1 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))
+            buf2 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))
+            buf3 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))]
+        (.put lru "buf1" buf1)
+        (.put lru "buf2" buf2)
+        (t/is (= buf1 (.get lru "buf1")))
+        (t/is (= buf2 (.get lru "buf2")))
+        (.put lru "buf3" buf3)
+        (t/is (nil? (.get lru "buf1")))
+        (t/is (= buf3 (.get lru "buf3"))))))
 
   (t/testing "max byte size restriction"
-    (let [allocator (RootAllocator.)
-          lru (ArrowBufLRU. 1 5 32)
-          buf1 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))
-          buf2 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))
-          buf3 (util/->arrow-buf-view allocator (ByteBuffer/wrap (byte-array (range 16))))]
-      (.put lru "buf1" buf1)
-      (.put lru "buf2" buf2)
-      (t/is (= buf1 (.get lru "buf1")))
-      (t/is (= buf2 (.get lru "buf2")))
-      (.put lru "buf3" buf3)
-      (t/is (nil? (.get lru "buf1")))
-      (t/is (= buf3 (.get lru "buf3"))))))
+    (with-open [lru (closeable (ArrowBufLRU. 1 5 32) #'bp/free-memory)]
+      (let [^Map lru @lru
+            buf1 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))
+            buf2 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))
+            buf3 (util/->arrow-buf-view tu/*allocator* (ByteBuffer/wrap (byte-array (range 16))))]
+        (.put lru "buf1" buf1)
+        (.put lru "buf2" buf2)
+        (t/is (= buf1 (.get lru "buf1")))
+        (t/is (= buf2 (.get lru "buf2")))
+        (.put lru "buf3" buf3)
+        (t/is (nil? (.get lru "buf1")))
+        (t/is (= buf3 (.get lru "buf3")))))))
+
+(defn copy-byte-buffer ^ByteBuffer [^ByteBuffer buf]
+  (-> (ByteBuffer/allocate (.remaining buf))
+      (.put buf)
+      (.flip)))
+
+(defn concat-byte-buffers ^ByteBuffer [buffers]
+  (let [n (reduce + (map #(.remaining ^ByteBuffer %) buffers))
+        dst (ByteBuffer/allocate n)]
+    (doseq [^ByteBuffer src buffers]
+      (.put dst src))
+    (.flip dst)))
+
+(defn utf8-buf [s] (ByteBuffer/wrap (.getBytes (str s) "utf-8")))
+
+(defn arrow-buf-bytes ^bytes [^ArrowBuf arrow-buf]
+  (let [n (.capacity arrow-buf)
+        barr (byte-array n)]
+    (.getBytes arrow-buf 0 barr)
+    barr))
+
+(defn arrow-buf-utf8 [arrow-buf]
+  (String. (arrow-buf-bytes arrow-buf) "utf-8"))
+
+(defn arrow-buf->nio [arrow-buf]
+  ;; todo get .nioByteBuffer to work
+  (ByteBuffer/wrap (arrow-buf-bytes arrow-buf)))
+
+(defn evict-buffer [bp k] (.close (.remove (:memory-store bp) k)))
+
+(defn test-get-object [bp ^String k ^ByteBuffer expected]
+  (let [{:keys [^Path disk-store, object-store]} bp]
+
+    (t/testing "immediate get from buffers map produces correct buffer"
+      (with-open [buf @(.getBuffer bp k)]
+        (t/is (= 0 (util/compare-nio-buffers-unsigned expected (arrow-buf->nio buf))))))
+
+    (when disk-store
+      (t/testing "expect a file to exist under our :data-dir"
+        (t/is (util/path-exists (.resolve disk-store k)))
+        (t/is (= 0 (util/compare-nio-buffers-unsigned expected (util/->mmap-path (.resolve disk-store k))))))
+
+      (t/testing "if the buffer is evicted, it is loaded from disk"
+        (evict-buffer bp k)
+        (with-open [buf @(.getBuffer bp k)]
+          (t/is (= 0 (util/compare-nio-buffers-unsigned expected (arrow-buf->nio buf)))))))
+
+    (when object-store
+      (t/testing "if the buffer is evicted and deleted from disk, it is delivered from object storage"
+        (evict-buffer bp k)
+        (util/delete-file (.resolve disk-store k))
+        (with-open [buf @(.getBuffer bp k)]
+          (t/is (= 0 (util/compare-nio-buffers-unsigned expected (arrow-buf->nio buf)))))))))
+
+(defrecord SimulatedObjectStore [calls buffers]
+  ObjectStore
+  (getObject [_ k] (CompletableFuture/completedFuture (get @buffers k)))
+  (getObject [_ k path]
+    (if-some [^ByteBuffer nio-buf (get @buffers k)]
+      (let [barr (byte-array (.remaining nio-buf))]
+        (.get (.duplicate nio-buf) barr)
+        (io/copy barr (.toFile path))
+        (CompletableFuture/completedFuture path))
+      (CompletableFuture/failedFuture (os/obj-missing-exception k))))
+  (putObject [_ k buf]
+    (swap! buffers assoc k buf)
+    (swap! calls conj :put)
+    (CompletableFuture/completedFuture nil))
+  SupportsMultipart
+  (startMultipart [_ k]
+    (let [parts (atom [])]
+      (CompletableFuture/completedFuture
+        (reify IMultipartUpload
+          (uploadPart [_ buf]
+            (swap! calls conj :upload)
+            (swap! parts conj (copy-byte-buffer buf))
+            (CompletableFuture/completedFuture nil))
+          (complete [_]
+            (swap! calls conj :complete)
+            (swap! buffers assoc k (concat-byte-buffers @parts))
+            (CompletableFuture/completedFuture nil))
+          (abort [_]
+            (swap! calls conj :abort)
+            (CompletableFuture/completedFuture nil)))))))
+
+(defn remote-test-buffer-pool []
+  (bp/->remote {:allocator tu/*allocator*
+                :object-store (->SimulatedObjectStore (atom []) (atom {}))
+                :data-dir (create-tmp-dir)}))
+
+(defn get-remote-calls [test-bp]
+  @(:calls (:remote-store test-bp)))
+
+(defn put-buf [bp k nio-buf]
+  (with-open [channel (.openChannel bp k)]
+    (when (.hasRemaining nio-buf)
+      (.write channel nio-buf))))
+
+(t/deftest below-min-size-put-test
+  (with-open [bp (remote-test-buffer-pool)]
+    (t/testing "if <= min part size, putObject is used"
+      (with-redefs [bp/min-multipart-part-size 2]
+        (put-buf bp "min-part-put" (utf8-buf "12"))
+        (t/is (= [:put] (get-remote-calls bp)))
+        (test-get-object bp "min-part-put" (utf8-buf "12"))))))
+
+(t/deftest above-min-size-multipart-test
+  (with-open [bp (remote-test-buffer-pool)]
+    (t/testing "if above min part size, multipart is used"
+      (with-redefs [bp/min-multipart-part-size 2]
+        (put-buf bp "min-part-multi" (utf8-buf "1234"))
+        (t/is (= [:upload :upload :complete] (get-remote-calls bp)))
+        (test-get-object bp "min-part-multi" (utf8-buf "1234"))))))
+
+(t/deftest small-end-part-test
+  (with-open [bp (remote-test-buffer-pool)]
+    (t/testing "multipart, smaller end part"
+      (with-redefs [bp/min-multipart-part-size 2]
+        (put-buf bp "min-part-multi2" (utf8-buf "123"))
+        (t/is (= [:upload :upload :complete] (get-remote-calls bp)))
+        (test-get-object bp "min-part-multi2" (utf8-buf "123"))))))
+
+(t/deftest arrow-ipc-test
+  (with-open [bp (remote-test-buffer-pool)]
+    (t/testing "multipart, arrow ipc"
+      (let [schema (Schema. [(types/col-type->field "a" :i32)])
+            ->RemoteArrowFileChannel bp/->RemoteArrowFileChannel
+            multipart-branch-taken (atom false)]
+        (with-redefs [bp/min-multipart-part-size 320
+                      bp/->RemoteArrowFileChannel
+                      (fn [& args]
+                        (reset! multipart-branch-taken true)
+                        (apply ->RemoteArrowFileChannel args))]
+          (with-open [vsr (VectorSchemaRoot/create schema tu/*allocator*)
+                      w (.openArrowFileWriter bp "aw" vsr)]
+            (let [^IntVector v (.getVector vsr "a")]
+              (.setValueCount v 10)
+              (dotimes [x 10] (.set v x x))
+              (.start w)
+              (.writeBatch w)
+              (.end w))))
+
+        (t/is @multipart-branch-taken true)
+        (t/is (= [:upload :upload :complete] (get-remote-calls bp)))
+        (with-open [buf @(.getBuffer bp "aw")]
+          (let [{:keys [root]} (util/read-arrow-buf buf)]
+            (util/close root)))))))

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -358,6 +358,8 @@
     (with-open [node (tu/->local-node {:node-dir node-dir})]
       (let [object-dir (.resolve node-dir "objects")]
 
+        (util/mkdirs object-dir)
+
         (t/is (= last-tx-key
                  (last (for [tx-ops txs]
                          (xt/submit-tx node tx-ops)))))


### PR DESCRIPTION
This PR:

- Adds ArrowFileWriter / WriteableByteChannel options to enable streaming writes
  - Multipart is used when write is large enough 
- Removes FileSystemObjectStore (responsibility sits entirely within buffer pool)
- Caches are warmed with writes, assumption: written buffers will be likely future reads
- Handful of new tests to cover at least in part remote multipart branches, which would not be exercised by existing test

This PR does not:

- Integrate streaming writes with compactor/indexer (will be a separate PR)
- Test record batch cuts (alignment of record batches to part boundaries), due to unknown importance of feature.
- Test failure behaviour

The use of multipart for large files should partially or entirely solve #2814, pending testing with large compactions.

I would like to follow up with further tests but prefer to submit for review now.