### PR TITLE
Updates to `extract` function #3126

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -921,6 +921,20 @@
                     "MINUTE" `(int 0)
                     "SECOND" `(int 0)))})
 
+(defmethod expr/codegen-call [:extract :utf8 :interval] [{[{field :literal} _] :args}]
+  {:return-type :i32
+   :->call-code (fn [[_ pd]]
+                  (let [period `(.getPeriod ^PeriodDuration ~pd)
+                        duration `(.getDuration ^PeriodDuration ~pd)]
+                    (case field
+                      "TIMEZONE_HOUR" (throw (UnsupportedOperationException. "Extract \"timezone_hour\" not supported for type interval"))
+                      "TIMEZONE_MINUTE" (throw (UnsupportedOperationException. "Extract \"timezone_minute\" not supported for type interval"))
+                      "YEAR" `(-> (.toTotalMonths ~period) (/ 12) (int))
+                      "MONTH" `(-> (.toTotalMonths ~period) (rem 12) (int))
+                      "DAY" `(.getDays ~period)
+                      "HOUR" `(-> (.toHours ~duration) (int))
+                      "MINUTE" `(-> (.toMinutes ~duration) (rem 60) (int))
+                      "SECOND" `(-> (.toSeconds ~duration) (rem 60) (int)))))})
 
 (defn field->truncate-fn
   [field]

--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -930,6 +930,16 @@
                       "SECOND" `(-> (.toSeconds ~duration) (rem 60) (int))
                       (throw (UnsupportedOperationException. (format "Extract \"%s\" not supported for type interval" field))))))})
 
+(defmethod expr/codegen-call [:extract :utf8 :time-local] [{[{field :literal} _] :args [_ [_tm tm-unit]] :arg-types}]
+  {:return-type :i32
+   :->call-code (fn [[_ tm]]
+                  (let [local-time `(LocalTime/ofNanoOfDay ~(with-conversion tm tm-unit :nano))]
+                    (case field
+                      "HOUR" `(.getHour ~local-time)
+                      "MINUTE" `(.getMinute ~local-time)
+                      "SECOND" `(.getSecond ~local-time)
+                      (throw (UnsupportedOperationException. (format "Extract \"%s\" not supported for type time without timezone" field))))))})
+
 (defn field->truncate-fn
   [field]
   (case field

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -585,8 +585,15 @@
               "ASYMMETRIC" 'between)]
       (list 'not (list f (expr rvp-1) (expr rvp-2) (expr rvp-3))))
 
-    [:extract_expression "EXTRACT"
-     [:primary_datetime_field [:non_second_primary_datetime_field extract-field]] "FROM" ^:z es]
+    [:extract_expression "EXTRACT" [:primary_datetime_field [:non_second_primary_datetime_field extract-field]] "FROM" ^:z es]
+    ;;=>
+    (list 'extract extract-field (expr es))
+
+    [:extract_expression "EXTRACT" [:primary_datetime_field "SECOND"] "FROM" ^:z es]
+    ;;=>
+    (list 'extract "SECOND" (expr es))
+
+    [:extract_expression "EXTRACT" [:time_zone_field extract-field] "FROM" ^:z es]
     ;;=>
     (list 'extract extract-field (expr es))
 

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -269,6 +269,14 @@ a| Returns true iff `p1` starts after `p2` ends
 | Truncates the given interval to the given time-unit, which must be one of `MILLENNIUM`, `CENTURY`, `DECADE`, `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND` or `MICROSECOND`
 
 | `(extract "field" date-time)` | `EXTRACT('field', date_time)`
-| Extracts the given field from the date-time, which must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE`.
+| Extracts the given field from the date-time. Field must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE` or `SECOND`. Datetimes with timezones additionally support field values of `TIMEZONE_HOUR` and `TIMEZONE_MINUTE`.
 
+| `(extract "field" date)` | `EXTRACT('field', date)`
+| Extracts the given field from the date. Field must be one of `YEAR`, `MONTH` or `DAY`.
+
+| `(extract "field" time)` | `EXTRACT('field', time)`
+| Extracts the given field from the time. Field must be one of `HOUR`, `MINUTE` or `SECOND`.
+
+| `(extract "field" interval)` | `EXTRACT('field', interval)`
+| Extracts the given field from the interval. Field must be one of `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE` or `SECOND`.
 |===

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -11,7 +11,7 @@
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import (java.nio ByteBuffer)
-           (java.time Clock Duration Instant LocalDate LocalDateTime Period ZoneId ZonedDateTime)
+           (java.time Clock Duration Instant LocalDate LocalDateTime LocalTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            (org.apache.arrow.vector DurationVector PeriodDuration TimeStampVector ValueVector)
            (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp)
@@ -273,6 +273,23 @@
       (t/is (= 8 (extract "DAY" itvl)))
       (t/is (= 4 (extract "MONTH" itvl)))
       (t/is (= 1 (extract "YEAR" itvl))))))
+
+(t/deftest test-time-extract
+  (letfn [(extract [part time-val] (project1 (list 'extract part 'time) {:time time-val}))]
+    (let [tm (LocalTime/of 3 23 20)]
+      (t/is (= 20 (extract "SECOND" tm)))
+      (t/is (= 23 (extract "MINUTE" tm)))
+      (t/is (= 3 (extract "HOUR" tm)))
+
+      (t/is (thrown-with-msg?
+             UnsupportedOperationException
+             #"Extract \"DAY\" not supported for type time without timezone"
+             (extract "DAY" tm)))
+      
+      (t/is (thrown-with-msg?
+             UnsupportedOperationException
+             #"Extract \"TIMEZONE_HOUR\" not supported for type time without timezone"
+             (extract "TIMEZONE_HOUR" tm))))))
 
 (t/deftest test-timezone-extract
   (letfn [(extract [part value] (project1 (list 'extract part 'value) {:value value}))]

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -14,7 +14,7 @@
            (java.time Clock Duration Instant LocalDate LocalDateTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            (org.apache.arrow.vector DurationVector PeriodDuration TimeStampVector ValueVector)
-           (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp) 
+           (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp)
            org.apache.arrow.vector.types.TimeUnit
            (xtdb.util StringUtil)
            xtdb.vector.IVectorReader))
@@ -215,11 +215,11 @@
       (t/is (= #xt/interval-mdn ["P12000M" "PT0S"] (trunc "MILLENNIUM"))))))
 
 (t/deftest test-date-extract
-  ;; TODO units below minute are not yet implemented for any type
   (letfn [(extract [part date-like] (project1 (list 'extract part 'date) {:date date-like}))
           (extract-all [part date-likes] (project (list 'extract part 'date) (map (partial array-map :date) date-likes)))]
     (t/testing "java.time.Instant"
-      (let [inst (time/->instant #inst "2022-03-21T13:44:52.344")]
+      (let [inst (time/->instant #inst "2022-03-21T13:44:52.344")] 
+        (t/is (= 52 (extract "SECOND" inst)))
         (t/is (= 44 (extract "MINUTE" inst)))
         (t/is (= 13 (extract "HOUR" inst)))
         (t/is (= 21 (extract "DAY" inst)))
@@ -228,15 +228,26 @@
 
     (t/testing "java.time.ZonedDateTime"
       (let [zdt (-> (time/->zdt #inst "2022-03-21T13:44:52.344")
-                    (.withZoneSameLocal (ZoneId/of "Europe/London")))]
+                    (.withZoneSameLocal (ZoneId/of "Asia/Calcutta")))] 
+        (t/is (= 52 (extract "SECOND" zdt)))
         (t/is (= 44 (extract "MINUTE" zdt)))
         (t/is (= 13 (extract "HOUR" zdt)))
         (t/is (= 21 (extract "DAY" zdt)))
         (t/is (= 3 (extract "MONTH" zdt)))
         (t/is (= 2022 (extract "YEAR" zdt)))))
+    
+    (t/testing "java.time.LocalDateTime"
+      (let [ldt (LocalDateTime/of 2022 4 3 12 34 56 789456999)]
+        (t/is (= 56 (extract "SECOND" ldt)))
+        (t/is (= 34 (extract "MINUTE" ldt)))
+        (t/is (= 12 (extract "HOUR" ldt)))
+        (t/is (= 3 (extract "DAY" ldt)))
+        (t/is (= 4 (extract "MONTH" ldt)))
+        (t/is (= 2022 (extract "YEAR" ldt)))))
 
     (t/testing "java.time.LocalDate"
       (let [ld (LocalDate/of 2022 03 21)]
+        (t/is (= 0 (extract "SECOND" ld)))
         (t/is (= 0 (extract "MINUTE" ld)))
         (t/is (= 0 (extract "HOUR" ld)))
         (t/is (= 21 (extract "DAY" ld)))
@@ -246,13 +257,49 @@
     (t/testing "mixed types"
       (let [dates [(time/->instant #inst "2022-03-22T13:44:52.344")
                    (-> (time/->zdt #inst "2021-02-23T21:19:10.692")
-                       (.withZoneSameLocal (ZoneId/of "Europe/London")))
+                       (.withZoneSameLocal (ZoneId/of "Asia/Calcutta")))
                    (LocalDate/of 2020 04 18)]]
+        (t/is (= [52 10 0] (extract-all "SECOND" dates)))
         (t/is (= [44 19 0] (extract-all "MINUTE" dates)))
         (t/is (= [13 21 0] (extract-all "HOUR" dates)))
         (t/is (= [22 23 18] (extract-all "DAY" dates)))
         (t/is (= [3 2 4] (extract-all "MONTH" dates)))
-        (t/is (= [2022 2021 2020] (extract-all "YEAR" dates)))))))
+        (t/is (= [2022 2021 2020] (extract-all "YEAR" dates))))))) 
+
+(t/deftest test-timezone-extract
+  (letfn [(extract [part value] (project1 (list 'extract part 'value) {:value value}))]
+    (t/testing "java.time.ZonedDateTime"
+      (let [zdt (-> (time/->zdt #inst "2022-03-21T13:44:52.344")
+                    (.withZoneSameLocal (ZoneId/of "Asia/Calcutta")))]
+        (t/is (= 5 (extract "TIMEZONE_HOUR" zdt)))
+        (t/is (= 30 (extract "TIMEZONE_MINUTE" zdt)))))
+    
+    (t/testing "java.time.Instant"
+      (let [inst (time/->instant #inst "2022-03-21T13:44:52.344")]
+        (t/is (= 0 (extract "TIMEZONE_HOUR" inst)))
+        (t/is (= 0 (extract "TIMEZONE_MINUTE" inst))))) 
+    
+    (t/testing "java.time.LocalDateTime"
+      (let [ldt (LocalDateTime/of 2022 4 3 12 34 56 789456999)]
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_hour\" not supported for type timestamp without timezone"
+               (extract "TIMEZONE_HOUR" ldt)))
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_minute\" not supported for type timestamp without timezone"
+               (extract "TIMEZONE_MINUTE" ldt)))))
+  
+    (t/testing "java.time.LocalDate"
+      (let [ld (LocalDate/of 2022 03 21)]
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_hour\" not supported for type date"
+               (extract "TIMEZONE_HOUR" ld)))
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_minute\" not supported for type date"
+               (extract "TIMEZONE_MINUTE" ld)))))))
 
 (defn run-projection [rel form]
   (let [col-types (->> rel

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -247,9 +247,10 @@
 
     (t/testing "java.time.LocalDate"
       (let [ld (LocalDate/of 2022 03 21)]
-        (t/is (= 0 (extract "SECOND" ld)))
-        (t/is (= 0 (extract "MINUTE" ld)))
-        (t/is (= 0 (extract "HOUR" ld)))
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"SECOND\" not supported for type date"
+               (extract "SECOND" ld))) 
         (t/is (= 21 (extract "DAY" ld)))
         (t/is (= 3 (extract "MONTH" ld)))
         (t/is (= 2022 (extract "YEAR" ld)))))
@@ -258,10 +259,7 @@
       (let [dates [(time/->instant #inst "2022-03-22T13:44:52.344")
                    (-> (time/->zdt #inst "2021-02-23T21:19:10.692")
                        (.withZoneSameLocal (ZoneId/of "Asia/Calcutta")))
-                   (LocalDate/of 2020 04 18)]]
-        (t/is (= [52 10 0] (extract-all "SECOND" dates)))
-        (t/is (= [44 19 0] (extract-all "MINUTE" dates)))
-        (t/is (= [13 21 0] (extract-all "HOUR" dates)))
+                   (LocalDate/of 2020 04 18)]] 
         (t/is (= [22 23 18] (extract-all "DAY" dates)))
         (t/is (= [3 2 4] (extract-all "MONTH" dates)))
         (t/is (= [2022 2021 2020] (extract-all "YEAR" dates))))))) 
@@ -288,39 +286,17 @@
       (let [inst (time/->instant #inst "2022-03-21T13:44:52.344")]
         (t/is (= 0 (extract "TIMEZONE_HOUR" inst)))
         (t/is (= 0 (extract "TIMEZONE_MINUTE" inst))))) 
-    
-    (t/testing "java.time.LocalDateTime"
-      (let [ldt (LocalDateTime/of 2022 4 3 12 34 56 789456999)]
-        (t/is (thrown-with-msg?
-               UnsupportedOperationException
-               #"Extract \"timezone_hour\" not supported for type timestamp without timezone"
-               (extract "TIMEZONE_HOUR" ldt)))
-        (t/is (thrown-with-msg?
-               UnsupportedOperationException
-               #"Extract \"timezone_minute\" not supported for type timestamp without timezone"
-               (extract "TIMEZONE_MINUTE" ldt)))))
   
-    (t/testing "java.time.LocalDate"
+    (t/testing "type that doesn't support timezone fields"
       (let [ld (LocalDate/of 2022 03 21)]
         (t/is (thrown-with-msg?
                UnsupportedOperationException
-               #"Extract \"timezone_hour\" not supported for type date"
+               #"Extract \"TIMEZONE_HOUR\" not supported for type date"
                (extract "TIMEZONE_HOUR" ld)))
         (t/is (thrown-with-msg?
                UnsupportedOperationException
-               #"Extract \"timezone_minute\" not supported for type date"
-               (extract "TIMEZONE_MINUTE" ld)))))
-  
-    (t/testing "interval"
-      (let [itvl (PeriodDuration. (Period/of 1 4 8) (Duration/parse "PT3H10M12.1S"))]
-        (t/is (thrown-with-msg?
-               UnsupportedOperationException
-               #"Extract \"timezone_hour\" not supported for type interval"
-               (extract "TIMEZONE_HOUR" itvl)))
-        (t/is (thrown-with-msg?
-               UnsupportedOperationException
-               #"Extract \"timezone_minute\" not supported for type interval"
-               (extract "TIMEZONE_MINUTE" itvl)))))))
+               #"Extract \"TIMEZONE_MINUTE\" not supported for type date"
+               (extract "TIMEZONE_MINUTE" ld)))))))
 
 (defn run-projection [rel form]
   (let [col-types (->> rel

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -266,6 +266,16 @@
         (t/is (= [3 2 4] (extract-all "MONTH" dates)))
         (t/is (= [2022 2021 2020] (extract-all "YEAR" dates))))))) 
 
+(t/deftest test-interval-extract
+  (letfn [(extract [part interval-val] (project1 (list 'extract part 'interval) {:interval interval-val}))]
+    (let [itvl (PeriodDuration. (Period/of 1 4 8) (Duration/parse "PT3H10M12.1S"))]
+      (t/is (= 12 (extract "SECOND" itvl)))
+      (t/is (= 10 (extract "MINUTE" itvl)))
+      (t/is (= 3 (extract "HOUR" itvl)))
+      (t/is (= 8 (extract "DAY" itvl)))
+      (t/is (= 4 (extract "MONTH" itvl)))
+      (t/is (= 1 (extract "YEAR" itvl))))))
+
 (t/deftest test-timezone-extract
   (letfn [(extract [part value] (project1 (list 'extract part 'value) {:value value}))]
     (t/testing "java.time.ZonedDateTime"
@@ -299,7 +309,18 @@
         (t/is (thrown-with-msg?
                UnsupportedOperationException
                #"Extract \"timezone_minute\" not supported for type date"
-               (extract "TIMEZONE_MINUTE" ld)))))))
+               (extract "TIMEZONE_MINUTE" ld)))))
+  
+    (t/testing "interval"
+      (let [itvl (PeriodDuration. (Period/of 1 4 8) (Duration/parse "PT3H10M12.1S"))]
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_hour\" not supported for type interval"
+               (extract "TIMEZONE_HOUR" itvl)))
+        (t/is (thrown-with-msg?
+               UnsupportedOperationException
+               #"Extract \"timezone_minute\" not supported for type interval"
+               (extract "TIMEZONE_MINUTE" itvl)))))))
 
 (defn run-projection [rel form]
   (let [col-types (->> rel

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -903,6 +903,27 @@
   (t/is (= [{:interval #xt/interval-mdn ["P3M" "PT0S"]}]
            (xt/q tu/*node* "SELECT DATE_TRUNC('MONTH', 3 MONTH + 4 DAY + 2 SECOND) as interval FROM (VALUES 1) AS x"))))
 
+(deftest test-extract-plan
+  (t/testing "TIMESTAMP behaviour"
+    (t/are
+     [sql expected]
+     (= expected (plan-expr sql))
+      "extract(second from timestamp '2021-10-21T12:34:56')" '(extract "SECOND" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(MINUTE FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "MINUTE" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(HOUR FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "HOUR" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(DAY FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "DAY" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(MONTH FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "MONTH" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(YEAR FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "YEAR" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "TIMEZONE_MINUTE" #time/date-time "2021-10-21T12:34:56")
+      "EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2021-10-21T12:34:56')" '(extract "TIMEZONE_HOUR" #time/date-time "2021-10-21T12:34:56")))
+
+  (t/testing "INTERVAL behaviour"
+    (t/are
+     [sql expected]
+     (= expected (plan-expr sql))
+      "EXTRACT(second from interval '3 02:47:33' day to second)" '(extract "SECOND" (multi-field-interval "3 02:47:33" "DAY" 2 "SECOND" 6))
+      "EXTRACT(MINUTE FROM INTERVAL '5' DAY)" '(extract "MINUTE" (single-field-interval "5" "DAY" 2 0)))))
+
 (deftest test-system-time-queries
   (t/testing "AS OF"
     (t/is

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -951,7 +951,19 @@
     (t/is (thrown-with-msg?
            UnsupportedOperationException
            #"Extract \"timezone_hour\" not supported for type date"
-           (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM DATE '2001-03-11') as x FROM (VALUES 1) AS z")))))
+           (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM DATE '2001-03-11') as x FROM (VALUES 1) AS z"))))
+  
+  (t/testing "interval behavior"
+    (t/is (= [{:x 3}]
+             (xt/q tu/*node* "SELECT EXTRACT(DAY FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))
+    
+    (t/is (= [{:x 47}]
+             (xt/q tu/*node* "SELECT EXTRACT(MINUTE FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))
+  
+    (t/is (thrown-with-msg?
+           UnsupportedOperationException
+           #"Extract \"timezone_hour\" not supported for type interval"
+           (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))))
 
 (deftest test-system-time-queries
   (t/testing "AS OF"

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -934,7 +934,7 @@
     
     (t/is (thrown-with-msg? 
            UnsupportedOperationException
-           #"Extract \"timezone_hour\" not supported for type timestamp without timezone"
+           #"Extract \"TIMEZONE_HOUR\" not supported for type timestamp without timezone"
            (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2021-10-21T12:34:56') as x FROM (VALUES 1) AS z"))))
   
   (t/testing "timestamp with timezone behavior"
@@ -950,7 +950,7 @@
 
     (t/is (thrown-with-msg?
            UnsupportedOperationException
-           #"Extract \"timezone_hour\" not supported for type date"
+           #"Extract \"TIMEZONE_HOUR\" not supported for type date"
            (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM DATE '2001-03-11') as x FROM (VALUES 1) AS z"))))
   
   (t/testing "interval behavior"
@@ -962,7 +962,7 @@
   
     (t/is (thrown-with-msg?
            UnsupportedOperationException
-           #"Extract \"timezone_hour\" not supported for type interval"
+           #"Extract \"TIMEZONE_HOUR\" not supported for type interval"
            (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))))
 
 (deftest test-system-time-queries

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -922,7 +922,14 @@
      [sql expected]
      (= expected (plan-expr sql))
       "EXTRACT(second from interval '3 02:47:33' day to second)" '(extract "SECOND" (multi-field-interval "3 02:47:33" "DAY" 2 "SECOND" 6))
-      "EXTRACT(MINUTE FROM INTERVAL '5' DAY)" '(extract "MINUTE" (single-field-interval "5" "DAY" 2 0)))))
+      "EXTRACT(MINUTE FROM INTERVAL '5' DAY)" '(extract "MINUTE" (single-field-interval "5" "DAY" 2 0))))
+  
+  (t/testing "TIME behaviour"
+    (t/are
+     [sql expected]
+     (= expected (plan-expr sql))
+      "EXTRACT(second from time '11:11:11')" '(extract "SECOND" #time/time "11:11:11")
+      "EXTRACT(MINUTE FROM TIME '11:11:11')" '(extract "MINUTE" #time/time "11:11:11"))))
 
 (deftest test-extract-query
   (t/testing "timestamp behavior"
@@ -931,19 +938,19 @@
 
     (t/is (= [{:x 2021}]
              (xt/q tu/*node* "SELECT EXTRACT(YEAR FROM TIMESTAMP '2021-10-21T12:34:56') as x FROM (VALUES 1) AS z")))
-    
-    (t/is (thrown-with-msg? 
+
+    (t/is (thrown-with-msg?
            UnsupportedOperationException
            #"Extract \"TIMEZONE_HOUR\" not supported for type timestamp without timezone"
            (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2021-10-21T12:34:56') as x FROM (VALUES 1) AS z"))))
-  
+
   (t/testing "timestamp with timezone behavior"
     (t/is (= [{:x 34}]
              (xt/q tu/*node* "SELECT EXTRACT(MINUTE FROM TIMESTAMP '2021-10-21T12:34:56+05:00') as x FROM (VALUES 1) AS z")))
-  
+
     (t/is (= [{:x 5}]
              (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2021-10-21T12:34:56+05:00') as x FROM (VALUES 1) AS z"))))
-  
+
   (t/testing "date behavior"
     (t/is (= [{:x 3}]
              (xt/q tu/*node* "SELECT EXTRACT(MONTH FROM DATE '2001-03-11') as x FROM (VALUES 1) AS z")))
@@ -952,14 +959,26 @@
            UnsupportedOperationException
            #"Extract \"TIMEZONE_HOUR\" not supported for type date"
            (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM DATE '2001-03-11') as x FROM (VALUES 1) AS z"))))
-  
+
+  (t/testing "time behavior"
+    (t/is (= [{:x 34}]
+             (xt/q tu/*node* "SELECT EXTRACT(MINUTE FROM TIME '12:34:56') as x FROM (VALUES 1) AS z")))
+
+    (t/is (= [{:x 12}]
+             (xt/q tu/*node* "SELECT EXTRACT(HOUR FROM TIME '12:34:56') as x FROM (VALUES 1) AS z")))
+
+    (t/is (thrown-with-msg?
+           UnsupportedOperationException
+           #"Extract \"TIMEZONE_HOUR\" not supported for type timestamp without timezone"
+           (xt/q tu/*node* "SELECT EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP '2021-10-21T12:34:56') as x FROM (VALUES 1) AS z"))))
+
   (t/testing "interval behavior"
     (t/is (= [{:x 3}]
              (xt/q tu/*node* "SELECT EXTRACT(DAY FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))
-    
+
     (t/is (= [{:x 47}]
              (xt/q tu/*node* "SELECT EXTRACT(MINUTE FROM INTERVAL '3 02:47:33' DAY TO SECOND) as x FROM (VALUES 1) AS z")))
-  
+
     (t/is (thrown-with-msg?
            UnsupportedOperationException
            #"Extract \"TIMEZONE_HOUR\" not supported for type interval"


### PR DESCRIPTION
Resolves #3126

- Following the SQL spec here, mainly - read through and highlighted some relevant parts.
- Seems like the EBNF was pretty much done already so haven't changed it.
- Have made sure we support all potential values of the `extract_field` in the planner, added some tests for that.
- Updated the implementation:
  - Updates the structure of the codegen-call somewhat.
  - Ensures we support `SECOND` for all types that support second.
  - Splits the `timestamp-tz` implementation into `timestamp-tz` and `timestamp-local` - ensure we actually construct a ZonedDateTime with the specified tz from the args (so that we can use it to extract TIMEZONE offset related stuff).
  - Handling `TIMEZONE_HOUR` and `TIMEZONE_MINUTES` for all current implementations, according to the SQL Spec:
    - For a timestamp with a timezone (ie, timestamp-tz), we return values based on the offset.
    - Otherwise (for a local timestamp, date, or interval), we return an appropriate exception at compile time.
      - Did look into handling this within the planner, but it seems fairly hard to distinguish if a timestamp has a timezone, especially given that one can pass around any form of timestamp_expression.   
  - Ensure that we similarly throw exceptions when attempting to extract a datetime field that the type does not have (ie, extracting `HOUR` from a `DATE`.
  - Added a codegen calls and tests around extracting fields from both `interval` and `local-time`.
- Updated the table of miscellaneous functions in `temporal.adoc` docs to discuss all valid values when calling `EXTRACT`.

