### PR TITLE
Json requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,6 +213,9 @@ dependencies {
 
     // for AWS profiles (managing datasets)
     devImplementation("software.amazon.awssdk", "sts", "2.16.76")
+
+    // hato uses cheshire for application/json encoding
+    testImplementation("cheshire", "cheshire", "5.12.0")
 }
 
 if (hasProperty("fin")) {

--- a/http-client-clj/build.gradle.kts
+++ b/http-client-clj/build.gradle.kts
@@ -20,4 +20,3 @@ dependencies {
     api("pro.juxt.clojars-mirrors.hato", "hato", "0.8.2")
     api("pro.juxt.clojars-mirrors.metosin", "reitit-core", "0.5.15")
 }
-

--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     testImplementation(project(":http-client-clj"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("pro.juxt.clojars-mirrors.hato", "hato", "0.8.2")
+    // hato uses cheshire for application/json encoding
+    testImplementation("cheshire", "cheshire", "5.12.0")
 }
 
 tasks.javadoc.get().enabled = false

--- a/http-server/src/main/clojure/xtdb/jackson.clj
+++ b/http-server/src/main/clojure/xtdb/jackson.clj
@@ -1,6 +1,9 @@
 (ns xtdb.jackson
   (:require [jsonista.core :as json])
-  (:import (xtdb.jackson JsonLdModule)))
+  (:import (java.io Reader)
+           (xtdb.jackson JsonLdModule XtdbMapper)
+           (xtdb.tx Tx)
+           (xtdb.query QueryRequest)))
 
 #_
 (defn decode-throwable [{:xtdb.error/keys [message class data] :as _err}]
@@ -13,3 +16,9 @@
   (json/object-mapper {:encode-key-fn true
                        :decode-key-fn true
                        :modules [(JsonLdModule.)]}))
+
+(defn read-tx ^Tx [^Reader rdr]
+  (.readValue XtdbMapper/TX_OP_MAPPER rdr Tx))
+
+(defn read-query-request ^QueryRequest [^Reader rdr]
+  (.readValue XtdbMapper/QUERY_MAPPER rdr QueryRequest))


### PR DESCRIPTION
This is currently based on top of #3060. 

This adds JSON request support to the server. Things that are explicitly not supported or not done in this PR.
- SQL tx decoding (separate work)
- XTQL DML decoding
- Planning errors (we need serializers (AST -> JSON) for that)