### PR TITLE
Updates to `date_trunc` & supporting it from SQL

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -103,15 +103,15 @@
   (if (= ts-unit :second)
     `(.toEpochSecond ~form)
     `(let [form# ~form]
-       (Math/addExact (Math/multiplyExact (.toEpochSecond form#) ~(types/ts-units-per-second ts-unit))
-                      (quot (.getNano form#) ~(quot (types/ts-units-per-second :nano) (types/ts-units-per-second ts-unit)))))))
+       (Math/addExact (Math/multiplyExact (long (.toEpochSecond form#)) ~(types/ts-units-per-second ts-unit))
+                      (quot (long (.getNano form#)) ~(quot (types/ts-units-per-second :nano) (types/ts-units-per-second ts-unit)))))))
 
 (defn- ldt->ts [form ts-unit]
   (if (= ts-unit :second)
     `(.toEpochSecond ~form ZoneOffset/UTC)
     `(let [form# ~form]
-       (Math/addExact (Math/multiplyExact (.toEpochSecond form# ZoneOffset/UTC) ~(types/ts-units-per-second ts-unit))
-                      (quot (.getNano form#) ~(quot (types/ts-units-per-second :nano) (types/ts-units-per-second ts-unit)))))))
+       (Math/addExact (Math/multiplyExact (long (.toEpochSecond form# ZoneOffset/UTC)) ~(types/ts-units-per-second ts-unit))
+                      (quot (long (.getNano form#)) ~(quot (types/ts-units-per-second :nano) (types/ts-units-per-second ts-unit)))))))
 
 (defn- ts->ldt [form ts-unit]
   `(let [form# ~form]

--- a/core/src/main/clojure/xtdb/sql/parser.clj
+++ b/core/src/main/clojure/xtdb/sql/parser.clj
@@ -294,6 +294,13 @@
   (sql-parser "IN ( col0 * col0 )" :in_predicate_part_2)
 
   (sql-parser "INTERVAL '3 4' DAY TO HOUR" :interval_literal)
+  (sql-parser "DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40')" :datetime_value_function)
+  (sql-parser "DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40', 'Australia/Sydney')" :datetime_value_function)
+  (sql-parser "DATE_TRUNC('hour', INTERVAL '3 4' DAY TO HOUR)" :interval_value_function)
+
+  (sql-parser
+   "SELECT DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40') FROM foo WHERE foo.a = 42"
+   :directly_executable_statement)
 
   (doseq [sql ["SELECT u.a[0] AS first_el FROM uo"
                "SELECT u.b[u.a[0]] AS dyn_idx FROM u"
@@ -330,3 +337,4 @@
     (time
      (dotimes [_ 1000]
        (sql-parser in :directly_executable_statement)))))
+  

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -863,6 +863,10 @@
     ;;=>
     (list 'date_trunc dtps (expr dte))
 
+    [:date_trunc_datetime_function "DATE_TRUNC" [:date_trunc_precision dtps] [:date_trunc_datetime_source ^:z dte] [:time_zone_region tzr]]
+    ;;=>
+    (list 'date_trunc dtps (expr dte) tzr)
+
     (expr-varargs z)))
 
 ;; Logical plan.

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -867,6 +867,10 @@
     ;;=>
     (list 'date_trunc dtps (expr dte) tzr)
 
+    [:date_trunc_interval_function "DATE_TRUNC" [:date_trunc_precision dtps] [:date_trunc_interval_source ^:z dte]]
+    ;;=>
+    (list 'date_trunc dtps (expr dte))
+
     (expr-varargs z)))
 
 ;; Logical plan.

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -859,6 +859,10 @@
     ;;=>
     (expr bve)
 
+    [:date_trunc_datetime_function "DATE_TRUNC" [:date_trunc_precision dtps] [:date_trunc_datetime_source ^:z dte]] 
+    ;;=>
+    (list 'date_trunc dtps (expr dte))
+
     (expr-varargs z)))
 
 ;; Logical plan.
@@ -1834,8 +1838,8 @@
     (build-values-list rvel)
 
     [:contextually_typed_table_value_constructor _ ^:z cttvl]
-    (build-values-list cttvl)
-
+    (build-values-list cttvl) 
+    
     (r/zcase z
       :query_expression (plan-query-expr z)
       :in_value_list (build-values-list z)

--- a/core/src/main/kotlin/xtdb/DateTruncator.kt
+++ b/core/src/main/kotlin/xtdb/DateTruncator.kt
@@ -1,0 +1,60 @@
+package xtdb
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime.MIDNIGHT
+import java.time.ZonedDateTime
+import java.time.LocalDate.of as date
+import java.time.LocalDateTime.of as dateTime
+
+object DateTruncator {
+
+    @JvmStatic
+    fun truncateYear(date: LocalDate, yearMultiple: Int) =
+        date((date.year / yearMultiple) * yearMultiple, 1, 1)
+
+    @JvmStatic
+    fun truncateYear(dateTime: LocalDateTime, yearMultiple: Int) =
+        dateTime(truncateYear(dateTime.toLocalDate(), yearMultiple), MIDNIGHT)
+
+    @JvmStatic
+    fun truncateYear(zdt: ZonedDateTime, yearMultiple: Int) =
+        zdt.with(truncateYear(zdt.toLocalDateTime(), yearMultiple))
+
+    @JvmStatic
+    fun truncateYear(date: LocalDate) = date(date.year, 1, 1)
+
+    @JvmStatic
+    fun truncateYear(dateTime: LocalDateTime) = dateTime(truncateYear(dateTime.toLocalDate()), MIDNIGHT)
+
+    @JvmStatic
+    fun truncateYear(zdt: ZonedDateTime) = zdt.with(truncateYear(zdt.toLocalDateTime()))
+
+    @JvmStatic
+    fun truncateQuarter(date: LocalDate) = date(date.year, date.month.firstMonthOfQuarter(), 1)
+
+    @JvmStatic
+    fun truncateQuarter(dateTime: LocalDateTime) = dateTime(truncateQuarter(dateTime.toLocalDate()), MIDNIGHT)
+
+    @JvmStatic
+    fun truncateQuarter(zdt: ZonedDateTime) = zdt.with(truncateQuarter(zdt.toLocalDateTime()))
+
+    @JvmStatic
+    fun truncateMonth(date: LocalDate) = date(date.year, date.month, 1)
+
+    @JvmStatic
+    fun truncateMonth(dateTime: LocalDateTime) = dateTime(truncateMonth(dateTime.toLocalDate()), MIDNIGHT)
+
+    @JvmStatic
+    fun truncateMonth(zdt: ZonedDateTime) = zdt.with(truncateMonth(zdt.toLocalDateTime()))
+
+    @JvmStatic
+    fun truncateWeek(date: LocalDate) = date.with(DayOfWeek.MONDAY)
+
+    @JvmStatic
+    fun truncateWeek(dateTime: LocalDateTime) = dateTime(truncateWeek(dateTime.toLocalDate()), MIDNIGHT)
+
+    @JvmStatic
+    fun truncateWeek(zdt: ZonedDateTime) = zdt.with(truncateWeek(zdt.toLocalDateTime()))
+}

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -1180,6 +1180,7 @@ datetime_factor
     | current_local_timestamp_value_function
     | current_local_time_value_function
     | end_of_time_value_function
+    | date_trunc_datetime_function
     ;
 
 current_date_value_function
@@ -1243,6 +1244,7 @@ interval_primary
 
 <interval_value_function>
     : interval_absolute_value_function
+    | date_trunc_interval_function
     ;
 
 interval_absolute_value_function
@@ -2494,6 +2496,41 @@ object_name
 end_of_time_value_function
     : 'END_OF_TIME' [ <left_paren> <right_paren> ]
     ;
+
+(* DATE_TRUNC function *)
+date_trunc_datetime_function
+    : 'DATE_TRUNC' <left_paren> date_trunc_precision_string <comma> date_trunc_datetime_source [ <comma> date_trunc_time_zone ] <right_paren>
+    
+date_trunc_interval_function
+    : 'DATE_TRUNC' <left_paren> date_trunc_precision_string <comma> date_trunc_interval_source <right_paren>
+
+<date_trunc_precision_string>
+    : <quote> date_trunc_precision <quote>
+
+date_trunc_precision
+    : 'MICROSECOND' 
+    | 'MILLISECOND' 
+    | 'SECOND' 
+    | 'MINUTE'
+    | 'HOUR'
+    | 'DAY'
+    | 'WEEK'
+    | 'MONTH'
+    | 'QUARTER'
+    | 'YEAR'
+    | 'DECADE'
+    | 'CENTURY'
+    | 'MILLENNIUM'
+    ;
+
+date_trunc_datetime_source
+    : datetime_value_expression
+
+date_trunc_interval_source
+    : interval_value_expression
+
+<date_trunc_time_zone>
+    : <quote> time_zone_region <quote>
 
 (* ARROW_TABLE <table primary>, based on SQL:2016 JSON_TABLE *)
 

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -260,7 +260,14 @@ a| Returns true iff `p1` starts after `p2` ends
 |===
 | XTQL | SQL |
 | `(date-trunc "unit" date-time)` | `DATE_TRUNC('unit', date_time)`
-| Truncates the date-time to the given time-unit, which must be one of `YEAR`, `MONTH`, `DAY`, 'HOUR', `MINUTE`, `SECOND`, `MILLISECOND`, `MICROSECOND.`
+| Truncates the date-time to the given time-unit, which must be one of `MILLENNIUM`, `CENTURY`, `DECADE`, `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND` or `MICROSECOND`
+
+| `(date-trunc "unit" date-time time-zone)` | `DATE_TRUNC('unit', date_time, 'time_zone')`
+| Truncates a **timezone aware** date-time to the given time-unit, which must be one of `MILLENNIUM`, `CENTURY`, `DECADE`, `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND` or `MICROSECOND`, and then converts it to the specified time-zone. The specified time-zone must be a valid time-zone identifier (see link:https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[here])
+
+| `(date-trunc "unit" interval)` | `DATE_TRUNC('unit', interval)`
+| Truncates the given interval to the given time-unit, which must be one of `MILLENNIUM`, `CENTURY`, `DECADE`, `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND` or `MICROSECOND`
+
 | `(extract "field" date-time)` | `EXTRACT('field', date_time)`
 | Extracts the given field from the date-time, which must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE`.
 

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -260,7 +260,7 @@ a| Returns true iff `p1` starts after `p2` ends
 |===
 | XTQL | SQL |
 | `(date-trunc "unit" date-time)` | `DATE_TRUNC('unit', date_time)`
-| Truncates the date-time to the given time-unit, which must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE`, `SECOND`, `MILLISECOND`, `MICROSECOND.`
+| Truncates the date-time to the given time-unit, which must be one of `YEAR`, `MONTH`, `DAY`, 'HOUR', `MINUTE`, `SECOND`, `MILLISECOND`, `MICROSECOND.`
 | `(extract "field" date-time)` | `EXTRACT('field', date_time)`
 | Extracts the given field from the date-time, which must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE`.
 

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -192,6 +192,28 @@
     (t/is (= #time/zoned-date-time "2001-02-16T08:00-05:00[America/New_York]"
              (project1 (list 'date-trunc "DAY" 'date "Australia/Sydney") test-doc)))))
 
+(t/deftest test-date-trunc-interval
+  (let [test-doc {:xt$id :foo,
+                  :year-interval (PeriodDuration. (Period/of 1111 4 8) (Duration/parse "PT1H1M1.111111S")) 
+                  :interval (PeriodDuration. (Period/of 0 4 8) (Duration/parse "PT1H1M1.111111S"))}]
+
+    (letfn [(trunc [time-unit] (project1 (list 'date-trunc time-unit 'interval) test-doc))]
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1.111111S"] (trunc "MICROSECOND")))
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1.111S"] (trunc "MILLISECOND")))
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1S"] (trunc "SECOND")))
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M"] (trunc "MINUTE")))
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H"] (trunc "HOUR")))
+      (t/is (= #xt/interval-mdn ["P4M8D" "PT0S"] (trunc "DAY")))
+      (t/is (= #xt/interval-mdn ["P4M7D" "PT0S"] (trunc "WEEK")))
+      (t/is (= #xt/interval-mdn ["P4M" "PT0S"] (trunc "MONTH")))
+      (t/is (= #xt/interval-mdn ["P3M" "PT0S"] (trunc "QUARTER"))))
+    
+    (letfn [(trunc [time-unit] (project1 (list 'date-trunc time-unit 'year-interval) test-doc))] 
+      (t/is (= #xt/interval-mdn ["P13332M" "PT0S"] (trunc "YEAR")))
+      (t/is (= #xt/interval-mdn ["P13320M" "PT0S"] (trunc "DECADE")))
+      (t/is (= #xt/interval-mdn ["P13200M" "PT0S"] (trunc "CENTURY")))
+      (t/is (= #xt/interval-mdn ["P12000M" "PT0S"] (trunc "MILLENNIUM"))))))
+
 (t/deftest test-date-extract
   ;; TODO units below minute are not yet implemented for any type
   (letfn [(extract [part date-like] (project1 (list 'extract part 'date) {:date date-like}))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -11,7 +11,7 @@
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import (java.nio ByteBuffer)
-           (java.time Clock Duration Instant LocalDate ZoneId ZonedDateTime)
+           (java.time Clock Duration Instant LocalDate LocalDateTime ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            (org.apache.arrow.vector DurationVector TimeStampVector ValueVector)
            (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp)
@@ -118,17 +118,25 @@
                      {:x true, :y false, :z false}
                      {:x false, :y false, :z true}]))))
 
-(t/deftest test-date-trunc
+(t/deftest test-date-trunc-zoned-date-time
   (let [test-doc {:xt$id :foo,
-                  :date (time/->instant #inst "2021-10-21T12:34:56Z")
+                  :date (time/->instant #inst "2021-10-21T12:34:56.111111Z")
                   :zdt (-> (time/->zdt #inst "2021-08-21T12:34:56Z")
                            (.withZoneSameLocal (ZoneId/of "Europe/London")))}]
     (letfn [(simple-trunc [time-unit] (project1 (list 'date-trunc time-unit 'date) test-doc))]
-
-      (t/is (= (time/->zdt #inst "2021-10-21") (simple-trunc "DAY")))
+      (t/is (= (time/->zdt #inst "2021-10-21T12:34:56.111111") (simple-trunc "MICROSECOND")))
+      (t/is (= (time/->zdt #inst "2021-10-21T12:34:56.111") (simple-trunc "MILLISECOND")))
+      (t/is (= (time/->zdt #inst "2021-10-21T12:34:56") (simple-trunc "SECOND")))
       (t/is (= (time/->zdt #inst "2021-10-21T12:34") (simple-trunc "MINUTE")))
-      (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "MONTH")))
-      (t/is (= (time/->zdt #inst "2021-01-01") (simple-trunc "YEAR"))))
+      (t/is (= (time/->zdt #inst "2021-10-21T12:00") (simple-trunc "HOUR")))
+      (t/is (= (time/->zdt #inst "2021-10-21") (simple-trunc "DAY"))) 
+      (t/is (= (time/->zdt #inst "2021-10-18") (simple-trunc "WEEK")))
+      (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "MONTH"))) 
+      (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "QUARTER")))
+      (t/is (= (time/->zdt #inst "2021-01-01") (simple-trunc "YEAR")))
+      (t/is (= (time/->zdt #inst "2020-01-01") (simple-trunc "DECADE")))
+      (t/is (= (time/->zdt #inst "2000-01-01") (simple-trunc "CENTURY")))
+      (t/is (= (time/->zdt #inst "2000-01-01") (simple-trunc "MILLENNIUM"))))
 
     (t/is (= (-> (time/->zdt #inst "2021-08-21")
                  (.withZoneSameLocal (ZoneId/of "Europe/London")))
@@ -137,15 +145,44 @@
 
     (t/is (= (time/->zdt #inst "2021-10-21") (project1 '(date-trunc "DAY" date) test-doc)))
 
-    (t/is (= (time/->zdt #inst "2021-10-21") (project1 '(date-trunc "DAY" (date-trunc "MINUTE" date)) test-doc)))
+    (t/is (= (time/->zdt #inst "2021-10-21") (project1 '(date-trunc "DAY" (date-trunc "MINUTE" date)) test-doc)))))
 
-    (t/testing "java.time.LocalDate"
-      (let [ld (LocalDate/of 2022 3 29)
-            trunc #(project1 (list 'date-trunc % 'date) {:date ld})]
-        (t/is (= (LocalDate/of 2022 3 29) (trunc "DAY")))
-        (t/is (= (LocalDate/of 2022 3 1) (trunc "MONTH")))
-        (t/is (= (LocalDate/of 2022 1 1) (trunc "YEAR")))
-        (t/is (= (LocalDate/of 2022 1 1) (project1 '(date-trunc "YEAR" (date-trunc "MONTH" date)) {:date ld})))))))
+(t/deftest test-date-trunc-local-date-time
+  (t/testing "java.time.LocalDateTime"
+    (let [ld (LocalDateTime/of 2022 4 3 12 34 56 789456999)
+          trunc #(project1 (list 'date-trunc % 'date) {:date ld})]
+      (t/is (= (LocalDateTime/of 2022 4 3 12 34 56 789456000) (trunc "MICROSECOND")))
+      (t/is (= (LocalDateTime/of 2022 4 3 12 34 56 789000000) (trunc "MILLISECOND")))
+      (t/is (= (LocalDateTime/of 2022 4 3 12 34 56) (trunc "SECOND")))
+      (t/is (= (LocalDateTime/of 2022 4 3 12 34) (trunc "MINUTE")))
+      (t/is (= (LocalDateTime/of 2022 4 3 12 0) (trunc "HOUR")))
+      (t/is (= (LocalDateTime/of 2022 4 3 0 0) (trunc "DAY")))
+      (t/is (= (LocalDateTime/of 2022 4 1 0 0) (trunc "MONTH")))
+      (t/is (= (LocalDateTime/of 2022 1 1 0 0) (trunc "YEAR")))
+      (t/is (= (LocalDateTime/of 2000 1 1 0 0) (trunc "MILLENNIUM")))
+      (t/is (= (LocalDateTime/of 2000 1 1 0 0) (trunc "CENTURY")))
+      (t/is (= (LocalDateTime/of 2020 1 1 0 0) (trunc "DECADE")))
+      (t/is (= (LocalDateTime/of 2022 4 1 0 0) (trunc "QUARTER")))
+      (t/is (= (LocalDateTime/of 2022 3 28 0 0) (trunc "WEEK"))))))
+
+(t/deftest test-date-trunc-local-date
+  (t/testing "java.time.LocalDate"
+    (let [ld (LocalDate/of 2022 3 29)
+          trunc #(project1 (list 'date-trunc % 'date) {:date ld})]
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "MICROSECOND")))
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "MILLISECOND")))
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "SECOND")))
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "MINUTE")))
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "HOUR")))
+      (t/is (= (LocalDate/of 2022 3 29) (trunc "DAY")))
+      (t/is (= (LocalDate/of 2022 3 1) (trunc "MONTH")))
+      (t/is (= (LocalDate/of 2022 1 1) (trunc "YEAR")))
+      (t/is (= (LocalDate/of 2022 1 1) (project1 '(date-trunc "YEAR" (date-trunc "MONTH" date)) {:date ld})))
+      (t/is (= (LocalDate/of 2000 1 1) (trunc "MILLENNIUM")))
+      (t/is (= (LocalDate/of 2000 1 1) (trunc "CENTURY")))
+      (t/is (= (LocalDate/of 2020 1 1) (trunc "DECADE")))
+      (t/is (= (LocalDate/of 2022 1 1) (trunc "QUARTER")))
+      (t/is (= (LocalDate/of 2022 3 28) (trunc "WEEK"))))))
 
 (t/deftest test-date-extract
   ;; TODO units below minute are not yet implemented for any type

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -11,10 +11,10 @@
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import (java.nio ByteBuffer)
-           (java.time Clock Duration Instant LocalDate LocalDateTime ZoneId ZonedDateTime)
+           (java.time Clock Duration Instant LocalDate LocalDateTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
-           (org.apache.arrow.vector DurationVector TimeStampVector ValueVector)
-           (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp)
+           (org.apache.arrow.vector DurationVector PeriodDuration TimeStampVector ValueVector)
+           (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp) 
            org.apache.arrow.vector.types.TimeUnit
            (xtdb.util StringUtil)
            xtdb.vector.IVectorReader))
@@ -129,9 +129,9 @@
       (t/is (= (time/->zdt #inst "2021-10-21T12:34:56") (simple-trunc "SECOND")))
       (t/is (= (time/->zdt #inst "2021-10-21T12:34") (simple-trunc "MINUTE")))
       (t/is (= (time/->zdt #inst "2021-10-21T12:00") (simple-trunc "HOUR")))
-      (t/is (= (time/->zdt #inst "2021-10-21") (simple-trunc "DAY"))) 
+      (t/is (= (time/->zdt #inst "2021-10-21") (simple-trunc "DAY")))
       (t/is (= (time/->zdt #inst "2021-10-18") (simple-trunc "WEEK")))
-      (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "MONTH"))) 
+      (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "MONTH")))
       (t/is (= (time/->zdt #inst "2021-10-01") (simple-trunc "QUARTER")))
       (t/is (= (time/->zdt #inst "2021-01-01") (simple-trunc "YEAR")))
       (t/is (= (time/->zdt #inst "2020-01-01") (simple-trunc "DECADE")))
@@ -183,6 +183,14 @@
       (t/is (= (LocalDate/of 2020 1 1) (trunc "DECADE")))
       (t/is (= (LocalDate/of 2022 1 1) (trunc "QUARTER")))
       (t/is (= (LocalDate/of 2022 3 28) (trunc "WEEK"))))))
+
+(t/deftest test-date-trunc-with-timezone-opt
+  (let [test-doc {:xt$id :foo,
+                  :date (-> (time/->zdt #inst "2001-02-16T20:38:40Z")
+                            (.withZoneSameInstant (ZoneId/of "America/New_York")))}]
+
+    (t/is (= #time/zoned-date-time "2001-02-16T08:00-05:00[America/New_York]"
+             (project1 (list 'date-trunc "DAY" 'date "Australia/Sydney") test-doc)))))
 
 (t/deftest test-date-extract
   ;; TODO units below minute are not yet implemented for any type

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -841,8 +841,28 @@
     (= expected (plan-expr sql))
     "DATE '3000-03-15'" #time/date "3000-03-15"))
 
-(deftest test-system-time-queries
+(deftest test-date-trunc-plan
+  (t/testing "TIMESTAMP behaviour"
+    (t/are
+     [sql expected]
+     (= expected (plan-expr sql))
+      "DATE_TRUNC('MICROSECOND', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MICROSECOND" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('MILLISECOND', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MILLISECOND" #time/date-time "2021-10-21T12:34:56")
+      "date_trunc('second', timestamp '2021-10-21T12:34:56')" '(date_trunc "SECOND" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('MINUTE', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MINUTE" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('HOUR', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "HOUR" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('DAY', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "DAY" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('MONTH', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MONTH" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('YEAR', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "YEAR" #time/date-time "2021-10-21T12:34:56"))))
 
+(deftest test-date-trunc-query
+  (t/is (= [{:timestamp #time/date-time "2021-10-21T12:34:00"}]
+           (xt/q tu/*node* "SELECT DATE_TRUNC('MINUTE', TIMESTAMP '2021-10-21T12:34:56') as timestamp FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:timestamp #time/date-time "2021-10-21T12:00:00"}]
+           (xt/q tu/*node* "select date_trunc('hour', timestamp '2021-10-21T12:34:56') as timestamp from (VALUES 1) as x"))))
+
+(deftest test-system-time-queries
   (t/testing "AS OF"
     (t/is
       (=plan-file

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -6,7 +6,8 @@
             [xtdb.sql :as sql]
             [xtdb.test-util :as tu])
 
-  (:import (java.time LocalDateTime)))
+  (:import (java.time LocalDateTime)
+           (java.time.zone ZoneRulesException)))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
@@ -852,12 +853,23 @@
       "DATE_TRUNC('MINUTE', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MINUTE" #time/date-time "2021-10-21T12:34:56")
       "DATE_TRUNC('HOUR', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "HOUR" #time/date-time "2021-10-21T12:34:56")
       "DATE_TRUNC('DAY', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "DAY" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('WEEK', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "WEEK" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('QUARTER', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "QUARTER" #time/date-time "2021-10-21T12:34:56")
       "DATE_TRUNC('MONTH', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MONTH" #time/date-time "2021-10-21T12:34:56")
-      "DATE_TRUNC('YEAR', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "YEAR" #time/date-time "2021-10-21T12:34:56"))))
+      "DATE_TRUNC('YEAR', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "YEAR" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('DECADE', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "DECADE" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('CENTURY', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "CENTURY" #time/date-time "2021-10-21T12:34:56")
+      "DATE_TRUNC('MILLENNIUM', TIMESTAMP '2021-10-21T12:34:56')" '(date_trunc "MILLENNIUM" #time/date-time "2021-10-21T12:34:56"))))
 
 (deftest test-date-trunc-query
-  (t/is (= [{:timestamp #time/date-time "2021-10-21T12:34:00"}]
-           (xt/q tu/*node* "SELECT DATE_TRUNC('MINUTE', TIMESTAMP '2021-10-21T12:34:56') as timestamp FROM (VALUES 1) AS x")))
+  (t/is (= [{:timestamp #time/zoned-date-time "2021-10-21T12:34:00Z"}]
+           (xt/q tu/*node* "SELECT DATE_TRUNC('MINUTE', TIMESTAMP '2021-10-21T12:34:56Z') as timestamp FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:timestamp #time/zoned-date-time "2021-10-21T12:00:00Z"}]
+           (xt/q tu/*node* "select date_trunc('hour', timestamp '2021-10-21T12:34:56Z') as timestamp from (VALUES 1) as x")))
+  
+  (t/is (= [{:timestamp #time/date "2001-01-01"}]
+           (xt/q tu/*node* "select date_trunc('year', DATE '2001-11-27') as timestamp from (VALUES 1) as x")))
   
   (t/is (= [{:timestamp #time/date-time "2021-10-21T12:00:00"}]
            (xt/q tu/*node* "select date_trunc('hour', timestamp '2021-10-21T12:34:56') as timestamp from (VALUES 1) as x"))))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -874,6 +874,15 @@
   (t/is (= [{:timestamp #time/date-time "2021-10-21T12:00:00"}]
            (xt/q tu/*node* "select date_trunc('hour', timestamp '2021-10-21T12:34:56') as timestamp from (VALUES 1) as x"))))
 
+(deftest test-date-trunc-with-timezone-query
+  (t/is (= [{:timestamp #time/zoned-date-time "2001-02-16T08:00-05:00"}]
+           (xt/q tu/*node* "select date_trunc('day', TIMESTAMP '2001-02-16 15:38:11-05:00', 'Australia/Sydney') as timestamp from (VALUES 1) as x")))
+  
+  (t/is (thrown-with-msg?
+         ZoneRulesException
+         #"Unknown time-zone ID: NotRealRegion"
+         (xt/q tu/*node* "select date_trunc('hour', TIMESTAMP '2000-01-02 00:43:11+00:00', 'NotRealRegion') as timestamp from (VALUES 1) as x"))))
+
 (deftest test-system-time-queries
   (t/testing "AS OF"
     (t/is


### PR DESCRIPTION
See #3084 

`DATE_TRUNC` from here https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
- Added DATE_TRUNC to `sql.ebnf`
- Added DATE_TRUNC to `xtdb.sql.plan`
- Added tests to `sql_test` - for planning and for behaviour.
- Included a direct cast to `long` on the forms inside of `zdt->ts` and `ldt->ts`. Saw some issues arise with `ArithmeticException: Integer Overflow` otherwise, related to how the reflector handles the forms.
- Updating the current implementation of `date_trunc`:
  - Code improved using the `DateTruncator` class and better sharing of field behaviour.
  - Supporting the (optional) third parameter for "time_zone"
    - Handled within the `sql.ebnf`, `plan`, added a new arity of codegen for date-trunc to handle this. 
    - Tests also added around this behaving itself. 
    - **Caveats**:
      - Also - If the user specifies an invalid timezone - we won't find out until the point of `expr/codegen-call`. Maybe we're okay with this? Error is fairly reasonable: `"java.time.zone.ZoneRulesException: Unknown time-zone ID: TZ/InvalidRegion (ZoneRulesProvider.java:882)"`. Added a test around this to sql_test.
      - Might be worth thinking about changes to the plan/analyze errors for certain cases. We should only really call `date_trunc` with three parameters IF the datetime we're passing in has a timezone. We don't allow this with `LocalDate` nor `LocalDateTime` (or interval, for that matter!) - user would get an error about missing codegen calls.   
  - Support for truncating intervals within `date_trunc`:
    - Handled within the `sql.ebnf`, `plan`, added a new arity of codegen for date-trunc to handle this. 
    - Tests also added around this behaving itself with different specified field values.
- Current docs updated - suspect we could do better than values in a table (formatting feels a bit hard to read), but all arities/supported values are at least mentioned in `temporal.adoc` now. 