### PR TITLE
Fix slack notification on 2.x fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           name: core-build-reports
           path: core/build/reports/
       - name: Post Slack Notification (On Fail)
-        if: github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
+        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}
@@ -66,7 +66,7 @@ jobs:
           name: build-reports
           path: build/reports/
       - name: Post Slack Notification (On Fail)
-        if: github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
+        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/2.x'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
Step wasn't actually running on failure as by default steps only run on `success()` status. Explicitly check for failure in the step to ensure that it runs. Added in a dummy commit to force a failure, which seemed to work fine, so will merge.