### PR TITLE
Numerous fixes - AWS docker config, Buffer Pool disk-store, integrant readers for CLI

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -392,14 +392,14 @@
 
 (defn ->remote ^xtdb.IBufferPool [{:keys [^BufferAllocator allocator
                                           object-store
-                                          data-dir
+                                          disk-store
                                           max-cache-bytes
                                           max-cache-entries]
                                    :or {max-cache-entries 1024
                                         max-cache-bytes 536870912}}]
   (->RemoteBufferPool (.newChildAllocator allocator "buffer-pool" 0 Long/MAX_VALUE)
                       (ArrowBufLRU. 16 max-cache-entries max-cache-bytes)
-                      data-dir
+                      disk-store
                       object-store))
 
 (defmethod ig/prep-key ::remote [_ opts]

--- a/core/src/main/clojure/xtdb/cli.clj
+++ b/core/src/main/clojure/xtdb/cli.clj
@@ -8,7 +8,8 @@
             [clojure.walk :as walk]
             [xtdb.error :as err]
             [xtdb.node :as xtn]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [juxt.clojars-mirrors.integrant.core :as ig])
   (:import java.io.File
            java.net.URL
            java.util.Map))
@@ -24,8 +25,8 @@
   (System/getenv (str env-var)))
 
 (defn edn-read-string [edn-string]
-  (edn/read-string {:readers {'env read-env-var}}
-                   edn-string))
+  (ig/read-string {:readers {'env read-env-var}}
+                  edn-string))
 
 (defn json-read-string [json-string]
   (walk/postwalk

--- a/docker/aws/aws_config.edn
+++ b/docker/aws/aws_config.edn
@@ -1,6 +1,11 @@
 {:xtdb.kafka/log {:topic-name #env XTDB_TOPIC_NAME
                   :bootstrap-servers #env KAFKA_BOOTSTRAP_SERVERS} 
+ 
+ :xtdb.buffer-pool/remote {:object-store #ig/ref :xtdb.s3/object-store
+                           :disk-store "/var/lib/xtdb/buffers"}
+ 
  :xtdb.s3/object-store {:bucket #env XTDB_S3_BUCKET,
                         :prefix "xtdb-object-store"
                         :sns-topic-arn #env XTDB_SNS_TOPIC}
+ 
  :xtdb/server {:port 3000}}

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -40,7 +40,7 @@
   (util/with-open [os (os-test/->InMemoryObjectStore (TreeMap.))
                    bp (bp/->remote {:allocator tu/*allocator*
                                     :object-store os
-                                    :data-dir (create-tmp-dir)})]
+                                    :disk-store (create-tmp-dir)})]
     (bp/clear-cache-counters)
     (t/is (= 0 (.get bp/cache-hit-byte-counter)))
     (t/is (= 0 (.get bp/cache-miss-byte-counter)))
@@ -128,7 +128,7 @@
         (t/is (= 0 (util/compare-nio-buffers-unsigned expected (arrow-buf->nio buf))))))
 
     (when disk-store
-      (t/testing "expect a file to exist under our :data-dir"
+      (t/testing "expect a file to exist under our :disk-store"
         (t/is (util/path-exists (.resolve disk-store k)))
         (t/is (= 0 (util/compare-nio-buffers-unsigned expected (util/->mmap-path (.resolve disk-store k))))))
 
@@ -183,7 +183,7 @@
 (defn remote-test-buffer-pool ^xtdb.IBufferPool []
   (bp/->remote {:allocator tu/*allocator*
                 :object-store (->SimulatedObjectStore (atom []) (atom {}))
-                :data-dir (create-tmp-dir)}))
+                :disk-store (create-tmp-dir)}))
 
 (defn get-remote-calls [test-bp]
   @(:calls (:remote-store test-bp)))


### PR DESCRIPTION
Numerous small fixes to ensure AWS docker image runs correctly with proper config:
- Ensure that we include a remote buffer pool using the object store.
- Fix to CLI to ensure `ig/ref` handled properly (using the integrant `read-string` function).
- Fix/update to buffer pool - ensure `disk-store` used everywhere (ensures string used there gets transformed to path) 