### PR TITLE
Core metrics + development metrics dashboard

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,6 +46,10 @@ dependencies {
     api("commons-codec", "commons-codec", "1.15")
     api("com.carrotsearch", "hppc", "0.9.1")
 
+    // monitoring
+    api("io.micrometer", "micrometer-core", "1.12.2")
+    api("io.micrometer", "micrometer-registry-prometheus", "1.12.2")
+
     api(kotlin("stdlib-jdk8"))
     api("com.charleskorn.kaml","kaml","0.56.0")
 

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -1,0 +1,65 @@
+(ns xtdb.metrics
+  (:require [clojure.tools.logging :as log]
+            [juxt.clojars-mirrors.integrant.core :as ig]
+            [xtdb.error :as err]
+            [xtdb.util :as util])
+  (:import (com.sun.net.httpserver HttpServer HttpHandler)
+           (java.net InetSocketAddress)
+           (io.micrometer.core.instrument MeterRegistry Meter Measurement Timer Gauge Tag Counter)
+           (io.micrometer.core.instrument.binder MeterBinder)
+           (io.micrometer.core.instrument.binder.jvm ClassLoaderMetrics JvmMemoryMetrics JvmHeapPressureMetrics JvmGcMetrics JvmThreadMetrics)
+           (io.micrometer.core.instrument.binder.system ProcessorMetrics)
+           (io.micrometer.core.instrument.simple SimpleMeterRegistry)
+           (io.micrometer.prometheus PrometheusMeterRegistry PrometheusConfig)))
+
+(defn meter-reg ^MeterRegistry
+  ([] (meter-reg (SimpleMeterRegistry.)))
+  ([meter-reg]
+   (doseq [^MeterBinder metric [(ClassLoaderMetrics.) (JvmMemoryMetrics.) (JvmHeapPressureMetrics.)
+                                (JvmGcMetrics.) (ProcessorMetrics.) (JvmThreadMetrics.)]]
+     (.bindTo metric meter-reg))
+   meter-reg))
+
+(defmethod ig/init-key :xtdb/meter-registry [_ {}]
+  (meter-reg (PrometheusMeterRegistry. PrometheusConfig/DEFAULT)))
+
+(defmethod ig/halt-key! :xtdb/meter-registry [_ ^MeterRegistry registry]
+  (.close registry))
+
+(defn add-counter [reg name {:keys [description]}]
+  (cond-> (Counter/builder name)
+    description (.description description)
+    :always (.register reg)))
+
+(def percentiles [0.75 0.85 0.95 0.98 0.99 0.999])
+
+(defn add-timer [reg name {:keys [^String description]}]
+  (cond-> (.. (Timer/builder name)
+              (publishPercentiles (double-array percentiles)))
+    description (.description description)
+    :always (.register reg)))
+
+(defmethod ig/prep-key :xtdb/metrics-server [_ opts]
+  (merge {:registry (ig/ref :xtdb/meter-registry)}
+         opts))
+
+(defmethod ig/init-key :xtdb/metrics-server [_ {:keys [^PrometheusMeterRegistry registry port] :or {port 8080}}]
+  (try
+    (let [port (if (util/port-free? port) port (util/free-port))
+          http-server (HttpServer/create (InetSocketAddress. port) 0)]
+      (.createContext http-server "/metrics"
+                      (reify HttpHandler
+                        (handle [_this exchange]
+                          (let [response (.getBytes (.scrape registry))]
+                            (.sendResponseHeaders exchange 200 (count response))
+                            (with-open [os (.getResponseBody exchange)]
+                              (.write os response))))))
+      (.start http-server)
+      (log/debug "Metrics server started on port: " port)
+      http-server)
+    (catch java.io.IOException e
+      (throw (err/runtime-err :metrics-server-error {} e)))))
+
+(defmethod ig/halt-key! :xtdb/metrics-server [_ ^HttpServer server]
+  (.stop server 0)
+  (log/debug "Metrics server stopped."))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -10,7 +10,7 @@
            (java.io ByteArrayOutputStream File)
            java.lang.AutoCloseable
            java.lang.reflect.Method
-           (java.net MalformedURLException URI URL)
+           (java.net MalformedURLException URI URL ServerSocket)
            java.nio.ByteBuffer
            (java.nio.channels Channels ClosedByInterruptException FileChannel FileChannel$MapMode SeekableByteChannel)
            java.nio.charset.StandardCharsets
@@ -570,3 +570,14 @@
          (with-tmp-dirs #{~@more-bindings}
            ~@body)))
     `(do ~@body)))
+
+(defn port-free? [^long port]
+  (try
+    (.close (ServerSocket. port))
+    true
+    (catch java.net.BindException _e
+      false)))
+
+(defn free-port ^long []
+  (with-open [s (ServerSocket. 0)]
+    (.getLocalPort s)))

--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -33,3 +33,13 @@ All run through scripts in `./bin`:
 - `run-bench.sh ts-devices [--size <small|med|big>] [--count 1]` - kicks off an ECS job.
 
 You can also run it locally with (e.g.) `clojure -Mxtdb:4gb:bench-tpch --scale-factor 0.05` from the top-level of the core2 repo.
+
+
+=== Prometheus and grafana
+For local node monitoring bring up a prometheus and grafana instance via `docker-compose up`.
+By default the node serves prometheus metrics under `localhost:8080/metrics` which the prometheus scrapes every 2 seconds.
+If the metrics are not exposed under `localhost:8080` you need to tweak the `.config/prometheus.yaml` config accordingly.
+
+Under `localhost:3001` you are able to access the grafana UI (`admin` for user and password).
+The XTDB node datasource should be setup and there should be a dashboard available with some basic metrics.
+In case you tweak the dashboard or add a new one you need to save the changes in the corresponding file in `.config/dashboards/dashboard_name.json`.

--- a/modules/bench/config/dashboards.yaml
+++ b/modules/bench/config/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'default'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 10 #how often Grafana will scan for changed dashboards
+  options:
+    path: /var/lib/grafana/dashboards

--- a/modules/bench/config/dashboards/XTDB_node_metrics.json
+++ b/modules/bench/config/dashboards/XTDB_node_metrics.json
@@ -1,0 +1,469 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"tx_op_timer_seconds\", instance=\"host.docker.internal:8080\", job=\"xtdb_v2_node\", quantile=\"0.98\"}",
+                  "{__name__=\"tx_op_timer_seconds\", instance=\"host.docker.internal:8080\", job=\"xtdb_v2_node\", quantile=\"0.99\"}",
+                  "{__name__=\"tx_op_timer_seconds\", instance=\"host.docker.internal:8080\", job=\"xtdb_v2_node\", quantile=\"0.999\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "editorMode": "builder",
+          "expr": "tx_op_timer_seconds",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"query_timer_seconds\", instance=\"host.docker.internal:8080\", job=\"xtdb_v2_node\", quantile=\"0.999\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "editorMode": "builder",
+          "expr": "query_timer_seconds",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 17
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "editorMode": "builder",
+          "expr": "tx_op_timer_seconds_count",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Transactions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusdatasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusdatasource"
+          },
+          "editorMode": "builder",
+          "expr": "query_timer_seconds_count",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Queries",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "XTDB v2 node metrics",
+  "uid": "jtBND72Sk",
+  "version": 2,
+  "weekStart": ""
+}

--- a/modules/bench/config/datasource.yaml
+++ b/modules/bench/config/datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    uid: prometheusdatasource

--- a/modules/bench/config/prometheus.yaml
+++ b/modules/bench/config/prometheus.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     2s # How frequently to scrape targets by default
+  evaluation_interval: 2s # How frequently to evaluate rules by default
+
+scrape_configs:
+  - job_name: 'xtdb_v2_node'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+    metrics_path: /metrics

--- a/modules/bench/docker-compose.yaml
+++ b/modules/bench/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  grafana:
+    image: 'grafana/grafana-oss:9.4.7'
+    container_name: grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./config/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+      - ./config/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./config/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - monitoring
+    depends_on:
+      - prometheus
+    restart: always
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus.yaml:/etc/prometheus/prometheus.yml
+    networks:
+      - monitoring
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
+networks:
+  monitoring:


### PR DESCRIPTION
- This adds Timer metrics for queries + transactions
- Adds a simple development setup for prometheus + grafana that scrapes the metrics locally and displays them in a simple dashboard. 