### PR TITLE
Use custom string/path serde for handling !Env, remove string pre-processing

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(DurationSerde::class, PathSerde::class)
+@file:UseSerializers(DurationSerde::class, PathWithEnvVarSerde::class)
 package xtdb.api.log
 
 import clojure.lang.IFn
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
-import xtdb.PathSerde
+import xtdb.api.PathWithEnvVarSerde
 import xtdb.api.TransactionKey
 import xtdb.util.requiringResolve
 import java.nio.ByteBuffer

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Storage")
-@file:UseSerializers(PathSerde::class)
+@file:UseSerializers(PathWithEnvVarSerde::class)
 
 package xtdb.api.storage
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.IBufferPool
-import xtdb.PathSerde
+import xtdb.api.PathWithEnvVarSerde
 import xtdb.util.requiringResolve
 import java.nio.file.Path
 

--- a/modules/azure/src/main/kotlin/xtdb/api/AzureObjectStoreFactory.kt
+++ b/modules/azure/src/main/kotlin/xtdb/api/AzureObjectStoreFactory.kt
@@ -1,13 +1,12 @@
-@file:UseSerializers(PathSerde::class)
+@file:UseSerializers(StringWithEnvVarSerde::class, PathWithEnvVarSerde::class)
 package xtdb.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import xtdb.PathSerde
-import xtdb.util.requiringResolve
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStoreFactory
+import xtdb.util.requiringResolve
 import java.nio.file.Path
 
 @Serializable

--- a/modules/google-cloud/src/main/kotlin/xtdb/api/GoogleCloudObjectStoreFactory.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/api/GoogleCloudObjectStoreFactory.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(PathSerde::class)
+@file:UseSerializers(StringWithEnvVarSerde::class, PathWithEnvVarSerde::class)
 package xtdb.api
 
 import kotlinx.serialization.SerialName
@@ -13,10 +13,10 @@ import java.nio.file.Path
 @Serializable
 @SerialName("!GoogleCloud")
 data class GoogleCloudObjectStoreFactory @JvmOverloads constructor(
-        val projectId: String,
-        val bucket: String,
-        val pubsubTopic: String,
-        var prefix: Path? = null,
+    val projectId: String,
+    val bucket: String,
+    val pubsubTopic: String,
+    var prefix: Path? = null,
 ) : ObjectStoreFactory {
     companion object {
         private val OPEN_OBJECT_STORE = requiringResolve("xtdb.google-cloud", "open-object-store")

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLogFactory.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLogFactory.kt
@@ -6,9 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
-import xtdb.api.ModuleRegistration
-import xtdb.api.ModuleRegistry
-import xtdb.api.TransactionKey
+import xtdb.api.*
 import xtdb.util.requiringResolve
 import java.nio.ByteBuffer
 import java.nio.file.Path
@@ -19,14 +17,14 @@ import java.util.concurrent.CompletableFuture
 @Serializable
 @SerialName("!Kafka")
 data class KafkaLogFactory @JvmOverloads constructor(
-    val bootstrapServers: String,
-    val topicName: String,
-    var autoCreateTopic: Boolean = true, 
+    @Serializable(with = StringWithEnvVarSerde::class) val bootstrapServers: String,
+    @Serializable(with = StringWithEnvVarSerde::class) val topicName: String,
+    var autoCreateTopic: Boolean = true,
     var replicationFactor: Int = 1,
     var pollDuration: Duration = Duration.ofSeconds(1),
     var topicConfig: Map<String, String> = emptyMap<String, String>(),
     var propertiesMap: Map<String, String> = emptyMap<String, String>(),
-    var propertiesFile: Path? = null
+    @Serializable(with = PathWithEnvVarSerde::class) var propertiesFile: Path? = null
 ) : LogFactory {
 
     companion object {

--- a/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
+++ b/modules/s3/src/main/kotlin/xtdb/api/S3ObjectStoreFactory.kt
@@ -1,11 +1,10 @@
-@file:UseSerializers(PathSerde::class)
+@file:UseSerializers(PathWithEnvVarSerde::class, StringWithEnvVarSerde::class)
 package xtdb.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.Transient
-import xtdb.PathSerde
 import xtdb.util.requiringResolve
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStoreFactory
@@ -17,10 +16,10 @@ data object DefaultS3Configurator: S3Configurator
 @Serializable
 @SerialName("!S3")
 data class S3ObjectStoreFactory @JvmOverloads constructor(
-        val bucket: String,
-        val snsTopicArn: String,
-        var prefix: Path? = null,
-        @Transient var s3Configurator: S3Configurator = DefaultS3Configurator
+    val bucket: String,
+    val snsTopicArn: String,
+    var prefix: Path? = null,
+    @Transient var s3Configurator: S3Configurator = DefaultS3Configurator
 ) : ObjectStoreFactory {
     companion object {
         private val OPEN_OBJECT_STORE = requiringResolve("xtdb.s3", "open-object-store")


### PR DESCRIPTION
Reworks the handling of `!Env` to make it part of the `kotlinx.serialization` handlign, using custom deserializers for particular classes to ensure we're only decoding Env for 'locations' of things, usually represented in remote classes as Strings/Paths. 

I think `handleEnvTag` is probably over complicated (I cannot imagine that `decoder.decodeString` has to do this much work to get at the scalar at the bottom), but that's mainly as a result to what we received in there (a YAMLInput with the whole Map surrounding the value we care to deserialize alongside a 'currentLocation'). Spent a fair while on this already, so thought I should make a PR.