### PR TITLE
Only scan for known columns of a table when necessary

### DIFF
--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo} [a b]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
@@ -1,0 +1,11 @@
+[:rename
+ {x1 lastname, x2 name, x5 frame}
+ [:single-join
+  []
+  [:mega-join
+   []
+   [[:rename
+     {lastname x1, name x2}
+     [:scan {:table foo} [lastname name]]]
+    [:rename {} [:scan {:table bar} []]]]]
+  [:rename {frame x5} [:scan {:table baz} [frame]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
@@ -1,0 +1,10 @@
+[:rename
+ {x1 lastname, x2 name, x4 jame, x5 lastjame}
+ [:mega-join
+  []
+  [[:rename
+    {lastname x1, name x2}
+    [:scan {:table foo} [lastname name]]]
+   [:rename
+    {jame x4, lastjame x5}
+    [:scan {:table bar} [jame lastjame]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-col-ref.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo} [name]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
@@ -1,0 +1,8 @@
+[:rename
+ {x1 lastname, x2 name, x4 jame}
+ [:mega-join
+  []
+  [[:rename
+    {lastname x1, name x2}
+    [:scan {:table foo} [lastname name]]]
+   [:rename {jame x4} [:scan {:table bar} [jame]]]]]]


### PR DESCRIPTION
Previous commit moved the knowledge of what columns must be scanned out as a result of using SELECT * to expand-asterisk. This commit makes it so that those columns are only included in the projected columns of a table primary (and therefore a scan) if there is an asterisk present in the select_list of that query.