### PR TITLE
Handling YAML file config from the Kotlin API

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 publishing {
@@ -44,6 +45,15 @@ dependencies {
     api("com.carrotsearch", "hppc", "0.9.1")
 
     api(kotlin("stdlib-jdk8"))
+    api("com.charleskorn.kaml","kaml","0.56.0")
+
+    testImplementation(project(":http-server"))
+    testImplementation(project(":pgwire-server"))
+    testImplementation(project(":modules:kafka"))
+    testImplementation(project(":modules:s3"))
+    testImplementation(project(":modules:google-cloud"))
+    testImplementation(project(":modules:azure"))
+    testImplementation(project(":modules:flight-sql"))
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -10,9 +10,13 @@ import xtdb.ZoneIdSerde
 import xtdb.api.log.LogFactory
 import xtdb.api.storage.StorageFactory
 import xtdb.util.requiringResolve
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZoneOffset
+import kotlin.io.path.extension
 
 object Xtdb {
     private val OPEN_NODE: IFn = requiringResolve("xtdb.node.impl", "open-node")
@@ -67,6 +71,21 @@ object Xtdb {
     @JvmOverloads
     fun openNode(config: Config = Config()) = config.open()
 
+    @JvmStatic
+    fun openNode(path: Path): IXtdb {
+        if (path.extension != "yaml") {
+            throw IllegalArgumentException("Invalid config file type - must be '.yaml'")
+        } else if (!path.toFile().exists()) {
+            throw IllegalArgumentException("Provided config file does not exist")
+        }
+
+        val yamlString = Files.readString(path)
+        val config = nodeConfig(yamlString)
+
+        return config.open()
+    }
+
     @JvmSynthetic
     fun openNode(build: Config.() -> Unit) = openNode(Config().also(build))
+
 }

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -1,6 +1,12 @@
+@file:UseSerializers(DurationSerde::class, ZoneIdSerde::class)
 package xtdb.api
 
 import clojure.lang.IFn
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.modules.SerializersModule
+import xtdb.DurationSerde
+import xtdb.ZoneIdSerde
 import xtdb.api.log.LogFactory
 import xtdb.api.storage.StorageFactory
 import xtdb.util.requiringResolve
@@ -11,6 +17,7 @@ import java.time.ZoneOffset
 object Xtdb {
     private val OPEN_NODE: IFn = requiringResolve("xtdb.node.impl", "open-node")
 
+    @Serializable
     data class IndexerConfig(
         var logLimit: Long = 64L,
         var pageLimit: Long = 1024L,
@@ -23,6 +30,7 @@ object Xtdb {
         fun flushDuration(flushDuration: Duration) = apply { this.flushDuration = flushDuration }
     }
 
+    @Serializable
     data class Config(
         override var txLog: LogFactory = LogFactory.DEFAULT,
         var storage: StorageFactory = StorageFactory.DEFAULT,

--- a/core/src/main/kotlin/xtdb/api/XtdbSubmitClient.kt
+++ b/core/src/main/kotlin/xtdb/api/XtdbSubmitClient.kt
@@ -1,6 +1,11 @@
+@file:UseSerializers(ZoneIdSerde::class)
+
 package xtdb.api
 
 import clojure.lang.IFn
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.ZoneIdSerde
 import xtdb.api.log.LogFactory
 import xtdb.util.requiringResolve
 import java.time.ZoneId
@@ -10,6 +15,7 @@ object XtdbSubmitClient {
 
     private val OPEN_CLIENT: IFn = requiringResolve("xtdb.node.impl", "open-submit-client")
 
+    @Serializable
     data class Config(
         override var txLog: LogFactory = LogFactory.DEFAULT,
         override var defaultTz: ZoneId = ZoneOffset.UTC,

--- a/core/src/main/kotlin/xtdb/api/XtdbSubmitClient.kt
+++ b/core/src/main/kotlin/xtdb/api/XtdbSubmitClient.kt
@@ -8,8 +8,12 @@ import kotlinx.serialization.UseSerializers
 import xtdb.ZoneIdSerde
 import xtdb.api.log.LogFactory
 import xtdb.util.requiringResolve
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.ZoneId
 import java.time.ZoneOffset
+import kotlin.io.path.extension
 
 object XtdbSubmitClient {
 
@@ -30,6 +34,20 @@ object XtdbSubmitClient {
     @JvmOverloads
     fun openSubmitClient(config: Config = Config()) = config.open()
 
+    @JvmStatic
+    fun openSubmitClient(path: Path): IXtdbSubmitClient {
+        if (path.extension != "yaml") {
+            throw IllegalArgumentException("Invalid config file type - must be '.yaml'")
+        } else if (!path.toFile().exists()) {
+            throw IllegalArgumentException("Provided config file does not exist")
+        }
+
+        val yamlString = Files.readString(path)
+        val config = submitClient(yamlString)
+
+        return config.open()
+    }
+    
     @JvmSynthetic
     fun openSubmitClient(build: Config.() -> Unit) = openSubmitClient(Config().also(build))
 }

--- a/core/src/main/kotlin/xtdb/api/YamlConfigDecoder.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlConfigDecoder.kt
@@ -1,0 +1,77 @@
+@file:JvmName("YamlConfigDecoder")
+
+package xtdb.api
+
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlinx.serialization.serializer
+import xtdb.api.log.InMemoryLogFactory
+import xtdb.api.log.LocalLogFactory
+import xtdb.api.log.LogFactory
+import xtdb.api.storage.InMemoryStorageFactory
+import xtdb.api.storage.LocalStorageFactory
+import xtdb.api.storage.ObjectStoreFactory
+import xtdb.api.storage.StorageFactory
+import java.util.ServiceLoader
+import java.util.ServiceLoader.Provider
+import kotlin.reflect.KClass
+
+interface ModuleRegistry {
+    @OptIn(InternalSerializationApi::class)
+    fun <F : Xtdb.ModuleFactory> registerModuleFactory(factory: KClass<F>, serializer: KSerializer<F> = factory.serializer())
+    @OptIn(InternalSerializationApi::class)
+    fun <F : LogFactory > registerLogFactory(factory: KClass<F>, serializer: KSerializer<F> = factory.serializer())
+    @OptIn(InternalSerializationApi::class)
+    fun <F : ObjectStoreFactory > registerObjectStore(factory: KClass<F>, serializer: KSerializer<F> = factory.serializer())
+}
+
+interface ModuleRegistration {
+    fun register(registry: ModuleRegistry)
+}
+
+val YAML_SERDE = Yaml(
+    serializersModule = SerializersModule {
+        polymorphic(LogFactory::class) {
+            subclass(InMemoryLogFactory::class)
+            subclass(LocalLogFactory::class)
+        }
+
+        ServiceLoader.load(ModuleRegistration::class.java)
+            .stream()
+            .map(Provider<ModuleRegistration>::get)
+            .forEach {
+                it.register(object : ModuleRegistry {
+                    override fun <F : Xtdb.ModuleFactory> registerModuleFactory(
+                        factory: KClass<F>,
+                        serializer: KSerializer<F>,
+                    ) {
+                        polymorphic(Xtdb.ModuleFactory::class) { subclass(factory, serializer) }
+                    }
+
+                    override fun <F : LogFactory> registerLogFactory(
+                        factory: KClass<F>,
+                        serializer: KSerializer<F>,
+                    ) {
+                        polymorphic(LogFactory::class) { subclass(factory, serializer) }
+                    }
+
+                    override fun <F : ObjectStoreFactory> registerObjectStore(
+                        factory: KClass<F>,
+                        serializer: KSerializer<F>,
+                    ) {
+                        polymorphic(ObjectStoreFactory::class) { subclass(factory, serializer) }
+                    }
+                })
+            }
+    })
+
+fun nodeConfig(yamlString: String): Xtdb.Config =
+    YAML_SERDE.decodeFromString<Xtdb.Config>(yamlString)
+
+fun submitClient(yamlString: String): XtdbSubmitClient.Config =
+    YAML_SERDE.decodeFromString<XtdbSubmitClient.Config>(yamlString)

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -1,4 +1,4 @@
-@file:JvmName("YamlConfigDecoder")
+@file:JvmName("YamlSerde")
 
 package xtdb.api
 
@@ -13,10 +13,7 @@ import kotlinx.serialization.serializer
 import xtdb.api.log.InMemoryLogFactory
 import xtdb.api.log.LocalLogFactory
 import xtdb.api.log.LogFactory
-import xtdb.api.storage.InMemoryStorageFactory
-import xtdb.api.storage.LocalStorageFactory
 import xtdb.api.storage.ObjectStoreFactory
-import xtdb.api.storage.StorageFactory
 import java.util.ServiceLoader
 import java.util.ServiceLoader.Provider
 import kotlin.reflect.KClass

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -1,6 +1,13 @@
+@file:UseSerializers(DurationSerde::class, PathSerde::class)
 package xtdb.api.log
 
 import clojure.lang.IFn
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import kotlinx.serialization.UseSerializers
+import xtdb.DurationSerde
+import xtdb.PathSerde
 import xtdb.api.TransactionKey
 import xtdb.util.requiringResolve
 import java.nio.ByteBuffer
@@ -33,7 +40,9 @@ interface LogFactory {
     }
 }
 
-class InMemoryLogFactory(var instantSource: InstantSource = InstantSource.system()) : LogFactory {
+@SerialName("!InMemory")
+@Serializable
+data class InMemoryLogFactory(@Transient var instantSource: InstantSource = InstantSource.system()) : LogFactory {
     companion object {
         private val OPEN_LOG: IFn = requiringResolve("xtdb.log.memory-log", "open-log")
     }
@@ -43,9 +52,11 @@ class InMemoryLogFactory(var instantSource: InstantSource = InstantSource.system
     override fun openLog() = OPEN_LOG(this) as Log
 }
 
-class LocalLogFactory @JvmOverloads constructor(
+@SerialName("!Local")
+@Serializable
+data class LocalLogFactory @JvmOverloads constructor(
     val path: Path,
-    var instantSource: InstantSource = InstantSource.system(),
+    @Transient var instantSource: InstantSource = InstantSource.system(),
     var bufferSize: Long = 4096,
     var pollSleepDuration: Duration = Duration.ofMillis(100),
 ) : LogFactory {

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -15,7 +15,7 @@ import java.nio.file.Path
 @Serializable
 sealed interface StorageFactory {
     companion object {
-        val DEFAULT = InMemoryStorageFactory
+        val DEFAULT = InMemoryStorageFactory()
     }
 
     fun openStorage(allocator: BufferAllocator): IBufferPool
@@ -23,9 +23,10 @@ sealed interface StorageFactory {
 
 @Serializable
 @SerialName("!InMemory")
-data object InMemoryStorageFactory : StorageFactory {
-    private val OPEN_STORAGE = requiringResolve("xtdb.buffer-pool", "open-in-memory-storage")
-
+class InMemoryStorageFactory() : StorageFactory {
+    companion object {
+        private val OPEN_STORAGE = requiringResolve("xtdb.buffer-pool", "open-in-memory-storage")
+    }
     override fun openStorage(allocator: BufferAllocator) = OPEN_STORAGE.invoke(allocator) as IBufferPool
 }
 

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -1,12 +1,18 @@
 @file:JvmName("Storage")
+@file:UseSerializers(PathSerde::class)
 
 package xtdb.api.storage
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.IBufferPool
+import xtdb.PathSerde
 import xtdb.util.requiringResolve
 import java.nio.file.Path
 
+@Serializable
 sealed interface StorageFactory {
     companion object {
         val DEFAULT = InMemoryStorageFactory
@@ -15,12 +21,16 @@ sealed interface StorageFactory {
     fun openStorage(allocator: BufferAllocator): IBufferPool
 }
 
+@Serializable
+@SerialName("!InMemory")
 data object InMemoryStorageFactory : StorageFactory {
     private val OPEN_STORAGE = requiringResolve("xtdb.buffer-pool", "open-in-memory-storage")
 
     override fun openStorage(allocator: BufferAllocator) = OPEN_STORAGE.invoke(allocator) as IBufferPool
 }
 
+@Serializable
+@SerialName("!Local")
 data class LocalStorageFactory(
     val path: Path,
     var maxCacheEntries: Long = 1024,
@@ -45,6 +55,9 @@ interface ObjectStoreFactory {
     fun openObjectStore(): ObjectStore
 }
 
+
+@Serializable
+@SerialName("!Remote")
 data class RemoteStorageFactory(
     val objectStore: ObjectStoreFactory,
     val localDiskCache: Path,

--- a/core/src/test/kotlin/xtdb/api/XtdbFileTest.kt
+++ b/core/src/test/kotlin/xtdb/api/XtdbFileTest.kt
@@ -1,0 +1,58 @@
+package xtdb.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.query.XtqlQuery
+import xtdb.api.tx.TxOp
+import kotlin.io.path.Path
+
+internal class XtdbFileTest {
+
+    @Test
+    fun nonYamlConfigFile() {
+        val thrown = assertThrows<IllegalArgumentException> {
+            Xtdb.openNode(path = Path("config-file.edn"))
+        }
+
+        assertEquals( "Invalid config file type - must be '.yaml'", thrown.message)
+    }
+
+    @Test
+    fun nonExistentConfigFile() {
+        val thrown = assertThrows<IllegalArgumentException> {
+            Xtdb.openNode(path = Path("non-existent-file.yaml"))
+        }
+
+        assertEquals( "Provided config file does not exist", thrown.message)
+    }
+
+    @Test
+    fun validConfigFile() {
+        val resourcePath = XtdbFileTest::class.java.classLoader.getResource("node-config.yaml")!!.path
+        val node = assertDoesNotThrow { Xtdb.openNode(path = Path(resourcePath)) }
+
+        // can use the created node
+        node.submitTx(TxOp.put("foo", mapOf("xt/id" to "jms")))
+
+        assertEquals(
+            listOf(mapOf("id" to "jms")),
+
+            node.openQuery(
+                XtqlQuery.from("foo") { "xt/id" boundTo "id" }
+            ).toList()
+        )
+    }
+
+    @Test
+    fun validConfigSubmitClient() {
+        val resourcePath = XtdbFileTest::class.java.classLoader.getResource("submit-client-config.yaml")!!.path
+        val submitClient = assertDoesNotThrow { XtdbSubmitClient.openSubmitClient(path = Path(resourcePath)) }
+
+        assertDoesNotThrow {
+            submitClient.submitTx(TxOp.put("foo", mapOf("xt/id" to "jms")))
+        }
+
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
@@ -77,22 +77,21 @@ class YamlConfigDecoderTest {
             nodeConfig(localConfig).storage
         )
 
-        // TODO - different instances of S3Configurator so test fails
-//        val s3Config = """
-//        storage: !Remote
-//            objectStore: !S3
-//              bucket: xtdb-bucket
-//              snsTopicArn: example-arn
-//            localDiskCache: test-path
-//        """
-//
-//        Assertions.assertEquals(
-//            RemoteStorageFactory(
-//                objectStore = S3ObjectStoreFactory(bucket = "xtdb-bucket", snsTopicArn = "example-arn"),
-//                localDiskCache = Paths.get("test-path")
-//                ),
-//            nodeConfig(s3Config).storage
-//        )
+        val s3Config = """
+        storage: !Remote
+            objectStore: !S3
+              bucket: xtdb-bucket
+              snsTopicArn: example-arn
+            localDiskCache: test-path
+        """
+
+        Assertions.assertEquals(
+            RemoteStorageFactory(
+                objectStore = S3ObjectStoreFactory(bucket = "xtdb-bucket", snsTopicArn = "example-arn"),
+                localDiskCache = Paths.get("test-path")
+            ),
+            nodeConfig(s3Config).storage
+        )
 
         val azureConfig = """
         storage: !Remote

--- a/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
@@ -60,13 +60,12 @@ class YamlConfigDecoderTest {
 
     @Test
     fun testStorageDecoding() {
-        // TODO: THIS doesnt work - because inmemorystorage is an object, check into this and fix
-//        val inMemoryConfig = "storage: !InMemory"
-//
-//        Assertions.assertEquals(
-//            InMemoryStorageFactory,
-//            nodeConfig(inMemoryConfig).storage
-//        )
+        val inMemoryConfig = "storage: !InMemory"
+
+        Assertions.assertEquals(
+            InMemoryStorageFactory::class,
+            nodeConfig(inMemoryConfig).storage::class
+        )
 
         val localConfig = """
         storage: !Local

--- a/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlConfigDecoderTest.kt
@@ -1,5 +1,164 @@
 package xtdb.api
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import xtdb.api.log.InMemoryLogFactory
+import xtdb.api.log.KafkaLogFactory
+import xtdb.api.log.LocalLogFactory
+import xtdb.api.storage.InMemoryStorageFactory
+import xtdb.api.storage.LocalStorageFactory
+import xtdb.api.storage.RemoteStorageFactory
+import java.nio.file.Paths
 
-class YamlConfigDecoderTest
+class YamlConfigDecoderTest {
+    @Test
+    fun testDecoder() {
+        val input = """
+        defaultTz: "America/Los_Angeles"
+        txLog: !InMemory
+        indexer:
+            logLimit: 65
+            flushDuration: PT4H
+        storage: !Local
+            path: local-storage
+            maxCacheEntries: 1025
+        """
+        val output = nodeConfig(input)
+        println(output.toString())
+    }
+
+    @Test
+    fun testTxlogDecoding() {
+        val inMemoryConfig = "txLog: !InMemory"
+
+        Assertions.assertEquals(
+            InMemoryLogFactory(),
+            nodeConfig(inMemoryConfig).txLog
+        )
+
+        val localConfig = """
+        txLog: !Local
+            path: test-path
+        """
+
+        Assertions.assertEquals(
+            LocalLogFactory(path= Paths.get("test-path")),
+            nodeConfig(localConfig).txLog
+        )
+
+        val kafkaConfig = """
+        txLog: !Kafka
+            bootstrapServers: localhost:9092
+            topicName: xtdb_topic
+        """
+
+        Assertions.assertEquals(
+            KafkaLogFactory(bootstrapServers = "localhost:9092", topicName = "xtdb_topic"),
+            nodeConfig(kafkaConfig).txLog
+        )
+    }
+
+    @Test
+    fun testStorageDecoding() {
+        // TODO: THIS doesnt work - because inmemorystorage is an object, check into this and fix
+//        val inMemoryConfig = "storage: !InMemory"
+//
+//        Assertions.assertEquals(
+//            InMemoryStorageFactory,
+//            nodeConfig(inMemoryConfig).storage
+//        )
+
+        val localConfig = """
+        storage: !Local
+            path: test-path
+        """
+
+        Assertions.assertEquals(
+            LocalStorageFactory(path= Paths.get("test-path")),
+            nodeConfig(localConfig).storage
+        )
+
+        // TODO - different instances of S3Configurator so test fails
+//        val s3Config = """
+//        storage: !Remote
+//            objectStore: !S3
+//              bucket: xtdb-bucket
+//              snsTopicArn: example-arn
+//            localDiskCache: test-path
+//        """
+//
+//        Assertions.assertEquals(
+//            RemoteStorageFactory(
+//                objectStore = S3ObjectStoreFactory(bucket = "xtdb-bucket", snsTopicArn = "example-arn"),
+//                localDiskCache = Paths.get("test-path")
+//                ),
+//            nodeConfig(s3Config).storage
+//        )
+
+        val azureConfig = """
+        storage: !Remote
+            objectStore: !Azure
+              storageAccount: storage-account
+              container: xtdb-container
+              servicebusNamespace: xtdb-service-bus
+              servicebusTopicName: xtdb-service-bus-topic
+            localDiskCache: test-path
+        """
+
+        Assertions.assertEquals(
+            RemoteStorageFactory(
+                objectStore = AzureObjectStoreFactory(
+                    storageAccount = "storage-account",
+                    container = "xtdb-container",
+                    servicebusNamespace = "xtdb-service-bus",
+                    servicebusTopicName = "xtdb-service-bus-topic"
+                ),
+                localDiskCache = Paths.get("test-path")
+            ),
+            nodeConfig(azureConfig).storage
+        )
+
+        val googleCloudConfig = """
+        storage: !Remote
+            objectStore: !GoogleCloud
+              projectId: xtdb-project
+              bucket: xtdb-bucket
+              pubsubTopic: xtdb-bucket-topic
+            localDiskCache: test-path
+        """
+
+        Assertions.assertEquals(
+            RemoteStorageFactory(
+                objectStore = GoogleCloudObjectStoreFactory(
+                    projectId = "xtdb-project",
+                    bucket ="xtdb-bucket",
+                    pubsubTopic = "xtdb-bucket-topic"
+                ),
+                localDiskCache = Paths.get("test-path")
+            ),
+            nodeConfig(googleCloudConfig).storage
+        )
+    }
+
+    @Test
+    fun testModuleDecoding() {
+        val input = """
+        modules:
+            - !HttpServer
+              port: 3001
+            - !PgwireServer
+              port: 5433
+            - !FlightSqlServer
+              port: 9833
+        """
+        val output = nodeConfig(input)
+        Assertions.assertEquals(
+            listOf(
+                HttpServerModule(port=3001),
+                PgwireServerModule(port=5433),
+                FlightSqlServerModule(port=9833)
+            ),
+            output.getModules()
+        )
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -10,7 +10,7 @@ import xtdb.api.storage.LocalStorageFactory
 import xtdb.api.storage.RemoteStorageFactory
 import java.nio.file.Paths
 
-class YamlConfigDecoderTest {
+class YamlSerdeTest {
     @Test
     fun testDecoder() {
         val input = """

--- a/core/src/test/resources/node-config.yaml
+++ b/core/src/test/resources/node-config.yaml
@@ -1,0 +1,9 @@
+defaultTz: "America/Los_Angeles"
+txLog: !Local
+  path: /tmp/test-log
+indexer:
+  logLimit: 65
+  flushDuration: PT4H
+storage: !Local
+  path: /tmp/test-storage
+  maxCacheEntries: 1025

--- a/core/src/test/resources/submit-client-config.yaml
+++ b/core/src/test/resources/submit-client-config.yaml
@@ -1,0 +1,3 @@
+defaultTz: "America/Los_Angeles"
+txLog: !Local
+  path: /tmp/test-log

--- a/http-server/src/main/kotlin/xtdb/api/HttpServer.kt
+++ b/http-server/src/main/kotlin/xtdb/api/HttpServer.kt
@@ -2,12 +2,16 @@
 
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import xtdb.api.Xtdb.Module
 import xtdb.util.requiringResolve
 
 private val OPEN_SERVER = requiringResolve("xtdb.server", "open-server")
 
-class HttpServerModule(
+@Serializable
+@SerialName("!HttpServer")
+data class HttpServerModule(
     var port: Int = 3000,
     var readOnly: Boolean = false,
 ) : Xtdb.ModuleFactory {
@@ -21,6 +25,12 @@ class HttpServerModule(
     companion object {
         @JvmStatic
         fun httpServer() = HttpServerModule()
+    }
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerModuleFactory(HttpServerModule::class)
+        }
     }
 }
 

--- a/http-server/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/http-server/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,1 +1,1 @@
-xtdb.api.HttpServerModule.Registration
+xtdb.api.HttpServerModule$Registration

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 ext {

--- a/modules/azure/src/main/kotlin/xtdb/api/AzureObjectStoreFactory.kt
+++ b/modules/azure/src/main/kotlin/xtdb/api/AzureObjectStoreFactory.kt
@@ -1,22 +1,34 @@
+@file:UseSerializers(PathSerde::class)
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.PathSerde
 import xtdb.util.requiringResolve
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStoreFactory
 import java.nio.file.Path
 
+@Serializable
+@SerialName("!Azure")
 data class AzureObjectStoreFactory @JvmOverloads constructor(
-        val storageAccount: String,
-        val container: String,
-        val servicebusNamespace: String,
-        val servicebusTopicName: String,
-        var prefix: Path? = null,
+    val storageAccount: String,
+    val container: String,
+    val servicebusNamespace: String,
+    val servicebusTopicName: String,
+    var prefix: Path? = null,
 ) : ObjectStoreFactory {
     companion object {
         private val OPEN_OBJECT_STORE = requiringResolve("xtdb.azure", "open-object-store")
     }
 
     fun prefix(prefix: Path) = apply { this.prefix = prefix }
-
     override fun openObjectStore() = OPEN_OBJECT_STORE.invoke(this) as ObjectStore
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerObjectStore(AzureObjectStoreFactory::class)
+        }
+    }
 }

--- a/modules/azure/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/modules/azure/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.AzureObjectStoreFactory$Registration

--- a/modules/flight-sql/build.gradle.kts
+++ b/modules/flight-sql/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 ext {

--- a/modules/flight-sql/src/main/kotlin/xtdb/api/FlightSqlServer.kt
+++ b/modules/flight-sql/src/main/kotlin/xtdb/api/FlightSqlServer.kt
@@ -2,12 +2,16 @@
 
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import xtdb.api.Xtdb.Module
 import xtdb.util.requiringResolve
 
 private val OPEN_SERVER = requiringResolve("xtdb.flight-sql", "open-server")
 
-class FlightSqlServerModule(
+@SerialName("!FlightSqlServer")
+@Serializable
+data class FlightSqlServerModule(
         var host: String = "127.0.0.1",
         var port: Int = 9832
 ) : Xtdb.ModuleFactory {
@@ -21,6 +25,12 @@ class FlightSqlServerModule(
     companion object {
         @JvmStatic
         fun flightSqlServer() = FlightSqlServerModule()
+    }
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerModuleFactory(FlightSqlServerModule::class)
+        }
     }
 }
 

--- a/modules/flight-sql/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/modules/flight-sql/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.FlightSqlServerModule$Registration

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 ext {

--- a/modules/google-cloud/src/main/kotlin/xtdb/api/GoogleCloudObjectStoreFactory.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/api/GoogleCloudObjectStoreFactory.kt
@@ -1,10 +1,17 @@
+@file:UseSerializers(PathSerde::class)
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.PathSerde
 import xtdb.util.requiringResolve
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStoreFactory
 import java.nio.file.Path
 
+@Serializable
+@SerialName("!GoogleCloud")
 data class GoogleCloudObjectStoreFactory @JvmOverloads constructor(
         val projectId: String,
         val bucket: String,
@@ -18,4 +25,10 @@ data class GoogleCloudObjectStoreFactory @JvmOverloads constructor(
     fun prefix(prefix: Path) = apply { this.prefix = prefix }
 
     override fun openObjectStore() = OPEN_OBJECT_STORE.invoke(this) as ObjectStore
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerObjectStore(GoogleCloudObjectStoreFactory::class)
+        }
+    }
 }

--- a/modules/google-cloud/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/modules/google-cloud/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.GoogleCloudObjectStoreFactory$Registration

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 publishing {

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLogFactory.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLogFactory.kt
@@ -1,6 +1,13 @@
+@file:UseSerializers(DurationSerde::class)
 package xtdb.api.log
 
 import clojure.lang.IFn
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.DurationSerde
+import xtdb.api.ModuleRegistration
+import xtdb.api.ModuleRegistry
 import xtdb.api.TransactionKey
 import xtdb.util.requiringResolve
 import java.nio.ByteBuffer
@@ -9,6 +16,8 @@ import java.time.Duration
 import java.time.InstantSource
 import java.util.concurrent.CompletableFuture
 
+@Serializable
+@SerialName("!Kafka")
 data class KafkaLogFactory @JvmOverloads constructor(
     val bootstrapServers: String,
     val topicName: String,
@@ -32,4 +41,10 @@ data class KafkaLogFactory @JvmOverloads constructor(
     fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
 
     override fun openLog() = OPEN_LOG(this) as Log
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerLogFactory(KafkaLogFactory::class)
+        }
+    }
 }

--- a/modules/kafka/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/modules/kafka/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.log.KafkaLogFactory$Registration

--- a/modules/s3/build.gradle.kts
+++ b/modules/s3/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 publishing {

--- a/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
+++ b/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
@@ -12,7 +12,7 @@ import xtdb.api.storage.ObjectStoreFactory
 import xtdb.s3.S3Configurator
 import java.nio.file.Path
 
-class DefaultS3Configurator: S3Configurator
+data object DefaultS3Configurator: S3Configurator
 
 @Serializable
 @SerialName("!S3")
@@ -20,7 +20,7 @@ data class S3ObjectStoreFactory @JvmOverloads constructor(
         val bucket: String,
         val snsTopicArn: String,
         var prefix: Path? = null,
-        @Transient var s3Configurator: S3Configurator = DefaultS3Configurator()
+        @Transient var s3Configurator: S3Configurator = DefaultS3Configurator
 ) : ObjectStoreFactory {
     companion object {
         private val OPEN_OBJECT_STORE = requiringResolve("xtdb.s3", "open-object-store")

--- a/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
+++ b/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
@@ -1,5 +1,11 @@
+@file:UseSerializers(PathSerde::class)
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.Transient
+import xtdb.PathSerde
 import xtdb.util.requiringResolve
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStoreFactory
@@ -8,11 +14,13 @@ import java.nio.file.Path
 
 class DefaultS3Configurator: S3Configurator
 
+@Serializable
+@SerialName("!S3")
 data class S3ObjectStoreFactory @JvmOverloads constructor(
         val bucket: String,
         val snsTopicArn: String,
         var prefix: Path? = null,
-        var s3Configurator: S3Configurator = DefaultS3Configurator()
+        @Transient var s3Configurator: S3Configurator = DefaultS3Configurator()
 ) : ObjectStoreFactory {
     companion object {
         private val OPEN_OBJECT_STORE = requiringResolve("xtdb.s3", "open-object-store")
@@ -22,4 +30,10 @@ data class S3ObjectStoreFactory @JvmOverloads constructor(
     fun s3Configurator(s3Configurator: S3Configurator) = apply { this.s3Configurator = s3Configurator }
 
     override fun openObjectStore() = OPEN_OBJECT_STORE.invoke(this) as ObjectStore
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerObjectStore(S3ObjectStoreFactory::class)
+        }
+    }
 }

--- a/modules/s3/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/modules/s3/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.S3ObjectStoreFactory$Registration

--- a/pgwire-server/build.gradle.kts
+++ b/pgwire-server/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 ext {

--- a/pgwire-server/src/main/kotlin/xtdb/api/PgWireServer.kt
+++ b/pgwire-server/src/main/kotlin/xtdb/api/PgWireServer.kt
@@ -2,12 +2,16 @@
 
 package xtdb.api
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import xtdb.api.Xtdb.Module
 import xtdb.util.requiringResolve
 
 private val OPEN_SERVER = requiringResolve("xtdb.pgwire", "open-server")
 
-class PgwireServerModule(
+@SerialName("!PgwireServer")
+@Serializable
+data class PgwireServerModule(
         var port: Int = 5432,
         var numThreads: Int = 42
 ) : Xtdb.ModuleFactory {
@@ -21,6 +25,12 @@ class PgwireServerModule(
     companion object {
         @JvmStatic
         fun pgwireServer() = PgwireServerModule()
+    }
+
+    class Registration: ModuleRegistration {
+        override fun register(registry: ModuleRegistry) {
+            registry.registerModuleFactory(PgwireServerModule::class)
+        }
     }
 }
 

--- a/pgwire-server/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
+++ b/pgwire-server/src/main/resources/META-INF/services/xtdb.api.ModuleRegistration
@@ -1,0 +1,1 @@
+xtdb.api.PgwireServerModule$Registration

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -25,7 +25,7 @@
 (def with-live-index
   (partial tu/with-system {:xtdb/allocator {}
                            :xtdb.indexer/live-index (Xtdb$IndexerConfig.)
-                           :xtdb/buffer-pool InMemoryStorageFactory/INSTANCE
+                           :xtdb/buffer-pool (InMemoryStorageFactory.)
                            ::meta/metadata-manager {}}))
 
 (t/use-fixtures :each tu/with-allocator with-live-index)


### PR DESCRIPTION
See #2890

## Done in this PR

- Handling YAML decoding to Xdtb.Config
   - Uses `kotlinx.serialization` and `kaml` to decode YAML based config, along with all necessary changes to the various module configs to allow for this.
   - Adds tests for the YAMLDecoder to ensure can use all of our module config from it.
   - Modules specified with YAML tags, ie, `!S3` or `!Remote`.
   - Things that cannot be serialized/dont make sense from YAML marked as `Transient`
   - Using ServiceLoader to load polymorphic class deserializers from plugin modules. 
- Makes DefaultS3Configurator a data object (ie, saves us making a new instance each time, allows proper comparison)
- Update `InMemoryStorageFactory` to be a class such that we can specify/serialize it.
- Adds a Path/File arity to openNode()
  - Checks if `yaml` file extension - if not, throws. Only handles YAML. 
  - Checks if file exists, if not, throws. 
  - If yaml file and exists - passes to our YAML Decoding function then calls open() on the produced config.
  - Adds tests for all of the above behaviour.
- Adds very similar, openSubmitClient() with File/Path.

## TODO

Thinking about how we want to handle things Clojure & CLI side, ie how should the clojure API should work/interract with things. Currently:
- On node/start-node , we expect a config map, and convert it to `Xtdb$Config`
- Our CLI, when passed a file, grabs the contents, turns them to EDN config (does this for YAML, also), then passes the EDN config to node/start-node

I'm wondering about how/if we should handle file config on the clojure API - I'm thinking we have a few different options:
- We could make start-node allow `XTDB$Config` to be passed in directly, in which case it just passes through to Kotlin.
  - This might be useful - could make CLI fairly straight forward (it handles & convert file contents in clojure, then just passes the config it gets back out)
- We could extend `start-node` / add a new function specifically for handling a config file  (`start-node-from-config-file`, for example).
  - Certainly _can_ do this - though I'm not too sure if in-process clojure users will want to be using yaml/config files vs a config map that lives in their code.  
  - Could make it just a pass through to the Kotlin API - with all the behaviour that has (ie, checking file exists, only deals with YAML, accepts a File or Path) 
- Could also just leave Clojure `xtdb.node` as it is, and within the CLI we just build up `Xtdb$Config` objects based on what we receive, then call `.open` on the built Config Objects. The CLI doesn't necessary need to call to functions in `xtdb.node`, it's just been historically convenient for it to do so.