### PR TITLE
Move `http-server` to Jetty-11

### DIFF
--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     api(project(":core"))
     api(project(":wire-formats"))
 
-    api("ring", "ring-core", "1.9.6")
+    api("ring", "ring-core", "1.10.0")
     api("info.sunng", "ring-jetty9-adapter", "0.22.4")
     api("org.eclipse.jetty", "jetty-alpn-server", "10.0.15")
 

--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
     api(project(":core"))
     api(project(":wire-formats"))
 
-    api("ring", "ring-core", "1.9.4")
-    api("info.sunng", "ring-jetty9-adapter", "0.15.2")
-    api("org.eclipse.jetty", "jetty-alpn-server", "10.0.6")
+    api("ring", "ring-core", "1.9.6")
+    api("info.sunng", "ring-jetty9-adapter", "0.22.4")
+    api("org.eclipse.jetty", "jetty-alpn-server", "10.0.15")
 
     api("metosin", "muuntaja", "0.6.8")
     api("metosin", "jsonista", "0.3.3")


### PR DESCRIPTION
###  Reason for upgrading

When accessed from an alien client over HTTP, the following sequence causes the server to (silently) send a 500 Error.
Say for example that the followig `tx`:
```
[[:put :lola {:xt/id #uuid "4cc2271a-ee7e-4438-88be-dbe6e73190f6", :user-id #uuid "ab75fbeb-c5b2-4faa-8d4e-ae8a6199b8dd", :text "yeayayaya"}]]
```
returns the `tx-key`:
```
{:tx-id 12712478, :system-time #time/instant "2023-11-21T13:18:44.703915Z"}
```

then issuing immediately after the following query:
```
{:query {:find [X], :where [($ :lola {:xt/* X, :xt/id #uuid "4cc2271a-ee7e-4438-88be-dbe6e73190f6"})]}, :opts {:basis {:tx #xt/tx-key {:tx-id 12712478, :system-time #time/instant "2023-11-21T13:18:44.703915Z"}}}}
```
will cause the server to client to received an HTTP 500 with no further notice in the server's logs. Setting the log-level for "org.eclipse.jetty" to `debug`  reveals the following stack trace:
```
13:37:21.134 [xtdb-tx-subscription-pool-1-thread-1] DEBUG o.eclipse.jetty.server.HttpChannel - COMMIT for null on HttpChannelOverHttp@529c7a09{s=HttpChannelState@7bbc1459{s=IDLE rs=BLOCKING os=COMMITTED is=IDLE awp=false se=false i=true al=0},r=3,c=false/false,a=IDLE,uri=null,age=0}
200 null null


13:37:21.134 [qtp1596194329-47] DEBUG o.eclipse.jetty.io.ManagedSelector - update org.eclipse.jetty.io.SocketChannelEndPoint$$Lambda$442/0x000000080402b568@6ca8b474
13:37:21.135 [xtdb-tx-subscription-pool-1-thread-1] DEBUG o.eclipse.jetty.server.HttpChannel - Commit failed
org.eclipse.jetty.http.BadMessageException: 500: No version
	at org.eclipse.jetty.http.HttpGenerator.generateResponse(HttpGenerator.java:364)
	at org.eclipse.jetty.server.HttpConnection$SendCallback.process(HttpConnection.java:738)
	at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:232)
	at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:214)
	at org.eclipse.jetty.server.HttpConnection.send(HttpConnection.java:568)
	at org.eclipse.jetty.server.HttpChannel.sendResponse(HttpChannel.java:958)
	at org.eclipse.jetty.server.HttpChannel.write(HttpChannel.java:1035)
	at org.eclipse.jetty.server.HttpOutput.channelWrite(HttpOutput.java:269)
	at org.eclipse.jetty.server.HttpOutput.close(HttpOutput.java:622)
	at ring.util.servlet$make_output_stream$fn__76000.invoke(servlet.clj:90)
	at ring.util.servlet.proxy$java.io.FilterOutputStream$ff19274a.close(Unknown Source)
	at muuntaja.protocols$eval69678$fn__69679.invoke(protocols.clj:25)
	at ring.core.protocols$eval69618$fn__69619$G__69609__69628.invoke(protocols.clj:8)
	at ring.util.servlet$update_servlet_response.invokeStatic(servlet.clj:108)
	at ring.util.servlet$update_servlet_response.invoke(servlet.clj:93)
	at ring.adapter.jetty9$proxy_async_handler$fn__76406$fn__76407.invoke(jetty9.clj:74)
	at reitit.http$ring_handler$fn__74938$respond_SINGLEQUOTE___74941.invoke(http.cljc:162)
	at sieppari.core$deliver_result.invokeStatic(core.cljc:79)
	at sieppari.core$deliver_result.invoke(core.cljc:73)
	at sieppari.core$deliver_result$fn__75857.invoke(core.cljc:75)
	at sieppari.async.FunctionWrapper.apply(async.cljc:18)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
	at xtdb.await$notify_tx.invokeStatic(await.clj:53)
	at xtdb.await$notify_tx.invoke(await.clj:46)
	at xtdb.indexer.Indexer.indexTx(indexer.clj:647)
	at xtdb.log.watcher$watch_log_BANG_$reify__69254.acceptRecord(watcher.clj:55)
	at xtdb.log$tx_handler$fn__36304.invoke(log.clj:35)
```
and  tcpdump extract:
```
13:30:48.283137 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 123, bad cksum 0 (->3c7b)!)
    localhost.hbci > localhost.64508: Flags [P.], cksum 0xfe6f (incorrect -> 0x0d51), seq 899:970, ack 1034, win 6363, options [nop,nop,TS val 1837744199 ecr 1928095906], length 71
E..{..@.@.................Q..`.L.....o.....
m..Gr.h.HTTP/1.1 500 Server Error
Connection: close
Server: Jetty(10.0.6)
```

### How to reproduce

The easiest way to reproduce is by using [cl-xtdb ](https://github.com/jsulmont/cl-xtdb.git) a (WIP) Common Lisp client for XTDB2. 
Assuming you have [sbcl](https://lisp-lang.org/learn/getting-started/) installed, then running:
```
$  make build
$ ./cl-xtdb foobar http://localhost:3000 
```
will run the sequence above in a loop (generating a  fresh `:xt/id` at each iteration).


