### PR TITLE
Extract `TransactionKey` to java class, replace clojure record, update calls

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -28,18 +28,6 @@
      (catch ExecutionException e#
        (throw (.getCause e#)))))
 
-(defrecord TransactionKey [^long tx-id, ^Instant system-time]
-  Comparable
-  (compareTo [_ tx-key]
-    (Long/compare tx-id (.tx-id ^TransactionKey tx-key))))
-
-(defmethod print-dup TransactionKey [tx-key ^Writer w]
-  (.write w "#xt/tx-key ")
-  (print-method (into {} tx-key) w))
-
-(defmethod print-method TransactionKey [tx-key w]
-  (print-dup tx-key w))
-
 (defn ->ClojureForm [form]
   (ClojureForm. form))
 

--- a/api/src/main/java/xtdb/api/TransactionKey.java
+++ b/api/src/main/java/xtdb/api/TransactionKey.java
@@ -1,0 +1,53 @@
+package xtdb.api;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class TransactionKey implements Comparable<TransactionKey> {
+    public long txId;
+    public Instant systemTime;
+
+    public TransactionKey(long txId, Instant systemTime) {
+        this.txId = txId;
+        this.systemTime = systemTime;
+    }
+
+    @Override
+    public int compareTo(TransactionKey otherKey) {
+        return Long.compare(this.txId, otherKey.txId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionKey that = (TransactionKey) o;
+        return txId == that.txId && Objects.equals(systemTime, that.systemTime);
+    }
+
+    public long getTxId() {
+        return txId;
+    }
+
+    public Instant getSystemTime() {
+        return systemTime;
+    }
+
+    public TransactionKey setTxId(long txId) {
+        this.txId = txId;
+
+        return this;
+    }
+
+    public TransactionKey setSystemTime(Instant systemTime) {
+        this.systemTime = systemTime;
+
+        return this;
+    }
+    
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(txId, systemTime);
+    }
+}

--- a/api/src/main/java/xtdb/api/TransactionKey.java
+++ b/api/src/main/java/xtdb/api/TransactionKey.java
@@ -25,29 +25,12 @@ public class TransactionKey implements Comparable<TransactionKey> {
         return txId == that.txId && Objects.equals(systemTime, that.systemTime);
     }
 
-    public long getTxId() {
-        return txId;
-    }
-
-    public Instant getSystemTime() {
-        return systemTime;
-    }
-
-    public TransactionKey setTxId(long txId) {
-        this.txId = txId;
-
-        return this;
-    }
-
-    public TransactionKey setSystemTime(Instant systemTime) {
-        this.systemTime = systemTime;
-
-        return this;
-    }
-    
-
     @Override
     public int hashCode() {
         return Objects.hash(txId, systemTime);
+    }
+
+    public TransactionKey withSystemTime(Instant systemTime) {
+        return new TransactionKey(this.txId, systemTime);
     }
 }

--- a/api/src/main/resources/data_readers.clj
+++ b/api/src/main/resources/data_readers.clj
@@ -1,4 +1,4 @@
-{xt/tx-key xtdb.api/map->TransactionKey
+{xt/tx-key xtdb.serde/tx-key-read-fn
  xt/clj-form xtdb.api/->ClojureForm
  xt/illegal-arg xtdb.error/-iae-reader
  xt/runtime-err xtdb.error/-runtime-err-reader

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -91,7 +91,7 @@
   ILiveTable
   (startTx [this-table tx-key new-live-table?]
     (let [!transient-trie (atom live-trie)
-          system-from-µs (time/instant->micros (.system-time tx-key))]
+          system-from-µs (time/instant->micros (.systemTime tx-key))]
       (reify ILiveTableTx
         (docWriter [_] put-wtr)
 

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -34,7 +34,7 @@
 
     (.acceptRecord subscriber record)
 
-    (.tx-id ^TransactionKey (.tx record))))
+    (.txId ^TransactionKey (.tx record))))
 
 (defn handle-polling-subscription [^Log log after-tx-id {:keys [^Duration poll-sleep-duration]} ^LogSubscriber subscriber]
   (doto (.newThread subscription-thread-factory
@@ -71,7 +71,7 @@
 (defrecord NotifyingSubscriberHandler [!state]
   INotifyingSubscriberHandler
   (notifyTx [_ tx]
-    (let [{:keys [semaphores]} (swap! !state assoc :latest-submitted-tx-id (.tx-id tx))]
+    (let [{:keys [semaphores]} (swap! !state assoc :latest-submitted-tx-id (.txId tx))]
       (doseq [^Semaphore semaphore semaphores]
         (.release semaphore))))
 
@@ -95,7 +95,7 @@
                                                                     (< ^long after-tx-id ^long latest-submitted-tx-id)))
                                                          ;; catching up
                                                          (->> (.readRecords log after-tx-id 100)
-                                                              (take-while #(<= ^long (.tx-id ^TransactionKey (.tx ^LogRecord %))
+                                                              (take-while #(<= ^long (.txId ^TransactionKey (.tx ^LogRecord %))
                                                                                ^long latest-submitted-tx-id)))
 
                                                          ;; running live

--- a/core/src/main/clojure/xtdb/log/local_directory_log.clj
+++ b/core/src/main/clojure/xtdb/log/local_directory_log.clj
@@ -14,6 +14,7 @@
            java.time.temporal.ChronoUnit
            java.util.ArrayList
            (java.util.concurrent ArrayBlockingQueue BlockingQueue CompletableFuture ExecutorService Executors Future)
+           (xtdb.api TransactionKey)
            (xtdb.log Log LogRecord)))
 
 (def ^:private ^{:tag 'byte} record-separator 0x1E)
@@ -52,7 +53,7 @@
                                     offset-check (.readLong log-in)]
                                 (when (and (= size read-bytes)
                                            (= offset-check offset))
-                                  (xt.log/->LogRecord (xt/->TransactionKey offset system-time) (ByteBuffer/wrap record))))
+                                  (xt.log/->LogRecord (TransactionKey. offset system-time) (ByteBuffer/wrap record))))
                               (catch EOFException _))]
               (recur (dec limit)
                      (conj acc record)
@@ -113,7 +114,7 @@
                       (while (.hasRemaining written-record)
                         (.write log-out (.get written-record)))
                       (.writeLong log-out offset)
-                      (.set elements n (MapEntry/create f (xt.log/->LogRecord (xt/->TransactionKey offset system-time) record)))
+                      (.set elements n (MapEntry/create f (xt.log/->LogRecord (TransactionKey. offset system-time) record)))
                       (recur (inc n) (+ offset header-size size footer-size)))))
                 (catch Throwable t
                   (.truncate log-channel previous-offset)

--- a/core/src/main/clojure/xtdb/log/memory_log.clj
+++ b/core/src/main/clojure/xtdb/log/memory_log.clj
@@ -5,6 +5,7 @@
   (:import java.time.InstantSource
            java.time.temporal.ChronoUnit
            java.util.concurrent.CompletableFuture
+           (xtdb.api TransactionKey)
            (xtdb.log INotifyingSubscriberHandler Log LogRecord)))
 
 (deftype InMemoryLog [!records, ^INotifyingSubscriberHandler subscriber-handler, ^InstantSource instant-src]
@@ -13,7 +14,7 @@
     (CompletableFuture/completedFuture
      (let [^LogRecord record (-> (swap! !records (fn [records]
                                                    (let [system-time (-> (.instant instant-src) (.truncatedTo ChronoUnit/MICROS))]
-                                                     (conj records (log/->LogRecord (xt/->TransactionKey (count records) system-time) record)))))
+                                                     (conj records (log/->LogRecord (TransactionKey. (count records) system-time) record)))))
                                  peek)]
        (.notifyTx subscriber-handler (.tx record))
        record)))

--- a/core/src/main/clojure/xtdb/log/watcher.clj
+++ b/core/src/main/clojure/xtdb/log/watcher.clj
@@ -50,9 +50,8 @@
 
                           (let [^TimeStampMicroTZVector system-time-vec (.getVector tx-root "system-time")
                                 ^TransactionKey record-tx (.tx record)
-                                tx-key (cond-> record-tx
-                                         (not (.isNull system-time-vec 0))
-                                         (.setSystemTime (-> (.get system-time-vec 0) (time/micros->instant))))]
+                                tx-key (cond-> record-tx (not (.isNull system-time-vec 0))
+                                         (.withSystemTime (-> (.get system-time-vec 0) (time/micros->instant))))]
 
                             (.indexTx indexer tx-key tx-root)))
 

--- a/core/src/main/clojure/xtdb/log/watcher.clj
+++ b/core/src/main/clojure/xtdb/log/watcher.clj
@@ -32,7 +32,7 @@
 (defn- watch-log! [{:keys [^BufferAllocator allocator, ^Log log, ^IIndexer indexer]}]
   (let [!cancel-hook (promise)]
     (.subscribe log
-                (:tx-id (.latestCompletedTx indexer))
+                (some-> (.latestCompletedTx indexer) (.txId))
                 (reify LogSubscriber
                   (onSubscribe [_ cancel-hook]
                     (deliver !cancel-hook cancel-hook))
@@ -49,9 +49,10 @@
                           (.loadNextBatch sr)
 
                           (let [^TimeStampMicroTZVector system-time-vec (.getVector tx-root "system-time")
-                                ^TransactionKey tx-key (cond-> (.tx record)
-                                                         (not (.isNull system-time-vec 0))
-                                                         (assoc :system-time (-> (.get system-time-vec 0) (time/micros->instant))))]
+                                ^TransactionKey record-tx (.tx record)
+                                tx-key (cond-> record-tx
+                                         (not (.isNull system-time-vec 0))
+                                         (.setSystemTime (-> (.get system-time-vec 0) (time/micros->instant))))]
 
                             (.indexTx indexer tx-key tx-root)))
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -80,7 +80,7 @@
                 :now (-> (.instant expr/*clock*)
                          (time/instant->micros))))]
 
-      (when-let [system-time (some-> at-tx (.system-time) time/instant->micros)]
+      (when-let [system-time (some-> at-tx (.systemTime) time/instant->micros)]
         (.lte (.systemFrom bounds) system-time)
 
         (when-not for-system-time

--- a/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
+++ b/core/src/main/clojure/xtdb/stagnant_log_flusher.clj
@@ -41,8 +41,8 @@
         ^Runnable f
         (bound-fn heartbeat []
           (on-heartbeat {:last-flush @!last-flush-tx-id, :last-seen @previously-seen-chunk-tx-id})
-          (when-some [{latest-tx-id :tx-id} (.latestCompletedTx indexer)]
-            (let [{latest-chunk-tx-id :tx-id} (.latestCompletedChunkTx indexer)]
+          (when-some [latest-tx-id (some-> (.latestCompletedTx indexer) (.txId))]
+            (let [latest-chunk-tx-id (some-> (.latestCompletedChunkTx indexer) (.txId))]
               (try
                 (when (and (= @previously-seen-chunk-tx-id latest-chunk-tx-id)
                            (or (nil? @!last-flush-tx-id)
@@ -54,7 +54,7 @@
                                        (.putLong (or latest-chunk-tx-id -1))
                                        .flip)
                         record @(.appendRecord log record-buf)]
-                   (reset! !last-flush-tx-id (:tx-id (:tx record)))))
+                   (reset! !last-flush-tx-id (some-> (:tx record) (.txId)))))
                 (catch InterruptedException _)
                 (catch ClosedByInterruptException _)
                 (catch Throwable e

--- a/core/src/main/clojure/xtdb/tx_producer.clj
+++ b/core/src/main/clojure/xtdb/tx_producer.clj
@@ -233,9 +233,9 @@
                                              (util/maybe-update :system-time time/->instant))]
       (-> (.appendRecord log (serialize-tx-ops allocator tx-ops opts))
           (util/then-apply
-            (fn [^LogRecord result]
-              (cond-> (.tx result)
-                system-time (assoc :system-time system-time)))))))
+           (fn [^LogRecord result]
+             (cond-> (.tx result)
+               system-time (.setSystemTime system-time)))))))
   AutoCloseable
   (close [_] (.close allocator)))
 

--- a/core/src/main/clojure/xtdb/tx_producer.clj
+++ b/core/src/main/clojure/xtdb/tx_producer.clj
@@ -235,7 +235,7 @@
           (util/then-apply
            (fn [^LogRecord result]
              (cond-> (.tx result)
-               system-time (.setSystemTime system-time)))))))
+               system-time (.withSystemTime system-time)))))))
   AutoCloseable
   (close [_] (.close allocator)))
 

--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -118,8 +118,8 @@
   (xt/submit-tx *node* [(xt/put :foo {:xt/id 1})])
   (Thread/sleep 100)
 
-  (t/is (= {:latest-submitted-tx {:tx-id 0, :system-time #time/instant "2020-01-01T00:00:00Z"},
-            :latest-completed-tx {:tx-id 0, :system-time #time/instant "2020-01-01T00:00:00Z"}}
+  (t/is (= {:latest-submitted-tx {:txId 0, :systemTime #time/instant "2020-01-01T00:00:00Z"},
+            :latest-completed-tx {:txId 0, :systemTime #time/instant "2020-01-01T00:00:00Z"}}
            (-> (http/request {:accept :json
                               :as :string
                               :request-method :get
@@ -128,7 +128,7 @@
                decode-json))
         "testing status")
 
-  (t/is (= {:tx-id 1, :system-time #time/instant "2020-01-02T00:00:00Z"}
+  (t/is (= {:txId 1, :systemTime #time/instant "2020-01-02T00:00:00Z"}
            (-> (http/request {:accept :json
                               :as :string
                               :request-method :post

--- a/modules/azure/src/main/clojure/xtdb/azure/log.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/log.clj
@@ -8,6 +8,7 @@
            java.nio.ByteBuffer
            java.time.Duration
            java.util.concurrent.CompletableFuture
+           [xtdb.api TransactionKey]
            [xtdb.log INotifyingSubscriberHandler Log]))
 
 (defn ->consumer [f]
@@ -17,7 +18,7 @@
      (f val))))
 
 (defn event-data->tx-instant [^EventData data]
-  (xt/->TransactionKey (.getOffset data) (.getEnqueuedTime data)))
+  (TransactionKey. (.getOffset data) (.getEnqueuedTime data)))
 
 (def producer-send-options
   (.setPartitionId (SendOptions.) "0"))
@@ -46,7 +47,7 @@
                       (->consumer (fn [e]
                                     (.completeExceptionally fut e)))
                       (fn [] (let [{:keys [offset timestamp]} (get-partition-properties consumer)]
-                               (.complete fut (log/->LogRecord (xt/->TransactionKey offset timestamp) record))))))
+                               (.complete fut (log/->LogRecord (TransactionKey. offset timestamp) record))))))
       fut))
 
   (readRecords [_ after-tx-id limit]

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -92,11 +92,13 @@
           (let [{:keys [latest-completed-tx] :as res} (xt/status node)]
             (or
              (when-some [[fut ms] @last-submitted]
-               (let [tx-id (:tx-id @fut)]
-                 (when-some [{completed-tx-id :tx-id
-                              completed-tx-time :system-time} latest-completed-tx]
-                   (when (< completed-tx-id tx-id)
-                     (* (long 1e6) (- ms (inst-ms completed-tx-time)))))))
+               (let [tx-id (.txId @fut)
+                     completed-tx-id (.txId latest-completed-tx)
+                     completed-tx-time (.systemTime latest-completed-tx)]
+                 (when (and (some? completed-tx-id)
+                            (some? completed-tx-time)
+                            (< completed-tx-id tx-id))
+                   (* (long 1e6) (- ms (inst-ms completed-tx-time))))))
              0)))
 
         compute-lag-abs
@@ -104,8 +106,9 @@
           (let [{:keys [latest-completed-tx] :as res} (xt/status node)]
             (or
              (when-some [[fut _] @last-submitted]
-               (let [tx-id (:tx-id @fut)]
-                 (when-some [{completed-tx-id :tx-id} latest-completed-tx ]
+               (let [tx-id (.txId @fut)
+                     completed-tx-id (.txId latest-completed-tx)]
+                 (when (some? completed-tx-id)
                    (- tx-id completed-tx-id))))
              0)))]
 

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -17,6 +17,7 @@
            [org.apache.kafka.clients.producer Callback KafkaProducer ProducerRecord]
            [org.apache.kafka.common.errors InterruptException TopicExistsException UnknownTopicOrPartitionException]
            org.apache.kafka.common.TopicPartition
+           [xtdb.api TransactionKey]
            [xtdb.log Log LogSubscriber]))
 
 (defn ->kafka-config [{:keys [bootstrap-servers ^Path properties-file properties-map]}]
@@ -57,7 +58,7 @@
       (throw (.getCause e)))))
 
 (defn- ->log-record [^ConsumerRecord record]
-  (log/->LogRecord (xt/->TransactionKey (.offset record) (Instant/ofEpochMilli (.timestamp record)))
+  (log/->LogRecord (TransactionKey. (.offset record) (Instant/ofEpochMilli (.timestamp record)))
                    (.value record)))
 
 (defn- handle-subscriber [{:keys [poll-duration tp kafka-config]} after-tx-id ^LogSubscriber subscriber]
@@ -98,8 +99,8 @@
                (onCompletion [_ record-metadata e]
                  (if e
                    (.completeExceptionally fut e)
-                   (.complete fut (log/->LogRecord (xt/->TransactionKey (.offset record-metadata)
-                                                                        (Instant/ofEpochMilli (.timestamp record-metadata)))
+                   (.complete fut (log/->LogRecord (TransactionKey. (.offset record-metadata)
+                                                                    (Instant/ofEpochMilli (.timestamp record-metadata)))
                                                    record))))))
       fut))
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -365,8 +365,9 @@
 (defn open-live-table [table-name]
   (li/->live-table *allocator* nil table-name))
 
-(defn index-tx! [^ILiveTable live-table, {:keys [system-time] :as tx-key}, docs]
-  (let [live-table-tx (.startTx live-table tx-key true)]
+(defn index-tx! [^ILiveTable live-table, tx-key, docs]
+  (let [system-time (.systemTime tx-key)
+        live-table-tx (.startTx live-table tx-key true)]
     (try
       (let [doc-wtr (.docWriter live-table-tx)]
         (doseq [{eid :xt/id, :as doc} docs

--- a/src/test/clojure/xtdb/as_of_test.clj
+++ b/src/test/clojure/xtdb/as_of_test.clj
@@ -28,10 +28,10 @@
                           {:basis {:at-tx tx1}})))))))
 
 (t/deftest test-app-time
-  (let [{:keys [system-time]} (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :doc, :version 1})
-                                                       (-> (xt/put :docs {:xt/id :doc-with-app-time})
-                                                           (xt/starting-from #inst "2021"))])
-        system-time (time/->zdt system-time)]
+  (let [tx (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :doc, :version 1})
+                                    (-> (xt/put :docs {:xt/id :doc-with-app-time})
+                                        (xt/starting-from #inst "2021"))])
+        system-time (time/->zdt (.systemTime tx))]
 
     (t/is (= {:doc {:xt/id :doc,
                     :xt/valid-from system-time
@@ -52,10 +52,10 @@
 
 (t/deftest test-system-time
   (let [tx1 (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :doc, :version 0})])
-        tt1 (time/->zdt (:system-time tx1))
+        tt1 (time/->zdt (.systemTime tx1))
 
         tx2 (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id :doc, :version 1})])
-        tt2 (time/->zdt (:system-time tx2))
+        tt2 (time/->zdt (.systemTime tx2))
 
         original-v0-doc {:xt/id :doc, :version 0
                          :xt/valid-from tt1

--- a/src/test/clojure/xtdb/await_test.clj
+++ b/src/test/clojure/xtdb/await_test.clj
@@ -2,10 +2,11 @@
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
             [xtdb.await :as await])
-  (:import java.util.concurrent.PriorityBlockingQueue))
+  (:import java.util.concurrent.PriorityBlockingQueue
+           xtdb.api.TransactionKey))
 
 (defn- ->tx [tx-id]
-  (xt/->TransactionKey tx-id nil))
+  (TransactionKey. tx-id nil))
 
 (t/deftest test-await
   (t/is (= (->tx 2)

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -15,6 +15,7 @@
            [org.apache.arrow.vector.ipc ArrowFileReader]
            xtdb.IBufferPool
            xtdb.indexer.live_index.ILiveIndex
+           (xtdb.api TransactionKey)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$Leaf HashTrie LiveHashTrie LiveHashTrie$Leaf)
            xtdb.vector.IVectorPosition))
 
@@ -37,7 +38,7 @@
                        (mapv (comp vec util/uuid->bytes)))]
 
     (t/testing "commit"
-      (let [live-idx-tx (.startTx live-index (xt/->TransactionKey 0 (.toInstant #inst "2000")))
+      (let [live-idx-tx (.startTx live-index (TransactionKey. 0 (.toInstant #inst "2000")))
             live-table-tx (.liveTable live-idx-tx "my-table")
             put-doc-wrt (.docWriter live-table-tx)]
         (let [wp (IVectorPosition/build)]

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -13,6 +13,7 @@
            (java.util Arrays HashMap)
            (org.apache.arrow.memory RootAllocator)
            xtdb.IBufferPool
+           (xtdb.api TransactionKey)
            (xtdb.indexer.live_index ILiveIndex TestLiveTable)
            (xtdb.trie LiveHashTrie LiveHashTrie$Leaf)
            (xtdb.util RefCounter)
@@ -40,7 +41,7 @@
                     allocator (RootAllocator.)
                     live-table (live-index/->live-table allocator bp "foo" {:->live-trie (partial live-index/->live-trie 2 4)})]
 
-          (let [live-table-tx (.startTx live-table (xt/->TransactionKey 0 (.toInstant #inst "2000")) false)]
+          (let [live-table-tx (.startTx live-table (TransactionKey. 0 (.toInstant #inst "2000")) false)]
             (let [wp (IVectorPosition/build)]
               (dotimes [_n n]
                 (.logPut live-table-tx (ByteBuffer/wrap (util/uuid->bytes uuid))
@@ -77,7 +78,7 @@
                     ^IBufferPool bp (tu/component node :xtdb/buffer-pool)
                     allocator (RootAllocator.)
                     live-table (live-index/->live-table allocator bp "foo")]
-          (let [live-table-tx (.startTx live-table (xt/->TransactionKey 0 (.toInstant #inst "2000")) false)]
+          (let [live-table-tx (.startTx live-table (TransactionKey. 0 (.toInstant #inst "2000")) false)]
 
             (let [wp (IVectorPosition/build)]
               (dotimes [_n n]
@@ -129,7 +130,7 @@
                 ^IBufferPool bp (tu/component node :xtdb/buffer-pool)
                 allocator (RootAllocator.)
                 live-table (live-index/->live-table allocator bp "foo")]
-      (let [live-table-tx (.startTx live-table (xt/->TransactionKey 0 (.toInstant #inst "2000")) false)]
+      (let [live-table-tx (.startTx live-table (TransactionKey. 0 (.toInstant #inst "2000")) false)]
 
         (let [wp (IVectorPosition/build)]
           (doseq [uuid uuids]
@@ -161,7 +162,7 @@
                 allocator (RootAllocator.)]
       (let [live-index-allocator (util/->child-allocator allocator "live-index")]
         (with-open [^ILiveIndex live-index (live-index/->LiveIndex live-index-allocator bp (HashMap.) (RefCounter.) 64 1024)]
-          (let [live-index-tx (.startTx live-index (xt/->TransactionKey 0 (.toInstant #inst "2000")))
+          (let [live-index-tx (.startTx live-index (TransactionKey. 0 (.toInstant #inst "2000")))
                 live-table-tx (.liveTable live-index-tx table-name)]
 
             (let [wp (IVectorPosition/build)]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -18,7 +18,8 @@
            java.nio.file.Files
            java.time.Duration
            [org.apache.arrow.memory BufferAllocator]
-           xtdb.IBufferPool
+           xtdb.IBufferPool 
+           (xtdb.api TransactionKey)
            (xtdb.metadata IMetadataManager)
            (xtdb.watermark IWatermarkSource)))
 
@@ -75,7 +76,7 @@
 
 (t/deftest can-build-chunk-as-arrow-ipc-file-format
   (let [node-dir (util/->path "target/can-build-chunk-as-arrow-ipc-file-format")
-        last-tx-key (xt/map->TransactionKey {:tx-id magic-last-tx-id, :system-time (time/->instant #inst "2020-01-02")})]
+        last-tx-key (TransactionKey. magic-last-tx-id (time/->instant #inst "2020-01-02"))]
     (util/delete-dir node-dir)
 
     (util/with-open [node (tu/->local-node {:node-dir node-dir})]
@@ -161,8 +162,9 @@
 
 (t/deftest temporal-watermark-is-immutable-2354
   (with-open [node (xtn/start-node {})]
-    (let [{tt :system-time, :as tx} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 0})]
-                                                  {:default-all-valid-time? false})]
+    (let [tx (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 0})]
+                           {:default-all-valid-time? false})
+          tt (.systemTime tx)]
       (t/is (= [{:xt/id :foo, :version 0,
                  :xt/valid-from (time/->zdt tt)
                  :xt/valid-to nil
@@ -174,8 +176,9 @@
                                xt$system_from, xt$system_to]]
                             {:node node})))
 
-      (let [{tt2 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 1})]
-                                             {:default-all-valid-time? false})]
+      (let [tx1 (xt/submit-tx node [(xt/put :xt_docs {:xt/id :foo, :version 1})]
+                              {:default-all-valid-time? false})
+            tt2 (.systemTime tx1)]
         (t/is (= #{{:xt/id :foo, :version 0,
                     :xt/valid-from (time/->zdt tt2)
                     :xt/valid-to nil
@@ -340,7 +343,7 @@
 
 (t/deftest can-stop-node-without-writing-chunks
   (let [node-dir (util/->path "target/can-stop-node-without-writing-chunks")
-        last-tx-key (xt/map->TransactionKey {:tx-id magic-last-tx-id, :system-time (time/->instant #inst "2020-01-02")})]
+        last-tx-key (TransactionKey. magic-last-tx-id (time/->instant #inst "2020-01-02"))]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
@@ -484,7 +487,7 @@
               (let [{:keys [latest-completed-tx, next-chunk-idx]}
                     (meta/latest-chunk-metadata mm)]
 
-                (t/is (< (:tx-id latest-completed-tx) (:tx-id first-half-tx-key)))
+                (t/is (< (.txId latest-completed-tx) (.txId first-half-tx-key)))
                 (t/is (< next-chunk-idx (count first-half-tx-ops)))
 
                 (Thread/sleep 250) ; wait for the chunk to finish writing to disk
@@ -506,18 +509,18 @@
                                         nil
                                         (partition-all 100 second-half-tx-ops))]
 
-                (t/is (<= (:tx-id first-half-tx-key)
-                          (:tx-id (tu/latest-completed-tx node))
-                          (:tx-id second-half-tx-key)))
+                (t/is (<= (.txId first-half-tx-key)
+                          (.txId (tu/latest-completed-tx node))
+                          (.txId second-half-tx-key)))
 
                 (with-open [new-node (tu/->local-node (assoc node-opts :buffers-dir "objects-2"))]
                   (doseq [node [new-node node]
                           :let [^IMetadataManager mm (tu/component node ::meta/metadata-manager)]]
 
-                    (t/is (<= (:tx-id first-half-tx-key)
-                              (:tx-id (-> first-half-tx-key
-                                          (tu/then-await-tx node (Duration/ofSeconds 10))))
-                              (:tx-id second-half-tx-key)))
+                    (t/is (<= (.txId first-half-tx-key)
+                              (.txId (-> first-half-tx-key
+                                         (tu/then-await-tx node (Duration/ofSeconds 10))))
+                              (.txId second-half-tx-key)))
 
                     (t/is (= :utf8
                              (types/field->col-type (.columnField mm "device_info" "xt$id")))))
@@ -612,7 +615,7 @@
       (let [mm (tu/component node ::meta/metadata-manager)]
         (t/is (nil? (meta/latest-chunk-metadata mm)))
 
-        (let [last-tx-key (xt/map->TransactionKey {:tx-id 0, :system-time (time/->instant #inst "2020-01-01")})]
+        (let [last-tx-key (TransactionKey. 0 (time/->instant #inst "2020-01-01"))]
           (t/is (= last-tx-key
                    (xt/submit-tx node [(-> (xt/sql-op "INSERT INTO table (xt$id, foo, bar, baz) VALUES (?, ?, ?, ?)")
                                            (xt/with-op-args

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -271,7 +271,8 @@
 
 (t/deftest test-only-scanning-temporal-cols-45
   (with-open [node (xtn/start-node {})]
-    (let [{tt :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :doc})])]
+    (let [tx (xt/submit-tx node [(xt/put :xt_docs {:xt/id :doc})])
+          tt (.systemTime tx)]
 
       (t/is (= #{{:xt/valid-from (time/->zdt tt)
                   :xt/valid-to nil

--- a/src/test/clojure/xtdb/operator_test.clj
+++ b/src/test/clojure/xtdb/operator_test.clj
@@ -113,8 +113,10 @@
 
 (t/deftest test-temporal-bounds
   (with-open [node (xtn/start-node {})]
-    (let [{tt1 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx1"})])
-          {tt2 :system-time} (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx2"})])]
+    (let [tx1 (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx1"})])
+          tt1 (.systemTime tx1)
+          tx2 (xt/submit-tx node [(xt/put :xt_docs {:xt/id :my-doc, :last-updated "tx2"})])
+          tt2 (.systemTime tx2)]
       (letfn [(q [& temporal-constraints]
                 (->> (tu/query-ra [:scan '{:table xt_docs, :for-system-time :all-time}
                                    (into '[last_updated] temporal-constraints)]

--- a/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
+++ b/src/test/clojure/xtdb/stagnant_log_flusher_test.clj
@@ -78,7 +78,7 @@
          (when-some [records (seq (.readRecords log (long offset) 100))]
            (concat
              (map clj-record records)
-             (! (:tx-id (:tx (last records))))))))
+             (! (.txId (:tx (last records))))))))
      -1)))
 
 (defn node-log [node]
@@ -110,8 +110,8 @@
       (let [[_ _ _ msg4] (node-log node)]
         (let [flush-tx-id (:flush-tx-id msg4)]
           (t/is flush-tx-id)
-          (t/is (= (:tx-id (.latestCompletedChunkTx ^IIndexer (tu/component node :xtdb/indexer))) flush-tx-id))))))
-
+          (t/is (= (some-> (.latestCompletedChunkTx ^IIndexer (tu/component node :xtdb/indexer)) (.txId)) 
+                   flush-tx-id))))))
 
   (t/testing "test :duration actually does something"
     (with-open [node (start-node #time/duration "PT1H")]

--- a/src/test/clojure/xtdb/tx_fn_test.clj
+++ b/src/test/clojure/xtdb/tx_fn_test.clj
@@ -101,13 +101,14 @@
                  '(from :docs [xt/id doc-count])))))
 
 (t/deftest test-tx-fn-current-tx
-  (let [{tt0 :system-time} (xt/submit-tx tu/*node* [(xt/put-fn :with-tx
-                                                               '(fn [id]
-                                                                  [(xt/put :docs (into {:xt/id id} *current-tx*))]))
-                                                    (xt/call :with-tx :foo)
-                                                    (xt/call :with-tx :bar)])
-
-        {tt1 :system-time} (xt/submit-tx tu/*node* [(xt/call :with-tx :baz)])]
+  (let [tx0 (xt/submit-tx tu/*node* [(xt/put-fn :with-tx
+                                                '(fn [id]
+                                                   [(xt/put :docs (into {:xt/id id} *current-tx*))]))
+                                     (xt/call :with-tx :foo)
+                                     (xt/call :with-tx :bar)])
+        tt0 (.systemTime tx0)
+        tx1 (xt/submit-tx tu/*node* [(xt/call :with-tx :baz)])
+        tt1 (.systemTime tx1)]
 
     (t/is (= #{{:xt/id :foo, :tx-id 0, :system-time (time/->zdt tt0)}
                {:xt/id :bar, :tx-id 0, :system-time (time/->zdt tt0)}

--- a/src/test/clojure/xtdb/xtql/temporal_test.clj
+++ b/src/test/clojure/xtdb/xtql/temporal_test.clj
@@ -1,7 +1,8 @@
 (ns xtdb.xtql.temporal-test
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
-            [xtdb.test-util :as tu]))
+            [xtdb.test-util :as tu])
+  (:import [xtdb.api TransactionKey]))
 
 (t/use-fixtures :each tu/with-node)
 
@@ -53,10 +54,10 @@
               (xt/q tu/*node* '{:find [foo]
                                 :where [(match :xt_docs {:xt/id 1})
                                         [1 :foo foo]]}
-                    {:basis {:at-tx (xt/->TransactionKey 0 (.toInstant #inst "2000"))}})))
+                    {:basis {:at-tx (TransactionKey. 0 (.toInstant #inst "2000"))}})))
 
     (t/is (=  [{:foo "2000-4000"}]
               (xt/q tu/*node* '{:find [foo]
                                 :where [(match :xt_docs {:xt/id 1})
                                         [1 :foo foo]]}
-                    {:basis {:at-tx (xt/->TransactionKey 0 (.toInstant (java.util.Date.)))}})))))
+                    {:basis {:at-tx (TransactionKey. 0 (.toInstant (java.util.Date.)))}})))))


### PR DESCRIPTION
- Splitting out `TransactionKey` to separate Java class.
- Updating numerous usages of `TransactionKey` to use the new class, replacing various clojure record method calls.
- Updating the data readers/writers for `tx-key`