### PR TITLE
add `xt/template` macro

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -1,5 +1,6 @@
 (ns xtdb.api
   (:require [clojure.spec.alpha :as s]
+            [xtdb.backtick :as backtick]
             [xtdb.error :as err]
             [xtdb.protocols :as xtp]
             [xtdb.time :as time]
@@ -314,3 +315,18 @@
 
 (defn with-op-arg-rows [^Ops$HasArgs op arg-rows]
   (.withArgs op ^List arg-rows))
+
+(defmacro template
+  "This macro quotes the given query, but additionally allows you to use Clojure's unquote (`~`) and unquote-splicing (`~@`) forms within the quoted form.
+
+  Usage:
+
+  (defn build-posts-query [{:keys [with-author?]}]
+    (xt/template (from :posts [{:xt/id id} text
+                               ~@(when with-author?
+                                   '[author])])))"
+
+  {:clj-kondo/ignore [:unresolved-symbol :unresolved-namespace]}
+  [query]
+
+  (backtick/quote-fn query))

--- a/api/src/main/clojure/xtdb/backtick.clj
+++ b/api/src/main/clojure/xtdb/backtick.clj
@@ -1,0 +1,39 @@
+;; THIRD-PARTY SOFTWARE NOTICE
+;;
+;; This file is derivative of the `backtick` library, which is licensed under the EPL (version 2.0),
+;; and hence this file is also licensed under the terms of that license.
+;;
+;; Originally accessed at https://github.com/brandonbloom/backtick/blob/0463b49ddb0863653231fc6c922bb124ff5f7d25/src/backtick.clj
+;; The EPL 2.0 license is available at https://opensource.org/license/epl-2-0/
+
+(ns xtdb.backtick
+  (:require [xtdb.error :as err]))
+
+(defn unquote? [form]
+  (and (seq? form) (= (first form) 'clojure.core/unquote)))
+
+(defn unquote-splicing? [form]
+  (and (seq? form) (= (first form) 'clojure.core/unquote-splicing)))
+
+(defn quote-fn [form]
+  (cond
+    (symbol? form) `'~form
+    (unquote? form) (second form)
+    (unquote-splicing? form) (throw (err/illegal-arg ::splice-not-in-list {::err/message "splice not in list", :form form}))
+    (record? form) `'~form
+    (coll? form)
+      (let [parts (for [x (if (map? form)
+                            (apply concat form)
+                            form)]
+                    (if (unquote-splicing? x)
+                      (second x)
+                      [(quote-fn x)]))
+            cat (doall `(concat ~@parts))]
+        (cond
+          (vector? form) `(vec ~cat)
+          (map? form) `(apply hash-map ~cat)
+          (set? form) `(set ~cat)
+          (seq? form) `(apply list ~cat)
+          :else (throw (err/illegal-arg ::unknown-coll-type {::err/message "Unknown collection type", :form form}))))
+    :else `'~form))
+


### PR DESCRIPTION
Allows `unquote` and `unquote-splicing` within a quoted form (inspiration from ['backtick'](https://github.com/brandonbloom/backtick/)).

e.g.

```clojure
(defn build-posts-query [{:keys [with-author?]}]
  (xt/template (from :posts [{:xt/id id} text
                             ~@(when with-author?
                                 '[author])])))"
```

* Need to requote once you're within an unquote(-splicing) form - same as Clojure macros. The user could re-call `xt/template` in there if it makes sense to.
* This pretty much obviates the need to go to 'mappy XTQL', I think?
* Naming RFC? bikeshedding welcome. I've taken this from 'backtick' itself.
  * `xt/quote`?
  * `xt/quq` (quote-unquote)?
  * I originally had `xt/ql` but, strictly speaking, it doesn't _just_ take a query - it takes any form - so I was wondering about a more general name.
  * :shrug: