### PR TITLE
Parsing "env" tags on the CLI.

### DIFF
--- a/src/test/clojure/xtdb/cli_test.clj
+++ b/src/test/clojure/xtdb/cli_test.clj
@@ -61,3 +61,20 @@
         (fn []
           (t/is (= {::foo {:baz {}}}
                    (->system []))))))))
+
+(t/deftest test-env-loading
+  (with-redefs [cli/read-env-var (fn [env-name] 
+                                   (when (= (str env-name) "TEST_ENV") "hello world"))]
+    (letfn [(->system [cli-args]
+              (-> (::cli/node-opts (cli/parse-args cli-args))
+                  ig/prep
+                  ig/init
+                  (->> (into {}))))]
+
+      (t/testing "EDN config - #env reader tag fetches from env"
+        (t/is (= {:foo "hello world"}
+                 (->system ["--edn" "{:xtdb.cli-test/foo #env TEST_ENV}"]))))
+
+      (t/testing "JSON config - edn object fetched from env"
+        (t/is (= {:foo "hello world"}
+                 (->system ["--json" "{\"xtdb.cli-test/foo\": {\"env\": \"TEST_ENV\"}}"])))))))


### PR DESCRIPTION
Allows environment variables to be referenced within EDN/JSON config and loaded at runtime by the CLI parser:
- Uses the `#env` tag for EDN
- Uses an `@env` Object for JSON

In practice, looks like the following:

**EDN**
```
;; Passed in:
{:xtdb.s3/bucket {:bucket #env XTDB_S3_BUCKET}}  

;; Transformed config to be used by 'start-node'
{:xtdb.s3/bucket {:bucket "<value of XTDB_S3_BUCKET>"}
```

**JSON**
```
;; Passed in:
{"xtdb.s3/bucket": {"bucket": {"@env": "XTDB_S3_BUCKET"}}}  

;; Parsed + transformed config to be used by 'start-node'
{:xtdb.s3/bucket {:bucket "<value of XTDB_S3_BUCKET>"}
```

I shall be using this within the AWS docker image to configure various keys of a config file using environment variables.