### PR TITLE
Setup automatic deployment of clojure API docs with docs site

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,6 +10,7 @@ applications:
             - yarn run build
             - yarn run build-openapi-docs
             - yarn run build-javadoc
+            - yarn run build-clj-docs
       artifacts:
         baseDirectory: /dist
         files:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.clojurephant.plugin.clojure.tasks.ClojureCompile
+import java.io.File
 
 evaluationDependsOnChildren()
 
@@ -201,6 +202,10 @@ dependencies {
     testImplementation("cheshire", "cheshire", "5.11.0")
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.3.0")
     testImplementation("org.clojure", "test.check", "1.1.1")
+    
+    // For generating clojure docs
+    testImplementation("codox", "codox", "0.10.8")
+
     // for AWS profiles (managing datasets)
     devImplementation("software.amazon.awssdk", "sts", "2.16.76")
 }
@@ -232,6 +237,20 @@ tasks.create("run-auctionmark", JavaExec::class) {
     addToArgsIfExistent("load-phase" , args)
     addToArgsIfExistent("duration", args)
 
+    this.args = args
+}
+
+val codoxOpts = File("codox.edn").readText()
+
+tasks.create("build-codox", JavaExec::class) {
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+    val args = mutableListOf<String>(
+        "-e", "(require 'codox.main)",
+        "-e", "(codox.main/generate-docs ${codoxOpts})"
+    )
+    
     this.args = args
 }
 

--- a/codox.edn
+++ b/codox.edn
@@ -1,0 +1,4 @@
+;; Used by the "build-codox" gradle task - can see options here: 
+;; https://github.com/weavejester/codox#project-options
+{:output-path "docs/dist/clojure-docs" 
+ :source-paths ["api/src/main"]}

--- a/codox.edn
+++ b/codox.edn
@@ -1,4 +1,6 @@
 ;; Used by the "build-codox" gradle task - can see options here: 
 ;; https://github.com/weavejester/codox#project-options
 {:output-path "docs/dist/clojure-docs" 
- :source-paths ["api/src/main"]}
+ :source-paths ["api/src/main"
+                "http-client-clj/src/main"]
+ :namespaces '[xtdb.api xtdb.client]}

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -45,6 +45,9 @@ All commands are run from the root of the project, from a terminal:
 
 | `yarn run build-javadoc` 
 | Builds the full aggregate set of project javadocs via gradle to `dist/javadoc` 
+
+| `yarn run build-clj-docs` 
+| Builds API docs for Clojure to `dist/clojure-docs`.
 |===
 
 == Reference documentation versioning

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "build-openapi-docs": "redoc-cli bundle openapi/openapi.yaml --output=dist/openapi/index.html",
-    "build-javadoc": "cd ../ && ./gradlew aggregateJavadoc && cp -r ./build/docs/aggregateJavadoc docs/dist/javadoc"
+    "build-javadoc": "cd ../ && ./gradlew aggregateJavadoc && cp -r ./build/docs/aggregateJavadoc docs/dist/javadoc",
+    "build-clj-docs": "cd ../ && ./gradlew build-codox"
   },
   "dependencies": {
     "@astrojs/mdx": "^1.1.2",


### PR DESCRIPTION
Resolves #2892 

Using `codox` to generate documentation:
- Adds a top level `codox.edn` file with configuration options:
  - Can select source folders and desired namespaces, for now just `xtdb.api` and `xtdb.client`.
- Adds a gradle task `:build-codox` to generate codox to `docs/dist/clojure-docs` 
- Adds a script for yarn to build codox, `build-clj-docs`.
- Uses the yarn script in the Amplify config. 