### PR TITLE
Post slack notification when test/integration-test fails on `2.x` on xtdb/xtdb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,22 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
-
       - name: Upload build reports (Core)
         if: success() || failure() # i.e. not cancelled
         uses: actions/upload-artifact@v3
         with:
           name: core-build-reports
           path: core/build/reports/
+      - name: Post Slack Notification (On Fail)
+        if: github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{workflow}* has {status_message}:"
+          message_format: "{emoji} `test` job has {status_message} in *{workflow}*"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   integration-test:
     name: Integration Test
@@ -56,6 +65,16 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
+      - name: Post Slack Notification (On Fail)
+        if: github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{workflow}* has {status_message}:"
+          message_format: "{emoji} `integration-test` job has {status_message} in *{workflow}*"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   slt-1:
     name: SLT 1


### PR DESCRIPTION
See #2863

Posts a slack notification to the dev channel via the webhook on job failure:
- Only runs on the main branch, `2.x`
- Only runs on the main repository, `xtdb/xtdb`.
- Currently only sending a notification on either `test` or `integration-test` failing - could add the same in for the `slt-test` jobs also?