### PR TITLE
change `without` behaviour to ignore non-existing columns

### DIFF
--- a/core/src/main/clojure/xtdb/xtql.clj
+++ b/core/src/main/clojure/xtdb/xtql.clj
@@ -515,12 +515,6 @@
   Query$Without
   (plan-query-tail [without {:keys [ra-plan provided-vars]}]
     (let [cols-to-be-removed (into #{} (map col-sym) (.cols without))
-          _ (when (not (set/subset? cols-to-be-removed provided-vars))
-              (throw (err/illegal-arg
-                      :xtql/invalid-without
-                      {:without-cols cols-to-be-removed
-                       :input-relation-cols provided-vars
-                       ::err/message "All cols in without must be present in input relation"})))
           output-projection (set/difference provided-vars cols-to-be-removed)]
       {:ra-plan [:project (vec output-projection) ra-plan]
        :provided-vars output-projection}))

--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -2119,11 +2119,11 @@
                  '(-> (table [{:x 1 :y 2}] [x y])
                       (without :x)))))
 
-  (t/is (thrown-with-msg? IllegalArgumentException
-                          #"All cols in without must be present in input relation"
-                          (xt/q tu/*node*
-                                '(-> (table [{:x 2}] [x])
-                                     (without :z))))))
+  (t/is (= [{:x 2}]
+           (xt/q tu/*node*
+                 '(-> (table [{:x 2}] [x])
+                      (without :z))))
+        "ignores missing columns"))
 
 (deftest test-without-normalisation-2959-2969
   (xt/submit-tx tu/*node*


### PR DESCRIPTION
More useful in query generation, as it means you can put a `without` in and list any number of columns that may or may not have been added in the query above - this is now closer to `dissoc`.