### PR TITLE
write tx-ops in terms of helper functions, #2987 pt 1

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -189,12 +189,16 @@
   "Writes transactions to the log for processing
 
   tx-ops: Datalog/SQL style transactions.
-    [[:put :table {:xt/id \"my-id\", ...}]
-     [:delete :table \"my-id\"]]
+    [(xt/put :table {:xt/id \"my-id\", ...})
+     (xt/delete :table \"my-id\")]
 
-    [[:sql [\"INSERT INTO foo (xt$id, a, b) VALUES ('foo', ?, ?)\" 0 1]]
-     [:sql-batch [\"INSERT INTO foo (xt$id, a, b) VALUES ('foo', ?, ?)\" [2 3] [4 5] [6 7]]]
-     [:sql \"UPDATE foo SET b = 1\"]]
+    [(-> (xt/sql-op \"INSERT INTO foo (xt$id, a, b) VALUES ('foo', ?, ?)\")
+         (xt/with-op-args [0 1]))
+
+     (-> (xt/sql-op \"INSERT INTO foo (xt$id, a, b) VALUES ('foo', ?, ?)\")
+         (xt/with-op-args [2 3] [4 5] [6 7]))
+
+     (xt/sql-op \"UPDATE foo SET b = 1\")]
 
   Returns a map with details about the submitted transaction, including system-time and tx-id.
 
@@ -217,3 +221,39 @@
   including details of both the latest submitted and completed tx"
   [node]
   (xtp/status node))
+
+(defn put [table doc]
+  [:put table doc])
+
+(defn put-fn [fn-id f]
+  [:put-fn fn-id f])
+
+(defn delete [table id]
+  [:delete table id])
+
+(defn during [tx-op from until]
+  (conj tx-op {:for-valid-time [:in from until]}))
+
+(defn starting-from [tx-op from]
+  (during tx-op from nil))
+
+(defn until [tx-op until]
+  (during tx-op nil until))
+
+(defn erase [table id]
+  [:evict table id])
+
+(defn call [f & args]
+  (into [:call f] args))
+
+(defn sql-op [sql]
+  [:sql sql])
+
+(defn xtql-op [xtql]
+  [:xtql xtql])
+
+(defn with-op-args [op & args]
+  (into op args))
+
+(defn with-op-arg-rows [op arg-rows]
+  (into op arg-rows))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -19,7 +19,7 @@
            (org.apache.arrow.memory BufferAllocator RootAllocator)
            xtdb.indexer.IIndexer
            xtdb.operator.IRaQuerySource
-           xtdb.tx.Ops$Sql
+           (xtdb.tx Ops Ops$Sql)
            (xtdb.tx_producer ITxProducer)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -41,7 +41,7 @@
     (doseq [tx-op (->> tx-ops
                        (map (fn [tx-op]
                               (cond-> tx-op
-                                (vector? tx-op) txp/parse-tx-op))))
+                                (not (instance? Ops tx-op)) txp/parse-tx-op))))
             :when (instance? Ops$Sql tx-op)]
       (sql/parse-query (.sql ^Ops$Sql tx-op)))
     (catch Throwable e

--- a/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
+++ b/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
@@ -91,6 +91,6 @@
 
   (defn submit [tx] (.submitTx (:xtdb.tx-producer/tx-producer sys) tx {}))
 
-  @(submit [[:put :foo {:xt/id 42, :msg "Hello, world!"}]])
+  @(submit [(xt/put :foo {:xt/id 42, :msg "Hello, world!"})])
 
   )

--- a/dev/xtql/README.adoc
+++ b/dev/xtql/README.adoc
@@ -571,8 +571,8 @@ We submit `insert` operations to `xt/submit-tx`.
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(insert :users (from :old-users [xt/id {:first-name given-name, :last-name surname}
-                                            xt/valid-from xt/valid-to]))]])
+  [{:xtql '(insert :users (from :old-users [xt/id {:first-name given-name, :last-name surname}
+                                            xt/valid-from xt/valid-to]))}])
 ----
 
 [source,sql]
@@ -600,8 +600,8 @@ We can delete documents using queries as well.
 ----
 (defn delete-a-post [node the-post-id]
   (xt/submit-tx node
-    [[:xtql '(delete :comments [{:post-id $post-id}])
-      {:post-id the-post-id}]]))
+    [{:xtql '(delete :comments [{:post-id $post-id}])
+      :args {:post-id the-post-id}}]))
 ----
 +
 [source,sql]
@@ -617,9 +617,9 @@ Let's say instead we wanted to delete all comments on posts by a certain author 
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(delete :comments [{:post-id pid}]
+  [{:xtql '(delete :comments [{:post-id pid}]
                    (from :posts [{:xt/id pid, :author-id $author}]))
-    {:author "james"}]])
+    :args {:author "james"}}])
 ----
 +
 [source,sql]
@@ -637,8 +637,8 @@ For example, if we want to take down all Christmas promotions on the 26th Decemb
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(delete :promotions {:bind [{:promotion-type "christmas"}]
-                                :for-valid-time (from #inst "2023-12-26")})]])
+  [{:xtql '(delete :promotions {:bind [{:promotion-type "christmas"}]
+                                :for-valid-time (from #inst "2023-12-26")})}])
 ----
 +
 [source,sql]
@@ -653,7 +653,7 @@ WHERE promotion_type = 'christmas'
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(delete :comments {})]])
+  [{:xtql '(delete :comments {})}])
 ----
 +
 [source,sql]
@@ -668,9 +668,9 @@ DELETE FROM comments
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(update :documents {:bind [{:xt/id $doc-id, :version v}]
+  [{:xtql '(update :documents {:bind [{:xt/id $doc-id, :version v}]
                                :set {:version (inc v)}})
-    {:doc-id "doc-id"}]])
+    :args {:doc-id "doc-id"}}])
 ----
 +
 [source,sql]
@@ -686,13 +686,13 @@ You can, for example, copy a value from another related table, or even update a 
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:put :comments {:xt/id (random-uuid), :post-id post-id}]
-   [:xtql '(update :posts {:bind [{:xt/id $post-id}], :set {:comment-count cc}}
+  [(xt/put :comments {:xt/id (random-uuid), :post-id post-id})
+   {:xtql '(update :posts {:bind [{:xt/id $post-id}], :set {:comment-count cc}}
 
                    (with {cc (q (-> (from :comments [{:post-id $post-id}])
                                     (aggregate {cc (count)}))
                                 [cc])}))
-    {:post-id "my-post-id"}]])
+    :args {:post-id "my-post-id"}}])
 ----
 +
 [source,sql]
@@ -715,7 +715,7 @@ We can irretrievably erase a document using an `erase` query.
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(erase :users [{:email "jms@example.com"}])]])
+  [{:xtql '(erase :users [{:email "jms@example.com"}])}])
 ----
 +
 [source,sql]
@@ -734,10 +734,10 @@ This query asserts that no user has the email `james@example.com` before inserti
 [source,clojure]
 ----
 (xt/submit-tx node
-  [[:xtql '(assert-not-exists (from :users [{:email $email}]))
-    {:email "james@example.com"}]
+  [{:xtql '(assert-not-exists (from :users [{:email $email}]))
+    :args {:email "james@example.com"}}
 
-   [:put :users {:xt/id :james, :email "james@example.com"}]])
+   (xt/put :users {:xt/id :james, :email "james@example.com"})])
 ----
 
 [source,sql]

--- a/docs/src/content/reference/main/datalog/queries.adoc
+++ b/docs/src/content/reference/main/datalog/queries.adoc
@@ -224,10 +224,10 @@ Examples:
 [source,clojure]
 ----
 ;; example data
-[[:put :people {:xt/id :matthew}]
- [:put :people {:xt/id :mark, :parent :matthew}]
- [:put :people {:xt/id :luke, :parent :mark}]
- [:put :people {:xt/id :john, :parent :mark}]]
+[(xt/put :people {:xt/id :matthew})
+ (xt/put :people {:xt/id :mark, :parent :matthew})
+ (xt/put :people {:xt/id :luke, :parent :mark})
+ (xt/put :people {:xt/id :john, :parent :mark})]
 
 ;; find me people who have children
 {:find [parent child]

--- a/docs/src/content/reference/main/sql/txs.adoc
+++ b/docs/src/content/reference/main/sql/txs.adoc
@@ -11,7 +11,7 @@ SQL transactions are submitted through `xtdb.api/submit-tx`.
 [#tx-ops]
 == Transaction operations
 
-SQL transaction operations are of the form `[:sql ["<sql query>" <params>*]]`.
+SQL transaction operations are of the form `(xt/sql-op "<sql query>")`.
 
 e.g.
 
@@ -19,15 +19,14 @@ e.g.
 ----
 (require '[xtdb.api :as xt])
 
-(xt/submit-tx node [[:sql "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')"]
+(xt/submit-tx node [(xt/sql-op "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')")
 
-                    ;; or as parameters
-                    [:sql ["INSERT INTO users (xt$id, name) VALUES (?, ?)" "jms" "James"]]
-
-                    ;; batch mode - pass multiple vectors of parameters
-                    [:sql ["INSERT INTO users (xt$id, name) VALUES (?, ?)"
-                           ["jdt", "Jeremy"]
-                           ["mat", "Matt"]]]])
+                    ;; with args - pass multiple vectors if required.
+                    ;; use `xt/with-op-arg-rows` if you don't want a variadic function
+                    ;; (i.e. you already have a vector of vectors).
+                    (-> (xt/sql-op "INSERT INTO users (xt$id, name) VALUES (?, ?)")
+                        (xt/with-op-args ["jms" "James"]
+                                         ["jdt", "Jeremy"]))])
 ----
 
 [NOTE]

--- a/docs/src/content/reference/main/xtql/txs.adoc
+++ b/docs/src/content/reference/main/xtql/txs.adoc
@@ -1,59 +1,64 @@
 = XTQL Transactions
 
-XTQL transactions are submitted through `xtdb.api/submit-tx`.
+XTQL transactions are submitted through `xtdb.api/submit-tx` (`xtdb.api` aliased here as `xt`).
 
-* `(xt/submit-tx <node> <tx-ops>)`: returns the transaction key of the submitted transaction.
+* `(xt/submit-tx <node> <tx-ops>)` returns the transaction key of the submitted transaction.
 ** `tx-ops`: vector of link:#tx-ops[transaction operations].
 * `(xt/submit-tx& <node> <tx-ops>)`: returns a `CompletableFuture` of the transaction key.
 
 [#tx-ops]
 == Transaction operations
 
-=== `:put`
+=== `put`
 
 Upserts a document into the given table, optionally during the given valid time period.
 
-`[:put <table> <document> <opts>?]`
+`(xt/put <table> <document>)`
 
 * `table` (keyword).
 * `document` (map): must contain `:xt/id`.
-* `opts` (map):
-** `:for-valid-time [:in <from> <to>]`:
-*** `from` (timestamp): may be `nil`.
+
+To specify a valid-time range:
+
+* `(-> (xt/put <table> <document>) (xt/starting <from>))`
+* `(-> (xt/put <table> <document>) (xt/until <to>))`
+* `(-> (xt/put <table> <document>) (xt/during <from> <to))`
+
+where:
+
+* `from` (timestamp): may be `nil`.
     Defaults to the current time of the transaction if not provided.
-*** `to` (timestamp): may be `nil`.
+* `to` (timestamp): may be `nil`.
     Defaults to the end-of-time if not provided.
 
-=== `:delete`
+=== `delete`
 
 Deletes a document from the given table, optionally during the given valid time period.
 
-`[:delete <table> <id> <opts>?]`
+`(xt/delete <table> <id>)`
 
-See `:put` for options.
+See `put` for options.
 
-=== `:erase`
+=== `erase`
 
-Irrevocably erase the document from the given table (including through system time), optionally during the given valid time period.
+Irrevocably erase the document from the given table (including through system time), for all valid-time.
 
-`[:erase <table> <id> <opts>?]`
+`(xt/erase <table> <id>)`
 
-See `:put` for options.
-
-=== `:call`
+=== `call`
 
 Call a transaction function.
 
-`[:call <fn> <args>...]`
+`(xt/call <fn-id> <args>*)`
 
-Transaction functions are defined using `:put-fn`:
+Transaction functions are defined using `put-fn`:
 
 [source,clojure]
 ----
-[:put-fn :increment
- '(fn [args...]
-    ...
-    )]
+(xt/put-fn :increment
+           '(fn [args...]
+              ...
+              ))
 ----
 
 Transaction functions are evaluated with the Small Clojure Interpreter (https://github.com/babashka/sci[SCI^]).

--- a/modules/bench/src/main/clojure/xtdb/bench/watdiv.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/watdiv.clj
@@ -34,8 +34,7 @@
                                       (map read-string)
                                       (partition-all 100))]
                  (xt/submit-tx node (for [doc doc-batch]
-                                      ;; TODO we don't support set vals yet
-                                      [:put (->> doc (into {} (remove (comp set? val))))])))))]
+                                      (xt/put :docs doc))))))]
     (bench/with-timing :await-tx
       (tu/then-await-tx tx node (Duration/ofHours 5)))
 

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -21,7 +21,7 @@
 
 (defn install-tx-fns [worker fns]
   (->> (for [[id fn-def] fns]
-         [:put-fn id fn-def])
+         (xt/put-fn id fn-def))
        (xt/submit-tx (:sut worker))))
 
 (defn generate

--- a/modules/datasets/src/main/clojure/xtdb/datasets/tpch.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/tpch.clj
@@ -69,7 +69,7 @@
                                                  (reduce (fn [[_!last-tx last-doc-count] batch]
                                                            [(xt/submit-tx& tx-producer
                                                                            (vec (for [doc batch]
-                                                                                  [:put (:table (meta doc)) doc])))
+                                                                                  (xt/put (:table (meta doc)) doc))))
                                                             (+ last-doc-count (count batch))])
                                                          [nil 0]))]
                    (log/debug "Transacted" doc-count (.getTableName t))
@@ -104,7 +104,8 @@
                                                  (partition-all 1000)
                                                  (reduce (fn [[_!last-tx last-doc-count] param-batch]
                                                            [(xt/submit-tx& tx-producer
-                                                                           [[:sql-batch (into [dml] param-batch)]])
+                                                                           [(-> (xt/sql-op dml)
+                                                                                (xt/with-op-arg-rows param-batch))])
                                                             (+ last-doc-count (count param-batch))])
                                                          [nil 0]))]
                    (log/debug "Transacted" doc-count (.getTableName table))

--- a/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
+++ b/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
@@ -69,8 +69,8 @@
            [initial-readings rest-readings] (split-at (count device-infos) readings)]
 
        (->> (for [{:keys [time] :as doc} (concat (interleave device-infos initial-readings) rest-readings)]
-              (cond-> [:put doc]
-                time (conj {:xt/valid-time time})))
+              (cond-> (xt/put :docs doc)
+                time (xt/starting-from time)))
             (partition-all batch-size)
             (reduce (fn [_acc tx-ops]
                       (xt/submit-tx tx-producer tx-ops))

--- a/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
+++ b/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
@@ -140,7 +140,7 @@
     (reify FlightSqlProducer
       (acceptPutStatement [_ cmd _ctx _flight-stream ack-stream]
         (fn []
-          @(-> (exec-dml [:sql (.getQuery cmd)]
+          @(-> (exec-dml (xt/sql-op (.getQuery cmd))
                          (when (.hasTransactionId cmd)
                            (.getTransactionId cmd)))
                (then-send-do-put-update-res ack-stream allocator))))

--- a/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
@@ -60,7 +60,7 @@
                     (flight-info->rows))))))
 
 (t/deftest test-jdbc-client
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')")])
 
   ;; NOTE FSQL JDBC driver doesn't seem happy with prepared statement updates
   ;; see https://issues.apache.org/jira/browse/ARROW-18294

--- a/pgwire-server/src/main/clojure/xtdb/pgwire.clj
+++ b/pgwire-server/src/main/clojure/xtdb/pgwire.clj
@@ -1407,7 +1407,8 @@
 
 (defn- submit-tx [{:keys [server conn-state]} dml-buf {:keys [default-all-valid-time?]}]
   (let [tx-ops (mapv (fn [{:keys [transformed-query params]}]
-                       [:sql-batch [transformed-query params]])
+                       (-> (xt/sql-op transformed-query)
+                           (xt/with-op-args params)))
                      dml-buf)]
     ;; TODO review err log policy
     (try
@@ -2085,7 +2086,7 @@
       (xt/submit-tx (:node server)
                     (for [row rows
                           :let [auto-id (str "pgwire-" (random-uuid))]]
-                      [:put (merge {:xt/id auto-id} row)])))
+                      (xt/put (merge {:xt/id auto-id} row)))))
 
     (defn read-xtdb [o]
       (if (instance? org.postgresql.util.PGobject o)

--- a/src/dev/clojure/arrow_readers_writers_doc.clj
+++ b/src/dev/clojure/arrow_readers_writers_doc.clj
@@ -20,8 +20,8 @@
 
   ;; Our engine works on relations. Think of a relation as a set of vectors where each vector has a name.
   ;; Lets say you submit the following two documents.
-  [:put :xt-docs {:xt/id 1 :column-name 42}]
-  [:put :xt-docs {:xt/id 2 :column-name "foo"}]
+  (xt/put :xt-docs {:xt/id 1 :column-name 42})
+  (xt/put :xt-docs {:xt/id 2 :column-name "foo"})
   ;; then this gets transformed into the relation (forgetting the special treatement of `xt/id` for the moment)
   {"xt/id" [1 2]
    "column-name" [42 "foo"]}

--- a/src/dev/clojure/azure_testing.clj
+++ b/src/dev/clojure/azure_testing.clj
@@ -41,9 +41,9 @@
 (comment
   (ir/go)
   (xt/status node)
-  (def submit (xt/submit-tx node [[:put :posts {:xt/id 1234
-                                                :user-id 5678
-                                                :text "hello world!"}]]))
+  (def submit (xt/submit-tx node [(xt/put :posts {:xt/id 1234
+                                                  :user-id 5678
+                                                  :text "hello world!"})]))
   
   (def a
     (.appendRecord (:xtdb.azure/event-hub-log (:system node))

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -21,7 +21,7 @@
   (t/is (map? (xt/status *node*))))
 
 (t/deftest test-simple-query
-  (let [tx (xt/submit-tx *node* [[:put :xt_docs {:xt/id :foo, :inst #inst "2021"}]])]
+  (let [tx (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :foo, :inst #inst "2021"})])]
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx))
 
     (t/is (= [{:e :foo, :inst (util/->zdt #inst "2021")}]
@@ -36,13 +36,13 @@
                      (util/rethrowing-cause))))
 
   (t/is (thrown? IllegalArgumentException
-                 (-> (xt/submit-tx *node* [[:put :xt_docs {}]])
+                 (-> (xt/submit-tx *node* [(xt/put :xt_docs {})])
                      (util/rethrowing-cause)))))
 
 (t/deftest round-trips-lists
-  (let [tx (xt/submit-tx *node* [[:put :xt_docs {:xt/id :foo, :list [1 2 ["foo" "bar"]]}]
-                                 [:sql ["INSERT INTO xt_docs (xt$id, list) VALUES ('bar', ARRAY[?, 2, 3 + 5])"
-                                        4]]])]
+  (let [tx (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :foo, :list [1 2 ["foo" "bar"]]})
+                                 (-> (xt/sql-op "INSERT INTO xt_docs (xt$id, list) VALUES ('bar', ARRAY[?, 2, 3 + 5])")
+                                     (xt/with-op-args [4]))])]
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx))
 
     (t/is (= [{:id :foo, :list [1 2 ["foo" "bar"]]}
@@ -60,7 +60,7 @@
                    {:basis-timeout (Duration/ofSeconds 1)})))))
 
 (t/deftest round-trips-sets
-  (let [tx (xt/submit-tx *node* [[:put :xt_docs {:xt/id :foo, :v #{1 2 #{"foo" "bar"}}}]])]
+  (let [tx (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :foo, :v #{1 2 #{"foo" "bar"}}})])]
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx))
 
     (t/is (= [{:id :foo, :v #{1 2 #{"foo" "bar"}}}]
@@ -73,8 +73,8 @@
              (xt/q *node* "SELECT b.xt$id, b.v FROM xt_docs b")))))
 
 (t/deftest round-trips-structs
-  (let [tx (xt/submit-tx *node* [[:put :xt_docs {:xt/id :foo, :struct {:a 1, :b {:c "bar"}}}]
-                                 [:put :xt_docs {:xt/id :bar, :struct {:a true, :d 42.0}}]])]
+  (let [tx (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :foo, :struct {:a 1, :b {:c "bar"}}})
+                                 (xt/put :xt_docs {:xt/id :bar, :struct {:a true, :d 42.0}})])]
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx))
 
     (t/is (= #{{:id :foo, :struct {:a 1, :b {:c "bar"}}}
@@ -92,8 +92,8 @@
             ;; :tmtz #time/offset-time "11:21:14.932254-08:00" ; TODO #323
             }]
 
-    (xt/submit-tx *node* [[:sql-batch ["INSERT INTO foo (xt$id, dt, ts, tstz, tm) VALUES ('foo', ?, ?, ?, ?)"
-                                       (mapv vs [:dt :ts :tstz :tm])]]])
+    (xt/submit-tx *node* [(-> (xt/sql-op "INSERT INTO foo (xt$id, dt, ts, tstz, tm) VALUES ('foo', ?, ?, ?, ?)")
+                              (xt/with-op-args (mapv vs [:dt :ts :tstz :tm])))])
 
     (t/is (= [(assoc vs :xt$id "foo")]
              (xt/q *node* "SELECT f.xt$id, f.dt, f.ts, f.tstz, f.tm FROM foo f"
@@ -108,21 +108,21 @@
                 [:tmtz "TIME '11:21:14.932254-08:00'"]]]
 
       (xt/submit-tx *node* (vec (for [[t lit] lits]
-                                  [:sql [(format "INSERT INTO bar (xt$id, v) VALUES (?, %s)" lit)
-                                         (name t)]])))
+                                  (-> (xt/sql-op (format "INSERT INTO bar (xt$id, v) VALUES (?, %s)" lit))
+                                      (xt/with-op-args [(name t)])))))
       (t/is (= (set (for [[t _lit] lits]
                       {:xt$id (name t), :v (get vs t)}))
                (set (xt/q *node* "SELECT b.xt$id, b.v FROM bar b"
                           {:default-tz (ZoneId/of "Europe/London")})))))))
 
 (t/deftest can-manually-specify-system-time-47
-  (let [tx1 (xt/submit-tx *node* [[:put :xt_docs {:xt/id :foo}]]
+  (let [tx1 (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :foo})]
                           {:system-time #inst "2012"})
 
-        _invalid-tx (xt/submit-tx *node* [[:put :xt_docs {:xt/id :bar}]]
+        _invalid-tx (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :bar})]
                                   {:system-time #inst "2011"})
 
-        tx3 (xt/submit-tx *node* [[:put :xt_docs {:xt/id :baz}]])]
+        tx3 (xt/submit-tx *node* [(xt/put :xt_docs {:xt/id :baz})])]
 
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2012")})
              tx1))
@@ -160,10 +160,10 @@
                   (into #{} (map #(update % :err (comp ex-data (fn [^ClojureForm clj-form] (some-> clj-form .form)))))))))))
 
 (def ^:private devs
-  [[:put :users {:xt/id :jms, :name "James"}]
-   [:put :users {:xt/id :hak, :name "Håkan"}]
-   [:put :users {:xt/id :mat, :name "Matt"}]
-   [:put :users {:xt/id :wot, :name "Dan"}]])
+  [(xt/put :users {:xt/id :jms, :name "James"})
+   (xt/put :users {:xt/id :hak, :name "Håkan"})
+   (xt/put :users {:xt/id :mat, :name "Matt"})
+   (xt/put :users {:xt/id :wot, :name "Dan"})])
 
 (t/deftest test-sql-roundtrip
   (let [tx (xt/submit-tx *node* devs)]
@@ -191,11 +191,12 @@
                         :default-all-valid-time? true})
                  (into #{} (map (juxt :first_name :last_name :xt$valid_from :xt$valid_to)))))]
 
-    (let [tx1 (xt/submit-tx *node* [[:sql-batch ["INSERT INTO users (xt$id, first_name, last_name, xt$valid_from) VALUES (?, ?, ?, ?)"
-                                                 ["dave", "Dave", "Davis", #inst "2018"]
-                                                 ["claire", "Claire", "Cooper", #inst "2019"]
-                                                 ["alan", "Alan", "Andrews", #inst "2020"]
-                                                 ["susan", "Susan", "Smith", #inst "2021"]]]])
+    (let [tx1 (xt/submit-tx *node* [(-> (xt/sql-op "INSERT INTO users (xt$id, first_name, last_name, xt$valid_from) VALUES (?, ?, ?, ?)")
+                                        (xt/with-op-args
+                                          ["dave", "Dave", "Davis", #inst "2018"]
+                                          ["claire", "Claire", "Cooper", #inst "2019"]
+                                          ["alan", "Alan", "Andrews", #inst "2020"]
+                                          ["susan", "Susan", "Smith", #inst "2021"]))])
           tx1-expected #{["Dave" "Davis", (util/->zdt #inst "2018"), nil]
                          ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
                          ["Alan" "Andrews", (util/->zdt #inst "2020"), nil]
@@ -205,8 +206,8 @@
 
       (t/is (= tx1-expected (all-users tx1)))
 
-      (let [tx2 (xt/submit-tx *node* [[:sql ["DELETE FROM users FOR PORTION OF VALID_TIME FROM DATE '2020-05-01' TO NULL AS u WHERE u.xt$id = ?"
-                                             "dave"]]])
+      (let [tx2 (xt/submit-tx *node* [(-> (xt/sql-op "DELETE FROM users FOR PORTION OF VALID_TIME FROM DATE '2020-05-01' TO NULL AS u WHERE u.xt$id = ?")
+                                          (xt/with-op-args ["dave"]))])
             tx2-expected #{["Dave" "Davis", (util/->zdt #inst "2018"), (util/->zdt #inst "2020-05-01")]
                            ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
                            ["Alan" "Andrews", (util/->zdt #inst "2020"), nil]
@@ -215,8 +216,8 @@
         (t/is (= tx2-expected (all-users tx2)))
         (t/is (= tx1-expected (all-users tx1)))
 
-        (let [tx3 (xt/submit-tx *node* [[:sql ["UPDATE users FOR PORTION OF VALID_TIME FROM DATE '2021-07-01' TO NULL AS u SET first_name = 'Sue' WHERE u.xt$id = ?"
-                                               "susan"]]])
+        (let [tx3 (xt/submit-tx *node* [(-> (xt/sql-op "UPDATE users FOR PORTION OF VALID_TIME FROM DATE '2021-07-01' TO NULL AS u SET first_name = 'Sue' WHERE u.xt$id = ?")
+                                            (xt/with-op-args ["susan"]))])
 
               tx3-expected #{["Dave" "Davis", (util/->zdt #inst "2018"), (util/->zdt #inst "2020-05-01")]
                              ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
@@ -230,24 +231,25 @@
 
 (deftest test-sql-insert
   (let [tx1 (xt/submit-tx *node*
-                          [[:sql-batch ["INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)"
-                                        ["dave", "Dave", #inst "2018"]
-                                        ["claire", "Claire", #inst "2019"]]]])]
+                          [(-> (xt/sql-op "INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)")
+                               (xt/with-op-args
+                                 ["dave", "Dave", #inst "2018"]
+                                 ["claire", "Claire", #inst "2019"]))])]
 
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx1))
 
     (xt/submit-tx *node*
-                  [[:sql "INSERT INTO people (xt$id, renamed_name, xt$valid_from)
+                  [(xt/sql-op "INSERT INTO people (xt$id, renamed_name, xt$valid_from)
                             SELECT users.xt$id, users.name, users.xt$valid_from
                             FROM users FOR VALID_TIME AS OF DATE '2019-06-01'
-                            WHERE users.name = 'Dave'"]])
+                            WHERE users.name = 'Dave'")])
 
     (t/is (= [{:renamed_name "Dave"}]
              (xt/q *node* "SELECT people.renamed_name FROM people FOR VALID_TIME AS OF DATE '2019-06-01'")))))
 
 (deftest test-sql-insert-app-time-date-398
   (let [tx (xt/submit-tx *node*
-                         [[:sql "INSERT INTO foo (xt$id, xt$valid_from) VALUES ('foo', DATE '2018-01-01')"]])]
+                         [(xt/sql-op "INSERT INTO foo (xt$id, xt$valid_from) VALUES ('foo', DATE '2018-01-01')")])]
 
     (t/is (= (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")}) tx))
 
@@ -263,15 +265,15 @@
                          "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo"
                          {:default-all-valid-time? true})))]
       (xt/submit-tx *node*
-                    [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                            "foo", 0]]])
+                    [(-> (xt/sql-op "INSERT INTO foo (xt$id, version) VALUES (?, ?)")
+                         (xt/with-op-args ["foo", 0]))])
 
       (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to nil}}
                (q)))
 
       (t/testing "update as-of-now"
         (xt/submit-tx *node*
-                      [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]]
+                      [(xt/sql-op "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")]
                       {:default-all-valid-time? false})
 
         (t/is (= #{{:version 0, :xt$valid_from tt1, :xt$valid_to tt2}
@@ -280,10 +282,10 @@
 
       (t/testing "`FOR PORTION OF` means flag is ignored"
         (xt/submit-tx *node*
-                      [[:sql [(str "UPDATE foo "
-                                   "FOR PORTION OF VALID_TIME FROM ? TO ? "
-                                   "SET version = 2 WHERE foo.xt$id = 'foo'")
-                              tt1 tt2]]]
+                      [(-> (xt/sql-op (str "UPDATE foo "
+                                           "FOR PORTION OF VALID_TIME FROM ? TO ? "
+                                           "SET version = 2 WHERE foo.xt$id = 'foo'"))
+                           (xt/with-op-args [tt1 tt2]))]
                       {:default-all-valid-time? false})
         (t/is (= #{{:version 2, :xt$valid_from tt1, :xt$valid_to tt2}
                    {:version 1, :xt$valid_from tt2, :xt$valid_to nil}}
@@ -291,7 +293,7 @@
 
       (t/testing "UPDATE for-all-time"
         (xt/submit-tx *node*
-                      [[:sql "UPDATE foo SET version = 3 WHERE foo.xt$id = 'foo'"]]
+                      [(xt/sql-op "UPDATE foo SET version = 3 WHERE foo.xt$id = 'foo'")]
                       {:default-all-valid-time? true})
 
         (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
@@ -300,7 +302,7 @@
 
       (t/testing "DELETE as-of-now"
         (xt/submit-tx *node*
-                      [[:sql "DELETE FROM foo WHERE foo.xt$id = 'foo'"]]
+                      [(xt/sql-op "DELETE FROM foo WHERE foo.xt$id = 'foo'")]
                       {:default-all-valid-time? false})
 
         (t/is (= #{{:version 3, :xt$valid_from tt1, :xt$valid_to tt2}
@@ -309,8 +311,8 @@
 
       (t/testing "UPDATE FOR ALL VALID_TIME"
         (xt/submit-tx *node*
-                      [[:sql "UPDATE foo FOR ALL VALID_TIME
-                                    SET version = 4 WHERE foo.xt$id = 'foo'"]]
+                      [(xt/sql-op "UPDATE foo FOR ALL VALID_TIME
+                                    SET version = 4 WHERE foo.xt$id = 'foo'")]
                       {:default-all-valid-time? false})
 
         (t/is (= #{{:version 4, :xt$valid_from tt1, :xt$valid_to tt2}
@@ -319,8 +321,8 @@
 
       (t/testing "DELETE FOR ALL VALID_TIME"
         (xt/submit-tx *node*
-                      [[:sql "DELETE FROM foo FOR ALL VALID_TIME
-                                    WHERE foo.xt$id = 'foo'"]]
+                      [(xt/sql-op "DELETE FROM foo FOR ALL VALID_TIME
+                                    WHERE foo.xt$id = 'foo'")]
                       {:default-all-valid-time? false})
 
         (t/is (= #{} (q)))))))
@@ -329,8 +331,8 @@
   (let [tt1 (util/->zdt #inst "2020-01-01")
         tt2 (util/->zdt #inst "2020-01-02")]
     (xt/submit-tx *node*
-                  [[:sql ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                          "foo", 0]]])
+                  [(-> (xt/sql-op "INSERT INTO foo (xt$id, version) VALUES (?, ?)")
+                       (xt/with-op-args ["foo", 0]))])
 
     (t/is (= [{:version 0, :xt$valid_from tt1, :xt$valid_to nil}]
              (xt/q *node*
@@ -342,7 +344,7 @@
                    "SELECT foo.version, foo.xt$valid_from, foo.xt$valid_to FROM foo")))
 
     (xt/submit-tx *node*
-                  [[:sql "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'"]])
+                  [(xt/sql-op "UPDATE foo SET version = 1 WHERE foo.xt$id = 'foo'")])
 
     (t/is (= [{:version 1, :xt$valid_from tt2, :xt$valid_to nil}]
              (xt/q *node*
@@ -378,10 +380,11 @@
                        {:basis {:tx tx}
                         :default-all-valid-time? true})))]
     (let [tx1 (xt/submit-tx *node*
-                            [[:sql-batch ["INSERT INTO foo (xt$id, version) VALUES (?, ?)"
-                                          ["foo", 0]
-                                          ["bar", 0]]]])
-          tx2 (xt/submit-tx *node* [[:sql "UPDATE foo SET version = 1"]])
+                            [(-> (xt/sql-op "INSERT INTO foo (xt$id, version) VALUES (?, ?)")
+                                 (xt/with-op-args
+                                   ["foo", 0]
+                                   ["bar", 0]))])
+          tx2 (xt/submit-tx *node* [(xt/sql-op "UPDATE foo SET version = 1")])
           v0 {:version 0,
               :xt$valid_from (util/->zdt #inst "2020-01-01"),
               :xt$valid_to (util/->zdt #inst "2020-01-02")}
@@ -405,7 +408,7 @@
                (q tx2)))
 
       (let [tx3 (xt/submit-tx *node*
-                              [[:sql "ERASE FROM foo WHERE foo.xt$id = 'foo'"]])]
+                              [(xt/sql-op "ERASE FROM foo WHERE foo.xt$id = 'foo'")])]
         (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx3)))
         (t/is (= #{(assoc v0 :xt$id "bar") (assoc v1 :xt$id "bar")} (q tx2)))
 
@@ -418,12 +421,12 @@
   (t/is (thrown-with-msg?
          xtdb.IllegalArgumentException
          #"Invalid SQL query: Parse error at line 1"
-         (-> (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, dt) VALUES ('id', DATE \"2020-01-01\")"]])
+         (-> (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, dt) VALUES ('id', DATE \"2020-01-01\")")])
              (util/rethrowing-cause)))
         "parse error - date with double quotes")
 
   (t/testing "still an active node"
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO users (xt$id, name) VALUES ('dave', 'Dave')"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO users (xt$id, name) VALUES ('dave', 'Dave')")])
 
     (t/is (= [{:name "Dave"}]
              (xt/q tu/*node* "SELECT users.name FROM users")))))
@@ -433,17 +436,17 @@
             (->> (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo")
                  (into {} (map (juxt :xt$id (juxt :xt$valid_from :xt$valid_to))))))]
 
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES (1)"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id) VALUES (1)")])
 
-    (xt/submit-tx tu/*node* [[:sql "
+    (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to)
-VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
+VALUES (2, DATE '2022-01-01', DATE '2021-01-01')")])
 
     (t/is (= {1 [(util/->zdt #inst "2020-01-01") nil]}
              (q-all)))
 
     (t/testing "continues indexing after abort"
-      (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES (3)"]])
+      (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id) VALUES (3)")])
 
       (t/is (= {1 [(util/->zdt #inst "2020-01-01") nil]
                 3 [(util/->zdt #inst "2020-01-03") nil]}
@@ -451,9 +454,9 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
 
 (deftest test-insert-from-other-table-with-as-of-now
   (xt/submit-tx *node*
-                [[:sql
-                  "INSERT INTO posts (xt$id, user_id, text, xt$valid_from)
-                    VALUES (9012, 5678, 'Happy 2050!', DATE '2050-01-01')"]])
+                [(xt/sql-op
+                   "INSERT INTO posts (xt$id, user_id, text, xt$valid_from)
+                    VALUES (9012, 5678, 'Happy 2050!', DATE '2050-01-01')")])
 
   (t/is (= [{:text "Happy 2050!"}]
            (xt/q *node*
@@ -465,8 +468,8 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                  {:default-all-valid-time? false})))
 
   (xt/submit-tx *node*
-                [[:sql
-                  "INSERT INTO t1 SELECT posts.xt$id, posts.text FROM posts"]]
+                [(xt/sql-op
+                   "INSERT INTO t1 SELECT posts.xt$id, posts.text FROM posts")]
                 {:default-all-valid-time? false})
 
   (t/is (= []
@@ -478,13 +481,13 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
   (t/is (thrown-with-msg?
          xtdb.IllegalArgumentException
          #"system-time must be an inst, supplied value: null"
-         (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (xt$id) VALUES (1)"]]
+         (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO xt_docs (xt$id) VALUES (1)")]
                        {:system-time nil})))
 
   (t/is (thrown-with-msg?
          IllegalArgumentException
          #"system-time must be an inst, supplied value: foo"
-         (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1}]]
+         (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id 1})]
                        {:system-time "foo"}))))
 
 (t/deftest test-basic-xtql-dml
@@ -495,10 +498,14 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                         :default-all-valid-time? true})
                  (into #{} (map (juxt :first-name :last-name :xt/valid-from :xt/valid-to)))))]
 
-    (let [tx1 (xt/submit-tx *node* [[:put :users {:xt/id "dave", :first-name "Dave", :last-name "Davis"} {:for-valid-time [:from #inst "2018"]}]
-                                    [:put :users {:xt/id "claire", :first-name "Claire", :last-name "Cooper"} {:for-valid-time [:from #inst "2019"]}]
-                                    [:put :users {:xt/id "alan", :first-name "Alan", :last-name "Andrews"} {:for-valid-time [:from #inst "2020"]}]
-                                    [:put :users {:xt/id "susan", :first-name "Susan", :last-name "Smith"} {:for-valid-time [:from #inst "2021"]}]])
+    (let [tx1 (xt/submit-tx *node* [(-> (xt/put :users {:xt/id "dave", :first-name "Dave", :last-name "Davis"})
+                                        (xt/starting-from #inst "2018"))
+                                    (-> (xt/put :users {:xt/id "claire", :first-name "Claire", :last-name "Cooper"})
+                                        (xt/starting-from #inst "2019"))
+                                    (-> (xt/put :users {:xt/id "alan", :first-name "Alan", :last-name "Andrews"})
+                                        (xt/starting-from #inst "2020"))
+                                    (-> (xt/put :users {:xt/id "susan", :first-name "Susan", :last-name "Smith"})
+                                        (xt/starting-from #inst "2021"))])
           tx1-expected #{["Dave" "Davis", (util/->zdt #inst "2018"), nil]
                          ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
                          ["Alan" "Andrews", (util/->zdt #inst "2020"), nil]
@@ -509,23 +516,21 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
       (t/is (= tx1-expected (all-users tx1)))
 
       (t/testing "insert by query"
-        (xt/submit-tx *node* [[:xtql '(insert :users2 (from :users [xt/id {:first-name given-name, :last-name surname} xt/valid-from xt/valid-to]))]]
-                      ;; TODO when `from` supports for-valid-time we can shift this to the query
-                      {:default-all-valid-time? true})
+        (xt/submit-tx *node* [(xt/xtql-op '(insert :users2 (from :users {:bind [xt/id {:first-name given-name, :last-name surname} xt/valid-from xt/valid-to]
+                                                                         :for-valid-time :all-time})))])
 
         (t/is (= #{["Dave" "Davis", (util/->zdt #inst "2018"), nil]
                    ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
                    ["Alan" "Andrews", (util/->zdt #inst "2020"), nil]
                    ["Susan" "Smith", (util/->zdt #inst "2021") nil]}
-                 (->> (xt/q *node* '(from :users2 [given-name surname xt/valid-from xt/valid-to])
-                            ;; TODO when `from` supports for-valid-time we can shift this to the query
-                            {:default-all-valid-time? true})
+                 (->> (xt/q *node* '(from :users2 {:bind [given-name surname xt/valid-from xt/valid-to]
+                                                   :for-valid-time :all-time}))
                       (into #{} (map (juxt :given-name :surname :xt/valid-from :xt/valid-to)))))))
 
-      (let [tx2 (xt/submit-tx *node* [[:xtql '(delete :users
-                                                      {:for-valid-time (from #inst "2020-05-01")
-                                                       :bind [{:xt/id $uid}]})
-                                       {:uid "dave"}]])
+      (let [tx2 (xt/submit-tx *node* [(-> (xt/xtql-op '(delete :users
+                                                               {:for-valid-time (from #inst "2020-05-01")
+                                                                :bind [{:xt/id $uid}]}))
+                                          (xt/with-op-args {:uid "dave"}))])
             tx2-expected #{["Dave" "Davis", (util/->zdt #inst "2018"), (util/->zdt #inst "2020-05-01")]
                            ["Claire" "Cooper", (util/->zdt #inst "2019"), nil]
                            ["Alan" "Andrews", (util/->zdt #inst "2020"), nil]
@@ -534,11 +539,11 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
         (t/is (= tx2-expected (all-users tx2)))
         (t/is (= tx1-expected (all-users tx1)))
 
-        (let [tx3 (xt/submit-tx *node* [[:xtql '(update :users
-                                                        {:for-valid-time (from #inst "2021-07-01")
-                                                         :bind [{:xt/id $uid}]
-                                                         :set {:first-name "Sue"}})
-                                         {:uid "susan"}]]
+        (let [tx3 (xt/submit-tx *node* [(-> (xt/xtql-op '(update :users
+                                                                 {:for-valid-time (from #inst "2021-07-01")
+                                                                  :bind [{:xt/id $uid}]
+                                                                  :set {:first-name "Sue"}}))
+                                            (xt/with-op-args {:uid "susan"}))]
 
                                 {:default-all-valid-time? true})
 
@@ -559,9 +564,9 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                        {:basis {:tx tx}
                         :default-all-valid-time? true})))]
     (let [tx1 (xt/submit-tx *node*
-                            [[:put :foo {:xt/id "foo", :version 0}]
-                             [:put :foo {:xt/id "bar", :version 0}]])
-          tx2 (xt/submit-tx *node* [[:xtql '(update :foo {:set {:version 1}})]])
+                            [(xt/put :foo {:xt/id "foo", :version 0})
+                             (xt/put :foo {:xt/id "bar", :version 0})])
+          tx2 (xt/submit-tx *node* [(xt/xtql-op '(update :foo {:set {:version 1}}))])
           v0 {:version 0,
               :xt/valid-from (util/->zdt #inst "2020-01-01"),
               :xt/valid-to (util/->zdt #inst "2020-01-02")}
@@ -584,8 +589,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                  (assoc v1 :xt/id "bar")}
                (q tx2)))
 
-      (let [tx3 (xt/submit-tx *node*
-                              [[:xtql '(erase :foo [{:xt/id "foo"}])]])]
+      (let [tx3 (xt/submit-tx *node* [(xt/xtql-op '(erase :foo [{:xt/id "foo"}]))])]
         (t/is (= #{(assoc v0 :xt/id "bar") (assoc v1 :xt/id "bar")} (q tx3)))
         (t/is (= #{(assoc v0 :xt/id "bar") (assoc v1 :xt/id "bar")} (q tx2)))
 
@@ -596,17 +600,17 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
 
 (t/deftest test-assert-dml
   (t/testing "assert-not-exists"
-    (xt/submit-tx tu/*node* [[:xtql '(assert-not-exists (from :users [{:first-name $name}]))
-                              {:name "James"}]
-                             [:put :users {:xt/id :james, :first-name "James"}]])
+    (xt/submit-tx tu/*node* [(-> (xt/xtql-op '(assert-not-exists (from :users [{:first-name $name}])))
+                                 (xt/with-op-args {:name "James"}))
+                             (xt/put :users {:xt/id :james, :first-name "James"})])
 
-    (xt/submit-tx tu/*node* [[:xtql '(assert-not-exists (from :users [{:first-name $name}]))
-                              {:name "Dave"}]
-                             [:put :users {:xt/id :dave, :first-name "Dave"}] ])
+    (xt/submit-tx tu/*node* [(-> (xt/xtql-op '(assert-not-exists (from :users [{:first-name $name}])))
+                                 (xt/with-op-args {:name "Dave"}))
+                             (xt/put :users {:xt/id :dave, :first-name "Dave"}) ])
 
-    (xt/submit-tx tu/*node* [[:xtql '(assert-not-exists (from :users [{:first-name $name}]))
-                              {:name "James"}]
-                             [:put :users {:xt/id :james2, :first-name "James"}] ])
+    (xt/submit-tx tu/*node* [(-> (xt/xtql-op '(assert-not-exists (from :users [{:first-name $name}])))
+                                 (xt/with-op-args {:name "James"}))
+                             (xt/put :users {:xt/id :james2, :first-name "James"}) ])
 
     (t/is (= #{{:xt/id :james, :first-name "James"}
                {:xt/id :dave, :first-name "Dave"}}
@@ -623,14 +627,14 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                          (update row :xt/error #(ex-data (.form ^ClojureForm %)))))))))
 
   (t/testing "assert-exists"
-    (xt/submit-tx tu/*node* [[:xtql '(assert-exists (from :users [{:first-name $name}]))
-                              {:name "Mike"}]
-                             [:put :users {:xt/id :mike, :first-name "Mike"}] ])
+    (xt/submit-tx tu/*node* [(-> (xt/xtql-op '(assert-exists (from :users [{:first-name $name}])))
+                                 (xt/with-op-args {:name "Mike"}))
+                             (xt/put :users {:xt/id :mike, :first-name "Mike"}) ])
 
-    (xt/submit-tx tu/*node* [[:xtql '(assert-exists (from :users [{:first-name $name}]))
-                              {:name "James"}]
-                             [:delete :users :james]
-                             [:put :users {:xt/id :james2, :first-name "James"}] ])
+    (xt/submit-tx tu/*node* [(-> (xt/xtql-op '(assert-exists (from :users [{:first-name $name}])))
+                                 (xt/with-op-args {:name "James"}))
+                             (xt/delete :users :james)
+                             (xt/put :users {:xt/id :james2, :first-name "James"}) ])
 
     (t/is (= #{{:xt/id :james2, :first-name "James"}
                {:xt/id :dave, :first-name "Dave"}}
@@ -648,13 +652,13 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                          (update row :xt/error #(ex-data (.form ^ClojureForm %))))))))))
 
 (t/deftest test-xtql-with-param-2933
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :petr :name "Petr"}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :petr :name "Petr"})])
 
   (t/is (= [{:name "Petr"}]
            (xt/q tu/*node* '(from :docs [{:xt/id $petr} name]) {:args {:petr :petr}}))))
 
 (t/deftest test-close-node-multiple-times
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :petr :name "Petr"}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :petr :name "Petr"})])
   (let [^AutoCloseable node tu/*node*]
     (.close node)
     (.close node)))
@@ -670,14 +674,14 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                                                (with {:foo (/ 1 0)})))))
 
   ;; Might need to get updated if this kind of error gets handled differently.
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :name 2}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :name 2})])
   (t/is (thrown-with-msg? Exception ;; Exception as type is different for local/remote
                           #"No method in multimethod 'codegen-call' for dispatch value"
                           (xt/q tu/*node* "SELECT UPPER(docs.name) AS name FROM docs"))))
 
 (def ivan+petr
-  [[:put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
-   [:put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
+  [(xt/put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"})
+   (xt/put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"})])
 
 (t/deftest normalisation-option
   (xt/submit-tx tu/*node* ivan+petr)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -117,7 +117,7 @@
 ;;                                                             :event-hub-name (str "xtdb.azure-test-hub." (UUID/randomUUID))
 ;;                                                             :create-event-hub? true
 ;;                                                             :retention-period-in-days 1}})]
-;;     (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
+;;     (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo}])])
 ;;     (t/is (= [{:id :foo}]
 ;;              (xt/q node '{:find [id]
 ;;                           :where [($ :xt_docs [{:xt/id id}])]})))))

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -88,7 +88,7 @@
       (letfn [(submit! [xs]
                 (doseq [batch (partition-all 8 xs)]
                   (xt/submit-tx node (for [x batch]
-                                       [:put :foo {:xt/id x}]))))
+                                       (xt/put :foo {:xt/id x})))))
 
               (q []
                 (->> (xt/q node

--- a/src/test/clojure/xtdb/datalog/temporal_test.clj
+++ b/src/test/clojure/xtdb/datalog/temporal_test.clj
@@ -6,10 +6,10 @@
 (t/use-fixtures :each tu/with-node)
 
 (deftest simple-temporal-tests
-  (let [tx1 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :foo "2000-4000"}
-                                      {:for-valid-time [:in #inst "2000" #inst "4000"]}]])
-        tx2 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :foo "3000-"}
-                                      {:for-valid-time [:in #inst "3000"]}]])]
+  (let [tx1 (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1 :foo "2000-4000"})
+                                         (xt/during #inst "2000" #inst "4000"))])
+        tx2 (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1 :foo "3000-"})
+                                         (xt/starting-from #inst "3000"))])]
 
     ;; as of tx tests
     (t/is (= [{:foo "2000-4000"}]

--- a/src/test/clojure/xtdb/datalog_test.clj
+++ b/src/test/clojure/xtdb/datalog_test.clj
@@ -16,8 +16,8 @@
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
 (def ivan+petr
-  [[:put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
-   [:put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
+  [(xt/put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"})
+   (xt/put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"})])
 
 (deftest test-scan
   (xt/submit-tx tu/*node* ivan+petr)
@@ -128,10 +128,10 @@
 ;; https://github.com/tonsky/datascript/blob/1.1.0/test/datascript/test/query.cljc#L12-L36
 (deftest datascript-test-joins
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id 1, :name "Ivan", :age 15}]
-                           [:put :xt_docs {:xt/id 2, :name "Petr", :age 37}]
-                           [:put :xt_docs {:xt/id 3, :name "Ivan", :age 37}]
-                           [:put :xt_docs {:xt/id 4, :age 15}]])]
+                          [(xt/put :xt_docs {:xt/id 1, :name "Ivan", :age 15})
+                           (xt/put :xt_docs {:xt/id 2, :name "Petr", :age 37})
+                           (xt/put :xt_docs {:xt/id 3, :name "Ivan", :age 37})
+                           (xt/put :xt_docs {:xt/id 4, :age 15})])]
 
     (t/is (= #{{:e 1, :v 15} {:e 3, :v 37}}
              (set (xt/q tu/*node*
@@ -181,8 +181,8 @@
           "cross join required here")))
 
 (deftest test-namespaced-attributes
-  (let [_tx (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :foo :foo/bar 1}]
-                                     [:put :xt_docs {:xt/id :bar :foo/bar 2}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :foo :foo/bar 1})
+                                     (xt/put :xt_docs {:xt/id :bar :foo/bar 2})])]
     (t/is (= [{:i :foo, :n 1} {:i :bar, :n 2}]
              (xt/q tu/*node*
                    '{:find [i n]
@@ -229,10 +229,10 @@
 ;; https://github.com/tonsky/datascript/blob/1.1.0/test/datascript/test/query_aggregates.cljc#L14-L39
 (t/deftest datascript-test-aggregates
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id :cerberus, :heads 3}]
-                           [:put :xt_docs {:xt/id :medusa, :heads 1}]
-                           [:put :xt_docs {:xt/id :cyclops, :heads 1}]
-                           [:put :xt_docs {:xt/id :chimera, :heads 1}]])]
+                          [(xt/put :xt_docs {:xt/id :cerberus, :heads 3})
+                           (xt/put :xt_docs {:xt/id :medusa, :heads 1})
+                           (xt/put :xt_docs {:xt/id :cyclops, :heads 1})
+                           (xt/put :xt_docs {:xt/id :chimera, :heads 1})])]
     (t/is (= #{{:heads 1, :count-heads 3} {:heads 3, :count-heads 1}}
              (set (xt/q tu/*node*
                         '{:find [heads (count heads)]
@@ -253,9 +253,9 @@
           "various aggs")))
 
 (t/deftest test-find-exprs
-  (let [_tx (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :o1, :unit-price 1.49, :quantity 4}]
-                                     [:put :xt_docs {:xt/id :o2, :unit-price 5.39, :quantity 1}]
-                                     [:put :xt_docs {:xt/id :o3, :unit-price 0.59, :quantity 7}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :o1, :unit-price 1.49, :quantity 4})
+                                     (xt/put :xt_docs {:xt/id :o2, :unit-price 5.39, :quantity 1})
+                                     (xt/put :xt_docs {:xt/id :o3, :unit-price 0.59, :quantity 7})])]
     (t/is (= #{{:oid :o1, :o-value 5.96}
                {:oid :o2, :o-value 5.39}
                {:oid :o3, :o-value 4.13}}
@@ -267,9 +267,9 @@
                                   [oid :quantity qty]]}))))))
 
 (deftest test-aggregate-exprs
-  (let [tx (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :foo, :category :c0, :v 1}]
-                                    [:put :xt_docs {:xt/id :bar, :category :c0, :v 2}]
-                                    [:put :xt_docs {:xt/id :baz, :category :c1, :v 4}]])]
+  (let [tx (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :foo, :category :c0, :v 1})
+                                    (xt/put :xt_docs {:xt/id :bar, :category :c0, :v 2})
+                                    (xt/put :xt_docs {:xt/id :baz, :category :c1, :v 4})])]
     (t/is (= [{:category :c0, :sum-doubles 6}
               {:category :c1, :sum-doubles 8}]
              (xt/q tu/*node*
@@ -482,8 +482,8 @@
 (deftest test-value-unification
   (let [_tx (xt/submit-tx tu/*node*
                           (conj ivan+petr
-                                [:put :xt_docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei"}]
-                                [:put :xt_docs {:xt/id :jeff :first-name "Sergei" :last-name "but-different"}]))]
+                                (xt/put :xt_docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei"})
+                                (xt/put :xt_docs {:xt/id :jeff :first-name "Sergei" :last-name "but-different"})))]
     (t/is (= [{:e :sergei, :n "Sergei"}]
              (xt/q
               tu/*node*
@@ -502,12 +502,12 @@
                              [f :first-name n]]}))))))
 
 (deftest test-implicit-match-unification
-  (xt/submit-tx tu/*node* [[:put :foo {:xt/id :ivan, :name "Ivan"}]
-                           [:put :foo {:xt/id :petr, :name "Petr"}]
-                           [:put :bar {:xt/id :sergei, :name "Sergei"}]
-                           [:put :bar {:xt/id :ivan,:name "Ivan"}]
-                           [:put :toto {:xt/id :jon, :name "John"}]
-                           [:put :toto {:xt/id :mat,:name "Matt"}]])
+  (xt/submit-tx tu/*node* [(xt/put :foo {:xt/id :ivan, :name "Ivan"})
+                           (xt/put :foo {:xt/id :petr, :name "Petr"})
+                           (xt/put :bar {:xt/id :sergei, :name "Sergei"})
+                           (xt/put :bar {:xt/id :ivan,:name "Ivan"})
+                           (xt/put :toto {:xt/id :jon, :name "John"})
+                           (xt/put :toto {:xt/id :mat,:name "Matt"})])
   (t/is (= [{:e :ivan, :name "Ivan"}]
            (xt/q tu/*node*
                  '{:find [e name]
@@ -523,9 +523,9 @@
 
 (deftest exists-with-no-outer-unification-692
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id :ivan, :name "Ivan"}]
-                           [:put :xt_docs {:xt/id :petr, :name "Petr"}]
-                           [:put :xt_docs {:xt/id :ivan2, :name "Ivan"}]])]
+                          [(xt/put :xt_docs {:xt/id :ivan, :name "Ivan"})
+                           (xt/put :xt_docs {:xt/id :petr, :name "Petr"})
+                           (xt/put :xt_docs {:xt/id :ivan2, :name "Ivan"})])]
 
     (t/is (= [{:e :ivan} {:e :ivan2}]
              (xt/q tu/*node*
@@ -552,9 +552,9 @@
 
 (deftest exists-with-keys-699
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id 1, :name "one"}]
-                           [:put :xt_docs {:xt/id 2, :name "two"}]
-                           [:put :xt_docs {:xt/id 3, :name "three"}]])]
+                          [(xt/put :xt_docs {:xt/id 1, :name "one"})
+                           (xt/put :xt_docs {:xt/id 2, :name "two"})
+                           (xt/put :xt_docs {:xt/id 3, :name "three"})])]
 
     (t/is (= [{:e 2} {:e 3}]
              (xt/q tu/*node*
@@ -569,10 +569,10 @@
 
 (deftest test-left-join
   (xt/submit-tx tu/*node*
-                [[:put :xt_docs {:xt/id :ivan, :name "Ivan"}]
-                 [:put :xt_docs {:xt/id :petr, :name "Petr", :parent :ivan}]
-                 [:put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
-                 [:put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])
+                [(xt/put :xt_docs {:xt/id :ivan, :name "Ivan"})
+                 (xt/put :xt_docs {:xt/id :petr, :name "Petr", :parent :ivan})
+                 (xt/put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr})
+                 (xt/put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr})])
 
   (t/is (= #{{:e :ivan, :c :petr}
              {:e :petr, :c :sergei}
@@ -614,10 +614,10 @@
 
 (deftest test-semi-join
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id :ivan, :name "Ivan"}]
-                           [:put :xt_docs {:xt/id :petr, :name "Petr", :parent :ivan}]
-                           [:put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
-                           [:put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])]
+                          [(xt/put :xt_docs {:xt/id :ivan, :name "Ivan"})
+                           (xt/put :xt_docs {:xt/id :petr, :name "Petr", :parent :ivan})
+                           (xt/put :xt_docs {:xt/id :sergei, :name "Sergei", :parent :petr})
+                           (xt/put :xt_docs {:xt/id :jeff, :name "Jeff", :parent :petr})])]
 
     (t/is (= #{{:e :ivan} {:e :petr}}
              (set (xt/q tu/*node*
@@ -653,9 +653,9 @@
 (deftest test-anti-join
   (let [_tx (xt/submit-tx
              tu/*node*
-             [[:put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1}]
-              [:put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov" :foo 1}]
-              [:put :xt_docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1}]])]
+             [(xt/put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1})
+              (xt/put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov" :foo 1})
+              (xt/put :xt_docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1})])]
 
     (t/is (= #{{:e :ivan} {:e :sergei}}
              (set (xt/q tu/*node*
@@ -831,9 +831,9 @@
                                                      [e :first-name "Sergei"]]})]}))))))
 
 (deftest test-simple-literals-in-find
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan, :age 15}]
-                           [:put :xt_docs {:xt/id :petr, :age 22}]
-                           [:put :xt_docs {:xt/id :slava, :age 37}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan, :age 15})
+                           (xt/put :xt_docs {:xt/id :petr, :age 22})
+                           (xt/put :xt_docs {:xt/id :slava, :age 37})])
 
 
   (t/is (= #{{:-column-0 1, :-column-1 "foo", :xt/id :ivan}
@@ -845,9 +845,9 @@
 
 (deftest calling-a-function-580
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id :ivan, :age 15}]
-                           [:put :xt_docs {:xt/id :petr, :age 22}]
-                           [:put :xt_docs {:xt/id :slava, :age 37}]])]
+                          [(xt/put :xt_docs {:xt/id :ivan, :age 15})
+                           (xt/put :xt_docs {:xt/id :petr, :age 22})
+                           (xt/put :xt_docs {:xt/id :slava, :age 37})])]
 
     (t/is (= #{{:e1 :petr, :e2 :ivan, :e3 :slava}
                {:e1 :ivan, :e2 :petr, :e3 :slava}}
@@ -878,7 +878,7 @@
                               [(+ a1 a2) a3]]}))))))
 
 (deftest test-namespaced-columns-within-match
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan :age 10}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan :age 10})])
   (t/is (= [{:xt/id :ivan, :age 10}]
            (xt/q tu/*node* '{:find [xt/id age]
                              :where [(match :xt_docs [xt/id])
@@ -894,9 +894,9 @@
 
 (deftest test-nested-expressions-581
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :xt_docs {:xt/id :ivan, :age 15}]
-                           [:put :xt_docs {:xt/id :petr, :age 22, :height 240, :parent 1}]
-                           [:put :xt_docs {:xt/id :slava, :age 37, :parent 2}]])]
+                          [(xt/put :xt_docs {:xt/id :ivan, :age 15})
+                           (xt/put :xt_docs {:xt/id :petr, :age 22, :height 240, :parent 1})
+                           (xt/put :xt_docs {:xt/id :slava, :age 37, :parent 2})])]
 
     (t/is (= #{{:e1 :ivan, :e2 :petr, :e3 :slava}
                {:e1 :petr, :e2 :ivan, :e3 :slava}}
@@ -948,10 +948,10 @@
                                [(+ a1 (+ a2 a3 1)) sum-ages]]}))))))
 
 (deftest test-union-join
-  (let [_tx (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan, :age 20, :role :developer}]
-                                     [:put :xt_docs {:xt/id :oleg, :age 30, :role :manager}]
-                                     [:put :xt_docs {:xt/id :petr, :age 35, :role :qa}]
-                                     [:put :xt_docs {:xt/id :sergei, :age 35, :role :manager}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan, :age 20, :role :developer})
+                                     (xt/put :xt_docs {:xt/id :oleg, :age 30, :role :manager})
+                                     (xt/put :xt_docs {:xt/id :petr, :age 35, :role :qa})
+                                     (xt/put :xt_docs {:xt/id :sergei, :age 35, :role :manager})])]
 
     (letfn [(q [query]
               (xt/q tu/*node* query))]
@@ -990,10 +990,10 @@
                                           [(+ age 10) older-age])]})))))))
 
 (deftest test-union-join-with-match-syntax-693
-  (let [_tx (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan, :age 20, :role :developer}]
-                                     [:put :xt_docs {:xt/id :oleg, :age 30, :role :manager}]
-                                     [:put :xt_docs {:xt/id :petr, :age 35, :role :qa}]
-                                     [:put :xt_docs {:xt/id :sergei, :age 35, :role :manager}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan, :age 20, :role :developer})
+                                     (xt/put :xt_docs {:xt/id :oleg, :age 30, :role :manager})
+                                     (xt/put :xt_docs {:xt/id :petr, :age 35, :role :qa})
+                                     (xt/put :xt_docs {:xt/id :sergei, :age 35, :role :manager})])]
     (t/is (= [{:e :ivan}]
              (xt/q tu/*node* '{:find [e]
                                :where [(union-join [e]
@@ -1008,10 +1008,10 @@
                                                         [e :xt/id :ivan]))]})))))
 
 (deftest test-union-join-with-subquery-638
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan, :age 20, :role :developer}]
-                           [:put :xt_docs {:xt/id :oleg, :age 30, :role :manager}]
-                           [:put :xt_docs {:xt/id :petr, :age 35, :role :qa}]
-                           [:put :xt_docs {:xt/id :sergei, :age 35, :role :manager}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan, :age 20, :role :developer})
+                           (xt/put :xt_docs {:xt/id :oleg, :age 30, :role :manager})
+                           (xt/put :xt_docs {:xt/id :petr, :age 35, :role :qa})
+                           (xt/put :xt_docs {:xt/id :sergei, :age 35, :role :manager})])
   (t/is (= [{:e :oleg}]
            (xt/q tu/*node* '{:find [e]
                              :where [(union-join [e]
@@ -1044,10 +1044,10 @@
         "films made by the Bond with the most films")
 
   (t/testing "(contrived) correlated sub-query"
-    (xt/submit-tx tu/*node* [[:put :a {:xt/id :a1, :a 1}]
-                             [:put :a {:xt/id :a2, :a 2}]
-                             [:put :b {:xt/id :b2, :b 2}]
-                             [:put :b {:xt/id :b3, :b 3}]])
+    (xt/submit-tx tu/*node* [(xt/put :a {:xt/id :a1, :a 1})
+                             (xt/put :a {:xt/id :a2, :a 2})
+                             (xt/put :b {:xt/id :b2, :b 2})
+                             (xt/put :b {:xt/id :b3, :b 3})])
 
     (t/is (= [{:aid :a2, :bid :b2}]
              (xt/q tu/*node*
@@ -1082,9 +1082,8 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)
-                                                   }])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)}))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))
 
@@ -1105,12 +1104,12 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)}])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)}))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))]
 
-      (xt/submit-tx node [[:put :xt_docs {:xt/id 0 :foo :bar}]])
+      (xt/submit-tx node [(xt/put :xt_docs {:xt/id 0 :foo :bar})])
       (submit-ops! (range 1010))
 
       (t/is (= 1010 (-> (xt/q node '{:find [(count id)]
@@ -1127,11 +1126,11 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)}])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)}))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))]
-      (let [_tx1 (xt/submit-tx node [[:put :xt_docs {:xt/id :some-doc}]])
+      (let [_tx1 (xt/submit-tx node [(xt/put :xt_docs {:xt/id :some-doc})])
             ;; going over the chunk boundary
             tx2 (submit-ops! (range 200))]
         (t/is (= [{:xt/id :some-doc}]
@@ -1140,9 +1139,9 @@
                                       [xt/id :xt/id :some-doc]]})))))))
 
 (deftest test-subquery-unification
-  (let [tx (xt/submit-tx tu/*node* [[:put :a {:xt/id :a1, :a 2 :b 1}]
-                                    [:put :a {:xt/id :a2, :a 2 :b 3}]
-                                    [:put :a {:xt/id :a3, :a 2 :b 0}]])]
+  (let [tx (xt/submit-tx tu/*node* [(xt/put :a {:xt/id :a1, :a 2 :b 1})
+                                    (xt/put :a {:xt/id :a2, :a 2 :b 3})
+                                    (xt/put :a {:xt/id :a3, :a 2 :b 0})])]
 
     (t/testing "variables returned from subqueries that must be run as an apply are unified"
 
@@ -1167,9 +1166,9 @@
 
 #_ ;; TODO currently don't work
 (deftest test-basic-rules
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :ivan :name "Ivan" :last-name "Ivanov" :age 21}]
-                           [:put :xt_docs {:xt/id :petr :name "Petr" :last-name "Petrov" :age 18}]
-                           [:put :xt_docs {:xt/id :georgy :name "Georgy" :last-name "George" :age 17}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :ivan :name "Ivan" :last-name "Ivanov" :age 21})
+                           (xt/put :xt_docs {:xt/id :petr :name "Petr" :last-name "Petrov" :age 18})
+                           (xt/put :xt_docs {:xt/id :georgy :name "Georgy" :last-name "George" :age 17})])
   (letfn [(q [query & args]
             (apply xt/q tu/*node* query args))]
     (t/testing "without rule"
@@ -1461,13 +1460,19 @@
     ;; 2023: Matthew, Mark (again)
     ;; 2024+: Matthew
 
-    (let [tx0 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in #inst "2015"]}]
-                                       [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in  #inst "2018"  #inst "2020"]}]
-                                       [:put :xt_docs {:xt/id :luke} {:for-valid-time [:in #inst "2021"]}]])
+    (let [tx0 (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id :matthew})
+                                           (xt/starting-from #inst "2015"))
+                                       (-> (xt/put :xt_docs {:xt/id :mark})
+                                           (xt/during #inst "2018" #inst "2020"))
+                                       (-> (xt/put :xt_docs {:xt/id :luke})
+                                           (xt/starting-from #inst "2021"))])
 
-          tx1 (xt/submit-tx tu/*node* [[:delete :xt_docs :luke {:for-valid-time [:in #inst "2022"]}]
-                                       [:put :xt_docs {:xt/id :mark} {:for-valid-time [:in #inst "2023" #inst "2024"]}]
-                                       [:put :xt_docs {:xt/id :john} {:for-valid-time [:in #inst "2016" #inst "2020"]}]])]
+          tx1 (xt/submit-tx tu/*node* [(-> (xt/delete :xt_docs :luke)
+                                           (xt/starting-from #inst "2022"))
+                                       (-> (xt/put :xt_docs {:xt/id :mark})
+                                           (xt/during #inst "2023" #inst "2024"))
+                                       (-> (xt/put :xt_docs {:xt/id :john})
+                                           (xt/during #inst "2016" #inst "2020"))])]
 
       (t/is (= #{{:id :matthew}, {:id :mark}}
                (set (q '{:find [id], :where [(match :xt_docs [{:xt/id id}])]}, tx1, #inst "2023"))))
@@ -1531,8 +1536,10 @@
             "for all sys time"))))
 
 (t/deftest test-for-valid-time-with-current-time-2493
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in nil #inst "2040"]}]])
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:in #inst "2022" #inst "2030"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id :matthew})
+                               (xt/until #inst "2040"))])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id :matthew})
+                               (xt/during #inst "2022" #inst "2030"))])
   (t/is (= #{{:id :matthew,
               :vt-from #time/zoned-date-time "2030-01-01T00:00Z[UTC]",
               :vt-to #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}
@@ -1558,9 +1565,12 @@
     ;; tx1
     ;; now - 2040 : Matthew
 
-    (let [tx0 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:from #inst "2015"]}]
-                                       [:put :xt_docs {:xt/id :mark} {:for-valid-time [:to #inst "2050"]}]])
-          tx1 (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :matthew} {:for-valid-time [:to #inst "2040"]}]])]
+    (let [tx0 (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id :matthew})
+                                           (xt/starting-from #inst "2015"))
+                                       (-> (xt/put :xt_docs {:xt/id :mark})
+                                           (xt/until #inst "2050"))])
+          tx1 (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id :matthew})
+                                           (xt/until #inst "2040"))])]
       (t/is (= #{{:id :matthew,
                   :vt-from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
                   :vt-to nil}
@@ -1600,53 +1610,55 @@
                   {:basis {:tx tx, :current-time (util/->instant current-time)}}))]
 
     (let [tx0 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-10"]}]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                 (xt/starting-from #inst "1998-01-10"))]
                             {:system-time #inst "1998-01-10"})
 
           tx1 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 827 :property-number 7797}
-                              {:for-valid-time [:in  #inst "1998-01-15"] }]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 827 :property-number 7797})
+                                 (xt/starting-from #inst "1998-01-15"))]
                             {:system-time #inst "1998-01-15"})
 
           _tx2 (xt/submit-tx tu/*node*
-                             [[:delete :docs 1 {:for-valid-time [:in #inst "1998-01-20"]}]]
+                             [(-> (xt/delete :docs 1)
+                                  (xt/starting-from #inst "1998-01-20"))]
                              {:system-time #inst "1998-01-20"})
 
           _tx3 (xt/submit-tx tu/*node*
-                             [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                               {:for-valid-time [:in #inst "1998-01-03" #inst "1998-01-10"]}]]
+                             [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                  (xt/during #inst "1998-01-03" #inst "1998-01-10"))]
                              {:system-time #inst "1998-01-23"})
 
           _tx4 (xt/submit-tx tu/*node*
-                             [[:delete :docs 1 {:for-valid-time [:in #inst "1998-01-03" #inst "1998-01-05"]}]]
+                             [(-> (xt/delete :docs 1) (xt/during #inst "1998-01-03" #inst "1998-01-05"))]
                              {:system-time #inst "1998-01-26"})
 
           tx5 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-05" #inst "1998-01-12"]}]
-                             [:put :docs {:xt/id 1 :customer-number 827 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-12" #inst "1998-01-20"]}]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                 (xt/during #inst "1998-01-05" #inst "1998-01-12"))
+                             (-> (xt/put :docs {:xt/id 1 :customer-number 827 :property-number 7797})
+                                 (xt/during #inst "1998-01-12" #inst "1998-01-20"))]
                             {:system-time #inst "1998-01-28"})
 
           tx6 (xt/submit-tx tu/*node*
-                            [[:put-fn :delete-1-week-records,
-                              '(fn delete-1-weeks-records []
-                                 (->> (q '{:find [id app-from app-to]
-                                           :where [(match :docs {:xt/id id
-                                                                 :xt/valid-from app-from
-                                                                 :xt/valid-to app-to}
-                                                          {:for-valid-time :all-time})
-                                                   [(= (- #inst "1970-01-08" #inst "1970-01-01")
-                                                       (- app-to app-from))]]})
-                                      (map (fn [{:keys [id app-from app-to]}]
-                                             [:delete :docs id {:for-valid-time [:in app-from app-to]}]))))]
-                             [:call :delete-1-week-records]]
+                            [(xt/put-fn :delete-1-week-records,
+                                        '(fn delete-1-weeks-records []
+                                           (->> (q '{:find [id app-from app-to]
+                                                     :where [(match :docs {:xt/id id
+                                                                           :xt/valid-from app-from
+                                                                           :xt/valid-to app-to}
+                                                                    {:for-valid-time :all-time})
+                                                             [(= (- #inst "1970-01-08" #inst "1970-01-01")
+                                                                 (- app-to app-from))]]})
+                                                (map (fn [{:keys [id app-from app-to]}]
+                                                       (-> (xt/delete :docs id)
+                                                           (xt/during app-from app-to)))))))
+                             (xt/call :delete-1-week-records)]
                             {:system-time #inst "1998-01-30"})
 
           tx7 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 2 :customer-number 827 :property-number 3621}
-                              {:for-valid-time [:in #inst "1998-01-15"]}]]
+                            [(-> (xt/put :docs {:xt/id 2 :customer-number 827 :property-number 3621})
+                                 (xt/starting-from #inst "1998-01-15"))]
                             {:system-time #inst "1998-01-31"})]
 
       (t/is (= [{:cust 145 :app-from (util/->zdt #inst "1998-01-10")}]
@@ -1784,11 +1796,11 @@
             "Case 8: Application-time sequenced and system-time nonsequenced"))))
 
 (deftest scalar-sub-queries-test
-  (xt/submit-tx tu/*node* [[:put :customer {:xt/id 0, :firstname "bob", :lastname "smith"}]
-                           [:put :customer {:xt/id 1, :firstname "alice" :lastname "carrol"}]
-                           [:put :order {:xt/id 0, :customer 0, :items [{:sku "eggs", :qty 1}]}]
-                           [:put :order {:xt/id 1, :customer 0, :items [{:sku "cheese", :qty 3}]}]
-                           [:put :order {:xt/id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]}]])
+  (xt/submit-tx tu/*node* [(xt/put :customer {:xt/id 0, :firstname "bob", :lastname "smith"})
+                           (xt/put :customer {:xt/id 1, :firstname "alice" :lastname "carrol"})
+                           (xt/put :order {:xt/id 0, :customer 0, :items [{:sku "eggs", :qty 1}]})
+                           (xt/put :order {:xt/id 1, :customer 0, :items [{:sku "cheese", :qty 3}]})
+                           (xt/put :order {:xt/id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]})])
 
   (t/are [q result] (= (into #{} result) (set (xt/q tu/*node* q)))
     '{:find [n-customers]
@@ -1914,8 +1926,10 @@
 
 (deftest test-period-predicates
 
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1} {:for-valid-time [:in #inst "2015" #inst "2020"]}]
-                           [:put :xt_cats {:xt/id 2} {:for-valid-time [:in #inst "2016" #inst "2018"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1})
+                               (xt/during #inst "2015" #inst "2020"))
+                           (-> (xt/put :xt_cats {:xt/id 2})
+                               (xt/during #inst "2016" #inst "2018"))])
 
   (t/is (= [{:xt/id 1, :id2 2,
              :xt-docs-app-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
@@ -1972,21 +1986,21 @@
             :where [[(period #inst "2022" #inst "2020") p1]]}))))
 
 (deftest test-period-and-temporal-col-projection
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1} {:for-valid-time [:in #inst "2015" #inst "2050"]}]])
-
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1})
+                               (xt/during #inst "2015" #inst "2050"))])
 
   (t/is (= [{:xt/id 1,
-             :app-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
-                        :to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"},
+             :valid-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
+                          :to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"},
              :xt/valid-from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
-             :app-time-to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
+             :valid-to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
            (xt/q
             tu/*node*
-            '{:find [xt/id app_time xt/valid-from app-time-to]
+            '{:find [xt/id valid-time xt/valid-from valid-to]
               :where [(match :xt_docs
                         [xt/id xt/valid-from
-                         {:xt/valid-time app_time
-                          :xt/valid-to app-time-to}]
+                         {:xt/valid-time valid-time
+                          :xt/valid-to valid-to}]
                         {:for-valid-time :all-time})]}))
         "projecting both period and underlying cols")
 
@@ -2035,7 +2049,7 @@
                               :for-system-time :all-time})]}))
         "period unification")
 
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 2}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id 2})])
 
   (t/is (= [{:xt/id 2,
              :time {:from #time/zoned-date-time "2020-01-02T00:00Z[UTC]",
@@ -2049,9 +2063,10 @@
                               :for-system-time :all-time})]}))
         "period unification within match")
 
-  (xt/submit-tx tu/*node* [[:put :xt_docs
-                            {:xt/id 3 :c {:from #inst "2015" :to #inst "2050"}}
-                            {:for-valid-time [:in #inst "2015" #inst "2050"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs
+                                       {:xt/id 3 :c {:from #inst "2015" :to #inst "2050"}})
+
+                               (xt/during #inst "2015" #inst "2050"))])
 
   (t/is (= [{:xt/id 3,
              :time
@@ -2068,7 +2083,8 @@
         "period unification within match with user period column"))
 
 (deftest test-period-literal-match
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1} {:for-valid-time [:in #inst "2015" #inst "2050"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1})
+                               (xt/during #inst "2015" #inst "2050"))])
 
   (t/is (thrown-with-msg?
          IllegalArgumentException
@@ -2195,8 +2211,10 @@
    "variables not exposed by subquery"))
 
 (t/deftest test-default-valid-time
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :foo "2000-4000"} {:for-valid-time [:in #inst "2000" #inst "4000"]}]
-                           [:put :xt_docs {:xt/id 1 :foo "3000-"} {:for-valid-time [:from #inst "3000"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt_docs {:xt/id 1 :foo "2000-4000"})
+                               (xt/during #inst "2000" #inst "4000"))
+                           (-> (xt/put :xt_docs {:xt/id 1 :foo "3000-"})
+                               (xt/starting-from #inst "3000"))])
 
   (t/is (= #{{:xt/id 1, :foo "2000-4000"} {:xt/id 1, :foo "3000-"}}
            (set (xt/q tu/*node*
@@ -2205,7 +2223,7 @@
                       {:default-all-valid-time? true})))))
 
 (t/deftest test-sql-insert
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES (0)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id) VALUES (0)")])
   (t/is (= [{:xt/id 0}]
            (xt/q tu/*node*
                  '{:find [xt/id]
@@ -2213,7 +2231,7 @@
 
 
 (t/deftest test-dml-insert
-  (xt/submit-tx tu/*node* [[:put :foo {:xt/id 0}]])
+  (xt/submit-tx tu/*node* [(xt/put :foo {:xt/id 0})])
   (t/is (= [{:id 0}]
            (xt/q tu/*node*
                  '{:find [id]
@@ -2221,16 +2239,16 @@
 
 (t/deftest test-metadata-filtering-for-time-data-607
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1}})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id 1 :from-date #time/date "2000-01-01"}]
-                        [:put :xt_docs {:xt/id 2 :from-date #time/date "3000-01-01"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id 1 :from-date #time/date "2000-01-01"})
+                        (xt/put :xt_docs {:xt/id 2 :from-date #time/date "3000-01-01"})])
     (t/is (= [{:id 1}]
              (xt/q node
                    '{:find [id]
                      :where [(match :xt_docs [{:xt/id id} from-date])
                              [(>= from-date #inst "1500")]
                              [(< from-date #inst "2500")]]})))
-    (xt/submit-tx node [[:put :xt_docs2 {:xt/id 1 :from-date #inst "2000-01-01"}]
-                        [:put :xt_docs2 {:xt/id 2 :from-date #inst "3000-01-01"}]])
+    (xt/submit-tx node [(xt/put :xt_docs2 {:xt/id 1 :from-date #inst "2000-01-01"})
+                        (xt/put :xt_docs2 {:xt/id 2 :from-date #inst "3000-01-01"})])
     (t/is (= [{:id 1}]
              (xt/q node
                    '{:find [id]
@@ -2239,7 +2257,7 @@
                              [(< from-date #time/date "2500-01-01")]]})))))
 
 (t/deftest bug-non-namespaced-nested-keys-747
-  (xt/submit-tx tu/*node* [[:put :bar {:xt/id 1 :foo {:a/b "foo"}}]])
+  (xt/submit-tx tu/*node* [(xt/put :bar {:xt/id 1 :foo {:a/b "foo"}})])
   (t/is (= [{:foo {:a/b "foo"}}]
            (xt/q tu/*node*
                  '{:find [foo]
@@ -2261,7 +2279,7 @@
 
         _
         (doseq [[doc system-time] inputs]
-          (xt/submit-tx tu/*node* [[:put :x doc]] {:system-time system-time}))
+          (xt/submit-tx tu/*node* [(xt/put :x doc)] {:system-time system-time}))
 
         q (partial xt/q tu/*node*)]
 
@@ -2287,7 +2305,8 @@
 
         _
         (doseq [[doc app-time] inputs]
-          (xt/submit-tx tu/*node* [[:put :x doc {:for-valid-time [:in app-time]}]]))
+          (xt/submit-tx tu/*node* [(-> (xt/put :x doc)
+                                       (xt/starting-from app-time))]))
 
         q (partial xt/q tu/*node*)]
 
@@ -2304,7 +2323,7 @@
                   :where [($ :x {:xt/* x} {:for-valid-time [:at #time/instant "2023-01-17T00:00:00Z"]})]})))))
 
 (t/deftest test-normalisation
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/hELLo-wORLd 2}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/hELLo-wORLd 2})])
   (t/is (= [{:foo/bar 1, :bar.foo/hello-world 2}]
            (xt/q tu/*node* '{:find [Foo/Bar Bar.Foo/Hello-World]
                              :where [(match :xt-docs [Foo/Bar Bar.Foo/Hello-World])]})))
@@ -2314,7 +2333,7 @@
 
 (t/deftest test-table-normalisation
   (let [doc {:xt/id "doc" :foo "bar"}]
-    (xt/submit-tx tu/*node* [[:put :xt/the-docs doc]])
+    (xt/submit-tx tu/*node* [(xt/put :xt/the-docs doc)])
     (t/is (= [{:id "doc"}]
              (xt/q tu/*node* '{:find [id]
                                :where [(match :xt/the-docs {:xt/id id})]})))
@@ -2323,13 +2342,15 @@
                                :where [(match :xt/the-docs {:xt/* doc})]})))))
 
 (t/deftest test-inconsistent-valid-time-range-2494
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1} {:for-valid-time [:in nil #inst "2011"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt-docs {:xt/id 1})
+                               (xt/until #inst "2011"))])
   (t/is (= [{:tx-id 0, :committed? false}]
            (xt/q tu/*node* '{:find [tx-id committed?]
                              :where [($ :xt/txs {:xt/id tx-id,
                                                  :xt/committed? committed?})]})))
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 2}]])
-  (xt/submit-tx tu/*node* [[:delete :xt-docs 2 {:for-valid-time [:in nil #inst "2011"]}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 2})])
+  (xt/submit-tx tu/*node* [(-> (xt/delete :xt-docs 2)
+                               (xt/until #inst "2011"))])
   (t/is (= #{{:tx-id 0, :committed? false}
              {:tx-id 1, :committed? true}
              {:tx-id 2, :committed? false}}
@@ -2353,7 +2374,7 @@
                                     :xtdb.tx-producer/tx-producer {:instant-src (tu/->mock-clock)}
                                     :xtdb.log/memory-log {:instant-src (tu/->mock-clock)}})]
     (doseq [i (range 10)]
-      (xt/submit-tx node [[:put :ints {:xt/id 0 :n i}]]))
+      (xt/submit-tx node [(xt/put :ints {:xt/id 0 :n i})]))
 
     (t/is (=
            #{{:n 0,
@@ -2380,10 +2401,12 @@
                                                              {:for-valid-time [:in #inst "2020-01-01" #inst "2020-01-06"]})]}))))))
 
 (deftest test-no-zero-width-intervals
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1 :v 1}]
-                           [:put :xt-docs {:xt/id 1 :v 2}]
-                           [:put :xt-docs {:xt/id 2 :v 1} {:for-valid-time [:in #inst "2020-01-01" #inst "2020-01-02"]}]])
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 2 :v 2} {:for-valid-time [:in #inst "2020-01-01" #inst "2020-01-02"]}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 1 :v 1})
+                           (xt/put :xt-docs {:xt/id 1 :v 2})
+                           (-> (xt/put :xt-docs {:xt/id 2 :v 1})
+                               (xt/during #inst "2020-01-01" #inst "2020-01-02"))])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt-docs {:xt/id 2 :v 2})
+                               (xt/during #inst "2020-01-01" #inst "2020-01-02"))])
   (t/is (= [{:v 2}]
            (xt/q tu/*node*
                  '{:find [v]
@@ -2396,8 +2419,8 @@
         "no zero width valid-time intervals"))
 
 (deftest row-alias-on-txs-tables-2809
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1 :v 1}]])
-  (xt/submit-tx tu/*node* [[:call :non-existing-fn]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 1 :v 1})])
+  (xt/submit-tx tu/*node* [(xt/call :non-existing-fn)])
 
   (let [txs (->> (xt/q tu/*node*
                        '{:find [tx]

--- a/src/test/clojure/xtdb/default_tz_test.clj
+++ b/src/test/clojure/xtdb/default_tz_test.clj
@@ -23,8 +23,8 @@
 
 (t/deftest can-specify-default-tz-in-dml-396
   (let [q "INSERT INTO foo (xt$id, dt, tstz) VALUES (?, DATE '2020-08-01', CAST(DATE '2020-08-01' AS TIMESTAMP WITH TIME ZONE))"]
-    (xt/submit-tx tu/*node* [[:sql [q "foo"]]])
-    (let [tx (xt/submit-tx tu/*node* [[:sql [q "bar"]]]
+    (xt/submit-tx tu/*node* [(-> (xt/sql-op q) (xt/with-op-args ["foo"]))])
+    (let [tx (xt/submit-tx tu/*node* [(-> (xt/sql-op q) (xt/with-op-args ["bar"]))]
                            {:default-tz #time/zone "America/Los_Angeles"})
           q "SELECT foo.xt$id, foo.dt, CAST(foo.dt AS TIMESTAMP WITH TIME ZONE) cast_tstz, foo.tstz FROM foo"]
 

--- a/src/test/clojure/xtdb/docker_test.clj
+++ b/src/test/clojure/xtdb/docker_test.clj
@@ -191,7 +191,7 @@
     (with-open [node (->> {:xtdb.log/local-directory-log {:root-path (io/file hostdir "log")}
                            :xtdb.buffer-pool/local {:path (io/file hostdir "objects")}}
                           (xtn/start-node))]
-      (-> (node/snapshot-async node (xt/submit-tx node [[:put {:xt/id 42, :greeting "Hello, world!"}]]))
+      (-> (node/snapshot-async node (xt/submit-tx node [(xt/put {:xt/id 42, :greeting "Hello, world!"})]))
           (.orTimeout 5 TimeUnit/SECONDS)
           deref))
 

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -96,21 +96,22 @@
       (t/is (= 0 (HashTrie/bucketFor (.getDataPointer iid-vec 0) 104))))))
 
 (def txs
-  [[[:put :hello {:xt/id #uuid "cb8815ee-85f7-4c61-a803-2ea1c949cf8d" :a 1}]
-    [:put :world {:xt/id #uuid "424f5622-c826-4ded-a5db-e2144d665c38" :b 2}]]
-   [[:delete :hello #uuid "cb8815ee-85f7-4c61-a803-2ea1c949cf8d"]
-    [:put :world {:xt/id #uuid "424f5622-c826-4ded-a5db-e2144d665c38" :b 3}
-     {:for-valid-time [:in #inst "2023" #inst "2024"]}]]
-   [[:evict :world #uuid "424f5622-c826-4ded-a5db-e2144d665c38"]]
+  [[(xt/put :hello {:xt/id #uuid "cb8815ee-85f7-4c61-a803-2ea1c949cf8d" :a 1})
+    (xt/put :world {:xt/id #uuid "424f5622-c826-4ded-a5db-e2144d665c38" :b 2})]
+   [(xt/delete :hello #uuid "cb8815ee-85f7-4c61-a803-2ea1c949cf8d")
+    (-> (xt/put :world {:xt/id #uuid "424f5622-c826-4ded-a5db-e2144d665c38" :b 3})
+
+        (xt/during #inst "2023" #inst "2024"))]
+   [(xt/erase :world #uuid "424f5622-c826-4ded-a5db-e2144d665c38")]
    ;; sql
-   [[:sql "INSERT INTO foo (xt$id, bar, toto) VALUES (1, 1, 'toto')"]
-    [:sql "UPDATE foo SET bar = 2 WHERE foo.xt$id = 1"]
-    [:sql "DELETE FROM foo WHERE foo.bar = 2"]
-    [:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 2)"]]
+   [(xt/sql-op "INSERT INTO foo (xt$id, bar, toto) VALUES (1, 1, 'toto')")
+    (xt/sql-op "UPDATE foo SET bar = 2 WHERE foo.xt$id = 1")
+    (xt/sql-op "DELETE FROM foo WHERE foo.bar = 2")
+    (xt/sql-op "INSERT INTO foo (xt$id, bar) VALUES (2, 2)")]
    ;; sql evict
-   [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]]
+   [(xt/sql-op "ERASE FROM foo WHERE foo.xt$id = 2")]
    ;; abort
-   [[:sql "INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')"]]])
+   [(xt/sql-op "INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')")]])
 
 (t/deftest can-build-live-index
   (let [node-dir (util/->path "target/can-build-live-index")]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -25,48 +25,48 @@
 (t/use-fixtures :once tu/with-allocator)
 
 (def txs
-  [[[:put :device-info
-     {:xt/id "device-info-demo000000",
-      :api-version "23",
-      :manufacturer "iobeam",
-      :model "pinto",
-      :os-name "6.0.1"}]
-    [:put :device-readings
-     {:xt/id "reading-demo000000",
-      :device-id "device-info-demo000000",
-      :cpu-avg-15min 8.654,
-      :rssi -50.0,
-      :cpu-avg-5min 10.802,
-      :battery-status "discharging",
-      :ssid "demo-net",
-      :time #inst "2016-11-15T12:00:00.000-00:00",
-      :battery-level 59.0,
-      :bssid "01:02:03:04:05:06",
-      :battery-temperature 89.5,
-      :cpu-avg-1min 24.81,
-      :mem-free 4.10011078E8,
-      :mem-used 5.89988922E8}]]
-   [[:put :device-info
-     {:xt/id "device-info-demo000001",
-      :api-version "23",
-      :manufacturer "iobeam",
-      :model "mustang",
-      :os-name "6.0.1"}]
-    [:put :device-readings
-     {:xt/id "reading-demo000001",
-      :device-id "device-info-demo000001",
-      :cpu-avg-15min 8.822,
-      :rssi -61.0,
-      :cpu-avg-5min 8.106,
-      :battery-status "discharging",
-      :ssid "stealth-net",
-      :time #inst "2016-11-15T12:00:00.000-00:00",
-      :battery-level 86.0,
-      :bssid "A0:B1:C5:D2:E0:F3",
-      :battery-temperature 93.7,
-      :cpu-avg-1min 4.93,
-      :mem-free 7.20742332E8,
-      :mem-used 2.79257668E8}]]])
+  [[(xt/put :device-info
+            {:xt/id "device-info-demo000000",
+             :api-version "23",
+             :manufacturer "iobeam",
+             :model "pinto",
+             :os-name "6.0.1"})
+    (xt/put :device-readings
+            {:xt/id "reading-demo000000",
+             :device-id "device-info-demo000000",
+             :cpu-avg-15min 8.654,
+             :rssi -50.0,
+             :cpu-avg-5min 10.802,
+             :battery-status "discharging",
+             :ssid "demo-net",
+             :time #inst "2016-11-15T12:00:00.000-00:00",
+             :battery-level 59.0,
+             :bssid "01:02:03:04:05:06",
+             :battery-temperature 89.5,
+             :cpu-avg-1min 24.81,
+             :mem-free 4.10011078E8,
+             :mem-used 5.89988922E8})]
+   [(xt/put :device-info
+            {:xt/id "device-info-demo000001",
+             :api-version "23",
+             :manufacturer "iobeam",
+             :model "mustang",
+             :os-name "6.0.1"})
+    (xt/put :device-readings
+            {:xt/id "reading-demo000001",
+             :device-id "device-info-demo000001",
+             :cpu-avg-15min 8.822,
+             :rssi -61.0,
+             :cpu-avg-5min 8.106,
+             :battery-status "discharging",
+             :ssid "stealth-net",
+             :time #inst "2016-11-15T12:00:00.000-00:00",
+             :battery-level 86.0,
+             :bssid "A0:B1:C5:D2:E0:F3",
+             :battery-temperature 93.7,
+             :cpu-avg-1min 4.93,
+             :mem-free 7.20742332E8,
+             :mem-used 2.79257668E8})]])
 
 (def magic-last-tx-id
   "This value will change if you vary the structure of log entries, such
@@ -161,7 +161,7 @@
 
 (t/deftest temporal-watermark-is-immutable-2354
   (with-open [node (xtn/start-node {})]
-    (let [{tt :system-time, :as tx} (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :version 0}]]
+    (let [{tt :system-time, :as tx} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 0})]
                                                   {:default-all-valid-time? false})]
       (t/is (= [{:xt/id :foo, :version 0,
                  :xt/valid-from (util/->zdt tt)
@@ -174,7 +174,7 @@
                                xt$system_from, xt$system_to]]
                             {:node node})))
 
-      (let [{tt2 :system-time} (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :version 1}]]
+      (let [{tt2 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 1})]
                                              {:default-all-valid-time? false})]
         (t/is (= #{{:xt/id :foo, :version 0,
                     :xt/valid-from (util/->zdt tt2)
@@ -211,16 +211,16 @@
 
 (t/deftest can-handle-dynamic-cols-in-same-block
   (let [node-dir (util/->path "target/can-handle-dynamic-cols-in-same-block")
-        tx-ops [[:put :xt_docs {:xt/id "foo"
-                                :list [12.0 "foo"]}]
-                [:put :xt_docs {:xt/id 24}]
-                [:put :xt_docs {:xt/id "bar"
-                                :list [#inst "2020-01-01" false]}]
-                [:put :xt_docs {:xt/id :baz
-                                :struct {:a 1, :b "b"}}]
-                [:put :xt_docs {:xt/id 52}]
-                [:put :xt_docs {:xt/id :quux
-                                :struct {:a true, :c "c"}}]]]
+        tx-ops [(xt/put :xt_docs {:xt/id "foo"
+                                  :list [12.0 "foo"]})
+                (xt/put :xt_docs {:xt/id 24})
+                (xt/put :xt_docs {:xt/id "bar"
+                                  :list [#inst "2020-01-01" false]})
+                (xt/put :xt_docs {:xt/id :baz
+                                  :struct {:a 1, :b "b"}})
+                (xt/put :xt_docs {:xt/id 52})
+                (xt/put :xt_docs {:xt/id :quux
+                                  :struct {:a true, :c "c"}})]]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
@@ -234,16 +234,16 @@
 
 (t/deftest test-multi-block-metadata
   (let [node-dir (util/->path "target/multi-block-metadata")
-        tx0 [[:put :xt_docs {:xt/id "foo"
-                             :list [12.0 "foo"]}]
-             [:put :xt_docs {:xt/id :bar
-                             :struct {:a 1, :b "b"}}]
-             [:put :xt_docs {:xt/id "baz"
-                             :list [#inst "2020-01-01" false]}]
-             [:put :xt_docs {:xt/id 24}]]
-        tx1 [[:put :xt_docs {:xt/id 52}]
-             [:put :xt_docs {:xt/id :quux
-                             :struct {:a true, :b {:c "c", :d "d"}}}]]]
+        tx0 [(xt/put :xt_docs {:xt/id "foo"
+                               :list [12.0 "foo"]})
+             (xt/put :xt_docs {:xt/id :bar
+                               :struct {:a 1, :b "b"}})
+             (xt/put :xt_docs {:xt/id "baz"
+                               :list [#inst "2020-01-01" false]})
+             (xt/put :xt_docs {:xt/id 24})]
+        tx1 [(xt/put :xt_docs {:xt/id 52})
+             (xt/put :xt_docs {:xt/id :quux
+                               :struct {:a true, :b {:c "c", :d "d"}}})]]
     (util/delete-dir node-dir)
 
     (util/with-open [node (tu/->local-node {:node-dir node-dir, :rows-per-block 3})]
@@ -289,11 +289,11 @@
 
 (t/deftest round-trips-nils
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id "nil-bar"
-                                        :foo "foo"
-                                        :bar nil}]
-                        [:put :xt_docs {:xt/id "no-bar"
-                                        :foo "foo"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id "nil-bar"
+                                          :foo "foo"
+                                          :bar nil})
+                        (xt/put :xt_docs {:xt/id "no-bar"
+                                          :foo "foo"})])
     (t/is (= [{:id "nil-bar", :foo "foo", :bar nil}
               {:id "no-bar", :foo "foo"}]
              (xt/q node '{:find [id foo bar]
@@ -308,7 +308,7 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
-      (-> (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :uuid uuid}]])
+      (-> (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :uuid uuid})])
           (tu/then-await-tx node (Duration/ofMillis 2000)))
 
       (tu/finish-chunk! node)
@@ -329,15 +329,16 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
-      (xt/submit-tx node [[:put :xt_docs {:xt/id "foo"}]
-                          [:put :xt_docs {:xt/id "bar"}]])
+      (xt/submit-tx node [(xt/put :xt_docs {:xt/id "foo"})
+                          (xt/put :xt_docs {:xt/id "bar"})])
 
       ;; aborted tx shows up in log
-      (xt/submit-tx node [[:sql "INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')"]])
+      (xt/submit-tx node [(xt/sql-op "INSERT INTO foo (xt$id, xt$valid_from, xt$valid_to) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')")])
 
-      (-> (xt/submit-tx node [[:delete :xt_docs "foo" {:for-valid-time [:in #inst "2020-04-01"]}]
-                              [:put :xt_docs {:xt/id "bar", :month "april"},
-                               {:for-valid-time [:in #inst "2020-04-01" #inst "2020-05-01"]}]])
+      (-> (xt/submit-tx node [(-> (xt/delete :xt_docs "foo")
+                                  (xt/starting-from #inst "2020-04-01"))
+                              (-> (xt/put :xt_docs {:xt/id "bar", :month "april"},)
+                                  (xt/during #inst "2020-04-01" #inst "2020-05-01"))])
           (tu/then-await-tx node))
 
       (tu/finish-chunk! node)
@@ -384,7 +385,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put (:table (meta doc)) doc])]
+                     (xt/put (:table (meta doc)) doc))]
 
         (t/is (= 11000 (count tx-ops)))
 
@@ -428,7 +429,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put (:table (meta doc)) doc])]
+                     (xt/put (:table (meta doc)) doc))]
 
         (t/is (= 11000 (count tx-ops)))
 
@@ -439,7 +440,7 @@
                            (partition-all 100 tx-ops))]
 
           (Thread/sleep 250) ; wait for the chunk to finish writing to disk
-                             ; we don't have an accessible hook for this, beyond awaiting the tx
+                                        ; we don't have an accessible hook for this, beyond awaiting the tx
           (doseq [^Node node (shuffle (take 6 (cycle [node-1 node-2 node-3])))
                   :let [^IBufferPool bp (util/component node :xtdb/buffer-pool)
                         ^IMetadataManager mm (util/component node ::meta/metadata-manager)]]
@@ -468,7 +469,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put (:table (meta doc)) doc])
+                     (xt/put (:table (meta doc)) doc))
             [first-half-tx-ops second-half-tx-ops] (split-at (/ (count tx-ops) 2) tx-ops)]
 
         (t/is (= 5500 (count first-half-tx-ops)))
@@ -495,7 +496,7 @@
                 (t/is (< next-chunk-idx (count first-half-tx-ops)))
 
                 (Thread/sleep 250) ; wait for the chunk to finish writing to disk
-                                   ; we don't have an accessible hook for this, beyond awaiting the tx
+                                        ; we don't have an accessible hook for this, beyond awaiting the tx
                 (let [objs (mapv str (.listObjects bp))]
                   (t/is (= 5 (count (filter #(re-matches #"chunk-metadata/\p{XDigit}+\.transit.json" %) objs))))
                   (t/is (= 4 (count (filter #(re-matches #"tables/device_info/(.+?)/.+\.arrow" %) objs))))
@@ -535,7 +536,7 @@
                     (t/is (= second-half-tx-key (tu/latest-completed-tx node))))
 
                   (Thread/sleep 250) ; wait for the chunk to finish writing to disk
-                                     ; we don't have an accessible hook for this, beyond awaiting the tx
+                                        ; we don't have an accessible hook for this, beyond awaiting the tx
                   (doseq [^Node node [new-node node]
                           :let [^IBufferPool bp (tu/component node :xtdb/buffer-pool)
                                 ^IMetadataManager mm (tu/component node ::meta/metadata-manager)]]
@@ -559,7 +560,7 @@
     (with-open [node1 (tu/->local-node (assoc node-opts :buffers-dir "objects-1"))]
       (let [^IMetadataManager mm1 (tu/component node1 ::meta/metadata-manager)]
 
-        (-> (xt/submit-tx node1 [[:put :xt_docs {:xt/id 0, :v "foo"}]])
+        (-> (xt/submit-tx node1 [(xt/put :xt_docs {:xt/id 0, :v "foo"})])
             (tu/then-await-tx node1 (Duration/ofSeconds 1)))
 
         (tu/finish-chunk! node1)
@@ -567,9 +568,9 @@
         (t/is (=  :utf8
                   (types/field->col-type (.columnField mm1 "xt_docs" "v"))))
 
-        (let [tx2 (xt/submit-tx node1 [[:put :xt_docs {:xt/id 1, :v :bar}]
-                                       [:put :xt_docs {:xt/id 2, :v #uuid "8b190984-2196-4144-9fa7-245eb9a82da8"}]
-                                       [:put :xt_docs {:xt/id 3, :v #xt/clj-form :foo}]])]
+        (let [tx2 (xt/submit-tx node1 [(xt/put :xt_docs {:xt/id 1, :v :bar})
+                                       (xt/put :xt_docs {:xt/id 2, :v #uuid "8b190984-2196-4144-9fa7-245eb9a82da8"})
+                                       (xt/put :xt_docs {:xt/id 3, :v #xt/clj-form :foo})])]
           (tu/then-await-tx tx2 node1 (Duration/ofMillis 200))
 
           (tu/finish-chunk! node1)
@@ -594,7 +595,7 @@
                                  (log* logger level throwable message))))]
       (with-open [node (xtn/start-node {})]
         (t/is (thrown-with-msg? Exception #"oh no!"
-                                (-> (xt/submit-tx node [[:put :xt_docs {:xt/id "foo", :count 42}]])
+                                (-> (xt/submit-tx node [(xt/put :xt_docs {:xt/id "foo", :count 42})])
                                     (tu/then-await-tx node (Duration/ofSeconds 1)))))))))
 
 (t/deftest bug-catch-closed-by-interrupt-exception-740
@@ -607,7 +608,7 @@
                                  (log* logger level throwable message))))]
       (with-open [node (xtn/start-node {})]
         (t/is (thrown-with-msg? Exception #"ClosedByInterruptException"
-                                (-> (xt/submit-tx node [[:sql "INSERT INTO foo(xt$id) VALUES (1)"]])
+                                (-> (xt/submit-tx node [(xt/sql-op "INSERT INTO foo(xt$id) VALUES (1)")])
                                     (tu/then-await-tx node (Duration/ofSeconds 1)))))))))
 
 (t/deftest test-indexes-sql-insert
@@ -621,9 +622,10 @@
 
         (let [last-tx-key (xt/map->TransactionKey {:tx-id 0, :system-time (util/->instant #inst "2020-01-01")})]
           (t/is (= last-tx-key
-                   (xt/submit-tx node [[:sql-batch ["INSERT INTO table (xt$id, foo, bar, baz) VALUES (?, ?, ?, ?)"
-                                                    [0, 2, "hello", 12]
-                                                    [1, 1, "world", 3.3]]]])))
+                   (xt/submit-tx node [(-> (xt/sql-op "INSERT INTO table (xt$id, foo, bar, baz) VALUES (?, ?, ?, ?)")
+                                           (xt/with-op-args
+                                             [0, 2, "hello", 12]
+                                             [1, 1, "world", 3.3]))])))
 
           (t/is (= last-tx-key
                    (tu/then-await-tx last-tx-key node (Duration/ofSeconds 1)))))

--- a/src/test/clojure/xtdb/james_bond.clj
+++ b/src/test/clojure/xtdb/james_bond.clj
@@ -1,12 +1,13 @@
 (ns xtdb.james-bond
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [xtdb.api :as xt]))
 
 (def tx-ops
   (vec
    (for [doc (read-string (slurp (io/resource "james-bond.edn")))]
-     [:put (keyword (:type doc))
-      (-> doc
-          (dissoc :type)
-          ;; no sets as yet
-          (update :film/vehicles vec)
-          (update :film/bond-girls vec))])))
+     (xt/put (keyword (:type doc))
+             (-> doc
+                 (dissoc :type)
+                 ;; no sets as yet
+                 (update :film/vehicles vec)
+                 (update :film/bond-girls vec))))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -9,7 +9,7 @@
 (t/deftest ^:requires-docker ^:kafka test-kafka
   (let [topic-name (str "xtdb.kafka-test." (UUID/randomUUID))]
     (with-open [node (xtn/start-node {::k/log {:topic-name topic-name}})]
-      (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
+      (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo})])
 
       (t/is (= [{:xt/id :foo}]
                (tu/query-ra '[:scan {:table xt_docs} [xt/id]]

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -16,9 +16,10 @@
 
 (t/deftest test-param-metadata-error-310
   (let [tx1 (xt/submit-tx tu/*node*
-                          [[:sql-batch ["INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)"
-                                        ["dave", "Dave", #inst "2018"]
-                                        ["claire", "Claire", #inst "2019"]]]])]
+                          [(-> (xt/sql-op "INSERT INTO users (xt$id, name, xt$valid_from) VALUES (?, ?, ?)")
+                               (xt/with-op-args
+                                 ["dave", "Dave", #inst "2018"]
+                                 ["claire", "Claire", #inst "2019"]))])]
 
     (t/is (= [{:name "Dave"}]
              (xt/q tu/*node* ["SELECT users.name FROM users WHERE users.xt$id = ?" "dave"]
@@ -26,12 +27,12 @@
           "#310")))
 
 (deftest test-bloom-filter-for-num-types-2133
-  (let [tx (-> (xt/submit-tx tu/*node* [[:put :xt_docs {:num 0 :xt/id "a"}]
-                                        [:put :xt_docs {:num 1 :xt/id "b"}]
-                                        [:put :xt_docs {:num 1.0 :xt/id "c"}]
-                                        [:put :xt_docs {:num 4 :xt/id "d"}]
-                                        [:put :xt_docs {:num (short 3) :xt/id "e"}]
-                                        [:put :xt_docs {:num 2.0 :xt/id "f"}]])
+  (let [tx (-> (xt/submit-tx tu/*node* [(xt/put :xt_docs {:num 0 :xt/id "a"})
+                                        (xt/put :xt_docs {:num 1 :xt/id "b"})
+                                        (xt/put :xt_docs {:num 1.0 :xt/id "c"})
+                                        (xt/put :xt_docs {:num 4 :xt/id "d"})
+                                        (xt/put :xt_docs {:num (short 3) :xt/id "e"})
+                                        (xt/put :xt_docs {:num 2.0 :xt/id "f"})])
                (tu/then-await-tx tu/*node*))]
 
     (tu/finish-chunk! tu/*node*)
@@ -57,10 +58,10 @@
                           {:node tu/*node* :basis {:tx tx} :params {'?x (float 3)}})))))
 
 (deftest test-bloom-filter-for-datetime-types-2133
-  (let [tx (-> (xt/submit-tx tu/*node* [[:put :xt_docs {:timestamp #time/date "2010-01-01" :xt/id "a"}]
-                                        [:put :xt_docs {:timestamp #time/zoned-date-time "2010-01-01T00:00:00Z" :xt/id "b"}]
-                                        [:put :xt_docs {:timestamp #time/date-time "2010-01-01T00:00:00" :xt/id "c"}]
-                                        [:put :xt_docs {:timestamp #time/date "2020-01-01" :xt/id "d"}]]
+  (let [tx (-> (xt/submit-tx tu/*node* [(xt/put :xt_docs {:timestamp #time/date "2010-01-01" :xt/id "a"})
+                                        (xt/put :xt_docs {:timestamp #time/zoned-date-time "2010-01-01T00:00:00Z" :xt/id "b"})
+                                        (xt/put :xt_docs {:timestamp #time/date-time "2010-01-01T00:00:00" :xt/id "c"})
+                                        (xt/put :xt_docs {:timestamp #time/date "2020-01-01" :xt/id "d"})]
                              {:default-tz #time/zone "Z"})
                (tu/then-await-tx tu/*node*))]
 
@@ -89,8 +90,8 @@
                           {:node tu/*node* :basis {:tx tx} :default-tz #time/zone "Z"})))))
 
 (deftest test-bloom-filter-for-time-types
-  (let [tx (-> (xt/submit-tx tu/*node* [[:put :xt_docs {:time #time/time "01:02:03" :xt/id "a"}]
-                                        [:put :xt_docs {:time #time/time "04:05:06" :xt/id "b"}]]
+  (let [tx (-> (xt/submit-tx tu/*node* [(xt/put :xt_docs {:time #time/time "01:02:03" :xt/id "a"})
+                                        (xt/put :xt_docs {:time #time/time "04:05:06" :xt/id "b"})]
                              {:default-tz #time/zone "Z"})
                (tu/then-await-tx tu/*node*))]
 
@@ -103,7 +104,7 @@
 
 (deftest test-min-max-on-xt-id
   (with-open [node (xtn/start-node {:xtdb.indexer/live-index {:page-limit 16}})]
-    (-> (xt/submit-tx node (for [i (range 20)] [:put :xt_docs {:xt/id i}]))
+    (-> (xt/submit-tx node (for [i (range 20)] (xt/put :xt_docs {:xt/id i})))
         (tu/then-await-tx node))
 
     (tu/finish-chunk! node)
@@ -138,7 +139,7 @@
             (t/is (true? (.test page-idx-pred page-idx)))))))))
 
 (t/deftest test-boolean-metadata
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id 1 :boolean-or-int true}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id 1 :boolean-or-int true})])
   (tu/finish-chunk! tu/*node*)
 
   (let [^IMetadataManager metadata-mgr (tu/component tu/*node* ::meta/metadata-manager)

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -31,25 +31,25 @@ FROM %s FOR ALL SYSTEM_TIME AS p"
                                            :xt$system_from :xt$system_to)
                                      :text)))))]
 
-    (xt/submit-tx tu/*node* [[:sql "
+    (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO posts (xt$id, text, xt$valid_from)
 VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
        (1, 'Happy 2025!', DATE '2025-01-01'),
-       (1, 'Happy 2026!', DATE '2026-01-01')"]])
+       (1, 'Happy 2026!', DATE '2026-01-01')")])
 
     (t/is (= (expected (util/->zdt #inst "2020-01-01"))
              (q "posts")))
 
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2024!', DATE '2024-01-01')"]
-                             [:sql "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2025!', DATE '2025-01-01')"]
-                             [:sql "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2026!', DATE '2026-01-01')"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2024!', DATE '2024-01-01')")
+                             (xt/sql-op "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2025!', DATE '2025-01-01')")
+                             (xt/sql-op "INSERT INTO posts2 (xt$id, text, xt$valid_from) VALUES (1, 'Happy 2026!', DATE '2026-01-01')")])
 
     (t/is (= (expected (util/->zdt #inst "2020-01-02"))
              (q "posts2")))))
 
 (t/deftest test-dml-sees-in-tx-docs
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)"]
-                           [:sql "UPDATE foo SET v = 1"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, v) VALUES ('foo', 0)")
+                           (xt/sql-op "UPDATE foo SET v = 1")])
 
   (t/is (= [{:xt$id "foo", :v 1}]
            (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo"))))
@@ -58,31 +58,31 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
   (letfn [(q []
             (xt/q tu/*node* "SELECT foo.xt$id, foo.xt$valid_from, foo.xt$valid_to FROM foo"
                   {:default-all-valid-time? true}))]
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES ('foo')"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id) VALUES ('foo')")])
 
     (t/is (= [{:xt$id "foo",
                :xt$valid_from (util/->zdt #inst "2020")
                :xt$valid_to nil}]
              (q)))
 
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "DELETE FROM foo")])
 
     (t/is (= [{:xt$id "foo"
                :xt$valid_from (util/->zdt #inst "2020")
                :xt$valid_to (util/->zdt #inst "2020-01-02")}]
              (q)))
 
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo"]]
+    (xt/submit-tx tu/*node* [(xt/sql-op "DELETE FROM foo")]
                   {:default-all-valid-time? true})
 
     (t/is (= [] (q)))))
 
 (t/deftest test-update-set-field-from-param-328
-  (xt/submit-tx tu/*node* [[:sql ["INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)"
-                                  "susan", "Susan", "Smith"]]])
+  (xt/submit-tx tu/*node* [(-> (xt/sql-op "INSERT INTO users (xt$id, first_name, last_name) VALUES (?, ?, ?)")
+                               (xt/with-op-args ["susan", "Susan", "Smith"]))])
 
-  (xt/submit-tx tu/*node* [[:sql ["UPDATE users FOR PORTION OF VALID_TIME FROM ? TO NULL AS u SET first_name = ? WHERE u.xt$id = ?"
-                                  #inst "2021", "sue", "susan"]]])
+  (xt/submit-tx tu/*node* [(-> (xt/sql-op "UPDATE users FOR PORTION OF VALID_TIME FROM ? TO NULL AS u SET first_name = ? WHERE u.xt$id = ?")
+                               (xt/with-op-args [#inst "2021", "sue", "susan"]))])
 
   (t/is (= #{["Susan" "Smith", (util/->zdt #inst "2020") (util/->zdt #inst "2021")]
              ["sue" "Smith", (util/->zdt #inst "2021") nil]}
@@ -91,9 +91,9 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
                 (into #{} (map (juxt :first_name :last_name :xt$valid_from :xt$valid_to)))))))
 
 (t/deftest test-can-submit-same-id-into-multiple-tables-338
-  (let [tx1 (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')"]
-                                     [:sql "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')"]])
-        tx2 (xt/submit-tx tu/*node* [[:sql "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'"]])]
+  (let [tx1 (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1 (xt$id, foo) VALUES ('thing', 't1-foo')")
+                                     (xt/sql-op "INSERT INTO t2 (xt$id, foo) VALUES ('thing', 't2-foo')")])
+        tx2 (xt/submit-tx tu/*node* [(xt/sql-op "UPDATE t2 SET foo = 't2-foo-v2' WHERE t2.xt$id = 'thing'")])]
 
     (t/is (= [{:xt$id "thing", :foo "t1-foo"}]
              (xt/q tu/*node* "SELECT t1.xt$id, t1.foo FROM t1"
@@ -121,25 +121,25 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
                  (into {})))]
 
     (xt/submit-tx tu/*node*
-                  [[:put :xt_docs {:xt/id :foo, :v "implicit table"}]
-                   [:put :explicit_table1 {:xt/id :foo, :v "explicit table 1"}]
-                   [:put :explicit_table2 {:xt/id :foo, :v "explicit table 2"}]])
+                  [(xt/put :xt_docs {:xt/id :foo, :v "implicit table"})
+                   (xt/put :explicit_table1 {:xt/id :foo, :v "explicit table 1"})
+                   (xt/put :explicit_table2 {:xt/id :foo, :v "explicit table 2"})])
 
     (t/is (= {:xt #{"implicit table"}, :t1 #{"explicit table 1"}, :t2 #{"explicit table 2"}}
              (foos)))
 
-    (xt/submit-tx tu/*node* [[:delete :xt_docs :foo]])
+    (xt/submit-tx tu/*node* [(xt/delete :xt_docs :foo)])
 
     (t/is (= {:xt #{}, :t1 #{"explicit table 1"}, :t2 #{"explicit table 2"}}
              (foos)))
 
-    (xt/submit-tx tu/*node* [[:delete :explicit_table1 :foo]])
+    (xt/submit-tx tu/*node* [(xt/delete :explicit_table1 :foo)])
 
     (t/is (= {:xt #{}, :t1 #{}, :t2 #{"explicit table 2"}}
              (foos)))))
 
 (t/deftest test-array-element-reference-is-one-based-336
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, arr) VALUES ('foo', ARRAY[9, 8, 7, 6])"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, arr) VALUES ('foo', ARRAY[9, 8, 7, 6])")])
 
   (t/is (= [{:xt$id "foo", :arr [9 8 7 6], :fst 9, :snd 8, :lst 6}]
            (xt/q tu/*node* "SELECT foo.xt$id, foo.arr, foo.arr[1] AS fst, foo.arr[2] AS snd, foo.arr[4] AS lst FROM foo"))))
@@ -149,13 +149,13 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
            (xt/q tu/*node* "select a.a from (values (1 year)) a (a)"))))
 
 (t/deftest test-overrides-range
-  (xt/submit-tx tu/*node* [[:sql "
+  (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO foo (xt$id, v, xt$valid_from, xt$valid_to)
-VALUES (1, 1, DATE '1998-01-01', DATE '2000-01-01')"]])
+VALUES (1, 1, DATE '1998-01-01', DATE '2000-01-01')")])
 
-  (xt/submit-tx tu/*node* [[:sql "
+  (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO foo (xt$id, v, xt$valid_from, xt$valid_to)
-VALUES (1, 2, DATE '1997-01-01', DATE '2001-01-01')"]])
+VALUES (1, 2, DATE '1997-01-01', DATE '2001-01-01')")])
 
   (t/is (= #{{:xt$id 1, :v 1,
               :xt$valid_from (util/->zdt #inst "1998")
@@ -175,9 +175,9 @@ SELECT foo.xt$id, foo.v,
 FROM foo FOR ALL SYSTEM_TIME FOR ALL VALID_TIME")))))
 
 (t/deftest test-current-timestamp-in-temporal-constraint-409
-  (xt/submit-tx tu/*node* [[:sql "
+  (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO foo (xt$id, v)
-VALUES (1, 1)"]])
+VALUES (1, 1)")])
 
   (t/is (= [{:xt$id 1, :v 1,
              :xt$valid_from (util/->zdt #inst "2020")
@@ -197,7 +197,7 @@ FROM foo FOR VALID_TIME AS OF CURRENT_TIMESTAMP"
                  {:basis {:current-time (util/->instant #inst "1999")}}))))
 
 (t/deftest test-repeated-row-id-scan-bug-also-409
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, v) VALUES (1, 1)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, v) VALUES (1, 1)")])
 
   (letfn [(q1 [opts]
             (xt/q tu/*node* "
@@ -209,16 +209,16 @@ ORDER BY foo.xt$valid_from"
             (frequencies
              (xt/q tu/*node* "SELECT foo.xt$id, foo.v FROM foo" opts)))]
 
-    (let [tx1 (xt/submit-tx tu/*node* [[:sql "
+    (let [tx1 (xt/submit-tx tu/*node* [(xt/sql-op "
 UPDATE foo
 FOR PORTION OF VALID_TIME FROM DATE '2022-01-01' TO DATE '2024-01-01'
 SET v = 2
-WHERE foo.xt$id = 1"]])
+WHERE foo.xt$id = 1")])
 
-          tx2 (xt/submit-tx tu/*node* [[:sql "
+          tx2 (xt/submit-tx tu/*node* [(xt/sql-op "
 DELETE FROM foo
 FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01'
-WHERE foo.xt$id = 1"]])]
+WHERE foo.xt$id = 1")])]
 
       (t/is (= [{:xt$id 1, :v 1
                  :xt$valid_from (util/->zdt #inst "2020")
@@ -258,7 +258,7 @@ WHERE foo.xt$id = 1"]])]
                (q2 {:basis {:tx tx2}, :default-all-valid-time? true}))))))
 
 (t/deftest test-error-handling-inserting-strings-into-app-time-cols-397
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, xt$valid_from) VALUES (1, '2018-01-01')"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, xt$valid_from) VALUES (1, '2018-01-01')")])
 
   ;; TODO check the rollback error when it's available, #401
   (t/is (= [] (xt/q tu/*node* "SELECT foo.xt$id FROM foo"))))
@@ -272,23 +272,23 @@ WHERE foo.xt$id = 1"]])]
 
 #_ ;TODO
 (t/deftest test-double-quoted-col-refs
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, \"kebab-case-col\") VALUES (1, 'kebab-case-value')"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, \"kebab-case-col\") VALUES (1, 'kebab-case-value')")])
   (t/is (= [{:xt$id 1, :kebab-case-col "kebab-case-value"}]
            (xt/q tu/*node* "SELECT foo.xt$id, foo.\"kebab-case-col\" FROM foo WHERE foo.\"kebab-case-col\" = 'kebab-case-value'")))
 
-  (xt/submit-tx tu/*node* [[:sql "UPDATE foo SET \"kebab-case-col\" = 'CamelCaseValue' WHERE foo.\"kebab-case-col\" = 'kebab-case-value'"]]
+  (xt/submit-tx tu/*node* [(xt/sql-op "UPDATE foo SET \"kebab-case-col\" = 'CamelCaseValue' WHERE foo.\"kebab-case-col\" = 'kebab-case-value'")]
                 {:default-all-valid-time? true})
   (t/is (= [{:xt$id 1, :kebab-case-col "CamelCaseValue"}]
            (xt/q tu/*node* "SELECT foo.xt$id, foo.\"kebab-case-col\" FROM foo")))
 
-  (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.\"kebab-case-col\" = 'CamelCaseValue'"]]
+  (xt/submit-tx tu/*node* [(xt/sql-op "DELETE FROM foo WHERE foo.\"kebab-case-col\" = 'CamelCaseValue'")]
                 {:default-all-valid-time? true})
   (t/is (= []
            (xt/q tu/*node* "SELECT foo.xt$id, foo.\"kebab-case-col\" FROM foo"))))
 
 (t/deftest test-select-left-join-471
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, x) VALUES (1, 1), (2, 2)"]
-                           [:sql "INSERT INTO bar (xt$id, x) VALUES (1, 1), (2, 3)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, x) VALUES (1, 1), (2, 2)")
+                           (xt/sql-op "INSERT INTO bar (xt$id, x) VALUES (1, 1), (2, 3)")])
 
   (t/is (= [{:foo 1, :x 1}, {:foo 2, :x 2}]
            (xt/q tu/*node* "SELECT foo.xt$id foo, foo.x FROM foo LEFT JOIN bar USING (xt$id, x)")))
@@ -298,11 +298,11 @@ WHERE foo.xt$id = 1"]])]
            (xt/q tu/*node* "SELECT foo.xt$id foo, foo.x FROM foo LEFT JOIN bar USING (xt$id) WHERE foo.x = bar.x"))))
 
 (t/deftest test-c1-importer-abort-op
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :foo}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :foo})])
 
-  (xt/submit-tx tu/*node* [[:put :xt_docs {:xt/id :bar}]
+  (xt/submit-tx tu/*node* [(xt/put :xt_docs {:xt/id :bar})
                            [:abort]
-                           [:put :xt_docs {:xt/id :baz}]])
+                           (xt/put :xt_docs {:xt/id :baz})])
   (t/is (= [{:id :foo}]
            (xt/q tu/*node*
                  '{:find [id]
@@ -310,8 +310,8 @@ WHERE foo.xt$id = 1"]])]
                            [id :xt$id]]}))))
 
 (t/deftest test-list-round-trip-2342
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t3(xt$id, data) VALUES (1, [2, 3])"]
-                           [:sql "INSERT INTO t3(xt$id, data) VALUES (2, [6, 7])"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t3(xt$id, data) VALUES (1, [2, 3])")
+                           (xt/sql-op "INSERT INTO t3(xt$id, data) VALUES (2, [6, 7])")])
 
   (t/is (= {{:data [2 3], :data:1 [2 3]} 1
             {:data [2 3], :data:1 [6 7]} 1
@@ -320,32 +320,32 @@ WHERE foo.xt$id = 1"]])]
            (frequencies (xt/q tu/*node* "SELECT t3.data, t2.data FROM t3, t3 AS t2")))))
 
 (t/deftest test-mutable-data-buffer-bug
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1(xt$id) VALUES(1)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id) VALUES(1)")])
 
   (t/is (= [{:$column_1$ [{:foo 5} {:foo 5}]}]
            (xt/q tu/*node* "SELECT ARRAY [OBJECT('foo': 5), OBJECT('foo': 5)] FROM t1"))))
 
 (t/deftest test-differing-length-lists-441
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1(xt$id, data) VALUES (1, [2, 3])"]
-                           [:sql "INSERT INTO t1(xt$id, data) VALUES (2, [5, 6, 7])"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id, data) VALUES (1, [2, 3])")
+                           (xt/sql-op "INSERT INTO t1(xt$id, data) VALUES (2, [5, 6, 7])")])
 
   (t/is (= #{{:data [2 3]} {:data [5 6 7]}}
            (set (xt/q tu/*node* "SELECT t1.data FROM t1"))))
 
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t2(xt$id, data) VALUES (1, [2, 3])"]
-                           [:sql "INSERT INTO t2(xt$id, data) VALUES (2, ['dog', 'cat'])"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t2(xt$id, data) VALUES (1, [2, 3])")
+                           (xt/sql-op "INSERT INTO t2(xt$id, data) VALUES (2, ['dog', 'cat'])")])
 
   (t/is (= #{{:data [2 3]} {:data ["dog" "cat"]}}
            (set (xt/q tu/*node* "SELECT t2.data FROM t2")))))
 
 (t/deftest test-cross-join-ioobe-2343
-  (xt/submit-tx tu/*node* [[:sql "
+  (xt/submit-tx tu/*node* [(xt/sql-op "
 INSERT INTO t2(xt$id, data)
-VALUES(2, OBJECT ('foo': OBJECT('bibble': false), 'bar': OBJECT('baz': 1002)))"]
+VALUES(2, OBJECT ('foo': OBJECT('bibble': false), 'bar': OBJECT('baz': 1002)))")
 
-                           [:sql "
+                           (xt/sql-op "
 INSERT INTO t1(xt$id, data)
-VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]])
+VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))")])
 
   (t/is (= [{:t2d {:foo {:bibble false}, :bar {:baz 1002}},
              :t1d {:foo {:bibble true}, :bar {:baz 1001}}}]
@@ -353,13 +353,13 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
 
 (t/deftest test-txs-table-485
   (tu/with-log-level 'xtdb.indexer :error
-    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])
+    (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :foo})])
     (xt/submit-tx tu/*node* [[:abort]])
-    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :bar}]])
-    (xt/submit-tx tu/*node* [[:put-fn :tx-fn-fail
-                              '(fn []
-                                 (throw (Exception. "boom")))]
-                             [:call :tx-fn-fail]])
+    (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :bar})])
+    (xt/submit-tx tu/*node* [(xt/put-fn :tx-fn-fail
+                                        '(fn []
+                                           (throw (Exception. "boom"))))
+                             (xt/call :tx-fn-fail)])
 
     (t/is (= #{{:tx-id 0, :tx-time (util/->zdt #inst "2020-01-01"), :committed? true}
                {:tx-id 1, :tx-time (util/->zdt #inst "2020-01-02"), :committed? false}
@@ -392,9 +392,9 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
 (t/deftest test-indexer-cleans-up-aborted-transactions-2489
   (t/testing "INSERT"
     (xt/submit-tx tu/*node*
-                  [[:sql "INSERT INTO xt_docs (xt$id, xt$valid_from, xt$valid_to)
+                  [(xt/sql-op "INSERT INTO xt_docs (xt$id, xt$valid_from, xt$valid_to)
                               VALUES (1, DATE '2010-01-01', DATE '2020-01-01'),
-                                     (1, DATE '2030-01-01', DATE '2020-01-01')"]])
+                                     (1, DATE '2030-01-01', DATE '2020-01-01')")])
 
     (t/is (= [{:committed? false}]
              (xt/q tu/*node*
@@ -404,7 +404,8 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
                     0])))))
 
 (t/deftest test-nulling-valid-time-columns-2504
-  (xt/submit-tx tu/*node* [[:sql ["INSERT INTO docs (xt$id, xt$valid_from, xt$valid_to) VALUES (1, NULL, ?), (2, ?, NULL), (3, NULL, NULL)" #inst "3000", #inst "3000"]]])
+  (xt/submit-tx tu/*node* [(-> (xt/sql-op "INSERT INTO docs (xt$id, xt$valid_from, xt$valid_to) VALUES (1, NULL, ?), (2, ?, NULL), (3, NULL, NULL)")
+                               (xt/with-op-args [#inst "3000" , #inst "3000"]))])
   (t/is (= #{{:id 1, :vf (util/->zdt #inst "2020"), :vt (util/->zdt #inst "3000")}
              {:id 2, :vf (util/->zdt #inst "3000"), :vt nil}
              {:id 3, :vf (util/->zdt #inst "2020"), :vt nil}}
@@ -414,10 +415,10 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
 
 (deftest test-select-star
   (xt/submit-tx tu/*node*
-                [[:sql "INSERT INTO foo (xt$id, a) VALUES (1, 1)"]
-                 [:sql "INSERT INTO foo (xt$id, b) VALUES (2, 2)"]
-                 [:sql "INSERT INTO bar (xt$id, a) VALUES (1, 3)"]
-                 [:sql "INSERT INTO bar (xt$id, b) VALUES (2, 4)"]])
+                [(xt/sql-op "INSERT INTO foo (xt$id, a) VALUES (1, 1)")
+                 (xt/sql-op "INSERT INTO foo (xt$id, b) VALUES (2, 2)")
+                 (xt/sql-op "INSERT INTO bar (xt$id, a) VALUES (1, 3)")
+                 (xt/sql-op "INSERT INTO bar (xt$id, b) VALUES (2, 4)")])
 
   (t/is (= #{{:a 1, :xt$id 1} {:b 2, :xt$id 2}}
            (set (xt/q tu/*node* "SELECT * FROM foo"))))
@@ -444,22 +445,22 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
          (set (xt/q tu/*node* "SELECT * FROM (SELECT * FROM foo, bar) AS baz"))))
 
   (xt/submit-tx tu/*node*
-                [[:sql "INSERT INTO bing (SELECT * FROM foo)"]])
+                [(xt/sql-op "INSERT INTO bing (SELECT * FROM foo)")])
 
   (t/is (= #{{:a 1, :xt$id 1} {:b 2, :xt$id 2}}
            (set (xt/q tu/*node* "SELECT * FROM bing")))))
 
 (deftest test-scan-all-table-col-names
   (t/testing "testing scan.allTableColNames combines table info from both live and past chunks"
-    (-> (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo1" :a 1}]
-                                 [:put :bar {:xt/id "bar1"}]
-                                 [:put :bar {:xt/id "bar2" :b 2}]])
+    (-> (xt/submit-tx tu/*node* [(xt/put :foo {:xt/id "foo1" :a 1})
+                                 (xt/put :bar {:xt/id "bar1"})
+                                 (xt/put :bar {:xt/id "bar2" :b 2})])
         (tu/then-await-tx tu/*node*))
 
     (tu/finish-chunk! tu/*node*)
 
-    (xt/submit-tx tu/*node* [[:put :foo {:xt/id "foo2" :c 3}]
-                             [:put :baz {:xt/id "foo1" :a 4}]])
+    (xt/submit-tx tu/*node* [(xt/put :foo {:xt/id "foo2" :c 3})
+                             (xt/put :baz {:xt/id "foo1" :a 4})])
 
     (t/is (= #{{:a 1, :xt$id "foo1"} {:xt$id "foo2", :c 3}}
              (set (xt/q tu/*node* "SELECT * FROM foo"))))
@@ -470,15 +471,15 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
 
 (deftest test-erase-after-delete-2607
   (t/testing "general case"
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (1, 1)"]])
-    (xt/submit-tx tu/*node* [[:sql "DELETE FROM foo WHERE foo.xt$id = 1"]])
-    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 1"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, bar) VALUES (1, 1)")])
+    (xt/submit-tx tu/*node* [(xt/sql-op "DELETE FROM foo WHERE foo.xt$id = 1")])
+    (xt/submit-tx tu/*node* [(xt/sql-op "ERASE FROM foo WHERE foo.xt$id = 1")])
     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME"))))
   (t/testing "zero width case"
-    (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id, bar) VALUES (2, 1)"]
-                             [:sql "DELETE FROM foo WHERE foo.xt$id = 2"]])
-    (xt/submit-tx tu/*node* [[:sql "ERASE FROM foo WHERE foo.xt$id = 2"]])
+    (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id, bar) VALUES (2, 1)")
+                             (xt/sql-op "DELETE FROM foo WHERE foo.xt$id = 2")])
+    (xt/submit-tx tu/*node* [(xt/sql-op "ERASE FROM foo WHERE foo.xt$id = 2")])
     (t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL VALID_TIME")))
     ;; TODO if it doesn't show up in valid-time it won't get deleted
     #_(t/is (= [] (xt/q tu/*node* "SELECT * FROM foo FOR ALL SYSTEM_TIME")))))
@@ -495,12 +496,12 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
                  {:explain? true}))))
 
 (t/deftest test-normalising-nested-cols-2483
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :foo {:a/b "foo"}}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :foo {:a/b "foo"}})])
   (t/is (= [{:foo {:a$b "foo"}}] (xt/q tu/*node* "SELECT docs.foo FROM docs")))
   (t/is (= [{:a$b "foo"}] (xt/q tu/*node* "SELECT docs.foo.a$b FROM docs"))))
 
 (t/deftest non-namespaced-keys-for-structs-2418
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo(xt$id, bar) VALUES (1, OBJECT('c$d': 'bar'))"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo(xt$id, bar) VALUES (1, OBJECT('c$d': 'bar'))")])
   (t/is (= [{:bar {:c/d "bar"}}]
            (xt/q tu/*node*
                  '{:find [bar]
@@ -516,20 +517,20 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
                          (assoc :xt/id id))))]
 
         (xt/submit-tx node (for [doc docs]
-                             [:put :docs doc]))
+                             (xt/put :docs doc)))
 
         (t/is (= (set docs)
                  (->> (xt/q node '{:find [e] :where [(match :docs {:xt/* e})]})
                       (into #{} (map :e)))))))))
 
 (t/deftest non-existant-column-no-nil-rows-2898
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo(xt$id, bar) VALUES (1, 2)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo(xt$id, bar) VALUES (1, 2)")])
   (t/is (= [{}]
            (xt/q tu/*node* "SELECT foo.not_a_column FROM foo"))))
 
 (t/deftest test-nested-field-normalisation
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1(xt$id, data) VALUES(1, OBJECT ('field-name1': OBJECT('field-name2': true),
-                                                                                'field/name3': OBJECT('baz': -4113466)))"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id, data) VALUES(1, OBJECT ('field-name1': OBJECT('field-name2': true),
+                                                                                'field/name3': OBJECT('baz': -4113466)))")])
 
   (t/is (= [{:data {:field$name3 {:baz -4113466}, :field_name1 {:field_name2 true}}}]
            (xt/q tu/*node* "SELECT t1.data FROM t1"))
@@ -541,15 +542,15 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
         "testing insert worked"))
 
 (t/deftest test-get-field-on-duv-with-struct-2425
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t2(xt$id, data) VALUES(1, 'bar')"]
-                           [:sql "INSERT INTO t2(xt$id, data) VALUES(2, OBJECT('foo': 2))"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t2(xt$id, data) VALUES(1, 'bar')")
+                           (xt/sql-op "INSERT INTO t2(xt$id, data) VALUES(2, OBJECT('foo': 2))")])
 
   (t/is (= [{:foo 2} {:foo nil}]
            (xt/q tu/*node* "SELECT t2.data.foo FROM t2"))))
 
 (t/deftest distinct-null-2535
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO t1(xt$id, foo) VALUES(1, NULL)"]
-                           [:sql "INSERT INTO t1(xt$id, foo) VALUES(2, NULL)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id, foo) VALUES(1, NULL)")
+                           (xt/sql-op "INSERT INTO t1(xt$id, foo) VALUES(2, NULL)")])
 
   (t/is (= [{:nil nil}]
            (xt/q tu/*node* "SELECT DISTINCT NULL AS nil FROM t1")))
@@ -567,9 +568,9 @@ VALUES(1, OBJECT ('foo': OBJECT('bibble': true), 'bar': OBJECT('baz': 1001)))"]]
 
 (t/deftest test-array-agg-2946
   (xt/submit-tx tu/*node*
-                [[:put :track {:xt/id :track-1 :name "foo1" :composer "bar" :album :album-1}]
-                 [:put :track {:xt/id :track-2 :name "foo2" :composer "bar" :album :album-1}]
-                 [:put :album  {:xt/id :album-1 :name "foo-album"}]])
+                [(xt/put :track {:xt/id :track-1 :name "foo1" :composer "bar" :album :album-1})
+                 (xt/put :track {:xt/id :track-2 :name "foo2" :composer "bar" :album :album-1})
+                 (xt/put :album  {:xt/id :album-1 :name "foo-album"})])
 
 
   (t/is (= [{:name "foo-album", :tracks ["foo1" "foo2"]}]

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -7,23 +7,20 @@
             [xtdb.test-util :as tu]
             [xtdb.types :as types]
             [xtdb.util :as util]
-            [xtdb.vector.writer :as vw]
-            [xtdb.trie :as trie])
+            [xtdb.vector.writer :as vw])
   (:import (java.util.function IntPredicate)
            org.apache.arrow.vector.types.pojo.Schema
            org.apache.arrow.vector.VectorSchemaRoot
-           org.apache.arrow.vector.complex.ListVector
            (xtdb.operator IRaQuerySource IRelationSelector)
-           [xtdb.trie ArrowHashTrie]
            xtdb.vector.RelationReader))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
 
 (t/deftest test-simple-scan
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :col1 "foo1"}]
-                        [:put :xt_docs {:xt/id :bar, :col1 "bar1", :col2 "bar2"}]
-                        [:put :xt_docs {:xt/id :foo, :col2 "baz2"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :col1 "foo1"})
+                        (xt/put :xt_docs {:xt/id :bar, :col1 "bar1", :col2 "bar2"})
+                        (xt/put :xt_docs {:xt/id :foo, :col2 "baz2"})])
 
     (t/is (= #{{:xt/id :bar, :col1 "bar1", :col2 "bar2"}
                {:xt/id :foo, :col2 "baz2"}}
@@ -32,9 +29,9 @@
 
 (t/deftest test-simple-scan-with-namespaced-attributes
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :the-ns/col1 "foo1"}]
-                        [:put :xt_docs {:xt/id :bar, :the-ns/col1 "bar1", :col2 "bar2"}]
-                        [:put :xt_docs {:xt/id :foo, :the-ns/col2 "baz2"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :the-ns/col1 "foo1"})
+                        (xt/put :xt_docs {:xt/id :bar, :the-ns/col1 "bar1", :col2 "bar2"})
+                        (xt/put :xt_docs {:xt/id :foo, :the-ns/col2 "baz2"})])
 
     (t/is (= #{{:xt/id :bar, :the-ns/col1 "bar1", :col2 "bar2"}
                {:xt/id :foo}}
@@ -43,7 +40,7 @@
 
 (t/deftest test-duplicates-in-scan-1
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :foo}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo})])
 
     (t/is (= [{:xt/id :foo}]
              (tu/query-ra '[:scan {:table xt_docs} [xt$id xt$id]]
@@ -52,7 +49,7 @@
 (t/deftest test-chunk-boundary
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 20}})]
     (->> (for [i (range 110)]
-           [:put :xt_docs {:xt/id i}])
+           (xt/put :xt_docs {:xt/id i}))
          (partition-all 10)
          (mapv #(xt/submit-tx node %)))
 
@@ -62,7 +59,7 @@
 
 (t/deftest test-smaller-page-limit
   (with-open [node (xtn/start-node {:xtdb.indexer/live-index {:page-limit 16}})]
-    (xt/submit-tx node (for [i (range 20)] [:put :xt_docs {:xt/id i}]))
+    (xt/submit-tx node (for [i (range 20)] (xt/put :xt_docs {:xt/id i})))
 
     (tu/finish-chunk! node)
 
@@ -73,7 +70,7 @@
 (t/deftest test-metadata
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 20}})]
     (->> (for [i (range 100)]
-           [:put :xt_docs {:xt/id i}])
+           (xt/put :xt_docs {:xt/id i}))
          (partition-all 20)
          (mapv #(xt/submit-tx node %)))
 
@@ -84,8 +81,8 @@
           "testing only getting some trie matches"))
 
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 20}})]
-    (xt/submit-tx node (for [i (range 20)] [:put :xt_docs {:xt/id i}]))
-    (xt/submit-tx node (for [i (range 20)] [:delete :xt_docs i]))
+    (xt/submit-tx node (for [i (range 20)] (xt/put :xt_docs {:xt/id i})))
+    (xt/submit-tx node (for [i (range 20)] (xt/delete :xt_docs i)))
 
     (t/is (= []
              (tu/query-ra '[:scan {:table xt_docs} [{xt$id (< xt$id 20)}]]
@@ -98,8 +95,8 @@
           "testing nothing matches"))
 
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id 1 :boolean-or-int true}]
-                        [:put :xt_docs {:xt/id 2 :boolean-or-int 2}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id 1 :boolean-or-int true})
+                        (xt/put :xt_docs {:xt/id 2 :boolean-or-int 2})])
     (tu/finish-chunk! node)
 
     (t/is (= [{:boolean-or-int true}]
@@ -109,13 +106,18 @@
 
 (t/deftest test-past-point-point-queries
   (with-open [node (xtn/start-node {})]
-    (let [tx1 (xt/submit-tx node [[:put :xt_docs {:xt/id :doc1 :v 1} {:for-valid-time [:from #inst "2015"]}]
-                                  [:put :xt_docs {:xt/id :doc2 :v 1} {:for-valid-time [:from #inst "2015"]}]
-                                  [:put :xt_docs {:xt/id :doc3 :v 1} {:for-valid-time [:from #inst "2018"]}]])
+    (let [tx1 (xt/submit-tx node [(-> (xt/put :xt_docs {:xt/id :doc1 :v 1})
+                                      (xt/starting-from #inst "2015"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc2 :v 1})
+                                      (xt/starting-from #inst "2015"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc3 :v 1})
+                                      (xt/starting-from #inst "2018"))])
 
-          tx2 (xt/submit-tx node [[:put :xt_docs {:xt/id :doc1 :v 2} {:for-valid-time [:from #inst "2020"]}]
-                                  [:put :xt_docs {:xt/id :doc2 :v 2} {:for-valid-time [:from #inst "2100"]}]
-                                  [:delete :xt_docs :doc3]])]
+          tx2 (xt/submit-tx node [(-> (xt/put :xt_docs {:xt/id :doc1 :v 2})
+                                      (xt/starting-from #inst "2020"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc2 :v 2})
+                                      (xt/starting-from #inst "2100"))
+                                  (xt/delete :xt_docs :doc3)])]
 
       ;; valid-time
       (t/is (= {{:v 1, :xt/id :doc1} 1 {:v 1, :xt/id :doc2} 1}
@@ -156,13 +158,18 @@
 
 (t/deftest test-past-point-point-queries-with-valid-time
   (with-open [node (xtn/start-node tu/*node-opts*)]
-    (let [tx1 (xt/submit-tx node [[:put :xt_docs {:xt/id :doc1 :v 1} {:for-valid-time [:from #inst "2015"]}]
-                                  [:put :xt_docs {:xt/id :doc2 :v 1} {:for-valid-time [:from #inst "2015"]}]
-                                  [:put :xt_docs {:xt/id :doc3 :v 1} {:for-valid-time [:from #inst "2018"]}]])
+    (let [tx1 (xt/submit-tx node [(-> (xt/put :xt_docs {:xt/id :doc1 :v 1})
+                                      (xt/starting-from #inst "2015"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc2 :v 1})
+                                      (xt/starting-from #inst "2015"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc3 :v 1})
+                                      (xt/starting-from #inst "2018"))])
 
-          tx2 (xt/submit-tx node [[:put :xt_docs {:xt/id :doc1 :v 2} {:for-valid-time [:from #inst "2020"]}]
-                                  [:put :xt_docs {:xt/id :doc2 :v 2} {:for-valid-time [:from #inst "2100"]}]
-                                  [:delete :xt_docs :doc3]])]
+          tx2 (xt/submit-tx node [(-> (xt/put :xt_docs {:xt/id :doc1 :v 2})
+                                      (xt/starting-from #inst "2020"))
+                                  (-> (xt/put :xt_docs {:xt/id :doc2 :v 2})
+                                      (xt/starting-from #inst "2100"))
+                                  (xt/delete :xt_docs :doc3)])]
 
       ;; valid-time
       (t/is (= #{{:v 1, :xt/id :doc1,
@@ -237,8 +244,8 @@
 
 (t/deftest test-scanning-temporal-cols
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :doc}
-                         {:for-valid-time [:in #inst "2021" #inst "3000"]}]])
+    (xt/submit-tx node [(-> (xt/put :xt_docs {:xt/id :doc})
+                            (xt/during #inst "2021" #inst "3000"))])
 
     (let [res (first (tu/query-ra '[:scan {:table xt_docs}
                                     [xt$id
@@ -262,7 +269,7 @@
 
 (t/deftest test-only-scanning-temporal-cols-45
   (with-open [node (xtn/start-node {})]
-    (let [{tt :system-time} (xt/submit-tx node [[:put :xt_docs {:xt/id :doc}]])]
+    (let [{tt :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :doc})])]
 
       (t/is (= #{{:xt/valid-from (util/->zdt tt)
                   :xt/valid-to nil
@@ -275,9 +282,9 @@
 
 (t/deftest test-aligns-temporal-columns-correctly-363
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :foo {:xt/id :my-doc, :last_updated "tx1"}]] {:system-time #inst "3000"})
+    (xt/submit-tx node [(xt/put :foo {:xt/id :my-doc, :last_updated "tx1"})] {:system-time #inst "3000"})
 
-    (xt/submit-tx node [[:put :foo {:xt/id :my-doc, :last_updated "tx2"}]] {:system-time #inst "3001"})
+    (xt/submit-tx node [(xt/put :foo {:xt/id :my-doc, :last_updated "tx2"})] {:system-time #inst "3001"})
 
     (tu/finish-chunk! node)
 
@@ -308,11 +315,11 @@
   (let [tt1 (util/->zdt #inst "2020-01-01")
         tt2 (util/->zdt #inst "2020-01-02")]
     (with-open [node (xtn/start-node {})]
-      (xt/submit-tx node [[:put :foo {:xt/id 1, :version "version 1" :last_updated "tx1"}
-                           {:app-time-start tt1 :app-time-end nil}]])
+      (xt/submit-tx node [(-> (xt/put :foo {:xt/id 1, :version "version 1" :last_updated "tx1"})
+                              (xt/starting-from tt1))])
 
-      (xt/submit-tx node [[:put :foo {:xt/id 2, :version "version 2" :last_updated "tx2"}
-                           {:app-time-start tt2 :app-time-end nil}]])
+      (xt/submit-tx node [(-> (xt/put :foo {:xt/id 2, :version "version 2" :last_updated "tx2"})
+                              (xt/starting-from tt2))])
       (t/is (= #{{:xt/id 1, :version "version 1"} {:xt/id 2, :version "version 2"}}
                (set (tu/query-ra '[:scan {:table foo,
                                           :for-valid-time [:between ?_start ?_end]}
@@ -336,14 +343,14 @@
                     (.columnFields)
                     (update-vals types/field->col-type)))]
 
-        (let [tx (-> (xt/submit-tx node [[:put :xt_docs {:xt/id :doc}]])
+        (let [tx (-> (xt/submit-tx node [(xt/put :xt_docs {:xt/id :doc})])
                      (tu/then-await-tx node))]
           (tu/finish-chunk! node)
 
           (t/is (= '{xt$id :keyword}
                    (->col-types tx))))
 
-        (let [tx (-> (xt/submit-tx node [[:put :xt_docs {:xt/id "foo"}]])
+        (let [tx (-> (xt/submit-tx node [(xt/put :xt_docs {:xt/id "foo"})])
                      (tu/then-await-tx node))]
 
           (t/is (= '{xt$id [:union #{:keyword :utf8}]}
@@ -412,8 +419,8 @@
 
 (t/deftest test-content-pred
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
-                        [:put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"})
+                        (xt/put :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"})])
     (t/is (= [{:first-name "Ivan", :xt/id :ivan}]
              (tu/query-ra '[:scan
                             {:table xt_docs,  :for-valid-time nil, :for-system-time nil}
@@ -422,8 +429,8 @@
 
 (t/deftest test-absent-columns
   (with-open [node (xtn/start-node {})]
-    (xt/submit-tx node [[:put :xt_docs {:xt/id :foo, :col1 "foo1"}]
-                        [:put :xt_docs {:xt/id :bar, :col1 "bar1", :col2 "bar2"}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :col1 "foo1"})
+                        (xt/put :xt_docs {:xt/id :bar, :col1 "bar1", :col2 "bar2"})])
 
 
     ;; column not existent in all docs
@@ -442,10 +449,10 @@
         search-uuid #uuid "80000000-0000-0000-0000-000000000000"
         after-uuid #uuid "f0000000-0000-0000-0000-000000000000"]
     (with-open [node (xtn/start-node {})]
-      (xt/submit-tx node [[:put :xt-docs {:xt/id before-uuid :version 1}]
-                          [:put :xt-docs {:xt/id search-uuid :version 1}]
-                          [:put :xt-docs {:xt/id after-uuid :version 1}]])
-      (xt/submit-tx node [[:put :xt-docs {:xt/id search-uuid :version 2}]])
+      (xt/submit-tx node [(xt/put :xt-docs {:xt/id before-uuid :version 1})
+                          (xt/put :xt-docs {:xt/id search-uuid :version 1})
+                          (xt/put :xt-docs {:xt/id after-uuid :version 1})])
+      (xt/submit-tx node [(xt/put :xt-docs {:xt/id search-uuid :version 2})])
 
       (t/is (nil? (scan/selects->iid-byte-buffer {} vw/empty-params)))
 
@@ -502,7 +509,7 @@
              (let [uuid (rand-nth uuids)]
                (when (= uuid search-uuid)
                  (swap! !search-uuid-versions conj i))
-               [[:put :xt_docs {:xt/id uuid :version i}]]))
+               [(xt/put :xt_docs {:xt/id uuid :version i})]))
            (mapv #(xt/submit-tx node %)))
 
       (t/is (= [{:version (last @!search-uuid-versions), :xt/id search-uuid}]
@@ -521,9 +528,9 @@
   (with-open [node (xtn/start-node {:xtdb.indexer/live-index {:page-limit 16}})]
     (let [uuids (tu/uuid-seq 40)
           search-uuid (rand-nth uuids)]
-      (xt/submit-tx node (for [uuid (take 20 uuids)] [:put :xt_docs {:xt/id uuid}]))
+      (xt/submit-tx node (for [uuid (take 20 uuids)] (xt/put :xt_docs {:xt/id uuid})))
       (tu/finish-chunk! node)
-      (xt/submit-tx node (for [uuid (drop 20 uuids)] [:put :xt_docs {:xt/id uuid}]))
+      (xt/submit-tx node (for [uuid (drop 20 uuids)] (xt/put :xt_docs {:xt/id uuid})))
       (tu/finish-chunk! node)
 
       (t/is (= [{:xt/id search-uuid}]
@@ -570,7 +577,7 @@
 
 (deftest test-live-tries-with-multiple-leaves-are-loaded-correctly-2710
   (with-open [node (xtn/start-node {:xtdb.indexer/live-index {:page-limit 16}})]
-    (-> (xt/submit-tx node (for [i (range 20)] [:put :xt_docs {:xt/id i}]))
+    (-> (xt/submit-tx node (for [i (range 20)] (xt/put :xt_docs {:xt/id i})))
         (tu/then-await-tx node))
 
     (t/is (= (into #{} (map #(hash-map :xt/id %)) (range 20))
@@ -578,10 +585,10 @@
                                {:node node}))))))
 
 (deftest test-pushdown-blooms
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id :foo, :col "foo"}]
-                           [:put :xt-docs {:xt/id :bar, :col "bar"}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id :foo, :col "foo"})
+                           (xt/put :xt-docs {:xt/id :bar, :col "bar"})])
   (tu/finish-chunk! tu/*node*)
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id :toto, :col "toto"}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id :toto, :col "toto"})])
   (tu/finish-chunk! tu/*node*)
 
   (let [!page-idxs-cnt (atom 0)
@@ -609,10 +616,10 @@
             second-page (for [i (range page-limit)] (java.util.UUID. 1 i))
             uuid (first first-page)]
         (xt/submit-tx node (for [uuid (concat first-page second-page)]
-                             [:put :docs {:xt/id uuid}]))
+                             (xt/put :docs {:xt/id uuid})))
         (tu/then-await-tx node)
         (tu/finish-chunk! node)
-        (xt/submit-tx node  [[:put :docs {:xt/id uuid}]])
+        (xt/submit-tx node [(xt/put :docs {:xt/id uuid})])
         (tu/then-await-tx node)
 
         ;; first + second page
@@ -627,8 +634,8 @@
                                          {:node node}))))))))
 
 (deftest dont-use-fast-path-on-non-literals-2768
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id "foo-start" :v "foo-start"}]
-                           [:put :xt-docs {:xt/id "bar-start" :v "bar-start"}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id "foo-start" :v "foo-start"})
+                           (xt/put :xt-docs {:xt/id "bar-start" :v "bar-start"})])
 
   (t/is (= [#:xt{:id "foo-start"}]
            (tu/query-ra

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -21,16 +21,16 @@
 
 (t/deftest test-find-gt-ivan
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 10}})]
-    (-> (xt/submit-tx node [[:put :xt_docs {:name "Håkan", :xt/id :hak}]])
+    (-> (xt/submit-tx node [(xt/put :xt_docs {:name "Håkan", :xt/id :hak})])
         (tu/then-await-tx node))
 
     (tu/finish-chunk! node)
 
-    (xt/submit-tx node [[:put :xt_docs {:name "Dan", :xt/id :dan}]
-                        [:put :xt_docs {:name "Ivan", :xt/id :iva}]])
+    (xt/submit-tx node [(xt/put :xt_docs {:name "Dan", :xt/id :dan})
+                        (xt/put :xt_docs {:name "Ivan", :xt/id :iva})])
 
-    (let [tx1 (-> (xt/submit-tx node [[:put :xt_docs {:name "James", :xt/id :jms}]
-                                      [:put :xt_docs {:name "Jon", :xt/id :jon}]])
+    (let [tx1 (-> (xt/submit-tx node [(xt/put :xt_docs {:name "James", :xt/id :jms})
+                                      (xt/put :xt_docs {:name "Jon", :xt/id :jon})])
                   (tu/then-await-tx node))]
 
       (tu/finish-chunk! node)
@@ -61,7 +61,7 @@
                     (t/is (true? (.test (.build lit-sel table-metadata) 0)))
                     (t/is (true? (.test (.build param-sel table-metadata) 0))))))))
 
-          (let [tx2 (xt/submit-tx node [[:put :xt_docs {:name "Jeremy", :xt/id :jdt}]])]
+          (let [tx2 (xt/submit-tx node [(xt/put :xt_docs {:name "Jeremy", :xt/id :jdt})])]
 
             (test-query-ivan #{{:xt/id :jms, :name "James"}
                                {:xt/id :jon, :name "Jon"}}
@@ -74,15 +74,15 @@
 
 (t/deftest test-find-eq-ivan
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 10}})]
-    (-> (xt/submit-tx node [[:put :xt_docs {:name "Håkan", :xt/id :hak}]
-                            [:put :xt_docs {:name "James", :xt/id :jms}]
-                            [:put :xt_docs {:name "Ivan", :xt/id :iva}]])
+    (-> (xt/submit-tx node [(xt/put :xt_docs {:name "Håkan", :xt/id :hak})
+                            (xt/put :xt_docs {:name "James", :xt/id :jms})
+                            (xt/put :xt_docs {:name "Ivan", :xt/id :iva})])
         (tu/then-await-tx node))
 
     (tu/finish-chunk! node)
-    (-> (xt/submit-tx node [[:put :xt_docs {:name "Håkan", :xt/id :hak}]
+    (-> (xt/submit-tx node [(xt/put :xt_docs {:name "Håkan", :xt/id :hak})
 
-                            [:put :xt_docs {:name "James", :xt/id :jms}]])
+                            (xt/put :xt_docs {:name "James", :xt/id :jms})])
         (tu/then-await-tx node))
 
     (tu/finish-chunk! node)
@@ -113,8 +113,8 @@
 
 (t/deftest test-temporal-bounds
   (with-open [node (xtn/start-node {})]
-    (let [{tt1 :system-time} (xt/submit-tx node [[:put :xt_docs {:xt/id :my-doc, :last-updated "tx1"}]])
-          {tt2 :system-time} (xt/submit-tx node [[:put :xt_docs {:xt/id :my-doc, :last-updated "tx2"}]])]
+    (let [{tt1 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx1"})])
+          {tt2 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx2"})])]
       (letfn [(q [& temporal-constraints]
                 (->> (tu/query-ra [:scan '{:table xt_docs, :for-system-time :all-time}
                                    (into '[last_updated] temporal-constraints)]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -856,7 +856,7 @@
 ;; maps cannot be created from SQL yet, or used as parameters - but we can read them from XT.
 (deftest map-read-test
   (with-open [conn (jdbc-conn)]
-    (-> (xt/submit-tx *node* [[:put :a {:xt/id "map-test", :a {:b 42}}]])
+    (-> (xt/submit-tx *node* [(xt/put :a {:xt/id "map-test", :a {:b 42}})])
         (tu/then-await-tx *node*))
 
     (let [rs (q conn ["select a.a from a a"])]
@@ -900,7 +900,7 @@
 ;; right now all isolation levels have the same defined behaviour
 (deftest transaction-by-default-pins-the-basis-to-last-tx-test
   (require-node)
-  (let [insert #(xt/submit-tx *node* [[:put %1 %2]])]
+  (let [insert #(xt/submit-tx *node* [(xt/put %1 %2)])]
     (-> (insert :a {:xt/id :fred, :name "Fred"})
         (tu/then-await-tx *node*))
 

--- a/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
@@ -186,7 +186,7 @@
 
 (defn- insert-statement [node insert-statement]
   (xt/submit-tx node (vec (for [doc (insert->docs node insert-statement)]
-                            [:put (:table (meta doc)) (merge {:xt/id (UUID/randomUUID)} doc)]))
+                            (xt/put (:table (meta doc)) (merge {:xt/id (UUID/randomUUID)} doc))))
                 {:default-all-valid-time? true})
   node)
 
@@ -201,10 +201,10 @@
 (defn- execute-sql-statement [node sql-statement variables opts]
   (binding [r/*memo* (HashMap.)]
     (xt/submit-tx node
-                  [[:sql sql-statement]]
+                  [(xt/sql-op sql-statement)]
                   (-> opts
-                           (assoc :default-all-valid-time? (not= (get variables "VALID_TIME_DEFAULTS") "AS_OF_NOW"))
-                           (cond-> (get variables "CURRENT_TIMESTAMP") (assoc-in [:basis :current-time] (Instant/parse (get variables "CURRENT_TIMESTAMP"))))))
+                      (assoc :default-all-valid-time? (not= (get variables "VALID_TIME_DEFAULTS") "AS_OF_NOW"))
+                      (cond-> (get variables "CURRENT_TIMESTAMP") (assoc-in [:basis :current-time] (Instant/parse (get variables "CURRENT_TIMESTAMP"))))))
     node))
 
 (defn- execute-sql-query [node sql-statement variables opts]

--- a/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
+++ b/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
@@ -96,7 +96,7 @@
 (t/deftest if-log-does-not-get-a-new-msg-in-xx-time-we-submit-a-flush-test
   (with-open [node (start-node #time/duration "PT0.001S")]
     (t/testing "sent after a first message"
-      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (xt/submit-tx node [(xt/put :foo {:xt/id 42})])
       (t/is (spin (log-indexed? node)))
       (t/is (spin (= 2 (count (node-log node)))))
       (let [[_ msg2] (node-log node)]
@@ -105,7 +105,7 @@
           (t/is (= -1 flush-tx-id)))))
 
     (t/testing "sent after a second message"
-      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (xt/submit-tx node [(xt/put :foo {:xt/id 42})])
       (t/is (spin (= 4 (count (node-log node)))))
       (let [[_ _ _ msg4] (node-log node)]
         (let [flush-tx-id (:flush-tx-id msg4)]
@@ -115,7 +115,7 @@
 
   (t/testing "test :duration actually does something"
     (with-open [node (start-node #time/duration "PT1H")]
-      (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+      (xt/submit-tx node [(xt/put :foo {:xt/id 42})])
       (t/is (spin (= 1 (count (node-log node)))))
       (t/is (spin-ensure 10 (= 1 (count (node-log node)))))))
 
@@ -126,7 +126,7 @@
           heartbeat (fn [] (.release control))]
       (with-open [node (start-node #time/duration "PT0.001S" :on-heartbeat on-heartbeat)
                   _ control-close]
-        (let [send-msg (fn [] (xt/submit-tx node [[:put :foo {:xt/id 42}]]))
+        (let [send-msg (fn [] (xt/submit-tx node [(xt/put :foo {:xt/id 42})]))
               check-sync (fn [] (spin (log-indexed? node)))
               check-count (fn [n] (spin (= n (count (node-log node)))))
               check-count-remains (fn [n] (spin-ensure 10 (= n (count (node-log node)))))]
@@ -168,9 +168,9 @@
 (t/deftest indexer-flushes-block-and-chunk-if-flush-op-test
   (with-open [node (start-node #time/duration "PT0.001S")]
     (t/is (spin-ensure 10 (= 0 (count (chunk-path-seq node)))))
-    (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+    (xt/submit-tx node [(xt/put :foo {:xt/id 42})])
     (t/is (spin (= 1 (count (chunk-path-seq node))))))
 
   (with-open [node (start-node #time/duration "PT1H")]
-    (xt/submit-tx node [[:put :foo {:xt/id 42}]])
+    (xt/submit-tx node [(xt/put :foo {:xt/id 42})])
     (t/is (spin-ensure 10 (= 0 (count (chunk-path-seq node)))))))

--- a/src/test/clojure/xtdb/stats_test.clj
+++ b/src/test/clojure/xtdb/stats_test.clj
@@ -12,14 +12,14 @@
 (deftest test-scan
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 2}})]
     (let [scan-emitter (util/component node :xtdb.operator.scan/scan-emitter)]
-      (xt/submit-tx node [[:put :foo {:xt/id "foo1"}]
-                          [:put :bar {:xt/id "bar1"}]])
+      (xt/submit-tx node [(xt/put :foo {:xt/id "foo1"})
+                          (xt/put :bar {:xt/id "bar1"})])
 
-      (xt/submit-tx node [[:put :foo {:xt/id "foo2"}]
-                          [:put :baz {:xt/id "baz1"}]])
+      (xt/submit-tx node [(xt/put :foo {:xt/id "foo2"})
+                          (xt/put :baz {:xt/id "baz1"})])
 
-      (-> (xt/submit-tx node [[:put :foo {:xt/id "foo3"}]
-                              [:put :bar {:xt/id "bar2"}]])
+      (-> (xt/submit-tx node [(xt/put :foo {:xt/id "foo3"})
+                              (xt/put :bar {:xt/id "bar2"})])
           (tu/then-await-tx node))
 
       (t/is (= {:row-count 3}

--- a/src/test/clojure/xtdb/tx_fn_test.clj
+++ b/src/test/clojure/xtdb/tx_fn_test.clj
@@ -11,11 +11,11 @@
 
 (t/deftest test-call-tx-fn
   (t/testing "simple call"
-    (xt/submit-tx tu/*node* [[:put-fn :my-fn
-                              '(fn [id n]
-                                 [[:put :foo {:xt/id id, :n n}]])]
-                             [:call :my-fn :foo 0]
-                             [:call :my-fn :bar 1]])
+    (xt/submit-tx tu/*node* [(xt/put-fn :my-fn
+                                        '(fn [id n]
+                                           [(xt/put :foo {:xt/id id, :n n})]))
+                             (xt/call :my-fn :foo 0)
+                             (xt/call :my-fn :bar 1)])
 
     (t/is (= #{{:xt/id :foo, :n 0}
                {:xt/id :bar, :n 1}}
@@ -23,15 +23,15 @@
                         '(from :foo [xt/id n]))))))
 
   (t/testing "nested tx fn"
-    (xt/submit-tx tu/*node* [[:put-fn :inner-fn
-                              '(fn [id]
-                                 [[:put :bar {:xt/id (keyword (str (name id) "-inner")), :from :inner}]])]
-                             [:put-fn :outer-fn
-                              '(fn [id]
-                                 [[:call :inner-fn id]
-                                  [:put :bar {:xt/id (keyword (str (name id) "-outer")), :from :outer}]])]
-                             [:call :inner-fn :foo]
-                             [:call :outer-fn :bar]])
+    (xt/submit-tx tu/*node* [(xt/put-fn :inner-fn
+                                        '(fn [id]
+                                           [(xt/put :bar {:xt/id (keyword (str (name id) "-inner")), :from :inner})]))
+                             (xt/put-fn :outer-fn
+                                        '(fn [id]
+                                           [(xt/call :inner-fn id)
+                                            (xt/put :bar {:xt/id (keyword (str (name id) "-outer")), :from :outer})]))
+                             (xt/call :inner-fn :foo)
+                             (xt/call :outer-fn :bar)])
 
     (t/is (= #{{:xt/id :foo-inner, :from :inner}
                {:xt/id :bar-inner, :from :inner}
@@ -40,11 +40,11 @@
                         '(from :bar [xt/id from])))))))
 
 (t/deftest test-tx-fn-return-values
-  (xt/submit-tx tu/*node* [[:put-fn :identity 'identity]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :identity 'identity)])
 
   (letfn [(run-test [ret-val put-id]
-            (xt/submit-tx tu/*node* [[:call :identity ret-val]
-                                     [:put :docs {:xt/id put-id}]])
+            (xt/submit-tx tu/*node* [(xt/call :identity ret-val)
+                                     (xt/put :docs {:xt/id put-id})])
 
             (->> (xt/q tu/*node*
                        '(from :docs [{:xt/id id} {:xt/id $id}])
@@ -57,29 +57,29 @@
     (t/is (= #{:true} (run-test true :true)))))
 
 (t/deftest test-tx-fn-q
-  (xt/submit-tx tu/*node* [[:put-fn :doc-counter
-                            '(fn [id]
-                               (let [doc-count (count (q '(from :foo [xt/id])))]
-                                 [[:put :foo {:xt/id id, :doc-count doc-count}]]))]
-                           [:call :doc-counter :foo]
-                           [:call :doc-counter :bar]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :doc-counter
+                                      '(fn [id]
+                                         (let [doc-count (count (q '(from :foo [xt/id])))]
+                                           [(xt/put :foo {:xt/id id, :doc-count doc-count})])))
+                           (xt/call :doc-counter :foo)
+                           (xt/call :doc-counter :bar)])
 
   (t/is (= [{:xt/id :foo, :doc-count 0}
             {:xt/id :bar, :doc-count 1}]
            (xt/q tu/*node*
                  '(from :foo [xt/id doc-count]))))
 
-  (let [tx2 (xt/submit-tx tu/*node* [[:put :accounts {:xt/id :petr :balance 100}]
-                                     [:put :accounts {:xt/id :ivan :balance 200}]
-                                     [:put-fn :update-balance
-                                      '(fn [id]
-                                         (let [[account] (q '(from :accounts [balance xt/id {:xt/id $id}])
-                                                            {:args {:id id}})]
-                                           (if account
-                                             [[:put :accounts (update account :balance inc)]]
-                                             [])))]
-                                     [:call :update-balance :petr]
-                                     [:call :update-balance :undefined]])]
+  (let [tx2 (xt/submit-tx tu/*node* [(xt/put :accounts {:xt/id :petr :balance 100})
+                                     (xt/put :accounts {:xt/id :ivan :balance 200})
+                                     (xt/put-fn :update-balance
+                                                '(fn [id]
+                                                   (let [[account] (q '(from :accounts [balance xt/id {:xt/id $id}])
+                                                                      {:args {:id id}})]
+                                                     (if account
+                                                       [(xt/put :accounts (update account :balance inc))]
+                                                       []))))
+                                     (xt/call :update-balance :petr)
+                                     (xt/call :update-balance :undefined)])]
     (t/is (= #{{:xt/id :petr, :balance 101}
                {:xt/id :ivan, :balance 200}}
              (set (xt/q tu/*node*
@@ -88,12 +88,12 @@
           "query in tx-fn with in-args")))
 
 (t/deftest test-tx-fn-sql-q
-  (xt/submit-tx tu/*node* [[:put-fn :doc-counter
-                            '(fn [id]
-                               (let [[{doc-count :doc_count}] (sql-q "SELECT COUNT(*) doc_count FROM docs")]
-                                 [[:put :docs {:xt/id id, :doc-count doc-count}]]))]
-                           [:call :doc-counter :foo]
-                           [:call :doc-counter :bar]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :doc-counter
+                                      '(fn [id]
+                                         (let [[{doc-count :doc_count}] (sql-q "SELECT COUNT(*) doc_count FROM docs")]
+                                           [(xt/put :docs {:xt/id id, :doc-count doc-count})])))
+                           (xt/call :doc-counter :foo)
+                           (xt/call :doc-counter :bar)])
 
   (t/is (= [{:xt/id :foo, :doc-count 0}
             {:xt/id :bar, :doc-count 1}]
@@ -101,13 +101,13 @@
                  '(from :docs [xt/id doc-count])))))
 
 (t/deftest test-tx-fn-current-tx
-  (let [{tt0 :system-time} (xt/submit-tx tu/*node* [[:put-fn :with-tx
-                                                     '(fn [id]
-                                                        [[:put :docs (into {:xt/id id} *current-tx*)]])]
-                                                    [:call :with-tx :foo]
-                                                    [:call :with-tx :bar]])
+  (let [{tt0 :system-time} (xt/submit-tx tu/*node* [(xt/put-fn :with-tx
+                                                               '(fn [id]
+                                                                  [(xt/put :docs (into {:xt/id id} *current-tx*))]))
+                                                    (xt/call :with-tx :foo)
+                                                    (xt/call :with-tx :bar)])
 
-        {tt1 :system-time} (xt/submit-tx tu/*node* [[:call :with-tx :baz]])]
+        {tt1 :system-time} (xt/submit-tx tu/*node* [(xt/call :with-tx :baz)])]
 
     (t/is (= #{{:xt/id :foo, :tx-id 0, :system-time (util/->zdt tt0)}
                {:xt/id :bar, :tx-id 0, :system-time (util/->zdt tt0)}
@@ -121,15 +121,15 @@
                       '(from :docs [xt/id version]))
                 first :version))]
 
-    (xt/submit-tx tu/*node* [[:put-fn :assoc-version
-                              '(fn [version]
-                                 [[:put :docs {:xt/id :foo, :version version}]])]
-                             [:call :assoc-version 0]])
+    (xt/submit-tx tu/*node* [(xt/put-fn :assoc-version
+                                        '(fn [version]
+                                           [(xt/put :docs {:xt/id :foo, :version version})]))
+                             (xt/call :assoc-version 0)])
     (t/is (= 0 (foo-version)))
 
     (t/testing "non existing tx fn"
-      (xt/submit-tx tu/*node* [[:call :non-existing-fn]
-                               [:call :assoc-version :fail]])
+      (xt/submit-tx tu/*node* [(xt/call :non-existing-fn)
+                               (xt/call :assoc-version :fail)])
 
       (t/is (= 0 (foo-version)))
       (t/is (thrown-with-msg? RuntimeException
@@ -137,19 +137,19 @@
                               (some-> (idx/reset-tx-fn-error!) throw))))
 
     (t/testing "invalid results"
-      (xt/submit-tx tu/*node* [[:put-fn :invalid-fn '(fn [] [[:foo]])]])
-      (xt/submit-tx tu/*node* [[:call :invalid-fn]
-                               [:call :assoc-version :fail]])
+      (xt/submit-tx tu/*node* [(xt/put-fn :invalid-fn '(fn [] [[:foo]]))])
+      (xt/submit-tx tu/*node* [(xt/call :invalid-fn)
+                               (xt/call :assoc-version :fail)])
       (t/is (= 0 (foo-version)))
 
       (t/is (thrown-with-msg? IllegalArgumentException #"invalid-tx-op"
                               (some-> (idx/reset-tx-fn-error!) throw))))
 
     (t/testing "no :fn"
-      (xt/submit-tx tu/*node* [[:put :xt/tx-fns {:xt/id :no-fn}]])
+      (xt/submit-tx tu/*node* [(xt/put :xt/tx-fns {:xt/id :no-fn})])
 
-      (xt/submit-tx tu/*node* [[:call :no-fn]
-                               [:call :assoc-version :fail]])
+      (xt/submit-tx tu/*node* [(xt/call :no-fn)
+                               (xt/call :assoc-version :fail)])
       (t/is (= 0 (foo-version)))
 
       (t/is (thrown-with-msg? RuntimeException
@@ -157,9 +157,9 @@
                               (some-> (idx/reset-tx-fn-error!) throw))))
 
     (t/testing "not a fn"
-      (xt/submit-tx tu/*node* [[:put :xt/tx-fns {:xt/id :not-a-fn, :xt/fn 0}]])
-      (xt/submit-tx tu/*node* [[:call :not-a-fn]
-                               [:call :assoc-version :fail]])
+      (xt/submit-tx tu/*node* [(xt/put :xt/tx-fns {:xt/id :not-a-fn, :xt/fn 0})])
+      (xt/submit-tx tu/*node* [(xt/call :not-a-fn)
+                               (xt/call :assoc-version :fail)])
       (t/is (= 0 (foo-version)))
 
       (t/is (thrown-with-msg? RuntimeException
@@ -167,9 +167,9 @@
                               (some-> (idx/reset-tx-fn-error!) throw))))
 
     (t/testing "compilation errors"
-      (xt/submit-tx tu/*node* [[:put-fn :compilation-error-fn '(fn [] unknown-symbol)]])
-      (xt/submit-tx tu/*node* [[:call :compilation-error-fn]
-                               [:call :assoc-version :fail]])
+      (xt/submit-tx tu/*node* [(xt/put-fn :compilation-error-fn '(fn [] unknown-symbol))])
+      (xt/submit-tx tu/*node* [(xt/call :compilation-error-fn)
+                               (xt/call :assoc-version :fail)])
 
       (t/is (= 0 (foo-version)))
       (t/is (thrown-with-msg? RuntimeException #":xtdb.call/error-compiling-tx-fn"
@@ -177,31 +177,31 @@
 
     (t/testing "exception thrown"
       #_{:clj-kondo/ignore [:unused-value]}
-      (xt/submit-tx tu/*node* [[:put-fn :exception-fn
-                                '(fn []
-                                   (/ 1 0)
-                                   [])]])
+      (xt/submit-tx tu/*node* [(xt/put-fn :exception-fn
+                                          '(fn []
+                                             (/ 1 0)
+                                             []))])
 
       (tu/with-log-level 'xtdb.indexer :error
-        (xt/submit-tx tu/*node* [[:call :exception-fn]
-                                 [:call :assoc-version :fail]])
+        (xt/submit-tx tu/*node* [(xt/call :exception-fn)
+                                 (xt/call :assoc-version :fail)])
         (t/is (= 0 (foo-version)))
         (t/is (thrown-with-msg? RuntimeException #":xtdb.call/error-evaluating-tx-fn"
                                 (some-> (idx/reset-tx-fn-error!) throw)))))
 
     (t/testing "still working after all these errors"
-      (xt/submit-tx tu/*node* [[:call :update-version :done]])
+      (xt/submit-tx tu/*node* [(xt/call :update-version :done)])
       (= :done (foo-version)))))
 
 (t/deftest handle-interrupted-exception-614
   (t/is (thrown-with-msg?
          Exception #"sleep interrupted"
          @(with-open [node (xtn/start-node {})]
-            (xt/submit-tx node [[:put-fn :hello-world
-                                 '(fn hello-world [id]
-                                    (sleep 200)
-                                    [[:put :xt_docs {:xt/id id :foo (str id)}]])]])
-            (xt/submit-tx node [[:call :hello-world 1]])
+            (xt/submit-tx node [(xt/put-fn :hello-world
+                                           '(fn hello-world [id]
+                                              (sleep 200)
+                                              [(xt/put :xt_docs {:xt/id id :foo (str id)})]))])
+            (xt/submit-tx node [(xt/call :hello-world 1)])
 
             (Thread/sleep 100)
 
@@ -210,36 +210,36 @@
 
 (t/deftest test-call-tx-fn-with-ns-attr
   (t/testing "simple call"
-    (xt/submit-tx tu/*node* [[:put-fn :my-fn
-                              '(fn [id n]
-                                 [[:put :docs {:xt/id id, :a/b n}]])]
-                             [:call :my-fn :foo 0]
-                             [:call :my-fn :bar 1]])
+    (xt/submit-tx tu/*node* [(xt/put-fn :my-fn
+                                        '(fn [id n]
+                                           [(xt/put :docs {:xt/id id, :a/b n})]))
+                             (xt/call :my-fn :foo 0)
+                             (xt/call :my-fn :bar 1)])
 
     (t/is (= [{:xt/id :foo, :n 0}
               {:xt/id :bar, :n 1}]
              (xt/q tu/*node* '(from :docs [xt/id {:a/b n}]))))))
 
 (t/deftest test-lazy-error-in-tx-fns-2811
-  (xt/submit-tx tu/*node* [[:put-fn :my-fn '(fn [ns] (for [n ns]
-                                                       (if (< n 100)
-                                                         [:put :foo {:xt/id n :v n}]
-                                                         (throw (ex-info "boom" {})))))]])
-  (xt/submit-tx tu/*node* [[:call :my-fn (range 200)]])
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :v 1}]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :my-fn '(fn [ns] (for [n ns]
+                                                         (if (< n 100)
+                                                           (xt/put :foo {:xt/id n :v n})
+                                                           (throw (ex-info "boom" {}))))))])
+  (xt/submit-tx tu/*node* [(xt/call :my-fn (range 200))])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :v 1})])
   (t/is (= [{:xt/id 1, :v 1}]
            (xt/q tu/*node*
                  '(from :docs [xt/id v])))))
 
 (t/deftest normalisation-in-tx-fn
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :first-name "Allan" :last-name "Turing"}]
-                           [:put-fn :my-fn '(fn []
-                                              (let [ks (->> (q '(from :docs [first-name last-name])
-                                                               {:key-fn :sql})
-                                                            (mapcat keys)
-                                                            (into []))]
-                                                [[:put :the-keys {:xt/id 1 :keys ks}]]))]
-                           [:call :my-fn]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :first-name "Allan" :last-name "Turing"})
+                           (xt/put-fn :my-fn '(fn []
+                                                (let [ks (->> (q '(from :docs [first-name last-name])
+                                                                 {:key-fn :sql})
+                                                              (mapcat keys)
+                                                              (into []))]
+                                                  [(xt/put :the-keys {:xt/id 1 :keys ks})])))
+                           (xt/call :my-fn)])
 
   (t/is (= #{{:key :first_name} {:key :last_name}}
            (set (xt/q tu/*node*
@@ -248,21 +248,21 @@
                            (return key)))))
         "testing `key-fn` in q")
 
-  (xt/submit-tx tu/*node* [[:put-fn :my-case-fn '(fn [{:keys [snake_case kebab-case]}]
-                                                   (cond-> []
-                                                     snake_case (conj [:put :casing {:xt/id snake_case}])
-                                                     kebab-case (conj [:put :casing {:xt/id kebab-case}])))]
-                           [:call :my-case-fn {:snake_case "foo"}]
-                           [:call :my-case-fn {:kebab-case "bar"}]
-                           [:call :my-case-fn {:snake_case "baz" :kebab-case "toto"}]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :my-case-fn '(fn [{:keys [snake_case kebab-case]}]
+                                                     (cond-> []
+                                                       snake_case (conj (xt/put :casing {:xt/id snake_case}))
+                                                       kebab-case (conj (xt/put :casing {:xt/id kebab-case})))))
+                           (xt/call :my-case-fn {:snake_case "foo"})
+                           (xt/call :my-case-fn {:kebab-case "bar"})
+                           (xt/call :my-case-fn {:snake_case "baz" :kebab-case "toto"})])
 
   (t/is (= [{:xt/id "baz"} {:xt/id "toto"} {:xt/id "bar"} {:xt/id "foo"}]
            (xt/q tu/*node*
                  '(from :casing [xt/id])))))
 
 (t/deftest test-unhandled-query-type
-  (xt/submit-tx tu/*node* [[:put-fn :my-fn '(fn [] (q "SELECT t1.foo FROM foo"))]
-                           [:call :my-fn]])
+  (xt/submit-tx tu/*node* [(xt/put-fn :my-fn '(fn [] (q "SELECT t1.foo FROM foo")))
+                           (xt/call :my-fn)])
 
   (t/is (= "Runtime error: ':xtdb.call/error-evaluating-tx-fn'"
            (let [^ClojureForm error (-> (xt/q tu/*node* '(from :xt/txs [{:xt/error error}]))

--- a/src/test/clojure/xtdb/tx_producer_test.clj
+++ b/src/test/clojure/xtdb/tx_producer_test.clj
@@ -2,6 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.test :as t]
+            [xtdb.api :as xt]
             [xtdb.test-json :as tj]
             [xtdb.test-util :as tu]
             [xtdb.tx-producer :as txp]
@@ -23,95 +24,96 @@
                 (tj/sort-arrow-json (json/parse-string actual))))))))
 
 (def devices-docs
-  [[:put :device-info
-    {:xt/id "device-info-demo000000",
-     :api-version "23",
-     :manufacturer "iobeam",
-     :model "pinto",
-     :os-name "6.0.1"}]
-   [:put :device-readings
-    {:xt/id "reading-demo000000",
-     :device-id "device-info-demo000000",
-     :cpu-avg-15min 8.654,
-     :rssi -50.0,
-     :cpu-avg-5min 10.802,
-     :battery-status "discharging",
-     :ssid "demo-net",
-     :time #inst "2016-11-15T12:00:00.000-00:00",
-     :battery-level 59.0,
-     :bssid "01:02:03:04:05:06",
-     :battery-temperature 89.5,
-     :cpu-avg-1min 24.81,
-     :mem-free 4.10011078E8,
-     :mem-used 5.89988922E8}]
-   [:put :device-info
-    {:xt/id "device-info-demo000001",
-     :api-version "23",
-     :manufacturer "iobeam",
-     :model "mustang",
-     :os-name "6.0.1"}]
-   [:put :device-readings
-    {:xt/id "reading-demo000001",
-     :device-id "device-info-demo000001",
-     :cpu-avg-15min 8.822,
-     :rssi -61.0,
-     :cpu-avg-5min 8.106,
-     :battery-status "discharging",
-     :ssid "stealth-net",
-     :time #inst "2016-11-15T12:00:00.000-00:00",
-     :battery-level 86.0,
-     :bssid "A0:B1:C5:D2:E0:F3",
-     :battery-temperature 93.7,
-     :cpu-avg-1min 4.93,
-     :mem-free 7.20742332E8,
-     :mem-used 2.79257668E8}]])
+  [(xt/put :device-info
+           {:xt/id "device-info-demo000000",
+            :api-version "23",
+            :manufacturer "iobeam",
+            :model "pinto",
+            :os-name "6.0.1"})
+   (xt/put :device-readings
+           {:xt/id "reading-demo000000",
+            :device-id "device-info-demo000000",
+            :cpu-avg-15min 8.654,
+            :rssi -50.0,
+            :cpu-avg-5min 10.802,
+            :battery-status "discharging",
+            :ssid "demo-net",
+            :time #inst "2016-11-15T12:00:00.000-00:00",
+            :battery-level 59.0,
+            :bssid "01:02:03:04:05:06",
+            :battery-temperature 89.5,
+            :cpu-avg-1min 24.81,
+            :mem-free 4.10011078E8,
+            :mem-used 5.89988922E8})
+   (xt/put :device-info
+           {:xt/id "device-info-demo000001",
+            :api-version "23",
+            :manufacturer "iobeam",
+            :model "mustang",
+            :os-name "6.0.1"})
+   (xt/put :device-readings
+           {:xt/id "reading-demo000001",
+            :device-id "device-info-demo000001",
+            :cpu-avg-15min 8.822,
+            :rssi -61.0,
+            :cpu-avg-5min 8.106,
+            :battery-status "discharging",
+            :ssid "stealth-net",
+            :time #inst "2016-11-15T12:00:00.000-00:00",
+            :battery-level 86.0,
+            :bssid "A0:B1:C5:D2:E0:F3",
+            :battery-temperature 93.7,
+            :cpu-avg-1min 4.93,
+            :mem-free 7.20742332E8,
+            :mem-used 2.79257668E8})])
 
 (t/deftest can-write-tx-to-arrow-ipc-streaming-format
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-tx.json") devices-docs))
 
 (t/deftest can-write-put-fns
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-put-fns.json")
-                         [[:put-fn :foo '(fn [id] [[:put :foo {:xt/id id}]])]
-                          [:put-fn :bar '(fn [id] [[:put :bar {:xt/id id}]])
-                           {:for-valid-time [:in #inst "2020" nil]}]]))
+                         [(xt/put-fn :foo '(fn [id] [(xt/put :foo {:xt/id id})]))
+                          (-> (xt/put-fn :bar '(fn [id] [(xt/put :bar {:xt/id id})]))
+                              (xt/starting-from #inst "2020"))]))
 
 (t/deftest can-write-tx-fn-calls
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-tx-fn-calls.json")
-                         [[:call :foo 12 nil :bar]
-                          [:call :foo2 "hello" "world"]]))
+                         [(xt/call :foo 12 nil :bar)
+                          (xt/call :foo2 "hello" "world")]))
 
 (t/deftest can-write-docs-with-different-keys
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/docs-with-different-keys.json")
-                         [[:put :foo {:xt/id :a, :a 1}]
-                          [:put :foo {:xt/id "b", :b 2}]
-                          [:put :bar {:xt/id 3, :c 3}]]))
+                         [(xt/put :foo {:xt/id :a, :a 1})
+                          (xt/put :foo {:xt/id "b", :b 2})
+                          (xt/put :bar {:xt/id 3, :c 3})]))
 
 (t/deftest can-write-sql-to-arrow-ipc-streaming-format
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-sql.json")
-                         [[:sql "INSERT INTO foo (xt$id) VALUES (0)"]
+                         [(xt/sql-op "INSERT INTO foo (xt$id) VALUES (0)")
 
-                          [:sql-batch ["INSERT INTO foo (xt$id, foo, bar) VALUES (?, ?, ?)"
-                                       [1 nil 3.3]
-                                       [2 "hello" 12]]]
+                          (-> (xt/sql-op "INSERT INTO foo (xt$id, foo, bar) VALUES (?, ?, ?)")
+                              (xt/with-op-args
+                                [1 nil 3.3]
+                                [2 "hello" 12]))
 
-                          [:sql ["UPDATE foo FOR PORTION OF VALID_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.xt$id = ?"
-                                 1]]
+                          (-> (xt/sql-op "UPDATE foo FOR PORTION OF VALID_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.xt$id = ?")
+                              (xt/with-op-args [1]))
 
-                          [:sql ["DELETE FROM foo FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01' WHERE foo.xt$id = ?"
-                                 1]]]))
+                          (-> (xt/sql-op "DELETE FROM foo FOR PORTION OF VALID_TIME FROM DATE '2023-01-01' TO DATE '2025-01-01' WHERE foo.xt$id = ?")
+                              (xt/with-op-args [1]))]))
 
 (t/deftest can-write-xtql
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-xtdml.json")
-                         [[:xtql '(update :users {:bind {:xt/id $uid, :version v}
-                                                  :set {v (inc v)}})
-                           {:uid :jms}]
+                         [(-> (xt/xtql-op '(update :users {:bind {:xt/id $uid, :version v}
+                                                           :set {v (inc v)}}))
+                              (xt/with-op-args {:uid :jms}))
 
-                          [:xtql '(delete :users {:bind {:xt/id $uid}})
-                           {:uid :jms}]]))
+                          (-> (xt/xtql-op '(delete :users {:bind {:xt/id $uid}}))
+                              (xt/with-op-args {:uid :jms}))]))
 
 (t/deftest can-write-opts
   (test-serialize-tx-ops (io/resource "xtdb/tx-producer-test/can-write-opts.json")
-                         [[:sql "INSERT INTO foo (id) VALUES (0)"]]
+                         [(xt/sql-op "INSERT INTO foo (id) VALUES (0)")]
 
                          {:system-time (util/->instant #inst "2021")
                           :default-all-valid-time? false

--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -7,18 +7,17 @@
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
             [xtdb.james-bond :as bond]
+            [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util]
-            [xtdb.node :as xtn])
-  (:import (xtdb.types ClojureForm)))
+            [xtdb.util :as util]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
 ;;TODO test nested subqueries
 
 (def ivan+petr
-  [[:put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
-   [:put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
+  [(xt/put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"})
+   (xt/put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"})])
 
 (deftest test-from
   (xt/submit-tx tu/*node* ivan+petr)
@@ -45,7 +44,7 @@
 (deftest test-from-unification
   (xt/submit-tx tu/*node*
                 (conj ivan+petr
-                      [:put :docs {:xt/id :jeff, :first-name "Jeff", :last-name "Jeff"}]))
+                      (xt/put :docs {:xt/id :jeff, :first-name "Jeff", :last-name "Jeff"})))
 
   (t/is (= #{{:name "Jeff"}}
            (set (xt/q tu/*node* '(from :docs [{:first-name name :last-name name}])))))
@@ -164,8 +163,8 @@
                         (offset 1)
                         (limit 1)))))
 
-    (xt/submit-tx tu/*node* [[:put :docs {:xt/id :dave :first-name nil}]
-                             [:put :docs {:xt/id :jeff :first-name "Jeff"}]])
+    (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :dave :first-name nil})
+                             (xt/put :docs {:xt/id :jeff :first-name "Jeff"})])
 
     (t/is (= [{:first-name nil}
               {:first-name "Ivan"}
@@ -185,10 +184,10 @@
 
 (deftest test-order-by-multiple-cols
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id 2, :n 2}]
-                           [:put :docs {:xt/id 3, :n 3}]
-                           [:put :docs {:xt/id 1, :n 2}]
-                           [:put :docs {:xt/id 4, :n 1}]])]
+                          [(xt/put :docs {:xt/id 2, :n 2})
+                           (xt/put :docs {:xt/id 3, :n 3})
+                           (xt/put :docs {:xt/id 1, :n 2})
+                           (xt/put :docs {:xt/id 4, :n 1})])]
     (t/is (= [{:i 4, :n 1}
               {:i 1, :n 2}
               {:i 2, :n 2}
@@ -200,10 +199,10 @@
 ;; https://github.com/tonsky/datascript/blob/1.1.0/test/datascript/test/query.cljc#L12-L36
 (deftest datascript-test-unify
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id 1, :name "Ivan", :age 15}]
-                           [:put :docs {:xt/id 2, :name "Petr", :age 37}]
-                           [:put :docs {:xt/id 3, :name "Ivan", :age 37}]
-                           [:put :docs {:xt/id 4, :age 15}]])]
+                          [(xt/put :docs {:xt/id 1, :name "Ivan", :age 15})
+                           (xt/put :docs {:xt/id 2, :name "Petr", :age 37})
+                           (xt/put :docs {:xt/id 3, :name "Ivan", :age 37})
+                           (xt/put :docs {:xt/id 4, :age 15})])]
 
     (t/is (= #{{:e 1, :v 15} {:e 3, :v 37}}
              (set (xt/q tu/*node*
@@ -247,8 +246,8 @@
           "cross join required here")))
 
 (deftest test-namespaced-attributes
-  (let [_tx (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo :foo/bar 1}]
-                                     [:put :docs {:xt/id :bar :foo/bar 2}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :foo :foo/bar 1})
+                                     (xt/put :docs {:xt/id :bar :foo/bar 2})])]
     (t/is (= [{:i :foo, :n 1} {:i :bar, :n 2}]
              (xt/q tu/*node*
                    '(from :docs [{:xt/id i :foo/bar n}])))
@@ -295,10 +294,10 @@
 
 (t/deftest datascript-test-aggregates
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id :cerberus, :heads 3}]
-                           [:put :docs {:xt/id :medusa, :heads 1}]
-                           [:put :docs {:xt/id :cyclops, :heads 1}]
-                           [:put :docs {:xt/id :chimera, :heads 1}]])]
+                          [(xt/put :docs {:xt/id :cerberus, :heads 3})
+                           (xt/put :docs {:xt/id :medusa, :heads 1})
+                           (xt/put :docs {:xt/id :cyclops, :heads 1})
+                           (xt/put :docs {:xt/id :chimera, :heads 1})])]
     (t/is (= #{{:heads 1, :count-heads 3} {:heads 3, :count-heads 1}}
              (set (xt/q tu/*node*
                         '(-> (from :docs [heads])
@@ -315,8 +314,8 @@
           "various aggs")))
 
 (deftest test-clojure-case-symbols-in-expr
-  (xt/submit-tx tu/*node* [[:put :customers {:xt/id 0, :name "bob"}]
-                           [:put :customers {:xt/id 1, :name "alice"}]])
+  (xt/submit-tx tu/*node* [(xt/put :customers {:xt/id 0, :name "bob"})
+                           (xt/put :customers {:xt/id 1, :name "alice"})])
 
   (t/is (= [{:count 2}]
            (xt/q tu/*node*
@@ -330,9 +329,9 @@
 
 
 (t/deftest test-with-op
-  (let [_tx (xt/submit-tx tu/*node* [[:put :docs {:xt/id :o1, :unit-price 1.49, :quantity 4}]
-                                     [:put :docs {:xt/id :o2, :unit-price 5.39, :quantity 1}]
-                                     [:put :docs {:xt/id :o3, :unit-price 0.59, :quantity 7}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :o1, :unit-price 1.49, :quantity 4})
+                                     (xt/put :docs {:xt/id :o2, :unit-price 5.39, :quantity 1})
+                                     (xt/put :docs {:xt/id :o3, :unit-price 0.59, :quantity 7})])]
     (t/is (= #{{:oid :o1, :o-value 5.96, :unit-price 1.49, :qty 4}
                {:oid :o2, :o-value 5.39, :unit-price 5.39, :qty 1}
                {:oid :o3, :o-value 4.13, :unit-price 0.59, :qty 7}}
@@ -355,7 +354,7 @@
                         (with {:a 2})))))))
 
 (t/deftest test-with-op-errs
-  (let [_tx (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo}]])]
+  (let [_tx (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :foo})])]
     (t/is (thrown-with-msg? IllegalArgumentException
                             #"Not all variables in expression are in scope"
                             (xt/q tu/*node*
@@ -374,9 +373,9 @@
                      (with {b 2} {b 3})))))))
 #_
 (deftest test-aggregate-exprs
-  (let [tx (xt/submit-tx tu/*node* [[:put :docs {:xt/id :foo, :category :c0, :v 1}]
-                                    [:put :docs {:xt/id :bar, :category :c0, :v 2}]
-                                    [:put :docs {:xt/id :baz, :category :c1, :v 4}]])]
+  (let [tx (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :foo, :category :c0, :v 1})
+                                    (xt/put :docs {:xt/id :bar, :category :c0, :v 2})
+                                    (xt/put :docs {:xt/id :baz, :category :c1, :v 4})])]
     (t/is (= [{:category :c0, :sum-doubles 6}
               {:category :c1, :sum-doubles 8}]
              (xt/q tu/*node*
@@ -458,7 +457,7 @@
                     [10 15 20 35 75]])))))
 
 (deftest test-composite-value-bindings
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :map {:foo 1} :set #{1 2 3}}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :map {:foo 1} :set #{1 2 3}})])
 
   (t/is (= [{:xt/id 1}]
            (xt/q tu/*node* '(from :docs [xt/id {:map {:foo 1}}]))))
@@ -556,10 +555,10 @@
 
 (deftest test-left-join
   (xt/submit-tx tu/*node*
-                [[:put :docs {:xt/id :ivan, :name "Ivan"}]
-                 [:put :docs {:xt/id :petr, :name "Petr", :parent :ivan}]
-                 [:put :docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
-                 [:put :docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])
+                [(xt/put :docs {:xt/id :ivan, :name "Ivan"})
+                 (xt/put :docs {:xt/id :petr, :name "Petr", :parent :ivan})
+                 (xt/put :docs {:xt/id :sergei, :name "Sergei", :parent :petr})
+                 (xt/put :docs {:xt/id :jeff, :name "Jeff", :parent :petr})])
 
   (t/is (= #{{:e :ivan, :c :petr}
              {:e :petr, :c :sergei}
@@ -597,10 +596,10 @@
 
 (deftest test-exists
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id :ivan, :name "Ivan"}]
-                           [:put :docs {:xt/id :petr, :name "Petr", :parent :ivan}]
-                           [:put :docs {:xt/id :sergei, :name "Sergei", :parent :petr}]
-                           [:put :docs {:xt/id :jeff, :name "Jeff", :parent :petr}]])]
+                          [(xt/put :docs {:xt/id :ivan, :name "Ivan"})
+                           (xt/put :docs {:xt/id :petr, :name "Petr", :parent :ivan})
+                           (xt/put :docs {:xt/id :sergei, :name "Sergei", :parent :petr})
+                           (xt/put :docs {:xt/id :jeff, :name "Jeff", :parent :petr})])]
 
     (t/is (= #{{:x true}}
              (set (xt/q tu/*node*
@@ -630,9 +629,9 @@
 (deftest test-not-exists
   (let [_tx (xt/submit-tx
              tu/*node*
-             [[:put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1}]
-              [:put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov" :foo 1}]
-              [:put :docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1}]])]
+             [(xt/put :docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1})
+              (xt/put :docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov" :foo 1})
+              (xt/put :docs {:xt/id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1})])]
 
     (t/is (= #{{:e :ivan} {:e :sergei}}
              (set (xt/q tu/*node*
@@ -701,9 +700,9 @@
 
 (deftest testing-unify-with
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id :ivan, :age 15}]
-                           [:put :docs {:xt/id :petr, :age 22}]
-                           [:put :docs {:xt/id :slava, :age 37}]])]
+                          [(xt/put :docs {:xt/id :ivan, :age 15})
+                           (xt/put :docs {:xt/id :petr, :age 22})
+                           (xt/put :docs {:xt/id :slava, :age 37})])]
 
     (t/is (= #{{:e1 :petr, :e2 :ivan, :e3 :slava}
                {:e1 :ivan, :e2 :petr, :e3 :slava}}
@@ -730,7 +729,7 @@
 
 
 (deftest test-namespaced-columns-in-from
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :ivan}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :ivan})])
   (t/is (= [{:xt/id :ivan}]
            (xt/q tu/*node* '(from :docs [xt/id]))))
   (t/is (= [{:id :ivan}]
@@ -739,9 +738,9 @@
 #_
 (deftest test-nested-expressions-581
   (let [_tx (xt/submit-tx tu/*node*
-                          [[:put :docs {:xt/id :ivan, :age 15}]
-                           [:put :docs {:xt/id :petr, :age 22, :height 240, :parent 1}]
-                           [:put :docs {:xt/id :slava, :age 37, :parent 2}]])]
+                          [(xt/put :docs {:xt/id :ivan, :age 15})
+                           (xt/put :docs {:xt/id :petr, :age 22, :height 240, :parent 1})
+                           (xt/put :docs {:xt/id :slava, :age 37, :parent 2})])]
 
     (t/is (= #{{:e1 :ivan, :e2 :petr, :e3 :slava}
                {:e1 :petr, :e2 :ivan, :e3 :slava}}
@@ -817,9 +816,9 @@
         "films made by the Bond with the most films"))
 
 (deftest test-join-clause-unification
-  (xt/submit-tx tu/*node* [[:put :a {:xt/id :a1, :a 2 :b 1}]
-                           [:put :a {:xt/id :a2, :a 2 :b 3}]
-                           [:put :a {:xt/id :a3, :a 2 :b 0}]])
+  (xt/submit-tx tu/*node* [(xt/put :a {:xt/id :a1, :a 2 :b 1})
+                           (xt/put :a {:xt/id :a2, :a 2 :b 3})
+                           (xt/put :a {:xt/id :a3, :a 2 :b 0})])
   (t/is (= [{:aid :a2 :a 2 :b 3}]
            (xt/q tu/*node*
                  '(unify (from :a [{:xt/id aid} a b])
@@ -854,9 +853,9 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)
-                                                   }])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)
+                                                     }))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))
 
@@ -876,12 +875,12 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)}])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)}))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))]
 
-      (xt/submit-tx node [[:put :docs {:xt/id 0 :foo :bar}]])
+      (xt/submit-tx node [(xt/put :docs {:xt/id 0 :foo :bar})])
       (submit-ops! (range 1010))
 
       (t/is (= 1010 (-> (xt/q node
@@ -898,22 +897,23 @@
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put :t1 {:xt/id id,
-                                                   :data (str "data" id)}])
+                                        (xt/put :t1 {:xt/id id,
+                                                     :data (str "data" id)}))
                                       (partition-all 20))]
                       (xt/submit-tx node tx-ops))))]
-      (let [_tx1 (xt/submit-tx node [[:put :docs {:xt/id :some-doc}]])
-            ;; going over the chunk boundary
-            tx2 (submit-ops! (range 200))]
-        (t/is (= [{:xt/id :some-doc}]
-                 (xt/q node '(-> (from :docs [xt/id])
-                                 (where (= xt/id :some-doc))))))))))
+      (xt/submit-tx node [(xt/put :docs {:xt/id :some-doc})])
+      ;; going over the chunk boundary
+      (submit-ops! (range 200))
+
+      (t/is (= [{:xt/id :some-doc}]
+               (xt/q node '(-> (from :docs [xt/id])
+                               (where (= xt/id :some-doc)))))))))
 
 #_
 (deftest test-basic-rules
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :ivan :name "Ivan" :last-name "Ivanov" :age 21}]
-                           [:put :docs {:xt/id :petr :name "Petr" :last-name "Petrov" :age 18}]
-                           [:put :docs {:xt/id :georgy :name "Georgy" :last-name "George" :age 17}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :ivan :name "Ivan" :last-name "Ivanov" :age 21})
+                           (xt/put :docs {:xt/id :petr :name "Petr" :last-name "Petrov" :age 18})
+                           (xt/put :docs {:xt/id :georgy :name "Georgy" :last-name "George" :age 17})])
   (letfn [(q [query & args]
             (apply xt/q tu/*node* query args))]
 
@@ -1206,13 +1206,13 @@
     ;; 2023: Matthew, Mark (again)
     ;; 2024+: Matthew
 
-    (let [tx0 (xt/submit-tx tu/*node* [[:put :docs {:xt/id :matthew} {:for-valid-time [:in #inst "2015"]}]
-                                       [:put :docs {:xt/id :mark} {:for-valid-time [:in  #inst "2018"  #inst "2020"]}]
-                                       [:put :docs {:xt/id :luke} {:for-valid-time [:in #inst "2021"]}]])
+    (let [tx0 (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id :matthew}) (xt/starting-from #inst "2015"))
+                                       (-> (xt/put :docs {:xt/id :mark}) (xt/during #inst "2018" #inst "2020"))
+                                       (-> (xt/put :docs {:xt/id :luke}) (xt/starting-from #inst "2021"))])
 
-          tx1 (xt/submit-tx tu/*node* [[:delete :docs :luke {:for-valid-time [:in #inst "2022"]}]
-                                       [:put :docs {:xt/id :mark} {:for-valid-time [:in #inst "2023" #inst "2024"]}]
-                                       [:put :docs {:xt/id :john} {:for-valid-time [:in #inst "2016" #inst "2020"]}]])]
+          tx1 (xt/submit-tx tu/*node* [(-> (xt/delete :docs :luke) (xt/starting-from #inst "2022"))
+                                       (-> (xt/put :docs {:xt/id :mark}) (xt/during #inst "2023" #inst "2024"))
+                                       (-> (xt/put :docs {:xt/id :john}) (xt/during #inst "2016" #inst "2020"))])]
 
       (t/is (= #{{:id :matthew}, {:id :mark}}
                (set (q '(from :docs [{:xt/id id}]), tx1, #inst "2023"))))
@@ -1272,8 +1272,10 @@
             "for all sys time"))))
 
 (t/deftest test-for-valid-time-with-current-time-2493
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :matthew} {:for-valid-time [:in nil #inst "2040"]}]])
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id :matthew} {:for-valid-time [:in #inst "2022" #inst "2030"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id :matthew})
+                               (xt/until #inst "2040"))])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id :matthew})
+                               (xt/during #inst "2022" #inst "2030"))])
   (t/is (= #{{:id :matthew,
               :vt-from #time/zoned-date-time "2030-01-01T00:00Z[UTC]",
               :vt-to #time/zoned-date-time "2040-01-01T00:00Z[UTC]"}
@@ -1299,9 +1301,9 @@
     ;; tx1
     ;; now - 2040 : Matthew
 
-    (let [tx0 (xt/submit-tx tu/*node* [[:put :docs {:xt/id :matthew} {:for-valid-time [:from #inst "2015"]}]
-                                       [:put :docs {:xt/id :mark} {:for-valid-time [:to #inst "2050"]}]])
-          tx1 (xt/submit-tx tu/*node* [[:put :docs {:xt/id :matthew} {:for-valid-time [:to #inst "2040"]}]])]
+    (let [tx0 (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id :matthew}) (xt/starting-from #inst "2015"))
+                                       (-> (xt/put :docs {:xt/id :mark}) (xt/until #inst "2050"))])
+          tx1 (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id :matthew}) (xt/until #inst "2040"))])]
       (t/is (= #{{:id :matthew,
                   :vt-from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
                   :vt-to nil}
@@ -1343,52 +1345,54 @@
                   {:args args :basis {:tx tx, :current-time (util/->instant current-time)}}))]
 
     (let [tx0 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-10"]}]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                 (xt/starting-from #inst "1998-01-10"))]
                             {:system-time #inst "1998-01-10"})
 
           tx1 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 827 :property-number 7797}
-                              {:for-valid-time [:in  #inst "1998-01-15"] }]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 827 :property-number 7797})
+                                 (xt/starting-from #inst "1998-01-15"))]
                             {:system-time #inst "1998-01-15"})
 
           _tx2 (xt/submit-tx tu/*node*
-                             [[:delete :docs 1 {:for-valid-time [:in #inst "1998-01-20"]}]]
+                             [(-> (xt/delete :docs 1)
+                                  (xt/starting-from #inst "1998-01-20"))]
                              {:system-time #inst "1998-01-20"})
 
           _tx3 (xt/submit-tx tu/*node*
-                             [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                               {:for-valid-time [:in #inst "1998-01-03" #inst "1998-01-10"]}]]
+                             [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                  (xt/during #inst "1998-01-03" #inst "1998-01-10"))]
                              {:system-time #inst "1998-01-23"})
 
           _tx4 (xt/submit-tx tu/*node*
-                             [[:delete :docs 1 {:for-valid-time [:in #inst "1998-01-03" #inst "1998-01-05"]}]]
+                             [(-> (xt/delete :docs 1) (xt/during #inst "1998-01-03" #inst "1998-01-05"))]
                              {:system-time #inst "1998-01-26"})
 
           tx5 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 1 :customer-number 145 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-05" #inst "1998-01-12"]}]
-                             [:put :docs {:xt/id 1 :customer-number 827 :property-number 7797}
-                              {:for-valid-time [:in #inst "1998-01-12" #inst "1998-01-20"]}]]
+                            [(-> (xt/put :docs {:xt/id 1 :customer-number 145 :property-number 7797})
+                                 (xt/during #inst "1998-01-05" #inst "1998-01-12"))
+                             (-> (xt/put :docs {:xt/id 1 :customer-number 827 :property-number 7797})
+                                 (xt/during #inst "1998-01-12" #inst "1998-01-20"))]
                             {:system-time #inst "1998-01-28"})
 
           tx6 (xt/submit-tx tu/*node*
-                            [[:put-fn :delete-1-week-records,
-                              '(fn delete-1-weeks-records []
-                                 (->> (q '(-> (from :docs {:bind [{:xt/id id
-                                                                   :xt/valid-from app-from
-                                                                   :xt/valid-to app-to}]
-                                                           :for-valid-time :all-time})
-                                              (where (= (- #inst "1970-01-08" #inst "1970-01-01")
-                                                        (- app-to app-from)))))
-                                      (map (fn [{:keys [id app-from app-to]}]
-                                             [:delete :docs id {:for-valid-time [:in app-from app-to]}]))))]
-                             [:call :delete-1-week-records]]
+                            [(xt/put-fn :delete-1-week-records,
+                                        '(fn delete-1-weeks-records []
+                                           (->> (q '(-> (from :docs {:bind [{:xt/id id
+                                                                             :xt/valid-from app-from
+                                                                             :xt/valid-to app-to}]
+                                                                     :for-valid-time :all-time})
+                                                        (where (= (- #inst "1970-01-08" #inst "1970-01-01")
+                                                                  (- app-to app-from)))))
+                                                (map (fn [{:keys [id app-from app-to]}]
+                                                       (-> (xt/delete :docs id)
+                                                           (xt/during app-from app-to)))))))
+                             (xt/call :delete-1-week-records)]
                             {:system-time #inst "1998-01-30"})
 
           tx7 (xt/submit-tx tu/*node*
-                            [[:put :docs {:xt/id 2 :customer-number 827 :property-number 3621}
-                              {:for-valid-time [:in #inst "1998-01-15"]}]]
+                            [(-> (xt/put :docs {:xt/id 2 :customer-number 827 :property-number 3621})
+                                 (xt/starting-from #inst "1998-01-15"))]
                             {:system-time #inst "1998-01-31"})]
 
       (t/is (= [{:cust 145 :app-from (util/->zdt #inst "1998-01-10")}]
@@ -1527,11 +1531,11 @@
             "Case 8: Application-time sequenced and system-time nonsequenced"))))
 
 (deftest scalar-sub-queries-test
-  (xt/submit-tx tu/*node* [[:put :customer {:xt/id 0, :firstname "bob", :lastname "smith"}]
-                           [:put :customer {:xt/id 1, :firstname "alice" :lastname "carrol"}]
-                           [:put :order {:xt/id 0, :customer 0, :items [{:sku "eggs", :qty 1}]}]
-                           [:put :order {:xt/id 1, :customer 0, :items [{:sku "cheese", :qty 3}]}]
-                           [:put :order {:xt/id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]}]])
+  (xt/submit-tx tu/*node* [(xt/put :customer {:xt/id 0, :firstname "bob", :lastname "smith"})
+                           (xt/put :customer {:xt/id 1, :firstname "alice" :lastname "carrol"})
+                           (xt/put :order {:xt/id 0, :customer 0, :items [{:sku "eggs", :qty 1}]})
+                           (xt/put :order {:xt/id 1, :customer 0, :items [{:sku "cheese", :qty 3}]})
+                           (xt/put :order {:xt/id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]})])
 
   (t/are [q result] (= (into #{} result) (set (xt/q tu/*node* q)))
 
@@ -1663,14 +1667,16 @@
     (t/is (thrown-with-msg? xtdb.IllegalArgumentException #"Scalar subquery must only return a single column"
                             (->> '(unify
                                    (with
-                                     {n-customers
-                                      (q (from :customer [{:customer customer, :firstname firstname}]))}))
+                                    {n-customers
+                                     (q (from :customer [{:customer customer, :firstname firstname}]))}))
                                  (xt/q tu/*node*))))))
 
 (deftest test-period-predicates
 
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1} {:for-valid-time [:in #inst "2015" #inst "2020"]}]
-                           [:put :xt_cats {:xt/id 2} {:for-valid-time [:in #inst "2016" #inst "2018"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id 1})
+                               (xt/during #inst "2015" #inst "2020"))
+                           (-> (xt/put :xt_cats {:xt/id 2})
+                               (xt/during #inst "2016" #inst "2018"))])
 
   (t/is (= [{:xt/id 1, :id2 2,
              :docs-app-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
@@ -1718,19 +1724,20 @@
 
 
 (deftest test-period-and-temporal-col-projection
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1} {:for-valid-time [:in #inst "2015" #inst "2050"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id 1})
+                               (xt/during #inst "2015" #inst "2050"))])
 
 
   (t/is (= [{:xt/id 1,
-             :app-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
-                        :to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"},
+             :valid-time {:from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
+                          :to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"},
              :xt/valid-from #time/zoned-date-time "2015-01-01T00:00Z[UTC]",
-             :app-time-to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
+             :valid-to #time/zoned-date-time "2050-01-01T00:00Z[UTC]"}]
            (xt/q
             tu/*node*
             '(from :docs {:bind [xt/id xt/valid-from
-                                 {:xt/valid-time app_time
-                                  :xt/valid-to app-time-to}]
+                                 {:xt/valid-time valid-time
+                                  :xt/valid-to valid-to}]
                           :for-valid-time :all-time})))
         "projecting both period and underlying cols")
 
@@ -1776,7 +1783,7 @@
                                  :for-system-time :all-time}))))
         "period unification")
 
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 2}]])
+  (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 2})])
 
   (t/is (= [{:xt/id 2,
              :time {:from #time/zoned-date-time "2020-01-02T00:00Z[UTC]",
@@ -1790,9 +1797,8 @@
                     :for-system-time :all-time})))
         "period unification within match")
 
-  (xt/submit-tx tu/*node* [[:put :docs
-                            {:xt/id 3 :c {:from #inst "2015" :to #inst "2050"}}
-                            {:for-valid-time [:in #inst "2015" #inst "2050"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id 3 :c {:from #inst "2015" :to #inst "2050"}})
+                               (xt/during #inst "2015" #inst "2050"))])
 
   (t/is (= [{:xt/id 3,
              :time
@@ -1826,8 +1832,10 @@
                  {:explain? true}))))
 
 (t/deftest test-default-valid-time
-  (xt/submit-tx tu/*node* [[:put :docs {:xt/id 1 :foo "2000-4000"} {:for-valid-time [:in #inst "2000" #inst "4000"]}]
-                           [:put :docs {:xt/id 1 :foo "3000-"} {:for-valid-time [:from #inst "3000"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :docs {:xt/id 1 :foo "2000-4000"})
+                               (xt/during #inst "2000" #inst "4000"))
+                           (-> (xt/put :docs {:xt/id 1 :foo "3000-"})
+                               (xt/starting-from #inst "3000"))])
 
   (t/is (= #{{:xt/id 1, :foo "2000-4000"} {:xt/id 1, :foo "3000-"}}
            (set (xt/q tu/*node*
@@ -1836,22 +1844,22 @@
 
 
 (t/deftest test-sql-insert
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (xt$id) VALUES (0)"]])
+  (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO foo (xt$id) VALUES (0)")])
   (t/is (= [{:xt/id 0}]
            (xt/q tu/*node*
                  '(from :foo [xt/id])))))
 
 
 (t/deftest test-put
-  (xt/submit-tx tu/*node* [[:put :foo {:xt/id 0}]])
+  (xt/submit-tx tu/*node* [(xt/put :foo {:xt/id 0})])
   (t/is (= [{:xt/id 0}]
            (xt/q tu/*node*
                  '(from :foo [xt/id])))))
 
 (t/deftest test-metadata-filtering-for-time-data-607
   (with-open [node (xtn/start-node {:xtdb/indexer {:rows-per-chunk 1}})]
-    (xt/submit-tx node [[:put :docs {:xt/id 1 :from-date #time/date "2000-01-01"}]
-                        [:put :docs {:xt/id 2 :from-date #time/date "3000-01-01"}]])
+    (xt/submit-tx node [(xt/put :docs {:xt/id 1 :from-date #time/date "2000-01-01"})
+                        (xt/put :docs {:xt/id 2 :from-date #time/date "3000-01-01"})])
     (t/is (= [{:id 1}]
 
              (xt/q node
@@ -1860,8 +1868,8 @@
                                (< from-date #inst "2500"))
                         (return id)))))
 
-    (xt/submit-tx node [[:put :docs2 {:xt/id 1 :from-date #inst "2000-01-01"}]
-                        [:put :docs2 {:xt/id 2 :from-date #inst "3000-01-01"}]])
+    (xt/submit-tx node [(xt/put :docs2 {:xt/id 1 :from-date #inst "2000-01-01"})
+                        (xt/put :docs2 {:xt/id 2 :from-date #inst "3000-01-01"})])
     (t/is (= [{:id 1}]
              (xt/q node
                    '(-> (from :docs2 [{:xt/id id} from-date])
@@ -1870,7 +1878,7 @@
                         (return id)))))))
 
 (t/deftest bug-non-namespaced-nested-keys-747
-  (xt/submit-tx tu/*node* [[:put :bar {:xt/id 1 :foo {:a/b "foo"}}]])
+  (xt/submit-tx tu/*node* [(xt/put :bar {:xt/id 1 :foo {:a/b "foo"}})])
   (t/is (= [{:foo {:a/b "foo"}}]
            (xt/q tu/*node*
                  '(from :bar [foo])))))
@@ -1893,7 +1901,7 @@
 
         _
         (doseq [[doc system-time] inputs]
-          (xt/submit-tx tu/*node* [[:put :x doc]] {:system-time system-time}))
+          (xt/submit-tx tu/*node* [(xt/put :x doc)] {:system-time system-time}))
 
         q (partial xt/q tu/*node*)]
 
@@ -1920,7 +1928,7 @@
 
         _
         (doseq [[doc app-time] inputs]
-          (xt/submit-tx tu/*node* [[:put :x doc {:for-valid-time [:in app-time]}]]))
+          (xt/submit-tx tu/*node* [(-> (xt/put :x doc) (xt/starting-at app-time))]))
 
         q (partial xt/q tu/*node*)]
 
@@ -1938,7 +1946,7 @@
 
 
 (t/deftest test-normalisation
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/hELLo-wORLd 2}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/hELLo-wORLd 2})])
   (t/is (= [{:foo/bar 1, :bar.foo/hello-world 2}]
            (xt/q tu/*node* '(from :xt-docs [Foo/Bar Bar.Foo/Hello-World]))))
   (t/is (= [{:bar 1, :foo 2}]
@@ -1947,23 +1955,25 @@
 
 (t/deftest test-table-normalisation
   (let [doc {:xt/id "doc" :foo "bar"}]
-    (xt/submit-tx tu/*node* [[:put :xt/the-docs doc]])
+    (xt/submit-tx tu/*node* [(xt/put :xt/the-docs doc)])
     (t/is (= [{:id "doc"}]
              (xt/q tu/*node* '(from :xt/the-docs [{:xt/id id}]))))
-    (xt/submit-tx tu/*node* [[:put :xt.docs/the-docs doc]])
+    (xt/submit-tx tu/*node* [(xt/put :xt.docs/the-docs doc)])
     (t/is (= [{:id "doc"}]
              (xt/q tu/*node* '(from :xt.docs/the-docs [{:xt/id id}])))
           "with dots in namespace")))
 
 (t/deftest test-inconsistent-valid-time-range-2494
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1} {:for-valid-time [:in nil #inst "2011"]}]])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt-docs {:xt/id 1})
+                               (xt/until #inst "2011"))])
   (t/is (= [{:tx-id 0, :committed? false}]
 
            (xt/q tu/*node*
                  '(from :xt/txs [{:xt/id tx-id,
                                   :xt/committed? committed?}]))))
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 2}]])
-  (xt/submit-tx tu/*node* [[:delete :xt-docs 2 {:for-valid-time [:in nil #inst "2011"]}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 2})])
+  (xt/submit-tx tu/*node* [(-> (xt/delete :xt-docs 2)
+                               (xt/until #inst "2011"))])
 
   (t/is (= #{{:tx-id 0, :committed? false}
              {:tx-id 1, :committed? true}
@@ -1988,7 +1998,7 @@
                                     :xtdb.tx-producer/tx-producer {:instant-src (tu/->mock-clock)}
                                     :xtdb.log/memory-log {:instant-src (tu/->mock-clock)}})]
     (doseq [i (range 10)]
-      (xt/submit-tx node [[:put :ints {:xt/id 0 :n i}]]))
+      (xt/submit-tx node [(xt/put :ints {:xt/id 0 :n i})]))
 
     (t/is (=
            #{{:n 0,
@@ -2015,10 +2025,12 @@
                                          :for-valid-time (in #inst "2020-01-01" #inst "2020-01-06")})))))))
 
 (deftest test-no-zero-width-intervals
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1 :v 1}]
-                           [:put :xt-docs {:xt/id 1 :v 2}]
-                           [:put :xt-docs {:xt/id 2 :v 1} {:for-valid-time [:in #inst "2020-01-01" #inst "2020-01-02"]}]])
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 2 :v 2} {:for-valid-time [:in #inst "2020-01-01" #inst "2020-01-02"]}]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 1 :v 1})
+                           (xt/put :xt-docs {:xt/id 1 :v 2})
+                           (-> (xt/put :xt-docs {:xt/id 2 :v 1})
+                               (xt/during #inst "2020-01-01" #inst "2020-01-02"))])
+  (xt/submit-tx tu/*node* [(-> (xt/put :xt-docs {:xt/id 2 :v 2})
+                               (xt/during #inst "2020-01-01" #inst "2020-01-02"))])
   (t/is (= [{:v 2}]
            (xt/q tu/*node*
                  '(from :xt-docs {:bind [{:xt/id 1} v] :for-system-time :all-time})))
@@ -2031,8 +2043,8 @@
 #_
 (deftest row-alias-on-txs-tables-2809
   ;;TODO from-star
-  (xt/submit-tx tu/*node* [[:put :xt-docs {:xt/id 1 :v 1}]])
-  (xt/submit-tx tu/*node* [[:call :non-existing-fn]])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id 1 :v 1})])
+  (xt/submit-tx tu/*node* [(xt/call :non-existing-fn)])
 
   (let [txs (->> (xt/q tu/*node*
                        '{:find [tx]
@@ -2054,11 +2066,11 @@
              (.getData ^xtdb.RuntimeException (.form ^ClojureForm (:xt/error (first txs))))))))
 
 (deftest test-pull
-  (xt/submit-tx tu/*node* [[:put :customers {:xt/id 0, :name "bob"}]
-                           [:put :customers {:xt/id 1, :name "alice"}]
-                           [:put :orders {:xt/id 0, :customer-id 0}]
-                           [:put :orders {:xt/id 1, :customer-id 0}]
-                           [:put :orders {:xt/id 2, :customer-id 1}]])
+  (xt/submit-tx tu/*node* [(xt/put :customers {:xt/id 0, :name "bob"})
+                           (xt/put :customers {:xt/id 1, :name "alice"})
+                           (xt/put :orders {:xt/id 0, :customer-id 0})
+                           (xt/put :orders {:xt/id 1, :customer-id 0})
+                           (xt/put :orders {:xt/id 2, :customer-id 1})])
 
 
   (t/is (=
@@ -2127,7 +2139,7 @@
 
 (deftest test-without-normalisation-2959-2969
   (xt/submit-tx tu/*node*
-                [[:put :users {:xt/id 1 :name "Oliver"}]])
+                [(xt/put :users {:xt/id 1 :name "Oliver"})])
 
   (t/is
    (= [{:name "Oliver"}]

--- a/src/test/resources/xtdb/tx-producer-test/can-write-put-fns.json
+++ b/src/test/resources/xtdb/tx-producer-test/can-write-put-fns.json
@@ -174,8 +174,8 @@
                   "name" : "clj-form",
                   "count" : 2,
                   "VALIDITY" : [1,1],
-                  "OFFSET" : [0,35,70],
-                  "DATA" : ["(fn [id] [[:put :foo {:xt/id id}]])","(fn [id] [[:put :bar {:xt/id id}]])"]
+                  "OFFSET" : [0,37,74],
+                  "DATA" : ["(fn [id] [(xt/put :foo {:xt/id id})])","(fn [id] [(xt/put :bar {:xt/id id})])"]
                 }]
               }]
             }]


### PR DESCRIPTION
... so that we can change their representation.

e.g.
* `(xt/put <table> <doc>)` (same for delete, erase, etc). thread it to set valid-time:
  * `(-> (xt/put <table> <doc>) (xt/starting-at <valid-from>))`
  * `(-> (xt/put <table> <doc>) (xt/until <valid-to>))`
  * `(-> (xt/put <table> <doc>) (xt/during <valid-from> <valid-to>))`
  * naming bikeshedding welcome
* `(xt/sql-op "sql")`, `(xt/xtql-op '(...))`. thread it to set args:
  * `(-> (xt/sql-op "sql") (xt/with-op-args & arg-vecs))`
  * `(-> (xt/xtql-op '(...)) (xt/with-op-args & arg-maps))`

Idea being that they're now much more consistent with XTQL. They're likely also a touch easier to migrate from XT1 (`[::xt/put <doc>]`), and we can put more validation at source (clj-kondo, but also on the arguments to the helper-fns themselves)

Next up: 
  * to actually change their underlying representation.
  * to move the XTQL DML (insert/update/delete) to the top level (out of `xt/xtql-op`)
