### PR TITLE
[ask] Clarify camelCase support, #3105

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -276,7 +276,7 @@
 
 (def ^:private table? keyword?)
 
-(defn- expect-table-name [table-name]
+(defn- expect-table-name ^String [table-name]
   (when-not (table? table-name)
     (throw (err/illegal-arg :xtdb.tx/invalid-table
                             {::err/message "expected table name" :table table-name})))

--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -179,7 +179,7 @@
 
 (extend-protocol xtp/PNode
   IXtdb
-  (open-query& [this query {:keys [args after-tx basis tx-timeout default-tz default-all-valid-time? explain? key-fn], :or {key-fn :clojure-kw}}]
+  (open-query& [this query {:keys [args after-tx basis tx-timeout default-tz default-all-valid-time? explain? key-fn], :or {key-fn :kebab-case-keyword}}]
     (let [query-opts (-> (QueryOptions/queryOpts)
                          (cond-> (map? args) (.args ^Map args)
                                  (vector? args) (.args ^List args)

--- a/api/src/main/clojure/xtdb/xtql/edn.clj
+++ b/api/src/main/clojure/xtdb/xtql/edn.clj
@@ -77,7 +77,7 @@
 
 (declare parse-arg-specs)
 
-(defn parse-expr [expr]
+(defn parse-expr ^xtdb.api.query.Expr [expr]
   (cond
     (nil? expr) Expr/NULL
     (true? expr) Expr/TRUE
@@ -471,23 +471,19 @@
   (when (> 1 (count clauses))
     (throw (err/illegal-arg :xtql/malformed-unify {:unify this
                                                    :message "Unify most contain at least one sub clause"})))
-  (->> clauses
-       (mapv parse-unify-clause)
-       (XtqlQuery/unify)))
+  (XtqlQuery/unify ^List (mapv parse-unify-clause clauses)))
 
 (defmethod parse-query 'union-all [[_ & queries :as this]]
   (when (> 1 (count queries))
     (throw (err/illegal-arg :xtql/malformed-union {:union this
                                                    :message "Union must contain a least one sub query"})))
-  (->> queries
-       (mapv parse-query)
-       (XtqlQuery/unionAll)))
+  (XtqlQuery/unionAll ^List (mapv parse-query queries)))
 
 (defn parse-where [[_ & preds :as this]]
   (when (> 1 (count preds))
     (throw (err/illegal-arg :xtql/malformed-where {:where this
                                                    :message "Where most contain at least one predicate"})))
-  (XtqlQuery/where (mapv parse-expr preds)))
+  (XtqlQuery/where ^List (mapv parse-expr preds)))
 
 (defmethod parse-query-tail 'where [this] (parse-where this))
 (defmethod parse-unify-clause 'where [this] (parse-where this))
@@ -496,7 +492,7 @@
   (when-not head
     (throw (err/illegal-arg :xtql/malformed-pipeline {:pipeline this
                                                       :message "Pipeline most contain at least one operator"})))
-  (XtqlQuery/pipeline (parse-query head) (mapv parse-query-tail tails)))
+  (XtqlQuery/pipeline (parse-query head) ^List (mapv parse-query-tail tails)))
 
 ;; TODO Align errors with json ones where appropriate.
 
@@ -511,7 +507,7 @@
   (when-not (every? keyword? cols)
     (throw (err/illegal-arg :xtql/malformed-without {:without this
                                                      ::err/message "Columns must be keywords in without"})))
-  (XtqlQuery/without (map (comp str symbol) cols)))
+  (XtqlQuery/without ^List (map (comp str symbol) cols)))
 
 (defmethod parse-query-tail 'return [[_ & cols :as this]]
   (XtqlQuery/returning (parse-col-specs cols this)))
@@ -591,7 +587,7 @@
     (XtqlQuery/orderSpec (parse-expr order-spec) nil nil)))
 
 (defmethod parse-query-tail 'order-by [[_ & order-specs :as this]]
-  (XtqlQuery/orderBy (mapv #(parse-order-spec % this) order-specs)))
+  (XtqlQuery/orderBy ^List (mapv #(parse-order-spec % this) order-specs)))
 
 (extend-protocol Unparse
   XtqlQuery$OrderSpec

--- a/api/src/main/kotlin/xtdb/util/NormalForm.kt
+++ b/api/src/main/kotlin/xtdb/util/NormalForm.kt
@@ -22,33 +22,31 @@ fun snakeCase(s: String): String {
     }
 }
 
-private fun normalise(s: String) =
-    s.lowercase()
-        .replace('.', '$')
-        .replace('-', '_')
+/**
+ * upper case letter preceded by a character that isn't upper-case nor an underscore
+ */
+private val UPPER_REGEX = Regex("(?<=[^\\p{Lu}_])\\p{Lu}")
 
-@Suppress("unused")
-fun normalForm(s: String): String {
-    val i = s.lastIndexOf('/')
-    return if (i < 0) {
-        normalise(s)
-    } else {
-        String.format("%s$%s", normalise(s.substring(0, i)), normalise(s.substring(i + 1)))
+fun normalForm(s: String): String = s
+    .replace('-', '_')
+    .split('.', '/', '$')
+    .joinToString(separator = "$") {
+        it
+            .replace(UPPER_REGEX) { ch -> "_${ch.value}" }
+            .lowercase()
     }
-}
 
-@Suppress("MemberVisibilityCanBePrivate") // Clojure
 fun normalForm(sym: Symbol): Symbol =
     if (sym.namespace != null) {
         Symbol.intern(
             String.format(
                 "%s$%s",
-                normalise(sym.namespace),
-                normalise(sym.name)
+                normalForm(sym.namespace),
+                normalForm(sym.name)
             )
         )
     } else {
-        Symbol.intern(normalise(sym.name))
+        Symbol.intern(normalForm(sym.name))
     }
 
 @Suppress("unused") // Clojure

--- a/api/src/main/kotlin/xtdb/util/NormalForm.kt
+++ b/api/src/main/kotlin/xtdb/util/NormalForm.kt
@@ -5,23 +5,6 @@ package xtdb.util
 import clojure.lang.Keyword
 import clojure.lang.Symbol
 
-@Suppress("unused")
-fun snakeCase(s: String): String {
-    val i = s.lastIndexOf('$')
-
-    return if (i < 0) {
-        s.lowercase()
-            .replace("$", "/")
-            .replace("-", "_")
-    } else {
-        String.format(
-            "%s/%s",
-            s.substring(0, i).replace("$", ".").replace("-", "_"),
-            s.substring(i + 1).replace("-", "_")
-        )
-    }
-}
-
 /**
  * upper case letter preceded by a character that isn't upper-case nor an underscore
  */

--- a/api/src/test/kotlin/xtdb/JsonSerdeTest.kt
+++ b/api/src/test/kotlin/xtdb/JsonSerdeTest.kt
@@ -425,7 +425,7 @@ class JsonSerdeTest {
                 .defaultTz(ZoneId.of("America/Los_Angeles"))
                 .defaultAllValidTime(true)
                 .explain(true)
-                .keyFn(IKeyFn.KeyFn.CLOJURE_KW)
+                .keyFn(IKeyFn.KeyFn.KEBAB_CASE_KEYWORD)
                 .build()
         ).assertRoundTrip2(
             """{
@@ -438,7 +438,7 @@ class JsonSerdeTest {
                               "defaultTz":"America/Los_Angeles",
                               "defaultAllValidTime":true,
                               "explain":true,
-                              "keyFn":"CLOJURE_KW"}
+                              "keyFn":"KEBAB_CASE_KEYWORD"}
               }
             """.trimJson()
         )

--- a/api/src/test/kotlin/xtdb/util/NormalFormTest.kt
+++ b/api/src/test/kotlin/xtdb/util/NormalFormTest.kt
@@ -1,0 +1,25 @@
+package xtdb.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NormalFormTest {
+    @Test
+    fun `test normalForm`() {
+        assertEquals("foo_bar", normalForm("foo_bar"))
+        assertEquals("foo_bar", normalForm("foo-bar"))
+        assertEquals("foo_bar", normalForm("fooBar"))
+        assertEquals("foo_bar", normalForm("FOO_BAR"))
+        assertEquals("foo_b_ar", normalForm("FOO_bAR"))
+
+        assertEquals("foo\$bar_baz", normalForm("foo/bar-baz"))
+        assertEquals("foo\$bar\$baz", normalForm("foo.bar/baz"))
+
+        assertEquals("foo\$b_ar\$baz", normalForm("foo.bAr/baz"))
+        assertEquals("foo\$bar\$baz", normalForm("foo.Bar/baz"))
+
+        assertEquals("xt\$id", normalForm("XT\$ID"))
+    }
+}
+
+

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -194,7 +194,7 @@
     ([query] (tx-fn-q* query {}))
 
     ([query opts]
-     (let [query-opts (-> (reduce into [{:key-fn :clojure-kw} tx-opts opts])
+     (let [query-opts (-> (reduce into [{:key-fn :kebab-case-keyword} tx-opts opts])
                           (update :key-fn serde/read-key-fn))
            plan (q/compile-query query query-opts nil)]
        (with-open [res (q/open-query allocator ra-src wm-src plan query-opts)]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -75,7 +75,7 @@
   (^CompletableFuture openQueryAsync [_ ^String query, ^QueryOptions query-opts]
    (let [query-opts (-> (into {:default-tz default-tz,
                                :after-tx @!latest-submitted-tx
-                               :key-fn #xt/key-fn :sql-str}
+                               :key-fn #xt/key-fn :snake-case-string}
                               query-opts)
                         (update :basis (fn [b] (cond->> b (instance? Basis b) (into {}))))
                         (with-after-tx-default))]
@@ -95,7 +95,7 @@
   (^CompletableFuture openQueryAsync [_ ^XtqlQuery query, ^QueryOptions query-opts]
    (let [query-opts (-> (into {:default-tz default-tz,
                                :after-tx @!latest-submitted-tx
-                               :key-fn #xt/key-fn :snake-case-str}
+                               :key-fn #xt/key-fn :camel-case-string}
                               query-opts)
                         (update :basis (fn [b] (cond->> b (instance? Basis b) (into {}))))
                         (with-after-tx-default))]

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -70,7 +70,7 @@
         field-sets (HashMap.)
         row-count (count rows)
         out-rows (ArrayList. row-count)
-        key-fn #xt/key-fn :clojure-kw
+        key-fn #xt/key-fn :kebab-case-keyword
         rows (map #(update-keys % keyword) rows)
         columns (->> (mapcat keys rows)
                      (into #{}))]

--- a/core/src/main/clojure/xtdb/vector/reader.clj
+++ b/core/src/main/clojure/xtdb/vector/reader.clj
@@ -90,7 +90,7 @@
                 (.rowCount rel))))
 
 (defn rel->rows
-  (^java.util.List [^RelationReader rel] (rel->rows rel #xt/key-fn :clojure-kw))
+  (^java.util.List [^RelationReader rel] (rel->rows rel #xt/key-fn :kebab-case-keyword))
   (^java.util.List [^RelationReader rel ^IKeyFn key-fn]
    (let [col-ks (for [^IVectorReader col rel]
                   [col (.denormalize key-fn (.getName col))])]

--- a/core/src/test/java/xtdb/api/IXtdbJavaTest.java
+++ b/core/src/test/java/xtdb/api/IXtdbJavaTest.java
@@ -30,15 +30,15 @@ class IXtdbJavaTest {
     @Test
     void javaApiTest() {
         node.submitTx(txOpts().systemTime(Instant.parse("2020-01-01T12:34:56.000Z")).build(),
-            put("docs", Map.of("xt/id", 1, "foo", "bar")));
+            put("docs", Map.of("xt$id", 1, "foo", "bar")));
 
         try (var res = node.openQuery(
-            from("docs").bindCols("xt/id", "xt/system_from").build())) {
+            from("docs").bindCols("xt$id", "xt$system_from").build())) {
 
             assertEquals(
                 List.of(Map.of(
-                    "xt/id", 1,
-                    "xt/system_from", ZonedDateTime.parse("2020-01-01T12:34:56Z[UTC]"))),
+                    "xt$id", 1,
+                    "xt$systemFrom", ZonedDateTime.parse("2020-01-01T12:34:56Z[UTC]"))),
                 res.toList());
         }
     }

--- a/core/src/test/kotlin/xtdb/api/XtdbTest.kt
+++ b/core/src/test/kotlin/xtdb/api/XtdbTest.kt
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.Test
 import xtdb.api.query.Basis
 import xtdb.api.query.Expr.Companion.call
 import xtdb.api.query.Expr.Companion.param
-import xtdb.api.query.IKeyFn.KeyFn.CLOJURE_STR
+import xtdb.api.query.IKeyFn.KeyFn.KEBAB_CASE_STRING
+import xtdb.api.query.QueryOptions
 import xtdb.api.query.XtqlQuery.Companion.from
 import xtdb.api.query.XtqlQuery.Companion.pipeline
 import xtdb.api.query.XtqlQuery.Companion.relation
 import xtdb.api.query.XtqlQuery.Companion.withCols
-import xtdb.api.query.QueryOptions
 import xtdb.api.tx.TxOp.Companion.put
 import java.time.Instant
 import java.time.LocalDate
@@ -38,13 +38,13 @@ internal class XtdbTest {
 
     @Test
     fun startsInMemoryNode() {
-        node.submitTx(put("foo", mapOf("xt/id" to "jms")))
+        node.submitTx(put("foo", mapOf("xt\$id" to "jms")))
 
         assertEquals(
             listOf(mapOf("id" to "jms")),
 
             node.openQuery(
-                from("foo") { "xt/id" boundTo "id" }
+                from("foo") { "xt\$id" boundTo "id" }
             ).doall()
         )
 
@@ -59,12 +59,12 @@ internal class XtdbTest {
 
     @Test
     fun `test query opts`() {
-        node.submitTx(put("docs2", mapOf("xt/id" to 1, "foo" to "bar")))
+        node.submitTx(put("docs2", mapOf("xt\$id" to 1, "foo" to "bar")))
 
         assertEquals(
-            listOf(mapOf("my_foo" to "bar")),
+            listOf(mapOf("myFoo" to "bar")),
             node.openQuery(
-                from("docs2") { "foo" boundTo "my_foo" }
+                from("docs2") { "foo" boundTo "myFoo" }
             ).doall(),
 
             "Java AST queries"
@@ -76,7 +76,7 @@ internal class XtdbTest {
             node.openQuery(
                 from("docs2") { "foo" boundTo "my_foo" },
 
-                QueryOptions(keyFn = CLOJURE_STR)
+                QueryOptions(keyFn = KEBAB_CASE_STRING)
             ).doall(),
 
             "key-fn"
@@ -85,7 +85,7 @@ internal class XtdbTest {
         assertEquals(
             listOf(mapOf("foo" to "bar")),
             node.openQuery(
-                from("docs2") { "xt/id" boundTo param("\$id"); +"foo" },
+                from("docs2") { "xt\$id" boundTo param("\$id"); +"foo" },
                 QueryOptions(args = mapOf("id" to 1))
             ).doall(),
 
@@ -93,12 +93,12 @@ internal class XtdbTest {
         )
 
         assertEquals(
-            listOf(mapOf("current_time" to LocalDate.parse("2020-01-01"))),
+            listOf(mapOf("currentTime" to LocalDate.parse("2020-01-01"))),
 
             node.openQuery(
                 pipeline(
                     emptyRel,
-                    withCols { "current-time" boundTo call("current-date") }
+                    withCols { "currentTime" boundTo call("current-date") }
                 ),
 
                 QueryOptions(basis = Basis(currentTime = Instant.parse("2020-01-01T12:34:56.000Z")))

--- a/http-client-clj/src/main/clojure/xtdb/client/impl.clj
+++ b/http-client-clj/src/main/clojure/xtdb/client/impl.clj
@@ -91,10 +91,10 @@
 (defrecord XtdbClient [base-url, !latest-submitted-tx]
   IXtdb
   (^CompletableFuture openQueryAsync [client ^String query ^QueryOptions query-opts]
-   (open-query& client query (into {:key-fn #xt/key-fn :sql-str} query-opts)))
+   (open-query& client query (into {:key-fn #xt/key-fn :snake-case-string} query-opts)))
 
   (^CompletableFuture openQueryAsync [client ^XtqlQuery query ^QueryOptions query-opts]
-   (open-query& client query (into {:key-fn #xt/key-fn :snake-case-str} query-opts)))
+   (open-query& client query (into {:key-fn #xt/key-fn :camel-case-string} query-opts)))
 
   (submitTxAsync [client opts tx-ops]
     (-> ^CompletableFuture

--- a/http-server/src/test/clojure/xtdb/json_serde_test.clj
+++ b/http-server/src/test/clojure/xtdb/json_serde_test.clj
@@ -478,7 +478,7 @@
                              (.defaultTz #time/zone "America/Los_Angeles")
                              (.defaultAllValidTime true)
                              (.explain true)
-                             (.keyFn #xt/key-fn :clojure-kw)
+                             (.keyFn #xt/key-fn :kebab-case-keyword)
                              (.build)))]
     (t/is (= v (roundtrip-query-request v))))
 

--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -267,14 +267,14 @@
                  decode-transit*))
           "testing query")
 
-    (t/is (= [{:xt$id 2}]
+    (t/is (= [{:xt/id 2}]
              (-> (http/request {:accept :transit+json
                                 :as :string
                                 :request-method :post
                                 :content-type :json
                                 :form-params {:query {"from" "docs", "bind" ["xt/id"]}
                                               :queryOpts {:basis {:atTx (tx-key->json-tx-key tx2)}
-                                                          :keyFn "SQL_KW"}}
+                                                          :keyFn "SNAKE_CASE_KEYWORD"}}
                                 :url (http-url "query")})
                  :body
                  decode-transit*))
@@ -429,7 +429,7 @@
                               :request-method :post
                               :content-type :json
                               :form-params {:query {"rel" [{"foo-bar" 1} {"foo-bar" 2}] "bind" ["foo-bar"]}
-                                            :queryOpts {:keyFn "SQL_STR"}}
+                                            :queryOpts {:keyFn "SNAKE_CASE_STRING"}}
                               :url (http-url "query")})
                :body
                decode-json*))))

--- a/modules/bench/src/main/clojure/xtdb/bench2/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/auctionmark.clj
@@ -103,17 +103,17 @@
        (cond-> []
          ;; increment number of bids on item
          i
-         (conj (xt/put :item (assoc (first (q '~item-query {:args {:i i}, :key-fn :snake-case-kw}))
+         (conj (xt/put :item (assoc (first (q '~item-query {:args {:i i}, :key-fn :snake-case-keyword}))
                                     :i_num_bids (inc nbids))))
 
          ;; if new bid exceeds old, bump it
          upd_curr_bid
-         (conj (xt/put :item-max-bid (assoc (first (q '~item-max-bid-query {:args {:imb imb}, :key-fn :snake-case-kw}))
+         (conj (xt/put :item-max-bid (assoc (first (q '~item-max-bid-query {:args {:imb imb}, :key-fn :snake-case-keyword}))
                                             :imb_bid bid)))
 
          ;; we exceed the old max, win the bid.
          (and curr_bid new_bid_win)
-         (conj (xt/put :item-max-bid (assoc (first (q '~item-max-bid-query {:args {:imb imb}, :key-fn :snake-case-kw}))
+         (conj (xt/put :item-max-bid (assoc (first (q '~item-max-bid-query {:args {:imb imb}, :key-fn :snake-case-keyword}))
                                             :imb_ib_id new_bid_id
                                             :imb_ib_u_id u_id
                                             :imb_updated now)))
@@ -180,7 +180,7 @@
                            (from :gav [{:xt/id gav-id, :gav-gag-id gag-id} gav-name])
                            (unnest {gag-id $gag-ids})
                            (unnest {gav-id $gav-ids}))
-                   {:args {:gag-ids gag-ids, :gav-ids gav-ids}, :key-fn :snake-case-kw})
+                   {:args {:gag-ids gag-ids, :gav-ids gav-ids}, :key-fn :snake-case-keyword})
              (str/join " ")
              (str description " "))]
 
@@ -219,7 +219,7 @@
 
 (defn item-status-groups [node]
   (let [items (xt/q node '(from :item [{:xt/id i} i_id i_u_id i_status i_end_date i_num_bids])
-                    {:key-fn :snake-case-kw})
+                    {:key-fn :snake-case-keyword})
         all (ArrayList.)
         open (ArrayList.)
         ending-soon (ArrayList.)
@@ -334,7 +334,7 @@
     (xt/q sut '(-> (from :item [{:xt/id i_id, :i_status :open}
                                 i_u_id i_initial_price i_current_price])
                    (where (= $iid i_id)))
-          {:args {:iid i_id}, :key-fn :snake-case-kw})))
+          {:args {:iid i_id}, :key-fn :snake-case-keyword})))
 
 (defn read-category-tsv []
   (let [cat-tsv-rows

--- a/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
+++ b/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
@@ -33,8 +33,9 @@
 
   (let [field-vecs (.getFieldVectors root)
         row-count (count rows)]
-    (doseq [^FieldVector field-vec field-vecs]
-      (vw/write-vec! field-vec (map (keyword (.getName (.getField field-vec))) rows)))
+    (doseq [^FieldVector field-vec field-vecs
+            :let [field-name (.getName (.getField field-vec))]]
+      (vw/write-vec! field-vec (map (fn [row] (get row field-name)) rows)))
 
     (.setRowCount root row-count)
     root))
@@ -130,7 +131,7 @@
                                      ;; HACK getting results in a Clojure data structure, putting them back in to a VSR
                                      ;; because we can get DUVs in the in-rel but the output just expects mono vecs.
 
-                                     (populate-root vsr (vr/rel->rows in-rel #xt/key-fn :sql-kw))
+                                     (populate-root vsr (vr/rel->rows in-rel #xt/key-fn :snake-case-string))
                                      (.putNext listener))))
 
               (.completed listener)))]

--- a/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
@@ -46,15 +46,15 @@
         (while (.next stream)
           ;; if this were a real client chances are they wouldn't just
           ;; eagerly turn the roots into Clojure maps...
-          (swap! !res into (vr/rel->rows (vr/<-root root) #xt/key-fn :sql-kw)))
+          (swap! !res into (vr/rel->rows (vr/<-root root) #xt/key-fn :snake-case-keyword)))
 
         @!res))))
 
 (t/deftest test-client
   (t/is (= -1 (.executeUpdate *client* "INSERT INTO users (xt$id, name) VALUES ('jms', 'James'), ('hak', 'Håkan')" empty-call-opts)))
 
-  (t/is (= #{{:xt$id "jms", :name "James"}
-             {:xt$id "hak", :name "Håkan"}}
+  (t/is (= #{{:xt/id "jms", :name "James"}
+             {:xt/id "hak", :name "Håkan"}}
            (set (-> (.execute *client* "SELECT users.xt$id, users.name FROM users" empty-call-opts)
                     (flight-info->rows))))))
 
@@ -99,8 +99,8 @@
                  (flight-info->rows))))
     (.commit *client* fsql-tx empty-call-opts)
 
-    (t/is (= #{{:xt$id "jms", :name "James"}
-               {:xt$id "hak", :name "Håkan"}}
+    (t/is (= #{{:xt/id "jms", :name "James"}
+               {:xt/id "hak", :name "Håkan"}}
              (set (-> (.execute *client* "SELECT users.xt$id, users.name FROM users" empty-call-opts)
                       (flight-info->rows)))))))
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -199,14 +199,14 @@
                  (->cursor allocator schema blocks))}))
 
 (defn <-reader
-  ([^IVectorReader col] (<-reader col #xt/key-fn :clojure-kw))
+  ([^IVectorReader col] (<-reader col #xt/key-fn :kebab-case-keyword))
   ([^IVectorReader col ^IKeyFn key-fn]
    (mapv (fn [idx]
            (.getObject col idx key-fn))
          (range (.valueCount col)))))
 
 (defn <-cursor
-  ([^ICursor cursor] (<-cursor cursor #xt/key-fn :clojure-kw))
+  ([^ICursor cursor] (<-cursor cursor #xt/key-fn :kebab-case-keyword))
   ([^ICursor cursor ^IKeyFn key-fn]
    (let [!res (volatile! (transient []))]
      (.forEachRemaining cursor
@@ -218,7 +218,7 @@
 (defn query-ra
   ([query] (query-ra query {}))
   ([query {:keys [node params preserve-blocks? with-col-types? key-fn] :as query-opts
-           :or {key-fn (serde/read-key-fn :clojure-kw)}}]
+           :or {key-fn (serde/read-key-fn :kebab-case-keyword)}}]
    (let [^IIndexer indexer (util/component node :xtdb/indexer)
          query-opts (cond-> query-opts
                       node (-> (time/after-latest-submitted-tx node)
@@ -396,7 +396,7 @@
     (map new-uuid (range n))))
 
 (defn vec->vals
-  ([^IVectorReader rdr] (vec->vals rdr #xt/key-fn :clojure-kw))
+  ([^IVectorReader rdr] (vec->vals rdr #xt/key-fn :kebab-case-keyword))
   ([^IVectorReader rdr ^IKeyFn key-fn]
    (->> (for [i (range (.valueCount rdr))]
           (.getObject rdr i key-fn))

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -658,18 +658,32 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')")])
   (t/is (= [{:xt/id :petr :first-name "Petr", :last-name "Petrov"}
             {:xt/id :ivan :first-name "Ivan", :last-name "Ivanov"}]
            (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
-                 {:key-fn :clojure-kw}))
-        "clojure key-fn")
+                 {:key-fn :kebab-case-keyword})))
 
-  (t/is (= [{:xt$id :petr :first_name "Petr", :last_name "Petrov"}
-            {:xt$id :ivan :first_name "Ivan", :last_name "Ivanov"}]
+  (t/is (= [{"xt$id" :petr "first-name" "Petr", "last-name" "Petrov"}
+            {"xt$id" :ivan "first-name" "Ivan", "last-name" "Ivanov"}]
            (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
-                 {:key-fn :sql-kw})))
+                 {:key-fn :kebab-case-string})))
 
-  (t/is (= [{:xt/id :petr :first_name "Petr", :last_name "Petrov"}
-            {:xt/id :ivan :first_name "Ivan", :last_name "Ivanov"}]
+  (t/is (= [{:xt/id :petr, :first_name "Petr", :last_name "Petrov"}
+            {:xt/id :ivan, :first_name "Ivan", :last_name "Ivanov"}]
            (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
-                 {:key-fn :snake-case-kw})))
+                 {:key-fn :snake-case-keyword})))
+
+  (t/is (= [{"xt$id" :petr, "first_name" "Petr", "last_name" "Petrov"}
+            {"xt$id" :ivan, "first_name" "Ivan", "last_name" "Ivanov"}]
+           (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
+                 {:key-fn :snake-case-string})))
+
+  (t/is (= [{:xt/id :petr, :firstName "Petr", :lastName "Petrov"}
+            {:xt/id :ivan, :firstName "Ivan", :lastName "Ivanov"}]
+           (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
+                 {:key-fn :camel-case-keyword})))
+
+  (t/is (= [{"xt$id" :petr, "firstName" "Petr", "lastName" "Petrov"}
+            {"xt$id" :ivan, "firstName" "Ivan", "lastName" "Ivanov"}]
+           (xt/q tu/*node* '(from :docs [xt/id first-name last-name])
+                 {:key-fn :camel-case-string})))
 
   (t/is (thrown-with-msg? IllegalArgumentException
                           #"Illegal argument: "

--- a/src/test/clojure/xtdb/bench2/auctionmark_test.clj
+++ b/src/test/clojure/xtdb/bench2/auctionmark_test.clj
@@ -125,16 +125,16 @@
         ;; (t/is (= nil (am/generate-new-bid-params worker)))
         (t/is (= {:i_num_bids 1}
                  (first (xt/q *node* '(from :item [i_num_bids])
-                              {:key-fn :snake-case-kw}))))
+                              {:key-fn :snake-case-keyword}))))
         ;; there exists a bid
         (t/is (= {:ib_i_id "i_0", :ib_id "ib_0"}
                  (first (xt/q *node* '(from :item-bid [ib_id ib_i_id])
-                              {:key-fn :snake-case-kw}))))
+                              {:key-fn :snake-case-keyword}))))
         ;; new max bid
         (t/is (= {:imb "ib_0-i_0", :imb_i_id "i_0"}
                  (first (xt/q *node*
                               '(from :item-max-bid [{:xt/id imb}, imb_i_id])
-                              {:key-fn :snake-case-kw})))))
+                              {:key-fn :snake-case-keyword})))))
 
       (t/testing "new bid but does not exceed max"
         (with-redefs [am/random-price (constantly Double/MIN_VALUE)]
@@ -143,12 +143,12 @@
 
           ;; new bid
           (t/is (= 2 (-> (xt/q *node* '(from :item [i_num_bids])
-                               {:key-fn :snake-case-kw})
+                               {:key-fn :snake-case-keyword})
                          first :i_num_bids)))
           ;; winning bid remains the same
           (t/is (= {:imb "ib_0-i_0", :imb_i_id "i_0"}
                    (first (xt/q *node* '(from :item-max-bid [{:xt/id imb} imb_i_id])
-                                {:key-fn :snake-case-kw})))))))))
+                                {:key-fn :snake-case-keyword})))))))))
 
 (t/deftest proc-new-item-test
   (with-redefs [am/sample-status (constantly :open)]
@@ -164,10 +164,10 @@
 
         ;; new item
         (let [{:keys [i_id i_u_id]} (first (xt/q *node* '(from :item [i_id i_u_id])
-                                                 {:key-fn :snake-case-kw}))]
+                                                 {:key-fn :snake-case-keyword}))]
           (t/is (= "i_0" i_id))
           (t/is (= "u_0" i_u_id)))
         (t/is (< (- (:u_balance (first (xt/q *node* '(from :user [u_balance])
-                                             {:key-fn :snake-case-kw})))
+                                             {:key-fn :snake-case-keyword})))
                     (double -1.0))
                  0.0001))))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -319,9 +319,8 @@ WHERE foo.xt$id = 1")])]
 (t/deftest test-mutable-data-buffer-bug
   (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id) VALUES(1)")])
 
-  (t/is (= [{:$column_1$ [{:foo 5} {:foo 5}]}]
-           (xt/q tu/*node* "SELECT ARRAY [OBJECT('foo': 5), OBJECT('foo': 5)] FROM t1"
-                 {:key-fn :sql-kw}))))
+  (t/is (= [{:col [{:foo 5} {:foo 5}]}]
+           (xt/q tu/*node* "SELECT ARRAY [OBJECT('foo': 5), OBJECT('foo': 5)] AS col FROM t1"))))
 
 (t/deftest test-differing-length-lists-441
   (xt/submit-tx tu/*node* [(xt/sql-op "INSERT INTO t1(xt$id, data) VALUES (1, [2, 3])")

--- a/src/test/clojure/xtdb/operator/rename_test.clj
+++ b/src/test/clojure/xtdb/operator/rename_test.clj
@@ -24,7 +24,7 @@
                              blocks-expr]
                             {:preserve-blocks? true
                              :with-col-types? true
-                             :key-fn :snake-case-kw}))))
+                             :key-fn :snake-case-keyword}))))
 
     (t/testing "prefix only"
       (t/is (= {:col-types '{r_a :i64, r_b :i64}
@@ -34,4 +34,4 @@
                              blocks-expr]
                             {:preserve-blocks? true
                              :with-col-types? true
-                             :key-fn :snake-case-kw}))))))
+                             :key-fn :snake-case-keyword}))))))

--- a/src/test/clojure/xtdb/operator/unnest_test.clj
+++ b/src/test/clojure/xtdb/operator/unnest_test.clj
@@ -23,20 +23,20 @@
                           {:preserve-blocks? true
                            :with-col-types? true})))
 
-    (t/is (= {:col-types '{a :i64, b [:list :i64], b* :i64, $ordinal :i32}
-              :res [[{:a 1, :b [1 2], :b* 1, :$ordinal 1}
-                     {:a 1, :b [1 2], :b* 2, :$ordinal 2}
-                     {:a 2, :b [3 4 5], :b* 3, :$ordinal 1}
-                     {:a 2, :b [3 4 5], :b* 4, :$ordinal 2}
-                     {:a 2, :b [3 4 5], :b* 5, :$ordinal 3}]
-                    [{:a 4, :b [6 7 8], :b* 6, :$ordinal 1}
-                     {:a 4, :b [6 7 8], :b* 7, :$ordinal 2}
-                     {:a 4, :b [6 7 8], :b* 8, :$ordinal 3}]]}
-             (tu/query-ra [:unnest '{b* b} '{:ordinality-column $ordinal}
+    (t/is (= {:col-types '{a :i64, b [:list :i64], b* :i64, ordinal :i32}
+              :res [[{:a 1, :b [1 2], :b* 1, :ordinal 1}
+                     {:a 1, :b [1 2], :b* 2, :ordinal 2}
+                     {:a 2, :b [3 4 5], :b* 3, :ordinal 1}
+                     {:a 2, :b [3 4 5], :b* 4, :ordinal 2}
+                     {:a 2, :b [3 4 5], :b* 5, :ordinal 3}]
+                    [{:a 4, :b [6 7 8], :b* 6, :ordinal 1}
+                     {:a 4, :b [6 7 8], :b* 7, :ordinal 2}
+                     {:a 4, :b [6 7 8], :b* 8, :ordinal 3}]]}
+             (tu/query-ra [:unnest '{b* b} '{:ordinality-column ordinal}
                            [::tu/blocks '{a :i64, b [:list :i64]} in-vals]]
                           {:preserve-blocks? true
                            :with-col-types? true
-                           :key-fn :sql-kw})))))
+                           :key-fn :snake-case-keyword})))))
 
 (t/deftest test-unnest-operator
   (t/is (= [{:a 1, :b [1 2], :b* 1}
@@ -87,14 +87,14 @@
                                         {:a 3, :b #{2 "bar"}}]}})))
         "handles mixed lists + sets + other things")
 
-  (t/is (= [{:a 1, :b* 1, :$ordinal 1}
-            {:a 1, :b* 2, :$ordinal 2}
-            {:a 2, :b* 3, :$ordinal 1}
-            {:a 2, :b* 4, :$ordinal 2}
-            {:a 2, :b* 5, :$ordinal 3}]
-           (tu/query-ra '[:project [a b* $ordinal]
-                          [:unnest {b* b} {:ordinality-column $ordinal}
+  (t/is (= [{:a 1, :b* 1, :ordinal 1}
+            {:a 1, :b* 2, :ordinal 2}
+            {:a 2, :b* 3, :ordinal 1}
+            {:a 2, :b* 4, :ordinal 2}
+            {:a 2, :b* 5, :ordinal 3}]
+           (tu/query-ra '[:project [a b* ordinal]
+                          [:unnest {b* b} {:ordinality-column ordinal}
                            [:table ?x]]]
                         {:params '{?x [{:a 1 :b [1 2]} {:a 2 :b [3 4 5]}]}
-                         :key-fn :sql-kw}))
+                         :key-fn :snake-case-keyword}))
         "with ordinality"))

--- a/src/test/clojure/xtdb/sql/analyze_test.clj
+++ b/src/test/clojure/xtdb/sql/analyze_test.clj
@@ -394,11 +394,11 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
   (invalid? [#"Please use a qualified reference to valid_time"]
     "SELECT foo.name, bar.also_name
     FROM foo, bar
-    WHERE foo.random_col OVERLAPS bar.VALID_TiME")
+    WHERE foo.random_col OVERLAPS bar.VALID_TIME")
   (invalid? [#"Please use a qualified reference to valid_time"]
     "SELECT foo.name, bar.also_name
     FROM foo, bar
-    WHERE foo.SYSTEM_TImE OVERLAPS bar.fooble"))
+    WHERE foo.systemTime OVERLAPS bar.fooble"))
 
 (t/deftest test-invalid-table-names
   (invalid? [#"Unexpected:\nVALID_TIME"]

--- a/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
@@ -209,15 +209,15 @@
 
 (defn- execute-sql-query [node sql-statement variables opts]
   (binding [r/*memo* (HashMap.)]
-    (let [projection (outer-projection (p/parse sql-statement :query_expression))]
+    (let [projection (mapv str (outer-projection (p/parse sql-statement :query_expression)))]
       (vec
        (for [row (xt/q node sql-statement
                        (-> opts
-                           (assoc :key-fn :sql-kw)
+                           (assoc :key-fn :snake-case-string)
                            (assoc :default-all-valid-time? (not= (get variables "VALID_TIME_DEFAULTS") "AS_OF_NOW"))
                            (cond-> (get variables "CURRENT_TIMESTAMP") (assoc-in [:basis :current-time] (Instant/parse (get variables "CURRENT_TIMESTAMP"))))))]
 
-         (mapv #(-> % name keyword row) projection))))))
+         (mapv row projection))))))
 
 (defn parse-create-table [^String x]
   (when-let [[_ table-name columns] (re-find #"(?is)^\s*CREATE\s+TABLE\s+(\w+)\s*\((.+)\)\s*$" x)]

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -71,7 +71,7 @@
       (tu/with-allocator
         (fn []
           (t/is (is-equal? res (tu/query-ra q {:node *node*, :params params, :table-args table-args
-                                               :key-fn :snake-case-kw}))
+                                               :key-fn :snake-case-keyword}))
                 (format "Q%02d" (inc n))))))))
 
 (t/deftest test-001-ra
@@ -111,7 +111,7 @@
     (when (contains? *xtql-qs* q)
       (let [query @(nth tpch-xtql/queries n)
             {::tpch-xtql/keys [args]} (meta query)]
-        (t/is (is-equal? expected-res (xt/q *node* query {:args args, :key-fn :snake-case-kw}))
+        (t/is (is-equal? expected-res (xt/q *node* query {:args args, :key-fn :snake-case-keyword}))
               (format "Q%02d" (inc n)))))))
 
 (t/deftest test-001-xtql
@@ -152,7 +152,7 @@
               (format "Q%02d" n))))))
 
 (defn test-sql-query
-  ([n res] (test-sql-query {:decorrelate? true, :key-fn :snake-case-kw} n res))
+  ([n res] (test-sql-query {:decorrelate? true, :key-fn :snake-case-keyword} n res))
   ([opts n res]
    (let [q (inc n)]
      (when (contains? *qs* q)

--- a/src/test/clojure/xtdb/tx_fn_test.clj
+++ b/src/test/clojure/xtdb/tx_fn_test.clj
@@ -236,7 +236,7 @@
   (xt/submit-tx tu/*node* [(xt/put :docs {:xt/id 1 :first-name "Allan" :last-name "Turing"})
                            (xt/put-fn :my-fn '(fn []
                                                 (let [ks (->> (q '(from :docs [first-name last-name])
-                                                                 {:key-fn :sql-kw})
+                                                                 {:key-fn :snake-case-keyword})
                                                               (mapcat keys)
                                                               (into []))]
                                                   [(xt/put :the-keys {:xt/id 1 :keys ks})])))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -28,7 +28,7 @@
 
       (let [duv-rdr (vw/vec-wtr->rdr duv-writer)]
         {:vs (vec (for [idx (range (count vs))]
-                    (.getObject duv-rdr idx #xt/key-fn :clojure-kw)))
+                    (.getObject duv-rdr idx #xt/key-fn :kebab-case-keyword)))
          :vec-types (vec (for [idx (range (count vs))]
                            (class (.getVectorByType duv (.getTypeId duv idx)))))}))))
 

--- a/src/test/clojure/xtdb/vector/reader_test.clj
+++ b/src/test/clojure/xtdb/vector/reader_test.clj
@@ -245,7 +245,7 @@
 (deftest struct-normalisation-testing
   (t/testing "structs"
     (with-open [rel-wtr1 (vw/->rel-writer tu/*allocator*)]
-      (let [my-column-wtr1 (.colWriter rel-wtr1 "my-column" (FieldType/notNullable #xt.arrow/type :struct))]
+      (let [my-column-wtr1 (.colWriter rel-wtr1 "my_column" (FieldType/notNullable #xt.arrow/type :struct))]
         (.startStruct my-column-wtr1)
         (-> (.structKeyWriter my-column-wtr1 "long_name" (FieldType/notNullable #xt.arrow/type :i64))
             (.writeLong 42))
@@ -255,7 +255,10 @@
         (.endRow rel-wtr1))
 
       (t/is (= [{:my-column {:short-name "forty-two", :long-name 42}}]
-               (vr/rel->rows (vw/rel-wtr->rdr rel-wtr1) #xt/key-fn :clojure-kw)))
+               (vr/rel->rows (vw/rel-wtr->rdr rel-wtr1) #xt/key-fn :kebab-case-keyword)))
 
       (t/is (= [{:my_column {:short_name "forty-two", :long_name 42}}]
-               (vr/rel->rows (vw/rel-wtr->rdr rel-wtr1) #xt/key-fn :snake-case-kw))))))
+               (vr/rel->rows (vw/rel-wtr->rdr rel-wtr1) #xt/key-fn :snake-case-keyword)))
+
+      (t/is (= [{:myColumn {:shortName "forty-two", :longName 42}}]
+               (vr/rel->rows (vw/rel-wtr->rdr rel-wtr1) #xt/key-fn :camel-case-keyword))))))

--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -6,12 +6,12 @@
 (ns xtdb.xtql-test
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
-            [xtdb.xtql :as xtql]
-            [xtdb.xtql.edn :as edn]
             [xtdb.james-bond :as bond]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
-            [xtdb.time :as time]))
+            [xtdb.time :as time]
+            [xtdb.xtql :as xtql]
+            [xtdb.xtql.edn :as edn]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
@@ -1990,14 +1990,14 @@
              (q '{:find [x]
                   :where [($ :x {:xt/* x} {:for-valid-time [:at #time/instant "2023-01-17T00:00:00Z"]})]})))))
 
-
 (t/deftest test-normalisation
-  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/hELLo-wORLd 2})])
+  (xt/submit-tx tu/*node* [(xt/put :xt-docs {:xt/id "doc" :Foo/Bar 1 :Bar.Foo/helloWorld 2})])
+
   (t/is (= [{:foo/bar 1, :bar.foo/hello-world 2}]
-           (xt/q tu/*node* '(from :xt-docs [Foo/Bar Bar.Foo/Hello-World]))))
+           (xt/q tu/*node* '(from :xt-docs [Foo/Bar Bar.Foo/hello-world]))))
+
   (t/is (= [{:bar 1, :foo 2}]
            (xt/q tu/*node* '(from :xt-docs [{:foo/bar bar :bar.foo/hello-world foo}])))))
-
 
 (t/deftest test-table-normalisation
   (let [doc {:xt/id "doc" :foo "bar"}]

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/identifier-case-insensitivity.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/identifier-case-insensitivity.test
@@ -4,10 +4,10 @@ statement ok
 INSERT INTO T1(xt$id, col1, col2) VALUES(1,'fish',1000)
 
 statement ok
-INSERT INTO t1(xt$id, coL1, COL2) VALUES(2,'dog',2000)
+INSERT INTO t1(xt$id, COL1, COL2) VALUES(2,'dog',2000)
 
 query ITI rowsort
-SELECT t1.XT$ID, T1.col1, t1.cOl2 FROM T1
+SELECT t1.XT$ID, T1.col1, t1.COL2 FROM T1
 ----
 1
 fish
@@ -17,7 +17,7 @@ dog
 2000
 
 query ITI rowsort
-SELECT "t1".xt$id, T1."col1", t1.cOl2 FROM "t1"
+SELECT "t1".xt$id, T1."col1", t1.COL2 FROM "t1"
 ----
 1
 fish
@@ -27,7 +27,7 @@ dog
 2000
 
 query ITI rowsort
-SELECT "T1".xt$id, "T1".col1, "T1".cOl2 FROM "T1"
+SELECT "T1".xt$id, "T1".col1, "T1".COL2 FROM "T1"
 ----
 1
 fish
@@ -37,10 +37,10 @@ dog
 2000
 
 statement ok
-INSERT INTO "T1"(xt$id, "COl1", "col2") VALUES(3,'cat',3000)
+INSERT INTO "T1"(xt$id, "COL1", "col2") VALUES(3,'cat',3000)
 
 query ITI rowsort
-SELECT "T1".xt$id, "T1"."COl1", "T1".cOl2 FROM "T1"
+SELECT "T1".xt$id, "T1"."Col1", "T1".COL2 FROM "T1"
 ----
 1
 fish
@@ -53,7 +53,7 @@ cat
 3000
 
 statement ok
-UPDATE T1 SET cOl1 = 30 WHERE t1.col2 IN (313, 2000)
+UPDATE T1 SET Col1 = 30 WHERE t1.COL2 IN (313, 2000)
 
 query ITI rowsort
 SELECT t1.xt$id, T1.col1, "t1".col2 FROM t1
@@ -86,21 +86,21 @@ fish
 cat
 
 query I
-SELECT teeone.col2 FROM t1 AS TEEoNE WHERE TEEone.col1 = ( SELECT t1.col1 FROM T1 WHERE t1.col1 = teeONe.cOL1 ) ORDER BY teeone."CoL2"
+SELECT teeone.col2 FROM t1 AS TEEONE WHERE TEEONE.col1 = ( SELECT t1.col1 FROM T1 WHERE t1.col1 = TEEONE.COL1 ) ORDER BY Teeone."COL2"
 ----
 1000
 2000
 3000
 
 query I
-SELECT "TeeoNE".col2 FROM "T1" AS "TeeoNE" WHERE "TeeoNE"."COl1" IN ( SELECT "T1"."COl1" FROM "T1" WHERE "T1"."COl1" = "TeeoNE"."COl1" ) ORDER BY "TeeoNE".col2
+SELECT "TEEONE".col2 FROM "T1" AS "teeone" WHERE "TEEONE"."COl1" IN ( SELECT "T1"."COl1" FROM "T1" WHERE "T1"."COL1" = "TEEONE"."COl1" ) ORDER BY "TEeone".col2
 ----
 1000
 2000
 3000
 
 statement ok
-DELETE FROM T1 WHERE t1.cOl1 = 'fish'
+DELETE FROM T1 WHERE t1.Col1 = 'fish'
 
 query ITI rowsort
 SELECT t1.XT$ID FROM T1
@@ -109,7 +109,7 @@ SELECT t1.XT$ID FROM T1
 3
 
 statement ok
-DELETE FROM "T1" WHERE "T1"."cOL2" IN (2000, 3000)
+DELETE FROM "T1" WHERE "T1"."COL2" IN (2000, 3000)
 
 query I rowsort
 SELECT "T1".xt$id FROM "T1"

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/object-array.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/object-array.test
@@ -8,12 +8,12 @@ INSERT INTO t1(xt$id) VALUES(1)
 query T rowsort
 SELECT OBJECT('id': 1) FROM t1
 ----
-{:id 1}
+{"id" 1}
 
 query T rowsort
 SELECT OBJECT ('foo': 2, 'bar': OBJECT('baz': 'biff')) FROM t1
 ----
-{:foo 2, :bar {:baz "biff"}}
+{"bar" {"baz" "biff"}, "foo" 2}
 
 query T rowsort
 SELECT OBJECT ('foo': OBJECT('bibble': true),
@@ -21,7 +21,7 @@ SELECT OBJECT ('foo': OBJECT('bibble': true),
 							 'flib': OBJECT('true': false)))
 FROM t1
 ----
-{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+{"bar" {"baz" -4113466, "flib" {"true" false}}, "foo" {"bibble" true}}
 
 query T rowsort
 SELECT ARRAY ['foo', 'bar'] FROM t1
@@ -41,12 +41,12 @@ SELECT ARRAY [true, FALSE, true, TRUE, false] FROM t1
 query T rowsort
 SELECT OBJECT ('foo': 5, 'bar': OBJECT('baz': ARRAY [-45, 1, 24])) FROM t1
 ----
-{:foo 5, :bar {:baz [-45 1 24]}}
+{"bar" {"baz" [-45 1 24]}, "foo" 5}
 
 query T rowsort
 SELECT ARRAY [OBJECT('foo': 5), OBJECT('foo': 5)] FROM t1
 ----
-[{:foo 5} {:foo 5}]
+[{"foo" 5} {"foo" 5}]
 
 statement ok
 INSERT INTO t1(xt$id) VALUES(2)
@@ -59,8 +59,8 @@ SELECT OBJECT ('foo': OBJECT('bibble': true),
 							 'flib': OBJECT('true': false)))
 FROM t1
 ----
-{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
-{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+{"bar" {"baz" -4113466, "flib" {"true" false}}, "foo" {"bibble" true}}
+{"bar" {"baz" -4113466, "flib" {"true" false}}, "foo" {"bibble" true}}
 
 # testing field refs
 
@@ -96,15 +96,15 @@ VALUES(2, {'foo': {'bibble': true},
 query T rowsort
 SELECT t2.data FROM t2
 ----
-{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
-{:foo {:bibble true}, :bar {:baz 1001}}
+{"bar" {"baz" -4113466, "flib" {"true" false}}, "foo" {"bibble" true}}
+{"bar" {"baz" 1001}, "foo" {"bibble" true}}
 
 # SEE 440
 #query T rowsort
 #SELECT t2.data.foo FROM t2
 #----
-#{:bibble true}
-#{:bibble true}
+#{"bibble" true}
+#{"bibble" true}
 
 #query T nosort
 #SELECT t2.data.foo.bibble FROM t2

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-a5.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-a5.test
@@ -44,12 +44,12 @@ INSERT INTO people (xt$id, name, friends)
 query T nosort
 SELECT people.friends FROM people
 ----
-[{:user "Dan"} {:user "Kath"}]
+[{"user" "Dan"} {"user" "Kath"}]
 
 query T nosort
 SELECT people.friends[2] FROM people
 ----
-{:user "Kath"}
+{"user" "Kath"}
 
 #Field Access works here but not in the general case, not on the a5
 query T nosort

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
@@ -1,14 +1,14 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:mega-join
    [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2}
-     [:scan {:table starsin} [movietitle starname]]]
+     {movie_title x1, star_name x2}
+     [:scan {:table stars_in} [movie_title star_name]]]
     [:rename
      {name x4, birthdate x5}
      [:scan
-      {:table moviestar}
+      {:table movie_star}
       [name {birthdate (= birthdate 1960)}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-11.edn
@@ -1,1 +1,1 @@
-[:scan {:table starsin} [name]]
+[:scan {:table stars_in} [name]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-12.edn
@@ -1,1 +1,1 @@
-[:rename {x1 bar} [:rename {name x1} [:scan {:table starsin} [name]]]]
+[:rename {x1 bar} [:rename {name x1} [:scan {:table stars_in} [name]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
@@ -1,1 +1,1 @@
-[:select (= name lastname) [:scan {:table starsin} [name lastname]]]
+[:select (= name lastname) [:scan {:table stars_in} [name lastname]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-14.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-14.edn
@@ -1,4 +1,4 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:distinct
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-15.edn
@@ -1,5 +1,5 @@
 [:rename
  {x1 name}
  [:difference
-  [:distinct [:rename {name x1} [:scan {:table starsin} [name]]]]
-  [:distinct [:rename {name x1} [:scan {:table starsin} [name]]]]]]
+  [:distinct [:rename {name x1} [:scan {:table stars_in} [name]]]]
+  [:distinct [:rename {name x1} [:scan {:table stars_in} [name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-16.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-16.edn
@@ -1,5 +1,5 @@
 [:rename
  {x1 name}
  [:union-all
-  [:rename {name x1} [:scan {:table starsin} [name]]]
-  [:rename {name x1} [:scan {:table starsin} [name]]]]]
+  [:rename {name x1} [:scan {:table stars_in} [name]]]
+  [:rename {name x1} [:scan {:table stars_in} [name]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-17.edn
@@ -2,5 +2,5 @@
  {x1 name}
  [:distinct
   [:intersect
-   [:rename {name x1} [:scan {:table starsin} [name]]]
-   [:rename {name x1} [:scan {:table starsin} [name]]]]]]
+   [:rename {name x1} [:scan {:table stars_in} [name]]]
+   [:rename {name x1} [:scan {:table stars_in} [name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-18.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-18.edn
@@ -1,6 +1,6 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:distinct
   [:union-all
-   [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]
-   [:rename {name x1} [:scan {:table starsin} [name]]]]]]
+   [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]
+   [:rename {name x1} [:scan {:table stars_in} [name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-19.edn
@@ -4,5 +4,5 @@
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
   [:distinct
    [:union-all
-    [:rename {name x1} [:scan {:table starsin} [name]]]
-    [:rename {name x1} [:scan {:table starsin} [name]]]]]]]
+    [:rename {name x1} [:scan {:table stars_in} [name]]]
+    [:rename {name x1} [:scan {:table stars_in} [name]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
@@ -1,15 +1,15 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:mega-join
    [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2}
-     [:scan {:table starsin} [movietitle starname]]]
+     {movie_title x1, star_name x2}
+     [:scan {:table stars_in} [movie_title star_name]]]
     [:rename
      {name x4, birthdate x5}
      [:scan
-      {:table moviestar}
+      {:table movie_star}
       [name
        {birthdate (and (< birthdate 1960) (> birthdate 1950))}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-20.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:top
   {:limit 10}
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-21.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:top
   {:skip 5}
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-22.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-22.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:top
   {:skip 5, :limit 10}
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-23.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-23.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-24.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-24.edn
@@ -1,7 +1,7 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:top
   {:skip 100}
   [:order-by
    [[x1 {:direction :asc, :null-ordering :nulls-last}]]
-   [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]]
+   [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-25.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-25.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:order-by
   [[x1 {:direction :desc, :null-ordering :nulls-last}]]
-  [:rename {movietitle x1} [:scan {:table starsin} [movietitle]]]]]
+  [:rename {movie_title x1} [:scan {:table stars_in} [movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:order-by
@@ -10,5 +10,5 @@
     [:map
      [{x4 (= x2 "foo")}]
      [:rename
-      {movietitle x1, year x2}
-      [:scan {:table starsin} [movietitle year]]]]]]]]
+      {movie_title x1, year x2}
+      [:scan {:table stars_in} [movie_title year]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:order-by
    [[x2 {:direction :asc, :null-ordering :nulls-last}]]
    [:rename
-    {movietitle x1, year x2}
-    [:scan {:table starsin} [movietitle year]]]]]]
+    {movie_title x1, year x2}
+    [:scan {:table stars_in} [movie_title year]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -4,4 +4,4 @@
   [[x3 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
    [{x3 (= x1 "foo")}]
-   [:rename {year x1} [:scan {:table starsin} [year]]]]]]
+   [:rename {year x1} [:scan {:table stars_in} [year]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-29.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-29.edn
@@ -5,4 +5,4 @@
   [:unnest
    {x3 x1}
    {}
-   [:rename {films x1} [:scan {:table starsin} [films]]]]]]
+   [:rename {films x1} [:scan {:table stars_in} [films]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
@@ -1,14 +1,14 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:mega-join
    [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2}
-     [:scan {:table starsin} [movietitle starname]]]
+     {movie_title x1, star_name x2}
+     [:scan {:table stars_in} [movie_title star_name]]]
     [:rename
      {name x4, birthdate x5}
      [:scan
-      {:table moviestar}
+      {:table movie_star}
       [{name (= name "Foo")} {birthdate (< birthdate 1960)}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
@@ -5,4 +5,4 @@
   [:unnest
    {x3 x1}
    {}
-   [:rename {films x1} [:scan {:table starsin} [films]]]]]]
+   [:rename {films x1} [:scan {:table stars_in} [films]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
@@ -5,4 +5,4 @@
   [:unnest
    {x3 x1}
    {:ordinality-column x4}
-   [:rename {films x1} [:scan {:table starsin} [films]]]]]]
+   [:rename {films x1} [:scan {:table stars_in} [films]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
@@ -1,16 +1,16 @@
 [:rename
- {x1 movietitle}
+ {x1 movie_title}
  [:project
   [x1]
   [:mega-join
    [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2}
-     [:scan {:table starsin} [movietitle starname]]]
+     {movie_title x1, star_name x2}
+     [:scan {:table stars_in} [movie_title star_name]]]
     [:project
      [x4]
      [:rename
       {name x4, birthdate x5}
       [:scan
-       {:table moviestar}
+       {:table movie_star}
        [name {birthdate (= birthdate 1960)}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
@@ -1,12 +1,12 @@
 [:rename
- {x4 movietitle}
+ {x4 movie_title}
  [:project
   [x4]
   [:mega-join
    [{x1 x4} {x2 x5}]
    [[:rename
-     {title x1, movieyear x2}
-     [:scan {:table movie} [title movieyear]]]
+     {title x1, movie_year x2}
+     [:scan {:table movie} [title movie_year]]]
     [:rename
-     {movietitle x4, year x5}
-     [:scan {:table starsin} [movietitle year]]]]]]]
+     {movie_title x4, year x5}
+     [:scan {:table stars_in} [movie_title year]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
@@ -1,12 +1,12 @@
 [:rename
- {x4 movietitle}
+ {x4 movie_title}
  [:project
   [x4]
   [:left-outer-join
    [{x1 x4} {x2 x5}]
    [:rename
-    {title x1, movieyear x2}
-    [:scan {:table movie} [title movieyear]]]
+    {title x1, movie_year x2}
+    [:scan {:table movie} [title movie_year]]]
    [:rename
-    {movietitle x4, year x5}
-    [:scan {:table starsin} [movietitle year]]]]]]
+    {movie_title x4, year x5}
+    [:scan {:table stars_in} [movie_title year]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-7.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-7.edn
@@ -5,4 +5,4 @@
   [:mega-join
    [{x1 x3}]
    [[:rename {title x1} [:scan {:table movie} [title]]]
-    [:rename {title x3} [:scan {:table starsin} [title]]]]]]]
+    [:rename {title x3} [:scan {:table stars_in} [title]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-8.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-8.edn
@@ -4,5 +4,5 @@
   [x1]
   [:left-outer-join
    [{x1 x3}]
-   [:rename {title x1} [:scan {:table starsin} [title]]]
+   [:rename {title x1} [:scan {:table stars_in} [title]]]
    [:rename {title x3} [:scan {:table movie} [title]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
@@ -10,7 +10,7 @@
      [{x2 x5}]
      [[:rename
        {name x1, cert x2}
-       [:scan {:table movieexec} [name cert]]]
+       [:scan {:table movie_exec} [name cert]]]
       [:rename
        {length x4, producer x5, year x6}
        [:scan {:table movie} [length producer year]]]]]]]]]


### PR DESCRIPTION
This PR:
* normalises incoming camel-case attributes into snake-case - e.g. `fooBar` -> `foo_bar`
  * capital letters preceded by a character that isn't upper-case nor an underscore get an underscore - see `NormalFormTest` for examples. This allows us to honour the SQL spec for 'UPPER_SNAKE_CASE' normalising to 'upper_snake_case'.
  * Users who stick to one standard case throughout will be fine; users who switch between standard camel and standard snake will also be fine. 
  * Users who have weird casing (e.g. `fOo_BaR`, spongebob-case) will still be fine (although I wouldn't want them in charge of my data); users who have weird casing and aren't consistent with it between queries are gonna have a Bad Time™
* (breaking change) adds camel-case key-fns, standardises naming of kebab-case and snake-case key-fns (previously 'clojure' and 'sql')
* (breaking change) anyone requesting strings back will get `$`-delimited col-names - it's only the keyword requestors that get the `$`s translated into dots and slashes (`foo$bar$baz` -> `:foo.bar/baz`, `:xt/id`, `:xt/valid-time` etc.)
* (breaking change) anyone making XTQL queries through the Java/Kotlin API, or the JSON client, get dollar-delimited, camel-case col-names by default (e.g. `foo$bar$baz_quux` -> `foo.bar$bazQuux`, `xt$id`, `xt$validTime`, etc.); SQL queries get dollar-delimited snake-case as chances are this is the casing they'll be using in the queries.
 
Regarding the casing decision:

* I could (and indeed did, at first) have excluded the SQL column-names from this normalisation (and just lower-cased them, per the spec) but I preferred to avoid one rule for XTQL, one rule for SQL.
* I could have made the SQL transform camel-case to snake-case too, but decided that there was way too much existing tooling that assumes that column names can be submitted in UPPER_CASE.
* I could have extended the key-fn to be bidirectional - i.e. it'd determine how to normalise column names on the way in too - but decided that was too complex.

Aware that this is potentially controversial, hence the 'ask' PR :sweat_smile: 