### PR TITLE
Add support for args to queries and subqueries

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -67,6 +67,9 @@
                     [(first q+args) (subvec q+args 1)]
                     [q+args nil])
 
+         args (or (:args opts) args) ;;TODO XTQL has no support for q+args vec,
+         ;; these approaches for should be exclusive.
+
          opts (-> (into {:default-all-valid-time? false} opts)
                   (assoc :args args)
                   (update :basis xtp/after-latest-submitted-tx node))]

--- a/api/src/main/java/xtdb/query/Expr.java
+++ b/api/src/main/java/xtdb/query/Expr.java
@@ -98,6 +98,23 @@ public interface Expr {
         return new LogicVar(lv);
     }
 
+    final class Param implements Expr {
+        public final String v;
+
+        private Param(String v) {
+            this.v = v;
+        }
+
+        @Override
+        public String toString() {
+            return v;
+        }
+
+    }
+    static Param param(String v) {
+        return new Param(v);
+    }
+
     final class Call implements Expr {
         public final String f;
         public final List<Expr> args;

--- a/api/src/main/java/xtdb/query/QueryOpts.java
+++ b/api/src/main/java/xtdb/query/QueryOpts.java
@@ -1,0 +1,22 @@
+package xtdb.query;
+
+import java.util.List;
+
+import static xtdb.query.QueryUtil.*;
+
+public final class QueryOpts {
+
+
+    public final List<ArgSpec> args;
+
+    public QueryOpts(List<ArgSpec> args) {
+        this.args = unmodifiableList(args);
+    }
+
+    @Override
+
+    public String toString() {
+        return stringifyList(args);
+    }
+
+}

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -83,9 +83,10 @@
         (list? query) (-> !await-tx
                           (util/then-apply
                             (fn [_]
-                              (let [query (xtql.edn/parse-query query)]
+                              (let [query (xtql.edn/parse-query query)
+                                    parsed-query-opts (xtql.edn/parse-query-opts query-opts)]
                                 (xtql/open-xtql-query allocator ra-src wm-src scan-emitter
-                                                      query query-opts))))))))
+                                                      query parsed-query-opts query-opts))))))))
 
   (latest-submitted-tx [_] @!latest-submitted-tx)
 

--- a/src/test/clojure/xtdb/xtql/edn_test.clj
+++ b/src/test/clojure/xtdb/xtql/edn_test.clj
@@ -7,6 +7,9 @@
 (defn- roundtrip-expr [expr]
   (edn/unparse (edn/parse-expr expr)))
 
+(defn- roundtrip-q-opts [opts]
+  (edn/unparse (edn/parse-query-opts opts)))
+
 (t/deftest test-parse-expr
   (t/is (= 'a (roundtrip-expr 'a)))
 
@@ -86,7 +89,7 @@
                                 (from :bar {:bind {:baz b}}))))))
 
 (t/deftest test-parse-where
-  (let [q '(where false (= 1 'foo))]
+  (let [q '(where false (= 1 foo))]
     (t/is (= q
              (roundtrip-q-tail q)))))
 
@@ -129,7 +132,7 @@
   (t/is (= '(join (from :foo {:bind [a]})
                   {:bind [{:a b}]})
            (roundtrip-unify-clause '(join (from :foo {:bind [a]})
-                                          {:bind {:a b}})))))
+                                          {:bind [{:a b}]})))))
 
 (t/deftest test-parse-order-by
   (t/is (= '(order-by (+ a b) [b {:dir :desc}])
@@ -148,3 +151,13 @@
 (t/deftest test-parse-offset-test
   (t/is (= '(offset 5)
            (roundtrip-q-tail '(offset 5)))))
+
+(t/deftest test-parse-query-opts
+  (let [opts {:args [{:a "foo"} {:b "bar"}]}]
+    (t/is (= opts
+             (roundtrip-q-opts opts)))))
+
+(t/deftest test-parse-params
+  (let [q '(where (= $bar foo))]
+    (t/is (= q
+             (roundtrip-unify-clause q)))))


### PR DESCRIPTION
Uses `$` as a prefix for params.

Top Level:

```
(xt/q tu/*node*
          '(from :docs {:bind {:xt/id e :first-name $name}})
           {:args [{:name "Ivan"}]})
```

Subquery:

```
(xt/q tu/*node*
         '(unify
            (with {name "Ivan"})
            (join (from :docs {:bind
                                           {:xt/id e
                                            :first-name $name
                                            :last-name last-name}})
                      {:args [name]
                       :bind [last-name]})))
```