### PR TITLE
xtql `table` operator

### DIFF
--- a/api/src/main/java/xtdb/query/Query.java
+++ b/api/src/main/java/xtdb/query/Query.java
@@ -365,4 +365,34 @@ public sealed interface Query {
         return new Offset(length);
 
     }
+    final class Table implements Query, UnifyClause {
+        public final List<Map<String, Expr>> documents;
+        public final Expr.Param param;
+        public final List<OutSpec> bindings;
+
+        private Table(List<Map<String, Expr>> documents, Expr.Param param, List<OutSpec> bindings) {
+            this.documents = documents;
+            this.bindings = bindings;
+            this.param = param;
+        }
+
+        public Table binding(List<OutSpec> bindings) { return new Table(documents, param, bindings); }
+
+        @Override
+        public String toString() {
+            if (this.documents != null) {
+                return String.format("(%s [%s])", "table", stringifyList(documents));
+            } else {
+                return String.format("(%s %s)", "table", this.param.toString());
+            }
+        }
+    }
+
+    static Table table(List<Map<String, Expr>> documents, List<OutSpec> bindings) {
+        return new Table(documents, null, bindings);
+    }
+
+    static Table table(Expr.Param param, List<OutSpec> bindings) {
+        return new Table(null, param, bindings);
+    }
 }

--- a/src/test/clojure/xtdb/operator/table_test.clj
+++ b/src/test/clojure/xtdb/operator/table_test.clj
@@ -71,7 +71,12 @@
   (t/is (= [{:a 1, :b 2}, {:a 3, :b 4}]
            (tu/query-ra '[:table [{:a ?p1, :b ?p2}
                                   {:a ?p3, :b ?p4}]]
-                        {:params {'?p1 1, '?p2 2, '?p3 3, '?p4 4}}))))
+                        {:params {'?p1 1, '?p2 2, '?p3 3, '?p4 4}})))
+
+  (t/is (= [{:a {:baz 1}, :b 2}]
+           (tu/query-ra '[:table [{:a {:baz ?p1} :b ?p2}]]
+                        {:params {'?p1 1, '?p2 2, '?p3 3, '?p4 4}}))
+        "nested param"))
 
 (t/deftest test-table-handles-symbols
   (t/is (= '[{:x50 true}]

--- a/src/test/clojure/xtdb/xtql/edn_test.clj
+++ b/src/test/clojure/xtdb/xtql/edn_test.clj
@@ -222,3 +222,31 @@
 
   (t/is (= '(assert-not-exists (from :users [{:email $email}]))
            (roundtrip-dml '(assert-not-exists (from :users [{:email $email}]))))))
+
+(t/deftest test-parse-table
+  (let [q '(table [{:a 12 :b "foo"} {:a 1 :c "bar"}] [a b c])]
+    (t/is (= q
+             (roundtrip-q q))
+          "simple static table"))
+
+  (let [q '(-> (table [{:first-name "Ivan"} {:first-name "Petr"}] [first-name last-name])
+               (where (= "Petr" first-name)))]
+    (t/is (= q
+             (roundtrip-q q))
+          "table in pipeline"))
+
+  (let [q '(unify (from :docs [first-name])
+                  (table [{:first-name "Ivan"} {:first-name "Petr"}] [first-name]))]
+    (t/is (= q
+             (roundtrip-q q))
+          "table in unify"))
+
+  (let [q '(table [{:foo :bar :baz {:nested-foo $nested-param}}] [foo baz])]
+    (t/is (= q
+             (roundtrip-q q))
+          "table with paramater in documents"))
+
+  (let [q '(table $bar [foo baz])]
+    (t/is (= q
+             (roundtrip-q q))
+          "table as a parameter")))


### PR DESCRIPTION
This adds a table operator which allows for 
```clj
(table [{:first-name "Ivan"} {:first-name "Petr"}] [first-name])
;; =>
[{:first-name "Ivan"} {:first-name "Petr"}]
```
and
```clj
(xt/q tu/*node* '(table $ivan+petr [name])
  {:args {:ivan+petr [{:name "Ivan"} {:name "Petr"}]}})
;; =>
[{:name "Ivan"} {:name "Petr"}]
```
Some things to decide:
- [ ] - no bindings option which results in all columns being projected (might be confusing in unify)
- [ ] - currently no unification in out bindings spec (filtering as well as same logic var unification)