### PR TITLE
Add handling of `!Env` tags in YAML Decoder, test.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     api(kotlin("stdlib-jdk8"))
     api("com.charleskorn.kaml","kaml","0.56.0")
 
+    testImplementation("io.mockk","mockk", "1.13.9")
     testImplementation(project(":http-server"))
     testImplementation(project(":pgwire-server"))
     testImplementation(project(":modules:kafka"))

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -67,8 +67,21 @@ val YAML_SERDE = Yaml(
             }
     })
 
-fun nodeConfig(yamlString: String): Xtdb.Config =
-    YAML_SERDE.decodeFromString<Xtdb.Config>(yamlString)
+fun getEnvVariable(name: String): String? = System.getenv(name)
 
-fun submitClient(yamlString: String): XtdbSubmitClient.Config =
-    YAML_SERDE.decodeFromString<XtdbSubmitClient.Config>(yamlString)
+fun replaceEnvVariables(input: String): String {
+    val envVarPattern = Regex("!Env\\s+(\\w+)")
+    return envVarPattern.replace(input) { matchResult ->
+        val envVarName = matchResult.groupValues[1]
+        getEnvVariable(envVarName) ?: "null"
+    }
+}
+fun nodeConfig(yamlString: String): Xtdb.Config {
+    val yamlWithEnv = replaceEnvVariables(yamlString)
+    return YAML_SERDE.decodeFromString<Xtdb.Config>(yamlWithEnv)
+}
+
+fun submitClient(yamlString: String): XtdbSubmitClient.Config {
+    val yamlWithEnv = replaceEnvVariables(yamlString)
+    return YAML_SERDE.decodeFromString<XtdbSubmitClient.Config>(yamlWithEnv)
+}


### PR DESCRIPTION
Resolves #3112 

Done outside of the usual kotlinx.serialization code since it's more of a pre-processing step - we'd otherwise have to ensure all decoders for all values handled `!Env` somehow. Looked into kaml's `YamlNode` but seemed like a bit of a dead end in terms of handling this specifically. As such, seemed simplest to do a bit of regex handling for it (similar, in a way, to how we use an #env reader for EDN). 

Tested using mockk to fake out setting the environment variable, seems to load correctly, and a null for a required parameter responds correctly..