### PR TITLE
coalescing table-args into params

### DIFF
--- a/core/src/main/clojure/xtdb/datalog.clj
+++ b/core/src/main/clojure/xtdb/datalog.clj
@@ -1119,19 +1119,10 @@
         (plan-query))))
 
 (defn- args->params [args in-bindings]
-  (->> (mapcat (fn [{::keys [binding-type in-cols]} arg]
+  (->> (mapcat (fn [{::keys [binding-type in-cols table-key]} arg]
                  (case binding-type
                    :scalar [(MapEntry/create (first in-cols) arg)]
                    :tuple (zipmap in-cols arg)
-                   (:collection :relation) nil))
-               in-bindings
-               args)
-       (into {})))
-
-(defn- args->tables [args in-bindings]
-  (->> (mapcat (fn [{::keys [binding-type in-cols table-key]} arg]
-                 (case binding-type
-                   (:scalar :tuple) nil
 
                    :collection (let [in-col (first in-cols)
                                      binding-k (keyword in-col)]
@@ -1215,7 +1206,6 @@
                                                        :actual args})))
 
         (util/with-close-on-catch [^AutoCloseable params (vw/open-params allocator (args->params args in-bindings))]
-          (-> (.bind pq wm-src {:params params, :table-args (args->tables args in-bindings),
-                                :basis basis, :default-tz default-tz :default-all-valid-time? default-all-valid-time?})
+          (-> (.bind pq wm-src {:params params, :basis basis, :default-tz default-tz :default-all-valid-time? default-all-valid-time?})
               (.openCursor)
               (op/cursor->result-set params)))))))

--- a/core/src/main/clojure/xtdb/operator.clj
+++ b/core/src/main/clojure/xtdb/operator.clj
@@ -103,7 +103,7 @@
                                           (mapcat scan/->scan-cols))))
            cache (ConcurrentHashMap.)]
        (reify PreparedQuery
-         (bind [_ wm-src {:keys [params table-args basis default-tz default-all-valid-time?]}]
+         (bind [_ wm-src {:keys [params basis default-tz default-all-valid-time?]}]
            (assert (or scan-emitter (empty? scan-cols)))
 
            (let [{:keys [tx after-tx current-time]} basis
@@ -116,7 +116,6 @@
                                                                              (with-open [wm (.openWatermark wm-src wm-tx)]
                                                                                (.scanFields scan-emitter wm scan-cols)))
                                                               :param-fields (expr/->param-fields params)
-                                                              :table-arg-fields (->table-arg-fields table-args)
                                                               :default-tz default-tz
                                                               :default-all-valid-time? default-all-valid-time?
                                                               :last-known-chunk (when metadata-mgr
@@ -144,7 +143,7 @@
                                                  (dissoc :after-tx)
                                                  (update :tx (fnil identity (some-> wm .txBasis)))
                                                  (assoc :current-time current-time))
-                                      :params params, :table-args table-args :default-all-valid-time? default-all-valid-time?})
+                                      :params params, :default-all-valid-time? default-all-valid-time?})
                            (wrap-cursor allocator wm clock ref-ctr fields)))
 
                      (catch Throwable t

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -8,7 +8,8 @@
             [xtdb.util :as util]
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
-  (:import (java.util ArrayList HashMap HashSet Set)
+  (:import clojure.lang.MapEntry
+           (java.util ArrayList HashMap HashSet Set)
            java.util.function.Function
            (org.apache.arrow.vector.types.pojo Field)
            (xtdb ICursor)
@@ -18,11 +19,11 @@
   (s/cat :op #{:table}
          :explicit-col-names (s/? (s/coll-of ::lp/column :kind vector?))
          :table (s/or :rows (s/coll-of (s/map-of simple-ident? any?))
-                      :table-arg ::lp/param)))
+                      :param ::lp/param)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype TableCursor [^:unsynchronized-mutable ^RelationReader out-rel]
+(deftype TableCursor [^:unsynchronized-mutable ^RelationReader out-rel, param?]
   ICursor
   (tryAdvance [this c]
     (boolean
@@ -32,7 +33,8 @@
          (.accept c out-rel)
          true
          (finally
-           (.close out-rel))))))
+           (when-not param? ; params get closed at toplevel
+             (.close out-rel)))))))
 
   (close [_] (some-> out-rel .close)))
 
@@ -115,22 +117,49 @@
                                (fn [v opts]
                                  (if (fn? v) (v opts) v))))})))
 
-(defn- emit-arg-table [param table-expr {:keys [table-arg-fields]}]
-  (let [fields (-> (or (get table-arg-fields param)
-                       (throw (err/illegal-arg :unknown-table
-                                               {::err/message "Table refers to unknown param"
-                                                :param param, :table-args (set (keys table-arg-fields))})))
+(defn- emit-arg-table [param table-expr {:keys [param-fields]}]
+  (let [fields (-> (into {} (for [^Field field (-> (or (get param-fields param)
+                                                       (throw (err/illegal-arg :unknown-table
+                                                                               {::err/message "Table refers to unknown param"
+                                                                                :param param, :params (set (keys param-fields))})))
+                                                   (types/flatten-union-field))
+                                  :when (or (= #xt.arrow/type :list (.getType field))
+                                            (throw (err/illegal-arg :illegal-param-type
+                                                                    {::err/message "Table param must be of type struct list"
+                                                                     :param param})))
+                                  :let [^Field el-field (first (.getChildren field))]
+                                  ^Field el-leg (types/flatten-union-field el-field)
+                                  :when (or (= #xt.arrow/type :struct (.getType el-leg))
+                                            (throw (err/illegal-arg :illegal-param-type
+                                                                    {::err/message "Table param must be of type struct list"
+                                                                     :param param})))
+                                  ^Field field (.getChildren el-leg)]
+                              (MapEntry/create (symbol (.getName field)) field)))
+
                    (restrict-cols table-expr))]
 
     {:fields fields
-     :->out-rel (fn [{:keys [table-args] :as opts}]
-                  (->out-rel opts fields (get table-args param) (fn [v _opts] v)))}))
+     :->out-rel (fn [{:keys [^RelationReader params]}]
+                  (let [vec-rdr (.readerForName params (str (symbol param)))
+                        list-rdr (cond-> vec-rdr
+                                   (.legs vec-rdr) (.legReader :list))
+                        el-rdr (some-> list-rdr .listElementReader)
+                        el-struct-rdr (cond-> el-rdr
+                                        (.legs el-rdr) (.legReader :struct))
+                        res (vr/rel-reader (for [k (some-> el-struct-rdr .structKeys)
+                                                 :let [datalog-k (util/normal-form-str->datalog-form-str k)
+                                                       in-datalog-form? (contains? fields (symbol datalog-k))]
+                                                 :when (or (contains? fields (symbol k)) in-datalog-form?)]
+                                             (cond-> (.structKeyReader el-struct-rdr k)
+                                               in-datalog-form? (.withName datalog-k)))
+                                           (.valueCount el-rdr))]
+                    res))}))
 
 (defmethod lp/emit-expr :table [{:keys [table] :as table-expr} opts]
-  (let [{:keys [fields ->out-rel]} (zmatch table
-                                           [:rows rows] (emit-rows-table rows table-expr opts)
-                                           [:table-arg param] (emit-arg-table param table-expr opts))]
+  (let [[{:keys [fields ->out-rel]} param?] (zmatch table
+                                                    [:rows rows] [(emit-rows-table rows table-expr opts) false]
+                                                    [:param param] [(emit-arg-table param table-expr opts) true])]
 
     {:fields fields
      :->cursor (fn [opts]
-                 (TableCursor. (->out-rel opts)))}))
+                 (TableCursor. (->out-rel opts) param?))}))

--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -949,6 +949,7 @@ public class ValueVectorReader implements IVectorReader {
         public IVectorReader legReader(Keyword legKey) {
             return legReaders.computeIfAbsent(legKey, k -> {
                 var child = v.getChild(k.sym.toString());
+                if (child == null) return null;
                 return new IndirectVectorReader(ValueVectorReader.from(child), new DuvIndirection(v, ((byte) legs.indexOf(k))));
             });
         }

--- a/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
@@ -335,15 +335,15 @@
              [:scan {:for-valid-time [:at :now] :table supplier} [s_suppkey {s_comment (like s_comment "%Customer%Complaints%")}]]]]]]]]
       (with-meta {::params {'?brand "Brand#45"
                             ;; '?type "MEDIUM POLISHED%"
-                            }
-                  ::table-args {'?sizes [{:p_size 49}
-                                         {:p_size 14}
-                                         {:p_size 23}
-                                         {:p_size 45}
-                                         {:p_size 19}
-                                         {:p_size 3}
-                                         {:p_size 36}
-                                         {:p_size 9}]}})))
+
+                            '?sizes [{:p_size 49}
+                                     {:p_size 14}
+                                     {:p_size 23}
+                                     {:p_size 45}
+                                     {:p_size 19}
+                                     {:p_size 3}
+                                     {:p_size 36}
+                                     {:p_size 9}]}})))
 
 (def q17-small-quantity-order-revenue
   (-> '[:project [{avg_yearly (/ sum_extendedprice 7)}]
@@ -476,13 +476,13 @@
              [:select (> c_acctbal 0.0)
               Customer]]]
            [:scan {:for-valid-time [:at :now] :table orders} [o_custkey]]]]]]
-      (with-meta {::table-args {'?cntrycodes [{:cntrycode "13"}
-                                              {:cntrycode "31"}
-                                              {:cntrycode "23"}
-                                              {:cntrycode "29"}
-                                              {:cntrycode "30"}
-                                              {:cntrycode "18"}
-                                              {:cntrycode "17"}]}})))
+      (with-meta {::params {'?cntrycodes [{:cntrycode "13"}
+                                          {:cntrycode "31"}
+                                          {:cntrycode "23"}
+                                          {:cntrycode "29"}
+                                          {:cntrycode "30"}
+                                          {:cntrycode "18"}
+                                          {:cntrycode "17"}]}})))
 
 (def queries
   [#'q1-pricing-summary-report

--- a/src/test/clojure/xtdb/operator/apply_test.clj
+++ b/src/test/clojure/xtdb/operator/apply_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.test-util :as tu]))
 
+(t/use-fixtures :each tu/with-allocator)
+
 (t/deftest test-apply-operator
   (letfn [(q [mode]
             (tu/query-ra [:apply mode '{c-id ?c-id}
@@ -76,14 +78,14 @@
                           [:table [{:y 0} {:y 1}]]
                           [:select (= ?y a)
                            [:table ?x]]]
-                        {:table-args '{?x [{:a 1, :b 2}]}})))
+                        {:params '{?x [{:a 1, :b 2}]}})))
 
   (t/is (thrown-with-msg? RuntimeException
                           #"cardinality violation"
                           (tu/query-ra '[:apply :single-join {}
                                          [:table [{:y 0}]]
                                          [:table ?x]]
-                                       {:table-args '{?x [{:a 1, :b 2} {:a 3, :b 4}]}}))
+                                       {:params '{?x [{:a 1, :b 2} {:a 3, :b 4}]}}))
         "throws on cardinality > 1")
 
   (t/testing "returns null on empty"
@@ -91,13 +93,13 @@
              (tu/query-ra '[:apply :single-join {}
                             [:table [{:y 0}]]
                             [:table ?x]]
-                          {:table-args '{?x []}})))
+                          {:params '{?x []}})))
 
     (t/is (= [{:y 0, :a nil, :b nil}]
              (tu/query-ra '[:apply :single-join {}
                             [:table [{:y 0}]]
                             [:table [a b] ?x]]
-                          {:table-args '{?x []}})))))
+                          {:params '{?x []}})))))
 
 (t/deftest test-apply-empty-rel-bug-237
   (t/is (= {:res [{:x3 nil}], :col-types '{x3 [:union #{:null :i64}]}}

--- a/src/test/clojure/xtdb/operator/order_by_test.clj
+++ b/src/test/clojure/xtdb/operator/order_by_test.clj
@@ -33,17 +33,17 @@
     (t/is (= [{:a nil, :b 15}, {:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}]
              (tu/query-ra '[:order-by [[a {:null-ordering :nulls-first}]]
                             [:table ?table]]
-                          {:table-args {'?table table-with-nil}}))
+                          {:params {'?table table-with-nil}}))
           "nulls first")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:a nil, :b 15}]
              (tu/query-ra '[:order-by [[a {:null-ordering :nulls-last}]]
                             [:table ?table]]
-                          {:table-args {'?table table-with-nil}}))
+                          {:params {'?table table-with-nil}}))
           "nulls last")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:a nil, :b 15}]
              (tu/query-ra '[:order-by [[a]]
                             [:table ?table]]
-                          {:table-args {'?table table-with-nil}}))
+                          {:params {'?table table-with-nil}}))
           "default nulls last")))

--- a/src/test/clojure/xtdb/operator/unwind_test.clj
+++ b/src/test/clojure/xtdb/operator/unwind_test.clj
@@ -45,27 +45,27 @@
             {:a 2, :b [3 4 5], :b* 5}]
            (tu/query-ra '[:unwind {b* b}
                           [:table ?x]]
-                        {:table-args '{?x [{:a 1, :b [1 2]} {:a 2, :b [3 4 5]}]}})))
+                        {:params '{?x [{:a 1, :b [1 2]} {:a 2, :b [3 4 5]}]}})))
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* 2}]
            (tu/query-ra '[:project [a b*]
                           [:unwind {b* b}
                            [:table ?x]]]
-                        {:table-args '{?x [{:a 1, :b [1 2]} {:a 2, :b []}]}}))
+                        {:params '{?x [{:a 1, :b [1 2]} {:a 2, :b []}]}}))
         "skips rows with empty lists")
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* 2}]
            (tu/query-ra '[:project [a b*]
                           [:unwind {b* b}
                            [:table ?x]]]
-                        {:table-args '{?x [{:a 2, :b 1} {:a 1, :b [1 2]}]}}))
+                        {:params '{?x [{:a 2, :b 1} {:a 1, :b [1 2]}]}}))
         "skips rows with non-list unwind column")
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* "foo"}]
            (tu/query-ra '[:project [a b*]
                           [:unwind {b* b}
                            [:table ?x]]]
-                        {:table-args '{?x [{:a 1, :b [1 "foo"]}]}}))
+                        {:params '{?x [{:a 1, :b [1 "foo"]}]}}))
         "handles multiple types")
 
   (t/is (= [{:a 1, :b* 1, :$ordinal 1}
@@ -76,5 +76,5 @@
            (tu/query-ra '[:project [a b* $ordinal]
                           [:unwind {b* b} {:ordinality-column $ordinal}
                            [:table ?x]]]
-                        {:table-args '{?x [{:a 1 :b [1 2]} {:a 2 :b [3 4 5]}]}}))
+                        {:params '{?x [{:a 1 :b [1 2]} {:a 2 :b [3 4 5]}]}}))
         "with ordinality"))

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -203,7 +203,7 @@
                               [{a (+ a 1)}
                                {b (* (+ a 1) b)}]
                               Fact]]]
-                          {:table-args {'?table [{:a 0 :b 1}]}}))))
+                          {:params {'?table [{:a 0 :b 1}]}}))))
 
   (t/testing "transitive closure"
     (t/is (= [{:x "a", :y "b"}
@@ -228,18 +228,18 @@
                              [:join [{z z}]
                               [:rename {y z} Path]
                               [:rename {x z} Path]]]]
-                          {:table-args {'?table [{:x "a" :y "b"}
-                                                 {:x "b" :y "c"}
-                                                 {:x "c" :y "d"}
-                                                 {:x "d" :y "a"}]}})))))
+                          {:params {'?table [{:x "a" :y "b"}
+                                             {:x "b" :y "c"}
+                                             {:x "c" :y "d"}
+                                             {:x "d" :y "a"}]}})))))
 
 (t/deftest test-assignment-operator
   (t/is (= [{:a 1 :b 1}]
            (tu/query-ra '[:assign [X [:table ?x]
                                    Y [:table ?y]]
                           [:join [{a b}] X Y]]
-                        {:table-args '{?x [{:a 1}]
-                                       ?y [{:b 1}]}})))
+                        {:params '{?x [{:a 1}]
+                                   ?y [{:b 1}]}})))
 
   (t/testing "can see earlier assignments"
     (t/is (= [{:a 1 :b 1}]
@@ -247,22 +247,22 @@
                                      Y [:join [{a b}] X [:table ?y]]
                                      X Y]
                             X]
-                          {:table-args '{?x [{:a 1}]
-                                         ?y [{:b 1}]}})))))
+                          {:params '{?x [{:a 1}]
+                                     ?y [{:b 1}]}})))))
 
 (t/deftest test-project-row-number
   (t/is (= [{:a 12, :$row-num 1}, {:a 0, :$row-num 2}, {:a 100, :$row-num 3}]
            (tu/query-ra '[:project [a {$row-num (row-number)}]
                           [:table ?a]]
 
-                        {:table-args {'?a [{:a 12} {:a 0} {:a 100}]}}))))
+                        {:params {'?a [{:a 12} {:a 0} {:a 100}]}}))))
 
 (t/deftest test-project-append-columns
   (t/is (= [{:a 12, :$row-num 1}, {:a 0, :$row-num 2}, {:a 100, :$row-num 3}]
            (tu/query-ra '[:project {:append-columns? true} [{$row-num (row-number)}]
                           [:table ?a]]
 
-                        {:table-args {'?a [{:a 12} {:a 0} {:a 100}]}}))))
+                        {:params {'?a [{:a 12} {:a 0} {:a 100}]}}))))
 
 (t/deftest test-array-agg
   (t/is (= [{:a 1, :bs [1 3 6]}
@@ -270,12 +270,12 @@
             {:a 3, :bs [5]}]
            (tu/query-ra '[:group-by [a {bs (array-agg b)}]
                           [:table ?ab]]
-                        {:table-args {'?ab [{:a 1, :b 1}
-                                            {:a 2, :b 2}
-                                            {:a 1, :b 3}
-                                            {:a 2, :b 4}
-                                            {:a 3, :b 5}
-                                            {:a 1, :b 6}]}}))))
+                        {:params {'?ab [{:a 1, :b 1}
+                                        {:a 2, :b 2}
+                                        {:a 1, :b 3}
+                                        {:a 2, :b 4}
+                                        {:a 3, :b 5}
+                                        {:a 1, :b 6}]}}))))
 
 (t/deftest test-between
   (t/is (= [[true true] [false true]
@@ -287,12 +287,12 @@
                 (tu/query-ra '[:project [{b (between x l r)}
                                          {bs (between-symmetric x l r)}]
                                [:table ?xlr]]
-                             {:table-args {'?xlr (map #(zipmap [:x :l :r] %)
-                                                      [[5 0 10] [5 10 0]
-                                                       [0 0 10] [0 10 0]
-                                                       [-1 0 10] [-1 10 0]
-                                                       [11 0 10] [11 10 0]
-                                                       [10 0 10] [10 10 0]])}})))))
+                             {:params {'?xlr (map #(zipmap [:x :l :r] %)
+                                                  [[5 0 10] [5 10 0]
+                                                   [0 0 10] [0 10 0]
+                                                   [-1 0 10] [-1 10 0]
+                                                   [11 0 10] [11 10 0]
+                                                   [10 0 10] [10 10 0]])}})))))
 
 (t/deftest test-join-theta
   (t/is (= [{:x3 "31" :x4 "13"} {:x3 "31" :x4 "31"}]


### PR DESCRIPTION
This removes the special treatment of table-args. Parameters passed to the table operator must now be a struct list vector. 