### PR TITLE
Adapt http client/server to encode xt errors correctly

### DIFF
--- a/wire-formats/src/main/clojure/xtdb/transit.clj
+++ b/wire-formats/src/main/clojure/xtdb/transit.clj
@@ -20,6 +20,7 @@
           "xtdb/tx-key" (transit/read-handler xtp/map->TransactionInstant)
           "xtdb/illegal-arg" (transit/read-handler err/-iae-reader)
           "xtdb/runtime-err" (transit/read-handler err/-runtime-err-reader)
+          "xtdb/exception-info" (transit/read-handler #(ex-info (first %) (second %)))
           "xtdb/period-duration" xt-edn/period-duration-reader
           "xtdb.interval/year-month" xt-edn/interval-ym-reader
           "xtdb.interval/day-time" xt-edn/interval-dt-reader
@@ -32,6 +33,7 @@
                                                       (FieldType/notNullable arrow-type))))
           "xtdb/field" (transit/read-handler (fn [[name field-type children]]
                                                (Field. name field-type children)))}))
+
 
 (def tj-write-handlers
   (merge (-> {Period "time/period"
@@ -53,6 +55,7 @@
          {TransactionInstant (transit/write-handler "xtdb/tx-key" #(select-keys % [:tx-id :system-time]))
           xtdb.IllegalArgumentException (transit/write-handler "xtdb/illegal-arg" ex-data)
           xtdb.RuntimeException (transit/write-handler "xtdb/runtime-err" ex-data)
+          clojure.lang.ExceptionInfo (transit/write-handler "xtdb/exception-info" #(vector (ex-message %) (ex-data %)))
 
           ClojureForm (transit/write-handler "xtdb/clj-form" #(.form ^ClojureForm %))
 


### PR DESCRIPTION
This changes a little how we encode errors in our client / server modules. There are two types of errors:
- IllegalArgument (we know there is an issue before we run anything): The body of that request just becomes the `xtdb.IllegalArgumentException`. We decode this accordingly on the client side for `4XX` repsonse codes. Essentially anything in the 4XX range should be decodable for us.
- RuntimeError (i.e. division by zero): We potentially only hit this when some results have been produced. I handled this by encoding the error into the result set and only throwing the error when result set is consumed on the client side. ~This is a problem if the results sets could actually contain RuntimeError's as values (for example in the `xt/txn` table, although currently encoded as `clj-form`).~ could only ever be nested 
- Anything else (essentially anything we don't (yet) have good error handling for, i.e. holes in the EE) we try to encode as a `clojure.lang.ExceptionInfo`. 