### PR TITLE
Add generated javadocs to Amplify docs

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,6 +9,7 @@ applications:
           commands:
             - yarn run build
             - yarn run build-openapi-docs
+            - yarn run build-javadoc
       artifacts:
         baseDirectory: /dist
         files:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ evaluationDependsOnChildren()
 plugins {
     `java-library`
     id("dev.clojurephant.clojure") version "0.7.0"
+    id("io.freefair.aggregate-javadoc") version "6.6"
 }
 
 val defaultJvmArgs = listOf(
@@ -39,12 +40,6 @@ allprojects {
 
             withSourcesJar()
             withJavadocJar()
-        }
-
-        tasks.javadoc {
-            options {
-                (this as CoreJavadocOptions).addStringOption("Xdoclint:none", "-quiet")
-            }
         }
 
         tasks.test {

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -42,6 +42,9 @@ All commands are run from the root of the project, from a terminal:
 
 | `yarn run build-openapi-docs` 
 | Build a static page from `openapi/openapi.yaml` to `dist/openapi-docs` 
+
+| `yarn run build-javadoc` 
+| Builds the full aggregate set of project javadocs via gradle to `dist/javadoc` 
 |===
 
 == Reference documentation versioning

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "build-openapi-docs": "redoc-cli bundle openapi/openapi.yaml --output=dist/openapi/index.html"
+    "build-openapi-docs": "redoc-cli bundle openapi/openapi.yaml --output=dist/openapi/index.html",
+    "build-javadoc": "cd ../ && ./gradlew aggregateJavadoc && cp -r ./build/docs/aggregateJavadoc docs/dist/javadoc"
   },
   "dependencies": {
     "@astrojs/mdx": "^1.1.2",


### PR DESCRIPTION
Resolves #2893

Adds scripts for building project Javadocs and calls these within Amplify.

Done in this PR:
- Add job to gradle to generate aggregated javadocs for the project using the `aggregateJavadoc` plugin/task
- Add a script to use with yarn to do so and copy the docs to the `dist/javadoc` folder
- Add step to Amplify to call `yarn build-javadoc`

Outside of this PR, updates have been made to the `xtdb/website-builder` docker image to ensure it has everything Gradle needs (Java 17 with JDK, xargs, approrpiate env vars). A successful build of this branch outputted the following:
https://generate-javadocs.d2zcybuz6k9g4m.amplifyapp.com/javadoc/index.html 