### PR TITLE
Guide for using XTDB over HTTP

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -55,6 +55,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
+            { label: 'Discover XTQL with cURL', link: '/learn/xtdb-http' },
           ],
         },
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -107,6 +107,7 @@ export default defineConfig({
               label: 'Formats',
               items: [
                 { label: 'Transit', link: '/reference/main/formats/transit'},
+                { label: 'JSON', link: '/reference/main/formats/json'},
               ]
             },
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -103,6 +103,11 @@ export default defineConfig({
                 { label: 'Temporal functions', link: '/reference/main/stdlib/temporal'},
                 { label: 'Aggregate functions', link: '/reference/main/stdlib/aggregates'},
               ]
+            }, {
+              label: 'Formats',
+              items: [
+                { label: 'Transit', link: '/reference/main/formats/transit'},
+              ]
             },
 
             {

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -11,14 +11,6 @@ We include practical examples and their expected outputs, so please follow along
 In this guide we'll be using `curl` to interact with XTDB. +
 You can also use the HTTP client from your programming language of choice.
 
-// TODO:
-// - Convert all examples to application/json
-// - Style admonitions
-// - Reference for transit extensions
-// - Reference for JSON syntax
-// - Confirm this doc is correct
-// - Special tables doc
-
 == Prerequisites
 
 To get started, ensure Docker is installed. Then pull and run the XTDB Docker image:
@@ -82,7 +74,7 @@ In this guide we'll be using the content type `application/json` but for more ef
 
 See link:https://github.com/cognitect/transit-format[here,window=_blank] to learn more about transit.
 
-// TODO: Link to our transit extensions reference
+See our transit extensions link:../reference/main/formats/transit#_transit_extensions[here].
 ====
 
 [#tx]

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -1,4 +1,6 @@
-= Interacting with XTDB using the HTTP API
+---
+title: Interacting with XTDB using the HTTP API
+---
 :resources: ../src/test/resources/docs/
 :script: {resources}/xtdb_http.sh
 :output: {resources}/xtdb_http.expected-output.txt

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -160,7 +160,7 @@ curl -X POST \
      -H "Content-Type: application/transit+json" \
      -H "Accept: application/transit+json" \
      -d '{"~:query": ["~#list",["~$from","~:users",["~$first-name", "~$last-name"]]],
-          "~:basis": {"~:after-tx": '"$last_tx"'}}' \
+          "~:after-tx": '"$last_tx"'}' \
      http://localhost:3000/query
 ----
 
@@ -184,7 +184,7 @@ curl -X POST \
      -H "Content-Type: application/transit+json" \
      -H "Accept: application/transit+json" \
      -d '{"~:query": "SELECT u.first_name, u.last_name FROM users AS u",
-          "~:basis": {"~:after-tx": '"$last_tx"'}}' \
+          "~:after-tx": '"$last_tx"'}' \
      http://localhost:3000/query
 ----
 

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -1,4 +1,7 @@
 = Interacting with XTDB using the HTTP API
+:resources: ../src/test/resources/docs/
+:script: {resources}/xtdb_http.sh
+:output: {resources}/xtdb_http.expected-output.txt
 
 This guide will show you how to use the HTTP API to interact with XTDB. +
 We include practical examples and their expected outputs, so please follow along!
@@ -52,18 +55,14 @@ To do so, send a GET request to server's status endpoint:
 
 [source,bash]
 ----
-curl -X GET \
-     -H "Accept: application/transit+json" \
-     http://localhost:3000/status
+include::{script}[tags=xtdb-status]
 ----
 
 If everything is working correctly, the response should be:
 
 [source,json]
 ----
-["^ ",
- "~:latest-completed-tx",null,
- "~:latest-submitted-tx",null]
+include::{output}[tags=xtdb-status]
 ----
 
 This output indicates that there are no completed or submitted transactions yet.
@@ -72,9 +71,7 @@ Once you've executed some transactions, you should see output similar to the fol
 
 [source,json]
 ----
-["^ ",
- "~:latest-completed-tx",["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2023-12-08T10:31:26.152675Z"]]],
- "~:latest-submitted-tx",["^1",["^ ","^2",0,"^3",["^4","2023-12-08T10:31:26.152675Z"]]]]
+include::{output}[tags=xtdb-post-tx-status]
 ----
 
 [NOTE]
@@ -100,27 +97,14 @@ To submit a new transaction, send a POST request to the server's transaction end
 
 [source,bash]
 ----
-curl -X POST \
-     -H "Content-Type: application/transit+json" \
-     -H "Accept: application/transit+json" \
-     -d '{"~:tx-ops": [
-           ["~#xtdb.tx/put", {
-             "~:table-name": "~:users",
-             "~:doc": {
-               "~:xt/id": 1,
-               "~:first-name": "John",
-               "~:last-name": "Doe"
-             }
-            }]
-         ]}' \
-     http://localhost:3000/tx 2>/dev/null
+include::{script}[tags=xtdb-tx]
 ----
 
 The expected output is the `transaction key` for the submitted transaction:
 
 [source,json]
 ----
-["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2023-12-08T09:55:21.010070Z"]]]
+include::{output}[tags=xtdb-tx]
 ----
 
 This indicates a successfully submitted transaction with a unique transaction ID and timestamp.
@@ -156,12 +140,7 @@ To run a query, send a POST request to the server's query endpoint:
 
 [source,bash]
 ----
-curl -X POST \
-     -H "Content-Type: application/transit+json" \
-     -H "Accept: application/transit+json" \
-     -d '{"~:query": ["~#list",["~$from","~:users",["~$first-name", "~$last-name"]]],
-          "~:after-tx": '"$last_tx"'}' \
-     http://localhost:3000/query
+include::{script}[tags=xtdb-xtql]
 ----
 
 NOTE: As mentioned in the link:#tx[`\tx`] section we've set `:after-tx` to the previous transaction's `transaction key`.
@@ -170,7 +149,7 @@ As you would expect, the data returned is what we put in:
 
 [source,json]
 ----
-["^ ","~:first-name","John","~:last-name","Doe"]
+include::{output}[tags=xtdb-xtql]
 ----
 
 ==== SQL
@@ -180,19 +159,14 @@ To learn more about XTDB's SQL see link:../reference/main/sql/queries[here].
 
 [source,bash]
 ----
-curl -X POST \
-     -H "Content-Type: application/transit+json" \
-     -H "Accept: application/transit+json" \
-     -d '{"~:query": "SELECT u.first_name, u.last_name FROM users AS u",
-          "~:after-tx": '"$last_tx"'}' \
-     http://localhost:3000/query
+include::{script}[tags=xtdb-sql]
 ----
 
 Again, we get the same data out that we put in:
 
 [source,json]
 ----
-["^ ","~:first_name","John","~:last_name","Doe"]
+include::{output}[tags=xtdb-sql]
 ----
 
 == Related Resources

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -1,0 +1,206 @@
+= Interacting with XTDB using the HTTP API
+
+This guide will show you how to use the HTTP API to interact with XTDB. +
+We include practical examples and their expected outputs, so please follow along!
+
+In this guide we'll be using `curl` to interact with XTDB. +
+You can also use the HTTP client from your programming language of choice.
+
+// TODO:
+// - Convert all examples to application/json
+// - Style admonitions
+// - Reference for transit extensions
+// - Reference for JSON syntax
+// - Confirm this doc is correct
+// - Special tables doc
+
+== Prerequisites
+
+To get started, ensure Docker is installed. Then pull and run the XTDB Docker image:
+
+[source,bash]
+----
+docker pull ghcr.io/xtdb/xtdb-standalone-ea
+docker run -tip 3000:3000 ghcr.io/xtdb/xtdb-standalone-ea
+----
+
+[NOTE]
+====
+In this guide we'll be using a local standalone instance of XTDB, but concepts in
+this guide can be applied to any XTDB instance connected to via HTTP.
+====
+
+[WARNING]
+====
+This setup includes **no persistence**.
+To learn how to setup XTDB's persistence see link:[here].
+====
+
+== Using the XTDB HTTP API
+
+XTDB has a rich query & transaction language behind a very simple REST API with just
+three endpoints: link:#status[`/status`], link:#tx[`/tx`], and link:#query[`/query`].
+
+See the link:https://docs.xtdb.com/openapi/index.html[HTTP API reference] for more detailed information.
+
+[#status]
+=== Checking the Status
+
+Let's start off by checking the status of the server.
+
+To do so, send a GET request to server's status endpoint:
+
+[source,bash]
+----
+curl -X GET \
+     -H "Accept: application/transit+json" \
+     http://localhost:3000/status
+----
+
+If everything is working correctly, the response should be:
+
+[source,json]
+----
+["^ ",
+ "~:latest-completed-tx",null,
+ "~:latest-submitted-tx",null]
+----
+
+This output indicates that there are no completed or submitted transactions yet.
+
+Once you've executed some transactions, you should see output similar to the following:
+
+[source,json]
+----
+["^ ",
+ "~:latest-completed-tx",["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2023-12-08T10:31:26.152675Z"]]],
+ "~:latest-submitted-tx",["^1",["^ ","^2",0,"^3",["^4","2023-12-08T10:31:26.152675Z"]]]]
+----
+
+[NOTE]
+====
+In this guide we'll be using the content type `application/json` but for more efficient communication we recommend using `application/transit+json`.
+
+See link:https://github.com/cognitect/transit-format[here,window=_blank] to learn more about transit.
+
+// TODO: Link to our transit extensions reference
+====
+
+[#tx]
+=== Creating a New Transaction
+
+Now let's insert a new user record into the `users` table.
+
+To do so we'll use the link:../reference/main/xtql/txs#_tx-ops[`put`] operation,
+other operations and their related syntax are documented link:../reference/main/xtql/txs#tx-ops[here].
+
+// TODO: Link to JSON syntax docs
+
+To submit a new transaction, send a POST request to the server's transaction endpoint:
+
+[source,bash]
+----
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:tx-ops": [
+           ["~#xtdb.tx/put", {
+             "~:table-name": "~:users",
+             "~:doc": {
+               "~:xt/id": 1,
+               "~:first-name": "John",
+               "~:last-name": "Doe"
+             }
+            }]
+         ]}' \
+     http://localhost:3000/tx 2>/dev/null
+----
+
+The expected output is the `transaction key` for the submitted transaction:
+
+[source,json]
+----
+["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2023-12-08T09:55:21.010070Z"]]]
+----
+
+This indicates a successfully submitted transaction with a unique transaction ID and timestamp.
+
+[NOTE]
+====
+`/tx` does not wait until the transaction is complete.
+
+This has two important consequences:
+
+// TODO: Confirm
+. As queries only have access to data from the lasted _completed_ transaction. +
+  To ensure your query includes data from a transaction you must pass it's `transaction key` to the query endpoint.
+. To find out if the transaction was successful, you need to query the `:xt/txs` table. See link:[here] for more information.
+====
+
+NOTE: We have stored the `transaction key` in the variable `$last_tx` for later use.
+
+[#query]
+=== Running a Query
+
+Finally let's query the document we just inserted.
+
+// TODO: Reword
+As noted in other guides XTDB supports two query languages, XTQL and SQL.
+The below query is in XTQL, to learn more about XTQL see link:../reference/main/xtql/queries[here] and to learn more about it's JSON syntax see here link:[here].
+
+
+
+==== XTQL
+
+To run a query, send a POST request to the server's query endpoint:
+
+[source,bash]
+----
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:query": ["~#list",["~$from","~:users",["~$first-name", "~$last-name"]]],
+          "~:basis": {"~:after-tx": '"$last_tx"'}}' \
+     http://localhost:3000/query
+----
+
+NOTE: As mentioned in the link:#tx[`\tx`] section we've set `:after-tx` to the previous transaction's `transaction key`.
+
+As you would expect, the data returned is what we put in:
+
+[source,json]
+----
+["^ ","~:first-name","John","~:last-name","Doe"]
+----
+
+==== SQL
+
+Running SQL is as simple as changing XTQL out for a string. +
+To learn more about XTDB's SQL see link:../reference/main/sql/queries[here].
+
+[source,bash]
+----
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:query": "SELECT u.first_name, u.last_name FROM users AS u",
+          "~:basis": {"~:after-tx": '"$last_tx"'}}' \
+     http://localhost:3000/query
+----
+
+Again, we get the same data out that we put in:
+
+[source,json]
+----
+["^ ","~:first_name","John","~:last_name","Doe"]
+----
+
+== Related Resources
+
+Want to learn more? Check out the following resources:
+- link:https://docs.xtdb.com/openapi/index.html[HTTP API reference]
+- link:../reference/main/xtql/queries[XTQL Query reference]
+- link:../reference/main/xtql/txs[XTQL Transaction reference]
+- link:[XTQL JSON syntax]
+- link:../reference/main/sql/queries[SQL Query reference]
+- link:../reference/main/sql/txs[SQL Transaction reference]

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -85,7 +85,7 @@ Now let's insert a new user record into the `users` table.
 To do so we'll use the link:../reference/main/xtql/txs#_tx-ops[`put`] operation,
 other operations and their related syntax are documented link:../reference/main/xtql/txs#tx-ops[here].
 
-// TODO: Link to JSON syntax docs
+To learn more about the JSON syntax for XTQL see link:../reference/main/formats/json[here].
 
 To submit a new transaction, send a POST request to the server's transaction endpoint:
 
@@ -124,7 +124,7 @@ Finally let's query the document we just inserted.
 
 // TODO: Reword
 As noted in other guides XTDB supports two query languages, XTQL and SQL.
-The below query is in XTQL, to learn more about XTQL see link:../reference/main/xtql/queries[here] and to learn more about it's JSON syntax see here link:[here].
+The below query is in XTQL, to learn more about XTQL see link:../reference/main/xtql/queries[here] and to learn more about it's JSON syntax see here link:../reference/main/formats/json[here].
 
 
 
@@ -169,6 +169,6 @@ Want to learn more? Check out the following resources:
 - link:https://docs.xtdb.com/openapi/index.html[HTTP API reference]
 - link:../reference/main/xtql/queries[XTQL Query reference]
 - link:../reference/main/xtql/txs[XTQL Transaction reference]
-- link:[XTQL JSON syntax]
+- link:../reference/main/formats/json[XTQL JSON syntax]
 - link:../reference/main/sql/queries[SQL Query reference]
 - link:../reference/main/sql/txs[SQL Transaction reference]

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -1,5 +1,5 @@
 ---
-title: Interacting with XTDB using the HTTP API
+title: Discover XTQL with cURL
 ---
 :resources: ../src/test/resources/docs/
 :script: {resources}/xtdb_http.sh
@@ -29,22 +29,20 @@ this guide can be applied to any XTDB instance connected to via HTTP.
 
 [WARNING]
 ====
-This setup includes **no persistence**.
+This setup includes **no persistence**. +
 To learn how to setup XTDB's persistence see link:[here].
 ====
 
 == Using the XTDB HTTP API
 
 XTDB has a rich query & transaction language behind a very simple REST API with just
-three endpoints: link:#status[`/status`], link:#tx[`/tx`], and link:#query[`/query`].
-
+three endpoints: link:#status[/status], link:#tx[/tx], and link:#query[/query]. +
 See the link:https://docs.xtdb.com/openapi/index.html[HTTP API reference] for more detailed information.
 
 [#status]
 === Checking the Status
 
-Let's start off by checking the status of the server.
-
+Let's start off by checking the status of the server. +
 To do so, send a GET request to server's status endpoint:
 
 [source,bash]
@@ -59,8 +57,7 @@ If everything is working correctly, the response should be:
 include::{output}[tags=xtdb-status]
 ----
 
-This output indicates that there are no completed or submitted transactions yet.
-
+This output indicates that there are no completed or submitted transactions yet. +
 Once you've executed some transactions, you should see output similar to the following:
 
 [source,json]
@@ -80,13 +77,10 @@ See our transit extensions link:../reference/main/formats/transit#_transit_exten
 [#tx]
 === Creating a New Transaction
 
-Now let's insert a new user record into the `users` table.
-
+Now let's insert a new user record into the `users` table. +
 To do so we'll use the link:../reference/main/xtql/txs#_tx-ops[`put`] operation,
-other operations and their related syntax are documented link:../reference/main/xtql/txs#tx-ops[here].
-
-To learn more about the JSON syntax for XTQL see link:../reference/main/formats/json[here].
-
+other operations and their related syntax are documented link:../reference/main/xtql/txs#tx-ops[here]. +
+You can learn more about the JSON syntax for XTQL see link:../reference/main/formats/json[here]. +
 To submit a new transaction, send a POST request to the server's transaction endpoint:
 
 [source,bash]
@@ -105,8 +99,7 @@ This indicates a successfully submitted transaction with a unique transaction ID
 
 [NOTE]
 ====
-`/tx` does not wait until the transaction is complete.
-
+`/tx` does not wait until the transaction is complete. +
 This has two important consequences:
 
 // TODO: Confirm
@@ -120,12 +113,9 @@ NOTE: We have stored the `transaction key` in the variable `$last_tx` for later 
 [#query]
 === Running a Query
 
-Finally let's query the document we just inserted.
-
-// TODO: Reword
-As noted in other guides XTDB supports two query languages, XTQL and SQL.
+Finally let's query the document we just inserted. +
+As noted in other guides XTDB supports two query languages, XTQL and SQL. +
 The below query is in XTQL, to learn more about XTQL see link:../reference/main/xtql/queries[here] and to learn more about it's JSON syntax see here link:../reference/main/formats/json[here].
-
 
 
 ==== XTQL

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -166,6 +166,7 @@ include::{output}[tags=xtdb-sql]
 == Related Resources
 
 Want to learn more? Check out the following resources:
+
 - link:https://docs.xtdb.com/openapi/index.html[HTTP API reference]
 - link:../reference/main/xtql/queries[XTQL Query reference]
 - link:../reference/main/xtql/txs[XTQL Transaction reference]

--- a/docs/src/content/docs/learn/xtdb-http.adoc
+++ b/docs/src/content/docs/learn/xtdb-http.adoc
@@ -112,7 +112,7 @@ This has two important consequences:
 // TODO: Confirm
 . As queries only have access to data from the lasted _completed_ transaction. +
   To ensure your query includes data from a transaction you must pass it's `transaction key` to the query endpoint.
-. To find out if the transaction was successful, you need to query the `:xt/txs` table. See link:[here] for more information.
+. To find out if the transaction was successful, you need to query the `:xt/txs` table. See link:../reference/main/special-tables[here] for more information.
 ====
 
 NOTE: We have stored the `transaction key` in the variable `$last_tx` for later use.

--- a/docs/src/content/docs/reference/main/formats/json.adoc
+++ b/docs/src/content/docs/reference/main/formats/json.adoc
@@ -1,0 +1,5 @@
+---
+title: XTQL JSON Syntax
+---
+
+Coming soon!

--- a/docs/src/content/docs/reference/main/formats/transit.adoc
+++ b/docs/src/content/docs/reference/main/formats/transit.adoc
@@ -2,11 +2,18 @@
 title: Transit
 ---
 
-Coming soon!
+XTDB's link:https://docs.xtdb.com/openapi/index.html[HTTP API] supports multiple formats including link:https://github.com/cognitect/transit-format[Transit,window=_blank].
 
-////
+We expect most developers to prefer using link:json[JSON].
+
+To have XTDB return Transit, set the `Accept` header to `application/transit+json`. +
+Similarly to send Transit to XTDB, set the `Content-Type` header to `application/transit+json`.
+
 
 == Transit Extensions
+
+XTDB supports the extensions from the link:https://github.com/henryw374/time-literals#usage[time-literals,window=_blank] library. +
+As well as the following custom extensions:
 
 [cols="1,2"]
 |===
@@ -61,4 +68,3 @@ Coming soon!
 |
 
 |===
-////

--- a/docs/src/content/docs/reference/main/formats/transit.adoc
+++ b/docs/src/content/docs/reference/main/formats/transit.adoc
@@ -1,0 +1,64 @@
+---
+title: Transit
+---
+
+Coming soon!
+
+////
+
+== Transit Extensions
+
+[cols="1,2"]
+|===
+| Extension | Description
+
+| `~#xtdb/clj-form`
+|
+
+| `~#xtdb/tx-key`
+|
+
+| `~#xtdb/illegal-arg`
+|
+
+| `~#xtdb/runtime-err`
+|
+
+| `~#xtdb/exception-info`
+|
+
+| `~#xtdb/period-duration`
+|
+
+| `~#xtdb.interval/year-month`
+|
+
+| `~#xtdb.interval/day-time`
+|
+
+| `~#xtdb.interval/month-day-nano`
+|
+
+| `~#xtdb/list`
+|
+
+| `~#xtdb.tx/sql`
+|
+
+| `~#xtdb.tx/xtql`
+|
+
+| `~#xtdb.tx/put`
+|
+
+| `~#xtdb.tx/delete`
+|
+
+| `~#xtdb.tx/erase`
+|
+
+| `~#xtdb.tx/call`
+|
+
+|===
+////

--- a/docs/src/content/docs/reference/main/special-tables.adoc
+++ b/docs/src/content/docs/reference/main/special-tables.adoc
@@ -1,0 +1,46 @@
+---
+title: Special Tables
+---
+:test: ../src/test/clojure/xtdb/docs/reference/special_tables.clj
+
+// TODO: Can users write/delete these tables? If so, what happens?
+
+XTDB only has one special table (link:https://github.com/xtdb/xtdb/issues/2500[at the moment]).
+
+== `:xt/txs`
+
+// TODO: Is this correct?
+Contains all submitted transactions on the node.
+
+=== Columns
+
+[cols="1,2"]
+|===
+| Column | Description
+
+| `:xt/id`
+| The transaction ID.
+
+| `:xt/committed?`
+| Boolean indicating whether the transaction has been committed.
+
+| `:xt/error`
+| If the transaction errored, this will contain the error message.
+|===
+
+=== Example Usage
+
+To figure out why a transaction failed:
+
+[source,clojure]
+----
+;; We've run this transaction
+include::{test}[tags=try-update,indent=0]
+
+;; Let's see why it's failed
+include::{test}[tags=query-txs,indent=0]
+
+;; As you can see, the assert failed.
+;; So the user `:john` must not exist!
+include::{test}[tags=query-result,indent=0]
+----

--- a/src/test/clojure/xtdb/docs/reference/special_tables.clj
+++ b/src/test/clojure/xtdb/docs/reference/special_tables.clj
@@ -1,0 +1,40 @@
+(ns xtdb.docs.reference.special-tables
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-node)
+
+(deftest test-examples
+  (let [*node* tu/*node*]
+    ;; TODO: Remove when this is fixed:
+    ;;       https://github.com/xtdb/xtdb/issues/3035
+    (xt/submit-tx *node*
+      [(xt/put :users {:xt/id :not-john})])
+
+    ;; tag::try-update[]
+    (xt/submit-tx *node*
+      [(xt/assert-exists '(from :users [{:xt/id :john}]))
+       (xt/update-table :users '{:bind {:xt/id :john :age age}
+                                 :set {:age (inc age)}})])
+    ;; end::try-update[]
+
+    (t/is (= ;; tag::query-result[]
+             [{:xt/id 0,
+               :xt/committed? true,
+               :xt/error nil}
+              {:xt/id 1,
+               :xt/committed? false,
+               :xt/error {:xtdb.error/error-type :runtime-error,
+                          :xtdb.error/error-key :xtdb/assert-failed,
+                          :xtdb.error/message "Precondition failed: assert-exists",
+                          :row-count 0}}]
+             ;; end::query-result[]
+
+             ;; tag::query-txs[]
+             (->> (xt/q *node*
+                    '(-> (from :xt/txs [xt/id xt/committed? xt/error])
+                         (order-by xt/id)))
+                  (map #(update % :xt/error ex-data)))
+             ;; end::query-txs[]
+             ,))))

--- a/src/test/clojure/xtdb/docs/reference/special_tables.clj
+++ b/src/test/clojure/xtdb/docs/reference/special_tables.clj
@@ -8,33 +8,31 @@
 (deftest test-examples
   (let [*node* tu/*node*]
     ;; TODO: Remove when this is fixed:
-    ;;       https://github.com/xtdb/xtdb/issues/3035
+    ;;       https://github.com/xtdb/xtdb/issues/3061
     (xt/submit-tx *node*
       [(xt/put :users {:xt/id :not-john})])
 
     ;; tag::try-update[]
     (xt/submit-tx *node*
       [(xt/assert-exists '(from :users [{:xt/id :john}]))
-       (xt/update-table :users '{:bind {:xt/id :john :age age}
+       (xt/update-table :users '{:bind [{:xt/id :john :age age}]
                                  :set {:age (inc age)}})])
     ;; end::try-update[]
 
     (t/is (= ;; tag::query-result[]
-             [{:xt/id 0,
-               :xt/committed? true,
-               :xt/error nil}
-              {:xt/id 1,
-               :xt/committed? false,
-               :xt/error {:xtdb.error/error-type :runtime-error,
-                          :xtdb.error/error-key :xtdb/assert-failed,
-                          :xtdb.error/message "Precondition failed: assert-exists",
-                          :row-count 0}}]
+             {:xt/id 1,
+              :xt/committed? false,
+              :xt/error {:xtdb.error/error-type :runtime-error,
+                         :xtdb.error/error-key :xtdb/assert-failed,
+                         :xtdb.error/message "Precondition failed: assert-exists",
+                         :row-count 0}}
              ;; end::query-result[]
 
              ;; tag::query-txs[]
-             (->> (xt/q *node*
-                    '(-> (from :xt/txs [xt/id xt/committed? xt/error])
-                         (order-by xt/id)))
-                  (map #(update % :xt/error ex-data)))
+             (-> (xt/q *node*
+                   '(-> (from :xt/txs [xt/id xt/committed? xt/error])
+                        (order-by xt/id)))
+                 last
+                 (update :xt/error ex-data))
              ;; end::query-txs[]
              ,))))

--- a/src/test/clojure/xtdb/docs/xtdb_http.clj
+++ b/src/test/clojure/xtdb/docs/xtdb_http.clj
@@ -1,0 +1,41 @@
+(ns xtdb.docs.xtdb-http
+  (:require [clojure.test :as t :refer [deftest]]
+            [clojure.string :as str]
+            [xtdb.test-util :as tu]
+            [clojure.java.shell :refer [sh]]))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-http-client-node)
+
+(defn load-test-file [name]
+  (slurp (str "./src/test/resources/docs/" name)))
+
+(defn script [name port]
+  (-> (str name ".sh")
+      load-test-file
+      (str/replace "3000" (str port))))
+
+(defn strip-comments [s]
+  (->> s
+       (str/split-lines)
+       (remove #(str/starts-with? % "# "))
+       (str/join "\n")))
+
+(defn expected-output [name]
+  (-> (str name ".expected-output.txt")
+      load-test-file
+      strip-comments
+      str/trim))
+
+(defn exec-output [script]
+  (-> (sh "sh" "-c" script)
+      :out
+      str/trim))
+
+(defn test-script [name]
+  (t/is (= (expected-output name)
+           (-> name
+               (script tu/*http-port*)
+               exec-output))))
+
+(deftest test-guide
+  (test-script "xtdb_http"))

--- a/src/test/resources/docs/xtdb_http.expected-output.txt
+++ b/src/test/resources/docs/xtdb_http.expected-output.txt
@@ -1,0 +1,20 @@
+>> Status
+# tag::xtdb-status[]
+["^ ","~:latest-completed-tx",null,"~:latest-submitted-tx",null]
+# end::xtdb-status[]
+>> Transaction
+# tag::xtdb-tx[]
+["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2020-01-01T00:00:00Z"]]]
+# end::xtdb-tx[]
+>> Post Transaction Status
+# tag::xtdb-post-tx-status[]
+["^ ","~:latest-completed-tx",["~#xtdb/tx-key",["^ ","~:tx-id",0,"~:system-time",["~#time/instant","2020-01-01T00:00:00Z"]]],"~:latest-submitted-tx",["^1",["^ ","^2",0,"^3",["^4","2020-01-01T00:00:00Z"]]]]
+# end::xtdb-post-tx-status[]
+>> XTQL Query
+# tag::xtdb-xtql[]
+["^ ","~:last-name","Doe","~:first-name","John"]
+# end::xtdb-xtql[]
+>> SQL Query
+# tag::xtdb-sql[]
+["^ ","~:first_name","John","~:last_name","Doe"]
+# end::xtdb-sql[]

--- a/src/test/resources/docs/xtdb_http.sh
+++ b/src/test/resources/docs/xtdb_http.sh
@@ -1,0 +1,55 @@
+echo ">> Status"
+# tag::xtdb-status[]
+curl -X GET \
+     -H "Accept: application/transit+json" \
+     http://localhost:3000/status
+# end::xtdb-status[]
+echo
+
+echo ">> Transaction"
+last_tx=$(
+# tag::xtdb-tx[]
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:tx-ops": [
+           ["~#xtdb.tx/put", {
+             "~:table-name": "~:users",
+             "~:doc": {
+               "~:xt/id": 1,
+               "~:first-name": "John",
+               "~:last-name": "Doe"
+             }
+            }]
+         ]}' \
+     http://localhost:3000/tx 2>/dev/null
+# end::xtdb-tx[]
+)
+echo "$last_tx"
+
+echo ">> Post Transaction Status"
+curl -X GET \
+     -H "Accept: application/transit+json" \
+     http://localhost:3000/status
+echo
+
+echo ">> XTQL Query"
+# tag::xtdb-xtql[]
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:query": ["~#list",["~$from","~:users",["~$first-name", "~$last-name"]]],
+          "~:after-tx": '"$last_tx"'}' \
+     http://localhost:3000/query
+# end::xtdb-xtql[]
+echo
+
+echo ">> SQL Query"
+# tag::xtdb-sql[]
+curl -X POST \
+     -H "Content-Type: application/transit+json" \
+     -H "Accept: application/transit+json" \
+     -d '{"~:query": "SELECT u.first_name, u.last_name FROM users AS u",
+          "~:after-tx": '"$last_tx"'}' \
+     http://localhost:3000/query
+# end::xtdb-sql[]


### PR DESCRIPTION
Lot's of things TODO:
- [x] Test? (need to look into [asciidoc includes](https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-blocks/#using-include-directives-in-source-blocks))
- [ ] Confirm this docs is correct
- [ ] Convert examples to `application/json`
- [ ] Links:
  - [x] Reference for transit extensions
  - [ ] How to configure XTDB's persistence
  - [x] Reference for JSON syntax
  - [x] Docs for special tables (e.g. `:xt/txs`)
- [ ] ~Style admonitions~ (I'm fine with how the table looks with starlight)
      I've got this so far: <img width="695" alt="Screenshot 2023-12-08 at 16 18 19" src="https://github.com/xtdb/xtdb/assets/8889986/5061b928-fd99-4891-83bf-2e2798211386">

Closes xtdb/devrel#20
