### PR TITLE
Iteration two at the Java/Kotlin API

### DIFF
--- a/api/src/main/kotlin/xtdb/api/query/Binding.kt
+++ b/api/src/main/kotlin/xtdb/api/query/Binding.kt
@@ -1,19 +1,59 @@
 package xtdb.api.query
 
 import xtdb.api.query.Expr.Companion.lVar
-import xtdb.api.query.Expr.Companion.param
 
 data class Binding(val binding: String, val expr: Expr) {
+    @JvmOverloads
+    constructor(binding: String, bindVar: String = binding) : this(binding, lVar(bindVar))
+
     companion object {
         @JvmStatic
-        @JvmOverloads
-        fun bindVar(binding: String, bindVar: String = binding) = Binding(binding, lVar(bindVar))
+        fun cols(vararg cols: String) = cols.map(::Binding).toTypedArray()
+    }
 
-        @JvmStatic
-        @JvmOverloads
-        fun bindParam(binding: String, bindParam: String = binding) = Binding(binding, param(bindParam))
+    abstract class ABuilder<B : ABuilder<B, O>, O> {
+        private val bindings: MutableList<Binding> = mutableListOf()
+
+        fun setBindings(bindings: Collection<Binding>) = this.apply {
+            this.bindings.clear()
+            this.bindings.addAll(bindings)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun bind(binding: String, expr: Expr): B = this.apply { bind(Binding(binding, expr)) } as B
+
+        @Suppress("UNCHECKED_CAST")
+        fun bind(binding: Binding): B = this.apply { bindings += binding } as B
+
+        @JvmSynthetic
+        infix fun String.boundTo(expr: Expr) = bind(this, expr)
+
+        @JvmSynthetic
+        infix fun String.boundTo(varName: String) = bind(this, lVar(varName))
+
+        @JvmSynthetic
+        operator fun String.unaryPlus() = this boundTo this
+
+        @JvmSynthetic
+        @JvmName("bindCols")
+        operator fun Collection<String>.unaryPlus() = this.apply { +map { Binding(it, lVar(it)) } }
+
+        @JvmSynthetic
+        @JvmName("bind")
+        operator fun Collection<Binding>.unaryPlus() = this.apply { bindings += this }
+
+        @JvmSynthetic
+        operator fun Binding.unaryPlus() = this.apply { bindings += this }
+
+        @Suppress("UNCHECKED_CAST")
+        fun bindCols(vararg cols: String): B = this.apply { +cols.toList() } as B
+
+        protected fun buildBindings(): List<Binding> = bindings
+
+        abstract fun build(): O
+    }
+
+    class Builder : ABuilder<Builder, List<Binding>>() {
+        override fun build() = buildBindings()
     }
 }
-
-infix fun String.toVar(`var`: String) = Binding(this, lVar(`var`))
-infix fun String.toParam(param: String) = Binding(this, param(param))

--- a/core/src/test/java/xtdb/api/IXtdbJavaTest.java
+++ b/core/src/test/java/xtdb/api/IXtdbJavaTest.java
@@ -1,20 +1,21 @@
 package xtdb.api;
 
-import clojure.lang.Keyword;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import xtdb.api.query.Expr;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static xtdb.api.tx.TxOptions.txOpts;
-import static xtdb.api.query.Binding.bindVar;
-import static xtdb.api.query.Query.from;
+import static xtdb.api.query.Expr.lVar;
+import static xtdb.api.query.Query.*;
 import static xtdb.api.tx.TxOp.put;
+import static xtdb.api.tx.TxOptions.txOpts;
 
 class IXtdbJavaTest {
     private IXtdb node;
@@ -32,17 +33,16 @@ class IXtdbJavaTest {
     @Test
     void javaApiTest() {
         node.submitTx(txOpts().systemTime(Instant.parse("2020-01-01T12:34:56.000Z")).build(),
-                put("docs", Map.of("xt/id", 1, "foo", "bar")));
+            put("docs", Map.of("xt/id", 1, "foo", "bar")));
 
         try (var res = node.openQuery(
-                from("docs",
-                        bindVar("xt/id"),
-                        bindVar("xt/system_from")))) {
+            from("docs").bindCols("xt/id", "xt/system_from").build())) {
+
             assertEquals(
-                    List.of(Map.of(
-                            "xt/id", 1,
-                            "xt/system_from", ZonedDateTime.parse("2020-01-01T12:34:56Z[UTC]"))),
-                    res.toList());
+                List.of(Map.of(
+                    "xt/id", 1,
+                    "xt/system_from", ZonedDateTime.parse("2020-01-01T12:34:56Z[UTC]"))),
+                res.toList());
         }
     }
 }

--- a/http-server/src/main/java/xtdb/query/FromDeserializer.java
+++ b/http-server/src/main/java/xtdb/query/FromDeserializer.java
@@ -14,6 +14,7 @@ import xtdb.api.query.Query;
 import xtdb.api.query.TemporalFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 public class FromDeserializer extends StdDeserializer<Query.From> {
     public FromDeserializer() {
@@ -28,14 +29,19 @@ public class FromDeserializer extends StdDeserializer<Query.From> {
         if (!node.isObject() || !node.has("from") || !node.has("bind")){
             throw IllegalArgumentException.create(Keyword.intern("xtql", "malformed-from"), PersistentHashMap.create(Keyword.intern("json"), node.toPrettyString()));
         }
-        var query = Query.from(node.get("from").asText(),
-                SpecListDeserializer.nodeToSpecs(codec, node.get("bind"), Binding::new));
+
+        var from = Query.from(node.get("from").asText());
+
+        from.setBindings(SpecListDeserializer.nodeToSpecs(codec, node.get("bind"), Binding::new));
+
         if (node.has("for_valid_time")) {
-            query = query.forValidTime(codec.treeToValue(node.get("for_valid_time"), TemporalFilter.class));
+            from.forValidTime(codec.treeToValue(node.get("for_valid_time"), TemporalFilter.class));
         }
+
         if (node.has("for_system_time")) {
-            query = query.forSystemTime(codec.treeToValue(node.get("for_system_time"), TemporalFilter.class));
+            from.forSystemTime(codec.treeToValue(node.get("for_system_time"), TemporalFilter.class));
         }
-        return query;
+
+        return from.build();
     }
 }

--- a/http-server/src/test/kotlin/xtdb/api/XtdbClientTest.kt
+++ b/http-server/src/test/kotlin/xtdb/api/XtdbClientTest.kt
@@ -1,10 +1,8 @@
 package xtdb.api
 
-import clojure.lang.Keyword
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import xtdb.api.query.Query.Companion.from
-import xtdb.api.query.toVar
 import xtdb.api.tx.TxOp.Companion.put
 import java.net.URL
 
@@ -19,7 +17,7 @@ internal class XtdbClientTest {
                     listOf(mapOf("id" to "jms")),
 
                     node.openQuery(
-                        from("foo", "xt/id" toVar "id")
+                        from("foo") { "xt/id" boundTo "id" }
                     ).use { it.toList() }
                 )
 


### PR DESCRIPTION
... this time, with a DSL for creating bindings. #3043

* In Java, this looks like standard builders. In Kotlin, we can take advantage of the standard builder DSL pattern, as well as things like infix fns (like `"col" boundTo <expr>`) within the builder scope.
* I haven't done anything for Join/LeftJoin yet, because they have both args and bindings, and hence need some more thought about how to handle them.
* Similarly, relations. I'm hoping that we'll generalise these to accept full expressions before I have to write out all the boilerplate for DocRelation and ParamRelation.
* Expr seems next up on the list - it's pretty verbose atm when you don't have sexprs. I demo'd a PoC today at the showcase, but that was Kotlin-only, would be good to get something similar for Java.
* `orderSpec` could also use some love.

Demos of TPC-H Q1

```clojure
(-> (from :lineitem [l-shipdate l-quantity l-extendedprice l-discount l-tax
                     l-returnflag l-linestatus])

    (where (<= l-shipdate #time/date "1998-09-02"))

    (aggregate l-returnflag l-linestatus
               {:sum-qty (sum l-quantity)
                :avg-qty (avg l-quantity)
                ;; ...
                })

    (order-by l-returnflag l-linestatus))
```

```java
// java
pipeline(
    from("lineitem")
        .bindCols(
            "l_shipdate", "l_quantity", "l_extendedprice", "l_discount", "l_tax",
            "l_returnflag", "l_linestatus")
        .build(),

    where(call("<=", lVar("l_shipdate"), val(LocalDate.parse("1998-09-02")))),

    aggregate()
        .bindCols("l_returnflag", "l_linestatus")
        .bind("sum_qty", call("sum", lVar("l_quantity")))
        .bind("avg_qty", call("avg", lVar("l_quantity")))
        // ...
        .build(),

    orderBy(
        orderSpec(lVar("l_returnflag")),
        orderSpec(lVar("l_linestatus"))));
```

```kotlin
// kotlin
pipeline(
    from("lineitem") {
        bindCols(
            "l_shipdate", "l_quantity", "l_extendedprice", "l_discount", "l_tax",
            "l_returnflag", "l_linestatus"
        )
    },

    where(call("<=", lVar("l_shipdate"), `val`(LocalDate.parse("1998-09-02")))),

    aggregate {
        bindCols("l_returnflag", "l_linestatus")
        "sum_qty" boundTo call("sum", lVar("l_quantity"))
        "avg_qty" boundTo call("avg", lVar("l_quantity"))
    },

    orderBy(
        orderSpec(lVar("l_returnflag")),
        orderSpec(lVar("l_linestatus"))
    )
)
```