### PR TITLE
Increase wm-cnt on startTx

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -562,7 +562,7 @@
                      (pr-str tx-key)
                      (pr-str latest-completed-tx))
 
-          (let [live-idx-tx (.startTx live-idx tx-key)]
+          (util/with-open [live-idx-tx (.startTx live-idx tx-key)]
             (add-tx-row! row-counter live-idx-tx tx-key
                          (err/illegal-arg :invalid-system-time
                                           {::err/message "specified system-time older than current tx"
@@ -625,7 +625,7 @@
                         (log/debug e "aborted tx")
                         (.abort live-idx-tx))
 
-                      (let [live-idx-tx (.startTx live-idx tx-key)]
+                      (util/with-open [live-idx-tx (.startTx live-idx tx-key)]
                         (add-tx-row! row-counter live-idx-tx tx-key e)
                         (.commit live-idx-tx)))
 

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -240,6 +240,7 @@
   (liveTable [_ table-name] (.get tables table-name))
 
   (startTx [this-table tx-key]
+    (.acquire wm-cnt)
     (let [table-txs (HashMap.)]
       (reify ILiveIndexTx
         (liveTable [_ table-name]
@@ -280,7 +281,7 @@
                 (util/close wms)))))
 
         AutoCloseable
-        (close [_]))))
+        (close [_] (.release wm-cnt)))))
 
   (openWatermark [_]
     (.acquire wm-cnt)


### PR DESCRIPTION
This is a fix for #2930 and more concretely #2800. Whenever a transaction starts we also increase the wm-cnt on the live-index to not shut it down prematurely. After this fix the `indexer` might still run into race conditions where the `live-index` is already shutting down, but the `indexer` tries to call `startTx`. That would currently result in a toplevel indexer error, but should no longer result in memory leaks. 