### PR TITLE
Add slack notification to nightly test run.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -45,3 +45,11 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
+      - name: Post Slack Notification
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*Nightly test*"
+          message_format: "{emoji} *Nightly test* has {status_message}!"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
See #2863

Adds a slack notification to the nightly test run - will post a message regardless of success or failure. We can change this however we want using the `notify_when` input but seemed like the default would be fine here (given that its a daily notification). See [**here**](https://github.com/ravsamhq/notify-slack-action#inputs) for more info.