### PR TITLE
Calculate expanded asterisk projected columns independently

### DIFF
--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1290,7 +1290,7 @@
 (deftest analyzer-error-returned-test
   (testing "Query"
     (with-open [conn (jdbc-conn)]
-      (is (thrown-with-msg? PSQLException #"Query does not select any columns" (q conn ["SELECT * FROM foo"])))))
+      (is (thrown-with-msg? PSQLException #"Table variable duplicated: baz" (q conn ["SELECT 1 FROM foo AS baz, baz"])))))
   (testing "DML"
     (with-open [conn (jdbc-conn)]
       (q conn ["BEGIN READ WRITE"])
@@ -1301,10 +1301,10 @@
   (deftest psql-analyzer-error-test
     (psql-session
      (fn [send read]
-       (send "SELECT * FROM foo;\n")
+       (send "SELECT 1 FROM foo AS baz, baz;\n")
        (let [s (read :err)]
          (is (not= :timeout s))
-         (is (re-find #"Query does not select any columns" s)))
+         (is (re-find #"Table variable duplicated: baz" s)))
 
        (send "BEGIN READ WRITE;\n")
        (read)

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
@@ -1,1 +1,1 @@
-[:select (= name lastname) [:scan {:table stars_in} [name lastname]]]
+[:select (= name lastname) [:scan {:table stars_in} [lastname name]]]


### PR DESCRIPTION
Prior to this change, expand-asterisk (calculating the projected columns as a result of using SELECT *) relied on projected-columns of the table_primary. This had the side effect that any columns referenced elsewhere in the query (such as in a WHERE clause) or columns not included in * (such as temporal columns) were implicitly included if they were present in the query. However the projected-columns attr of the table_primary still needs to be aware of the extra columns that * projects as this attribute is used to decide which columns need including in scan, it does this by being dependant on expand-asterisk.

Additionally this commit changes how * interacts with group by. The analyzer now first expands asterisks out into their underlying columns, before checking them against the group by clause to see if thay can be validly referenced in the select clause (or instead need adding to the group by clause), and raising an error for any columns for which this is not the case.

Note:
Current implementation duplicates a degree of the logic of projected-columns within expand-asterisk, there is probably a clean way to remove this duplication, however the goal here was primarily to create 2 sources of truth for projected-columns, one generally called by when planning the select clause, the other when planning the table_primary/scan.