### PR TITLE
Handling absents in the EE

### DIFF
--- a/core/src/main/clojure/xtdb/expression/comparator.clj
+++ b/core/src/main/clojure/xtdb/expression/comparator.clj
@@ -7,6 +7,32 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
+;; null-eq is an internal function used in situations where two nulls should compare equal,
+;; e.g when grouping rows in group-by.
+(defmethod expr/codegen-call [:null_eq :any :any] [call]
+  (expr/codegen-call (assoc call :f :=)))
+
+(defmethod expr/codegen-call [:null_eq :null :any] [_]
+  {:return-type :bool, :->call-code (constantly false)})
+
+(defmethod expr/codegen-call [:null_eq :any :null] [_]
+  {:return-type :bool, :->call-code (constantly false)})
+
+(defmethod expr/codegen-call [:null_eq :null :null] [_]
+  {:return-type :bool, :->call-code (constantly true)})
+
+(defmethod expr/codegen-call [:null_eq :null :absent] [_]
+  {:return-type :bool, :->call-code (constantly true)})
+
+(defmethod expr/codegen-call [:null_eq :absent :null] [_]
+  {:return-type :bool, :->call-code (constantly true)})
+
+(defmethod expr/codegen-call [:<> :num :num] [_]
+  {:return-type :bool, :->call-code #(do `(not (== ~@%)))})
+
+(defmethod expr/codegen-call [:<> :any :any] [_]
+  {:return-type :bool, :->call-code #(do `(not= ~@%))})
+
 (defmethod expr/codegen-call [:compare :bool :bool] [_]
   {:return-type :i32
    :->call-code (fn [emitted-args]
@@ -22,6 +48,18 @@
    :->call-code (fn [emitted-args]
                   `(Double/compare ~@emitted-args))})
 
+(defmethod expr/codegen-call [:compare :any :absent] [_]
+  {:return-type :null
+   :->call-code (constantly nil)})
+
+(defmethod expr/codegen-call [:compare :absent :any] [_]
+  {:return-type :null
+   :->call-code (constantly nil)})
+
+(defmethod expr/codegen-call [:compare :absent :absent] [_]
+  {:return-type :i32
+   :->call-code (constantly 0)})
+
 ;; NOTE UUID compares according to bytes rather than Java `compare` - https://bugs.openjdk.org/browse/JDK-7025832
 (doseq [col-type #{:varbinary :fixed-size-binary :utf8 :uri :keyword :uuid}]
   (defmethod expr/codegen-call [:compare col-type col-type] [_]
@@ -30,11 +68,22 @@
                     `(util/compare-nio-buffers-unsigned ~@emitted-args))}))
 
 (doseq [[f left-type right-type res] [[:compare_nulls_first :null :null 0]
+                                      [:compare_nulls_first :absent :absent 0]
+                                      [:compare_nulls_first :absent :null 1]
+                                      [:compare_nulls_first :null :absent -1]
                                       [:compare_nulls_first :null :any -1]
+                                      [:compare_nulls_first :absent :any -1]
                                       [:compare_nulls_first :any :null 1]
+                                      [:compare_nulls_first :any :absent 1]
+
                                       [:compare_nulls_last :null :null 0]
+                                      [:compare_nulls_last :absent :absent 0]
+                                      [:compare_nulls_last :null :absent 1]
+                                      [:compare_nulls_last :absent :null -1]
                                       [:compare_nulls_last :null :any 1]
-                                      [:compare_nulls_last :any :null -1]]]
+                                      [:compare_nulls_last :absent :any 1]
+                                      [:compare_nulls_last :any :null -1]
+                                      [:compare_nulls_last :any :absent -1]]]
   (defmethod expr/codegen-call [f left-type right-type] [_]
     {:return-type :i32
      :->call-code (constantly res)}))

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -174,7 +174,7 @@
 
               (.endStruct struct-wtr))))))))
 
-(doseq [type-head #{:null :bool :fixed-size-binary :transit}]
+(doseq [type-head #{:null :absent :bool :fixed-size-binary :transit}]
   (defmethod type->metadata-writer type-head [_write-col-meta! metadata-root col-type] (->bool-type-handler metadata-root col-type)))
 
 (doseq [type-head #{:int :float :utf8 :varbinary :keyword :uri :uuid

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -260,7 +260,7 @@
 
 (def col-type-hierarchy
   (-> (make-hierarchy)
-      (derive :null :any) (derive :absent :null)
+      (derive :null :any) (derive :absent :any)
       (derive :bool :any)
 
       (derive :f32 :float) (derive :f64 :float)

--- a/docs/src/content/docs/reference/main/data-types.adoc
+++ b/docs/src/content/docs/reference/main/data-types.adoc
@@ -153,3 +153,28 @@ XTDB supports arbitrarily nested data.
 |`#{"Lucy" "38"}`
 
 |===
+
+== Null/Absent
+
+XTDB differentiates between an explicitly provided 'null' value and the absence of a value - for example, none of these three documents are not considered equivalent:
+
+[source,json]
+----
+{ "xt$id" : "steve", "middleName" : null }
+{ "xt$id" : "steve", "middleName" : null } // i.e. null != null
+{ "xt$id" : "steve" } // i.e. null != absent
+----
+
+XTDB's expression engine handles null values using https://en.wikipedia.org/wiki/Three-valued_logic[3-valued logic], in keeping with the SQL standard - for example:
+
+* By default, whenever a function is passed any argument that is null, the whole function returns null - e.g. `4 + NULL` returns null.
+** The exceptions are well-defined - e.g. `IS_NULL(NULL)` is obviously true.
+** Null values are not equal to each other - e.g. two tables with a join condition of `left.a = right.b` will not yield any rows where either `left.a` or `right.b` is null.
+* When aggregating (e.g. `SELECT t.a, COUNT(t.b) FROM table t GROUP BY t.a`), all values with null `t.a` are grouped in the same bucket (again, in keeping with the SQL standard).
+
+Absence is handled similarly to null but with some subtle differences:
+
+* By default, whenever a function is passed any argument that is missing in the input document, the whole function returns null - e.g. `4 + a` returns null for rows missing `a`.
+* Absent values _are_ equal to each other - e.g. if you join using `left.a = right.b`, row pairs where neither table has a value defined for the given column will join.
+* When aggregating, rows with absent grouping values are grouped in the same bucket as the nulls.
+* When ordering by 'nulls first' or 'nulls last', we use `null < absent < any other value` and `any other value < absent < null` respectively.

--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -206,11 +206,11 @@
                                                          :throw-exceptions? false})
           body (decode-json body)]
       (t/is (= 500 status))
-      (t/is (= "No method in multimethod 'codegen-call' for dispatch value: [:upper :absent]"
+      (t/is (= "No method in multimethod 'codegen-call' for dispatch value: [:upper :i64]"
                (ex-message body)))
       (t/is (= {:xtdb.error/error-type :unknown-runtime-error,
                 :class "java.lang.IllegalArgumentException",
-                :stringified "java.lang.IllegalArgumentException: No method in multimethod 'codegen-call' for dispatch value: [:upper :absent]"}
+                :stringified "java.lang.IllegalArgumentException: No method in multimethod 'codegen-call' for dispatch value: [:upper :i64]"}
                (ex-data body))))))
 
 (defn- inst->str [^java.util.Date d] (str (.toInstant d)))

--- a/src/test/clojure/xtdb/expression/comparator_test.clj
+++ b/src/test/clojure/xtdb/expression/comparator_test.clj
@@ -1,0 +1,60 @@
+(ns xtdb.expression.comparator-test
+  (:require [clojure.test :as t]
+            [xtdb.expression-test :as et]
+            [xtdb.test-util :as tu]
+            [xtdb.types :as types]))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(t/deftest absent-handling-2944
+  (with-open [rel (tu/open-rel [(-> (types/col-type->field "x" [:struct '{float :f64
+                                                                          maybe-float [:union #{:f64 :absent}]
+                                                                          maybe-str [:union #{:utf8 :absent}]
+                                                                          null-float [:union #{:f64 :null}]}])
+                                    (tu/open-vec [{:float 12.0, :null-float nil}]))])]
+
+    (t/is (= {:res [0], :res-type [:union #{:i32 :null}]}
+             (et/run-projection rel '(compare (. x maybe-float) (. x maybe-float)))))
+
+    (t/is (= {:res [[false true false true false true]]
+              :res-type [:list :bool]}
+             (et/run-projection rel '[(<> (. x maybe-float) (. x maybe-float))
+                                      (= (. x maybe-float) (. x maybe-float))
+                                      (< (. x maybe-float) (. x maybe-float))
+                                      (<= (. x maybe-float) (. x maybe-float))
+                                      (> (. x maybe-float) (. x maybe-float))
+                                      (>= (. x maybe-float) (. x maybe-float))])))
+
+    (t/is (= {:res [[nil nil nil nil nil nil nil nil]]
+              :res-type [:list [:union #{:null :bool :i32}]]}
+             (et/run-projection rel '[(<> (. x maybe-float) (. x null-float))
+                                      (= (. x null-float) (. x maybe-float))
+                                      (< (. x null-float) (. x maybe-float))
+                                      (<= (. x maybe-float) (. x null-float))
+                                      (> (. x maybe-float) (. x null-float))
+                                      (>= (. x null-float) (. x maybe-float))
+                                      (compare (. x null-float) (. x maybe-float))
+                                      (compare (. x maybe-float) (. x null-float))])))
+
+    (t/is (= {:res [[-1 -1 0 0 -1 1, 1 1 0 0 1 -1]], :res-type [:list :i32]}
+             (et/run-projection rel '[(compare-nulls-first (. x null-float) (. x maybe-float))
+                                      (compare-nulls-first (. x null-float) (. x float))
+                                      (compare-nulls-first (. x null-float) (. x null-float))
+                                      (compare-nulls-first (. x maybe-float) (. x maybe-float))
+                                      (compare-nulls-first (. x maybe-float) (. x float))
+                                      (compare-nulls-first (. x maybe-float) (. x null-float))
+
+                                      (compare-nulls-last (. x null-float) (. x maybe-float))
+                                      (compare-nulls-last (. x null-float) (. x float))
+                                      (compare-nulls-last (. x null-float) (. x null-float))
+                                      (compare-nulls-last (. x maybe-float) (. x maybe-float))
+                                      (compare-nulls-last (. x maybe-float) (. x float))
+                                      (compare-nulls-last (. x maybe-float) (. x null-float))])))
+
+    (t/is (= {:res [[true false true true false true]], :res-type [:list :bool]}
+             (et/run-projection rel '[(null-eq (. x null-float) (. x maybe-float))
+                                      (null-eq (. x null-float) (. x float))
+                                      (null-eq (. x null-float) (. x null-float))
+                                      (null-eq (. x maybe-float) (. x maybe-float))
+                                      (null-eq (. x maybe-float) (. x float))
+                                      (null-eq (. x maybe-float) (. x null-float))])))))

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/numeric-value-functions-6.28.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/numeric-value-functions-6.28.test
@@ -55,8 +55,9 @@ SELECT CARDINALITY(t.arr) FROM (VALUES (ARRAY[1, 2, 3])) t (arr)
 ----
 3
 
-query II nosort
-SELECT LEAST(5, t1.xt$id, 12, 8), GREATEST(5, t1.id, 12, 8) FROM t1
+query III nosort
+SELECT LEAST(5, t1.xt$id, 12, 8), GREATEST(5, t1.xt$id, 12, 8), GREATEST(5, t1.missing, 12, 8) FROM t1
 ----
 1
 12
+NULL


### PR DESCRIPTION
More complete handling of 'absent' in the EE:

* Generally speaking, there seems to be precious little prior art here. Particularly, there's obviously nothing in the SQL spec for this, I've mainly taken inspiration from Mongo, [PartiQL](https://partiql.org/assets/PartiQL-Specification.pdf) and JS (although not much from JS, admittedly - to misquote Linus, "it's like 'what would Jesus do?', except it's 'what would JS _not_ do?'").
* By default, any calls passed an 'absent' argument shortcut to **null** - i.e. `(+ 4.0 ::absent)` -> `nil` - this is the Mongo behaviour.
* Absent values are treated as equal to each other - this is because, if you have two maps, both of which happen to be missing a `b` key, they should still be considered equal. Might sound silly, but if you have two documents in a different block, in one block they might have the type `{:a :i64}`, in the other (because of other documents in the block) they might have type `{:a :i64, :b [:union #{:f64 :absent}]}`.
* In groupings, rows with absent values are grouped in with the nulls (again, Mongo behaviour).
* When comparing with `NULLS FIRST`/`NULLS LAST`, I have arbitrarily chosen `null < absent < present`.