### PR TITLE
Add scalar subqueries to XTQL

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -262,7 +262,7 @@
           (when-let [mark-join-projection (:mark-join mode)]
             [(->projected-column mark-join-projection)])
           (case mode
-            (:cross-join :left-outer-join) (relation-columns dependent-relation)
+            (:cross-join :left-outer-join :single-join) (relation-columns dependent-relation)
             []))
         (vec))
 


### PR DESCRIPTION
See tests for further examples.

```
    '(-> (from :order {:bind [{:xt/id order, :customer customer}]})
         (where (= (q (from :customer {:bind [{:xt/id $customer, :firstname fn}]})
                      {:args [customer]})
                   "bob"))
         (without :customer))
```
