### PR TITLE
Updates to CLI config/file based config.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api("org.roaringbitmap", "RoaringBitmap", "0.9.32")
 
     api("pro.juxt.clojars-mirrors.integrant", "integrant", "0.8.0")
+    api("clj-commons", "clj-yaml", "1.0.27")
 
     api("org.babashka", "sci", "0.6.37")
     api("commons-codec", "commons-codec", "1.15")

--- a/core/src/main/clojure/xtdb/cli.clj
+++ b/core/src/main/clojure/xtdb/cli.clj
@@ -1,82 +1,31 @@
 (ns ^:no-doc xtdb.cli
-  (:require [clojure.data.json :as json]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
+  (:require [clojure.java.io :as io]
             [clojure.tools.cli :as cli]
-            [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
-            [xtdb.error :as err]
+            [clojure.tools.logging :as log] 
+            [xtdb.config :as config] 
             [xtdb.node :as xtn]
-            [xtdb.util :as util]
-            [juxt.clojars-mirrors.integrant.core :as ig])
-  (:import java.io.File
-           java.net.URL
-           java.util.Map))
+            [xtdb.util :as util])
+  (:import java.io.File))
 
 (defn- if-it-exists [^File f]
   (when (.exists f)
     f))
 
-(defn- file-extension [^File f]
-  (second (re-find #"\.(.+?)$" (.getName f))))
-
-(defn read-env-var [env-var]
-  (System/getenv (str env-var)))
-
-(defn edn-read-string [edn-string]
-  (ig/read-string {:readers {'env read-env-var}}
-                  edn-string))
-
-(defn json-read-string [json-string]
-  (walk/postwalk
-   (fn [item]
-     (let [env-key (keyword "@env")]
-       (cond
-         (env-key item) (read-env-var (env-key item))
-         :else item)))
-   (json/read-str json-string :key-fn keyword)))
-
 (def cli-options
   [["-f" "--file CONFIG_FILE" "Config file to load XTDB options from - EDN, JSON"
     :parse-fn io/file
     :validate [if-it-exists "Config file doesn't exist"
-               #(contains? #{"edn" "json"} (file-extension %)) "Config file must be .edn or .json"]]
+               #(contains? #{"edn" "json"} (util/file-extension %)) "Config file must be .edn or .json"]]
 
    ["-e" "--edn EDN" "Options as EDN."
     :default nil
-    :parse-fn edn-read-string]
+    :parse-fn config/edn-read-string]
 
    ["-j" "--json JSON" "Options as JSON."
     :default nil
-    :parse-fn json-read-string]
+    :parse-fn config/json-read-string]
 
    ["-h" "--help"]])
-
-(defprotocol OptsSource
-  (load-opts [src]))
-
-(alter-meta! #'load-opts assoc :private true)
-
-(defn- read-opts [src file-name]
-  (cond
-    (str/ends-with? file-name ".json") (json-read-string (slurp src))
-    (str/ends-with? file-name ".edn") (edn-read-string (slurp src))
-    :else (throw (err/illegal-arg :unsupported-options-type
-                                  {::err/message (format "Unsupported options type: '%s'" file-name)}))))
-
-(extend-protocol OptsSource
-  Map
-  (load-opts [src] src)
-
-  File
-  (load-opts [src] (read-opts src (.getName src)))
-
-  URL
-  (load-opts [src] (read-opts src (.getFile src)))
-
-  nil
-  (load-opts [_] nil))
 
 (defn parse-args [args]
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)]
@@ -86,16 +35,15 @@
       (:help options) {::help summary}
 
       :else (let [{:keys [file edn json]} options]
-              {::node-opts (->> [(or file
-                                     (some-> (io/file "xtdb.edn") if-it-exists)
-                                     (some-> (io/file "xtdb.json") if-it-exists)
-                                     (io/resource "xtdb.edn")
-                                     (io/resource "xtdb.json"))
-
-                                 json
-                                 edn]
-                                (map load-opts)
-                                (apply merge-with merge))}))))
+              {::node-opts (let [config-file (or file
+                                                 (some-> (io/file "xtdb.edn") if-it-exists)
+                                                 (some-> (io/file "xtdb.json") if-it-exists)
+                                                 (io/resource "xtdb.edn")
+                                                 (io/resource "xtdb.json"))
+                                 config-from-file (some-> config-file config/file->config-opts)]
+                             ;; TODO: Do we really want to merge config like this? Ie, if file provided/xtdb.edn exists, we merge in config map from --edn?
+                             ;; Seems like somewhat confusing behaviour. Kept from previous code here but worth a think.
+                             (apply merge-with merge [config-from-file json edn]))}))))
 
 (defn- shutdown-hook-promise []
   (let [main-thread (Thread/currentThread)

--- a/core/src/main/clojure/xtdb/cli.clj
+++ b/core/src/main/clojure/xtdb/cli.clj
@@ -12,7 +12,7 @@
     f))
 
 (def cli-options
-  [["-f" "--file CONFIG_FILE" "Config file to load XTDB options from - EDN, JSON"
+  [["-f" "--file CONFIG_FILE" "Config file to load XTDB options from - EDN, JSON, YAML"
     :parse-fn io/file
     :validate [if-it-exists "Config file doesn't exist"
                #(contains? #{"edn" "json" "yaml"} (util/file-extension %)) "Config file must be .edn, .json or .yaml"]]

--- a/core/src/main/clojure/xtdb/cli.clj
+++ b/core/src/main/clojure/xtdb/cli.clj
@@ -41,9 +41,7 @@
                                                  (io/resource "xtdb.edn")
                                                  (io/resource "xtdb.json"))
                                  config-from-file (some-> config-file config/file->config-opts)]
-                             ;; TODO: Do we really want to merge config like this? Ie, if file provided/xtdb.edn exists, we merge in config map from --edn?
-                             ;; Seems like somewhat confusing behaviour. Kept from previous code here but worth a think.
-                             (apply merge-with merge [config-from-file json edn]))}))))
+                             (or config-from-file json edn))}))))
 
 (defn- shutdown-hook-promise []
   (let [main-thread (Thread/currentThread)

--- a/core/src/main/clojure/xtdb/cli.clj
+++ b/core/src/main/clojure/xtdb/cli.clj
@@ -15,7 +15,7 @@
   [["-f" "--file CONFIG_FILE" "Config file to load XTDB options from - EDN, JSON"
     :parse-fn io/file
     :validate [if-it-exists "Config file doesn't exist"
-               #(contains? #{"edn" "json"} (util/file-extension %)) "Config file must be .edn or .json"]]
+               #(contains? #{"edn" "json" "yaml"} (util/file-extension %)) "Config file must be .edn, .json or .yaml"]]
 
    ["-e" "--edn EDN" "Options as EDN."
     :default nil
@@ -38,8 +38,10 @@
               {::node-opts (let [config-file (or file
                                                  (some-> (io/file "xtdb.edn") if-it-exists)
                                                  (some-> (io/file "xtdb.json") if-it-exists)
+                                                 (some-> (io/file "xtdb.yaml") if-it-exists) 
                                                  (io/resource "xtdb.edn")
-                                                 (io/resource "xtdb.json"))
+                                                 (io/resource "xtdb.json")
+                                                 (io/resource "xtdb.yaml"))
                                  config-from-file (some-> config-file config/file->config-opts)]
                              (or config-from-file json edn))}))))
 

--- a/core/src/main/clojure/xtdb/config.clj
+++ b/core/src/main/clojure/xtdb/config.clj
@@ -9,6 +9,9 @@
 (defn read-env-var [env-var]
   (System/getenv (str env-var)))
 
+(defn read-ig-ref [ref]
+  (ig/ref (keyword ref)))
+
 (defn edn-read-string [edn-string]
   (ig/read-string {:readers {'env read-env-var}}
                   edn-string))
@@ -16,12 +19,13 @@
 (defn json-read-string [json-string]
   (walk/postwalk
    (fn [item]
-     (let [env-key (keyword "@env")]
+     (let [env-key (keyword "@env")
+           ref-key (keyword "@ref")]
        (cond
          (env-key item) (read-env-var (env-key item))
+         (ref-key item) (read-ig-ref (ref-key item))
          :else item)))
    (json/read-str json-string :key-fn keyword)))
-
 
 (defn- read-opts-from-file [^File f]
   (let [file-extension (util/file-extension f)]

--- a/core/src/main/clojure/xtdb/config.clj
+++ b/core/src/main/clojure/xtdb/config.clj
@@ -1,0 +1,39 @@
+(ns xtdb.config
+  (:require [clojure.data.json :as json] 
+            [clojure.walk :as walk]
+            [juxt.clojars-mirrors.integrant.core :as ig] 
+            [xtdb.error :as err]
+            [xtdb.util :as util])
+  (:import java.io.File))
+
+(defn read-env-var [env-var]
+  (System/getenv (str env-var)))
+
+(defn edn-read-string [edn-string]
+  (ig/read-string {:readers {'env read-env-var}}
+                  edn-string))
+
+(defn json-read-string [json-string]
+  (walk/postwalk
+   (fn [item]
+     (let [env-key (keyword "@env")]
+       (cond
+         (env-key item) (read-env-var (env-key item))
+         :else item)))
+   (json/read-str json-string :key-fn keyword)))
+
+
+(defn- read-opts-from-file [^File f]
+  (let [file-extension (util/file-extension f)]
+    (cond
+      (= file-extension "json") (json-read-string (slurp f))
+      (= file-extension "edn") (edn-read-string (slurp f))
+      :else (throw (err/illegal-arg :unsupported-options-type
+                                    {::err/message (format "Unsupported type for options file: '%s'" file-extension)})))))
+
+(defn file->config-opts
+  [^File f]
+  (if (.exists f)
+    (read-opts-from-file f)
+    (throw (err/illegal-arg :opts-file-not-found
+                            {::err/message (format "File not found: '%s'" (.getName f))}))))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -246,6 +246,9 @@
     (when-not (path-exists parents)
       (mkdirs parents))))
 
+(defn file-extension [^File f]
+  (second (re-find #"\.(.+?)$" (.getName f))))
+
 (defn ->temp-file ^Path [^String prefix ^String suffix]
   (doto (Files/createTempFile prefix suffix (make-array FileAttribute 0))
     (delete-file)))

--- a/src/test/clojure/xtdb/cli_test.clj
+++ b/src/test/clojure/xtdb/cli_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [clojure.test :as t]
             [juxt.clojars-mirrors.integrant.core :as ig]
-            [xtdb.cli :as cli]))
+            [xtdb.cli :as cli]
+            [xtdb.config :as config]))
 
 (def xtdb-cli-edn
   (io/resource "xtdb/cli-test.edn"))
@@ -63,8 +64,8 @@
                    (->system []))))))))
 
 (t/deftest test-env-loading
-  (with-redefs [cli/read-env-var (fn [env-name]
-                                   (when (= (str env-name) "TEST_ENV") "hello world"))]
+  (with-redefs [config/read-env-var (fn [env-name]
+                                      (when (= (str env-name) "TEST_ENV") "hello world"))]
     (letfn [(->system [cli-args]
               (-> (::cli/node-opts (cli/parse-args cli-args))
                   (->> (into {}))))]

--- a/src/test/clojure/xtdb/cli_test.clj
+++ b/src/test/clojure/xtdb/cli_test.clj
@@ -89,15 +89,18 @@
                                       (when (= (str env-name) "TEST_ENV") "hello world"))]
     (letfn [(->system [cli-args]
               (-> (::cli/node-opts (cli/parse-args cli-args))
+                  ig/prep
+                  ig/init
                   (->> (into {}))))]
 
       (t/testing "EDN config - #env reader tag fetches from env"
         (t/is (= {::foo "hello world"}
                  (->system ["--edn" "{:xtdb.cli-test/foo #env TEST_ENV}"]))))
 
-      (t/testing "JSON config - edn object fetched from env"
+      (t/testing "JSON config - env object fetched from env"
         (t/is (= {::foo "hello world"}
                  (->system ["--json" "{\"xtdb.cli-test/foo\": {\"@env\": \"TEST_ENV\"}}"])))))))
+
 (defmethod ig/init-key ::bar [_ opts] opts)
 
 (t/deftest test-ref-handling

--- a/src/test/resources/xtdb/cli-test-env.yaml
+++ b/src/test/resources/xtdb/cli-test-env.yaml
@@ -1,0 +1,1 @@
+xtdb.cli-test/foo: !Env TEST_ENV

--- a/src/test/resources/xtdb/cli-test-ref.yaml
+++ b/src/test/resources/xtdb/cli-test-ref.yaml
@@ -1,0 +1,5 @@
+xtdb.cli-test/foo:
+  baz: 1
+
+xtdb.cli-test/bar:
+  foo: !Ref xtdb.cli-test/foo

--- a/src/test/resources/xtdb/cli-test.yaml
+++ b/src/test/resources/xtdb/cli-test.yaml
@@ -1,0 +1,2 @@
+xtdb.cli-test/foo:
+  baz: 1


### PR DESCRIPTION
See #3083 & #2890

Makes a number of updates to the way that the CLI handles config/how file based config is handled:
- Moves the file based config out to a separate namespace (to be shared/reused later).
- Cleans up the CLI namespace of a number of things it doesn't particularly need (Ie, URL handling, never seemed to be possible to actually pass in a URL)
- Removes merging of config passed into CLI - with a preference for files passed in first.
  - Previously, if the user passed in both a file (using `-f`, or by having something like `xtdb.edn` present) and then passed in config string via `--edn` or `--json`, it would merge all of these configs. 
  - This behaviour struck me as odd, so I removed it.
  - The preference order is somewhat random - can change this if we think it's appropriate.
- Updates JSON config to support `ig/ref` using an object with `@ref`.
- Adds YAML based file config handling to the CLI: 
  - Currently only through passing in a `.yaml` file (with the `-f` option) or having `xtdb.yaml` present.
  - Could also check for `.yml` but decided against it - as `.yaml` seems to be the suggested standard file extension.
  - Similar to JSON, ALSO handles env vars / integrant refs (using a `!Env` and `!Ref` tag respectively) 
  - Doesn't handle `--yaml` (as we do for `--edn` and `--json` - seemed less sensible for YAML to be passed in as a string?)
- Add/update numerous tests for all of the above.    