### PR TITLE
Move query-ra to extra non test namespace

### DIFF
--- a/core/src/main/clojure/xtdb/query_ra.clj
+++ b/core/src/main/clojure/xtdb/query_ra.clj
@@ -1,0 +1,67 @@
+(ns xtdb.query-ra
+  (:require [xtdb.protocols :as xtp]
+            [xtdb.query :as q]
+            [xtdb.serde :as serde]
+            [xtdb.time :as time]
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw]
+            [xtdb.vector.reader :as vr])
+  (:import (java.time Duration)
+           (xtdb.api TransactionKey)
+           xtdb.indexer.IIndexer
+           (xtdb.query IRaQuerySource PreparedQuery)
+           (xtdb.vector RelationReader)
+           (xtdb ICursor)
+           xtdb.api.query.IKeyFn
+           (java.util.function Consumer)))
+
+(defn- <-cursor
+  ([^ICursor cursor] (<-cursor cursor #xt/key-fn :kebab-case-keyword))
+  ([^ICursor cursor ^IKeyFn key-fn]
+   (let [!res (volatile! (transient []))]
+     (.forEachRemaining cursor
+                        (reify Consumer
+                          (accept [_ rel]
+                            (vswap! !res conj! (vr/rel->rows rel key-fn)))))
+     (persistent! @!res))))
+
+(defn- then-await-tx
+  (^TransactionKey [node]
+   (then-await-tx (:latest-submitted-tx (xtp/status node)) node nil))
+
+  (^TransactionKey [tx node]
+   (then-await-tx tx node nil))
+
+  (^TransactionKey [tx node ^Duration timeout]
+   @(.awaitTxAsync ^IIndexer (util/component node :xtdb/indexer) tx timeout)))
+
+
+(defn query-ra
+  ([query] (query-ra query {}))
+  ([query {:keys [allocator node params preserve-blocks? with-col-types? key-fn] :as query-opts
+           :or {key-fn (serde/read-key-fn :kebab-case-keyword)}}]
+   (let [^IIndexer indexer (util/component node :xtdb/indexer)
+         query-opts (cond-> query-opts
+                      node (-> (time/after-latest-submitted-tx node)
+                               (update :after-tx time/max-tx (get-in query-opts [:basis :at-tx]))
+                               (doto (-> :after-tx (then-await-tx node)))))
+         allocator (or allocator (util/component node :xtdb/allocator) )]
+
+     (with-open [^RelationReader
+                 params-rel (if params
+                              (vw/open-params allocator params)
+                              vw/empty-params)]
+       (let [^PreparedQuery pq (if node
+                                 (let [^IRaQuerySource ra-src (util/component node ::q/ra-query-source)]
+                                   (.prepareRaQuery ra-src query))
+                                 (q/prepare-ra query))
+             bq (.bind pq indexer
+                       (-> (select-keys query-opts [:basis :after-tx :table-args :default-tz :default-all-valid-time?])
+                           (assoc :params params-rel)))]
+         (util/with-open [res (.openCursor bq)]
+           (let [rows (-> (<-cursor res (serde/read-key-fn key-fn))
+                          (cond->> (not preserve-blocks?) (into [] cat)))]
+             (if with-col-types?
+               {:res rows, :col-types (update-vals (.columnFields bq) types/field->col-type)}
+               rows))))))))

--- a/modules/bench/src/main/clojure/xtdb/bench/multinode_tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/multinode_tpch.clj
@@ -6,7 +6,8 @@
             [xtdb.indexer.live-index :as li]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [xtdb.query-ra :as ra])
   (:import java.lang.AutoCloseable
            java.nio.file.attribute.FileAttribute
            java.nio.file.Files
@@ -39,7 +40,7 @@
                           (log/info "awaiting" k "node")
                           (tu/then-await-tx last-tx node (Duration/ofHours 1))
                           (log/info "rows:"
-                                    (count (tu/query-ra query {:node node, :params (::tpch/params (meta query))}))))]
+                                    (count (ra/query-ra query {:node node, :params (::tpch/params (meta query))}))))]
                   (doseq [[k node] {:primary primary-node
                                     :secondary1 secondary-node1
                                     :secondary2 secondary-node2

--- a/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
@@ -5,7 +5,8 @@
             [xtdb.buffer-pool :as bp]
             [xtdb.datasets.tpch :as tpch]
             [xtdb.datasets.tpch.ra :as tpch-ra]
-            [xtdb.test-util :as tu])
+            [xtdb.test-util :as tu]
+            [xtdb.query-ra :as ra])
   (:import java.time.Duration))
 
 (defn ingest-tpch [node {:keys [scale-factor]}]
@@ -26,7 +27,7 @@
           (let [q @q
                 {::tpch-ra/keys [params table-args]} (meta q)]
             (try
-              (count (tu/query-ra q {:node node
+              (count (ra/query-ra q {:node node
                                      :params params
                                      :table-args table-args}))
               (catch Exception e

--- a/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench2/xtdb2.clj
@@ -8,7 +8,8 @@
             [xtdb.node :as xtn]
             [xtdb.protocols :as xtp]
             [xtdb.test-util :as tu]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [xtdb.query-ra :as ra])
   (:import (io.micrometer.core.instrument MeterRegistry Timer)
            (java.io Closeable File)
            (java.nio.file Path)
@@ -262,7 +263,7 @@
                      (map :i)))
 
   (def q  (fn [open-id]
-            (tu/query-ra ra-query {:node node
+            (ra/query-ra ra-query {:node node
                                    :params {'?i_id open-id}})))
   ;; ra query
   (time

--- a/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
+++ b/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
@@ -134,9 +134,9 @@
                                      (= model "focus"))}]]]]]]])
 
 (comment
-  (require 'dev '[xtdb.test-util :as tu])
+  (require 'dev '[xtdb.query-ra :as ra])
 
   (submit-ts-devices dev/node :small)
 
   (time
-   (tu/query-ra query-recent-battery-temperatures {:node dev/node})))
+   (ra/query-ra query-recent-battery-temperatures {:node dev/node})))


### PR DESCRIPTION
This move the `query-ra` fn to an extra `xtdb.query-ra` namespace.