### PR TITLE
Fix sizing of parts when doing multipart upload on arrow files #3004

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -273,7 +273,7 @@
             new-cut (+ cut total-length)
             cut-len (- new-cut prev-cut)]
         (if (<= (int min-multipart-part-size) cut-len)
-          (recur (conj cuts new-cut) cut new-cut blocks)
+          (recur (conj cuts new-cut) new-cut new-cut blocks)
           (recur cuts prev-cut new-cut blocks)))
       cuts)))
 

--- a/src/test/clojure/xtdb/s3_test.clj
+++ b/src/test/clojure/xtdb/s3_test.clj
@@ -155,23 +155,20 @@
         (t/is (not-empty (.listObjects ^IObjectStore object-store)))))))
 
 ;; Using large enough TPCH ensures multiparts get properly used within the bufferpool
-;; FIXME: Currently failing due to mis-sized multipart upload parts, see issue here: 
-;; https://github.com/xtdb/xtdb/issues/3004
-;;
-;; (t/deftest ^:s3 tpch-test-node
-;;   (util/with-tmp-dirs #{disk-store}
-;;     (util/with-open [node (xtn/start-node {:xtdb.buffer-pool/remote {:object-store (ig/ref ::s3/object-store)
-;;                                                                      :disk-store disk-store}
-;;                                            ::s3/object-store {:bucket bucket
-;;                                                               :prefix (util/->path (str (random-uuid)))
-;;                                                               :sns-topic-arn sns-topic-arn}})]
-;;       ;; Submit tpch docs 
-;;       (-> (tpch/submit-docs! node 0.05)
-;;           (tu/then-await-tx node (Duration/ofHours 1)))
+(t/deftest ^:s3 tpch-test-node
+  (util/with-tmp-dirs #{disk-store}
+    (util/with-open [node (xtn/start-node {:xtdb.buffer-pool/remote {:object-store (ig/ref ::s3/object-store)
+                                                                     :disk-store disk-store}
+                                           ::s3/object-store {:bucket bucket
+                                                              :prefix (util/->path (str (random-uuid)))
+                                                              :sns-topic-arn sns-topic-arn}})]
+      ;; Submit tpch docs 
+      (-> (tpch/submit-docs! node 0.05)
+          (tu/then-await-tx node (Duration/ofHours 1)))
 
-;;       ;; Ensure finish-chunk! works
-;;       (t/is (nil? (tu/finish-chunk! node)))
+      ;; Ensure finish-chunk! works
+      (t/is (nil? (tu/finish-chunk! node)))
 
-;;       (let [object-store (get-in node [:system ::s3/object-store])]
-;;       ;; Ensure files have been written
-;;         (t/is (not-empty (.listObjects ^IObjectStore object-store)))))))
+      (let [object-store (get-in node [:system ::s3/object-store])]
+      ;; Ensure files have been written
+        (t/is (not-empty (.listObjects ^IObjectStore object-store)))))))


### PR DESCRIPTION
Resolves #3004

Was originally getting errors back from S3 on calling `finish-chunk!` inside the TPCH test - this was because it was trying to upload parts that were small than 5MiB. Ie: `Your proposed upload is smaller than the minimum allowed size`. 

After some digging, noticed that we were calling into the `arrow-buf-cuts` function, and with some logging, saw that the size differences between the cuts it was producing were below 5MiB. Seems like the bug was as follows:
- Behaviour is supposed to be that, when we can take a large enough (>5MiB) cut from recordbatches, we're supposed to add the cut point to the list of cut points, update the value of `prev-cut`, the value of `cut` and pass through the blocklist. 
- I'm pretty `prev-cut` is meant to be used to keep track of the last cut-point that we made, but we were passing through the wrong value, ie `cut` instead of `new-cut`.
- Updated this, test now works with part sizes >5MiB