### PR TITLE
Adding `DATE_DIFF` - Subtracting datetime values & returning intervals in the EE/SQL.

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -447,11 +447,13 @@
 ;; With start-field, end-field and precision provided
 (defmethod expr/codegen-call [:date_diff :timestamp-local :timestamp-local :utf8 :utf8 :int] [{[_ _ {start-field :literal} {end-field :literal} {precision :literal}] :args [[_ x-unit] [_ y-unit] _ _ _] :arg-types}] 
   (ensure-interval-fractional-precision-valid precision)
-  (date-diff-start-end-fields x-unit y-unit start-field end-field precision))
+  (-> (date-diff-start-end-fields x-unit y-unit start-field end-field precision)
+      (update :->call-code wrap-throw-eot2 `Long/MAX_VALUE `Long/MAX_VALUE)))
 
 ;; With start-field, end-field provided
 (defmethod expr/codegen-call [:date_diff :timestamp-local :timestamp-local :utf8 :utf8] [{[_ _ {start-field :literal} {end-field :literal}] :args [[_ x-unit] [_ y-unit] _ _] :arg-types}]
-  (date-diff-start-end-fields x-unit y-unit start-field end-field nil))
+  (-> (date-diff-start-end-fields x-unit y-unit start-field end-field nil)
+      (update :->call-code wrap-throw-eot2 `Long/MAX_VALUE `Long/MAX_VALUE)))
 
 (defn date-diff-start-field [x-unit y-unit start-field precision]
   {:return-type (if (#{"YEAR" "MONTH"} start-field)
@@ -471,11 +473,13 @@
 ;; With start-field, precision provided
 (defmethod expr/codegen-call [:date_diff :timestamp-local :timestamp-local :utf8 :int] [{[_ _ {start-field :literal} {precision :literal}] :args [[_ x-unit] [_ y-unit] _ _] :arg-types}]
   (ensure-interval-fractional-precision-valid precision)
-  (date-diff-start-field x-unit y-unit start-field precision))
+  (-> (date-diff-start-field x-unit y-unit start-field precision)
+      (update :->call-code wrap-throw-eot2 `Long/MAX_VALUE `Long/MAX_VALUE)))
 
 ;; With only start-field provided
 (defmethod expr/codegen-call [:date_diff :timestamp-local :timestamp-local :utf8] [{[_ _ {start-field :literal}] :args [[_ x-unit] [_ y-unit] _] :arg-types}]
-  (date-diff-start-field x-unit y-unit start-field nil))
+  (-> (date-diff-start-field x-unit y-unit start-field nil)
+      (update :->call-code wrap-throw-eot2 `Long/MAX_VALUE `Long/MAX_VALUE)))
 
 (defn date-diff-cast [expr]
   (let [[t1 t2] (take 2 (:arg-types expr))

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -1209,7 +1209,7 @@ interval_value_expression
     : interval_term
     | interval_value_expression_1 plus_sign interval_term_1
     | interval_value_expression_1 minus_sign interval_term_1
-    | <left_paren> datetime_value_expression minus_sign datetime_term <right_paren> interval_qualifier
+    | 'DATE_DIFF' <left_paren> datetime_value_expression <comma> datetime_term <comma> interval_qualifier <right_paren> 
     ;
 
 interval_term

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -368,33 +368,7 @@
                (test-arithmetic '- #time/zoned-date-time "2022-10-31T12:00+00:00[Europe/London]" #xt/interval-mdn ["P2D" "PT1H"] ))
             "clock change")
 
-      (t/is (nil? (test-arithmetic '- time/end-of-time #xt/interval-mdn ["P0D" "PT1H15M43.342S"]))))
-
-    (t/testing "(- datetime datetime)"
-      (t/is (= #time/duration "PT24H"
-               (test-arithmetic '- #time/date "2022-08-01" #time/date "2022-07-31")))
-
-      (t/is (= #time/duration "PT1H15M43.342S"
-               (test-arithmetic '- #time/date "2022-08-01" #time/date-time "2022-07-31T22:44:16.658")))
-
-      (t/is (= #time/duration "PT1H15M43.342S"
-               (test-arithmetic '- #time/date-time "2022-08-01T02:31:26.684" #time/date-time "2022-08-01T01:15:43.342")))
-
-      (t/is (= #time/duration "PT1H15M43.342S"
-               (test-arithmetic '- #time/zoned-date-time "2022-08-01T02:31:26.684+01:00[Europe/London]" #time/zoned-date-time "2022-08-01T01:15:43.342+01:00[Europe/London]")))
-
-      (t/is (= #time/duration "PT6H44M16.658S"
-               (test-arithmetic '- #time/date "2022-08-01" #time/zoned-date-time "2022-08-01T01:15:43.342+01:00[Europe/London]")))
-
-      (t/is (= #time/duration "PT-9H-15M-43.342S"
-               (test-arithmetic '- #time/zoned-date-time "2022-08-01T01:15:43.342+01:00[Europe/London]" #time/date-time "2022-08-01T02:31:26.684")))
-
-      (t/is (thrown-with-msg? RuntimeException #"cannot subtract infinite timestamps"
-                              (test-arithmetic '- time/end-of-time  #time/date-time "2022-08-01T02:31:26.684")))
-      (t/is (thrown-with-msg? RuntimeException #"cannot subtract infinite timestamps"
-                              (test-arithmetic '- #time/zoned-date-time "2022-08-01T01:15:43.342+01:00[Europe/London]" time/end-of-time)))
-      (t/is (thrown-with-msg? RuntimeException #"cannot subtract infinite timestamps"
-                              (test-arithmetic '- time/end-of-time time/end-of-time))))))
+      (t/is (nil? (test-arithmetic '- time/end-of-time #xt/interval-mdn ["P0D" "PT1H15M43.342S"]))))))
 
 (tct/defspec test-lt
   (tcp/for-all [t1 (tcg/one-of [ldt-gen ld-gen zdt-gen])

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -458,7 +458,7 @@
     (t/is
      (thrown-with-msg?
       IllegalArgumentException
-      #"The maximum fractional seconds precision is 9."
+      #"The minimum fractional seconds precision is 0."
       (project1 (list 'date-diff 'ldt1 'ldt2 "SECOND" -1) test-doc)))
 
     (t/is
@@ -477,7 +477,32 @@
      (thrown-with-msg?
       IllegalArgumentException
       #"The maximum fractional seconds precision is 9."
-      (project1 (list 'date-diff 'zdt1 'ldt1 "SECOND" -1) test-doc)))))
+      (project1 (list 'date-diff 'zdt1 'ldt1 "SECOND" 11) test-doc)))))
+
+
+(t/deftest test-date-diff-infinite-timestamp-throws
+  (let [test-doc {:xt$id :foo,
+                  :ldt1 time/end-of-time
+                  :ldt2 (LocalDateTime/of 2021 1 3 11 20 26 678345888)
+                  :zdt1 (ZonedDateTime/of 2021 1 1 11 20 10 0 (ZoneId/of "America/Chicago"))}]
+
+    (t/is
+     (thrown-with-msg?
+      RuntimeException
+      #"cannot subtract infinite timestamps"
+      (project1 (list 'date-diff 'ldt1 'ldt2 "SECOND") test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      RuntimeException
+      #"cannot subtract infinite timestamps"
+      (project1 (list 'date-diff 'ldt1 'ldt1 "SECOND") test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      RuntimeException
+      #"cannot subtract infinite timestamps"
+      (project1 (list 'date-diff 'zdt1 'ldt1 "SECOND") test-doc)))))
 
 (defn run-projection [rel form]
   (let [col-types (->> rel

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1599,12 +1599,6 @@
                                 #(->ts-vec "x" TimeUnit/MICROSECOND (time/instant->micros (time/->instant #inst "2021")))
                                 #(->dur-vec "y" TimeUnit/MILLISECOND 2)))))
 
-    (t/is (t/is (= {:res [(Duration/parse "PT23H59M59.999S")]
-                    :res-type [:duration :milli]}
-                   (test-projection '-
-                                    #(->ts-vec "x" TimeUnit/MILLISECOND (.toEpochMilli (time/->instant #inst "2021-01-02")))
-                                    #(->ts-vec "y" TimeUnit/MILLISECOND (.toEpochMilli (time/->instant #inst "2021-01-01T00:00:00.001Z")))))))
-
     (t/testing "durations"
       (letfn [(->bigint-vec [^String col-name, ^long value]
                 (tu/open-vec col-name [value]))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -449,6 +449,36 @@
         (t/is (= #xt/interval-mdn ["P799D" "PT10H24M2.777S"] (date-diff 'ld 'zdt   "DAY" "SECOND" 3)))
         (t/is (= #xt/interval-mdn ["P1142D" "PT11H25M3.888888S"] (date-diff 'ld 'ldt "DAY" "SECOND" 6)))))))
 
+(t/deftest test-date-diff-invalid-fractional-precision-throws
+  (let [test-doc {:xt$id :foo,
+                  :ldt1 (LocalDateTime/of 2022 4 3 12 34 56 789456999)
+                  :ldt2 (LocalDateTime/of 2021 1 3 11 20 26 678345888)
+                  :zdt1 (ZonedDateTime/of 2021 1 1 11 20 10 0 (ZoneId/of "America/Chicago"))}]
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"The maximum fractional seconds precision is 9."
+      (project1 (list 'date-diff 'ldt1 'ldt2 "SECOND" -1) test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"The maximum fractional seconds precision is 9."
+      (project1 (list 'date-diff 'ldt1 'ldt2 "SECOND" 10) test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"The maximum fractional seconds precision is 9."
+      (project1 (list 'date-diff 'ldt1 'ldt2 "DAY" "SECOND" 10) test-doc)))
+    
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"The maximum fractional seconds precision is 9."
+      (project1 (list 'date-diff 'zdt1 'ldt1 "SECOND" -1) test-doc)))))
+
 (defn run-projection [rel form]
   (let [col-types (->> rel
                        (into {} (map (juxt #(symbol (.getName ^IVectorReader %))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -504,6 +504,43 @@
       #"cannot subtract infinite timestamps"
       (project1 (list 'date-diff 'zdt1 'ldt1 "SECOND") test-doc)))))
 
+(t/deftest test-date-diff-invalid-interval-qualifier
+  (let [test-doc {:xt$id :foo
+                  :ldt1 (LocalDateTime/of 2021 1 3 11 20 26 678345888)}]
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"If YEAR specified as the interval start field, MONTH must be the end field."
+      (project1 (list 'date-diff 'ldt1 'ldt1 "YEAR" "DAY") test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"MONTH is not permitted as the interval start field."
+      (project1 (list 'date-diff 'ldt1 'ldt1 "MONTH" "DAY") test-doc)))
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"Interval end field must have less significance than the start field."
+      (project1 (list 'date-diff 'ldt1 'ldt1 "HOUR" "DAY") test-doc)))
+
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"Interval end field must have less significance than the start field."
+      (project1 (list 'date-diff 'ldt1 'ldt1 "MINUTE" "HOUR") test-doc)))
+
+
+    (t/is
+     (thrown-with-msg?
+      IllegalArgumentException
+      #"Interval end field must have less significance than the start field."
+      (project1 (list 'date-diff 'ldt1 'ldt1 "SECOND" "MINUTE") test-doc)))))
+
+
 (defn run-projection [rel form]
   (let [col-types (->> rel
                        (into {} (map (juxt #(symbol (.getName ^IVectorReader %))

--- a/src/test/clojure/xtdb/operator/table_test.clj
+++ b/src/test/clojure/xtdb/operator/table_test.clj
@@ -112,9 +112,9 @@
                         {:params {'?x53 "RAIL"}}))))
 
 (t/deftest test-date-subtraction-bug-435
-  (t/is (= [{:a #time/duration "PT24H"}] ; it returned PT24000000H :/
+  (t/is (= [{:a #xt/interval-mdn ["P0D" "PT24H"]}] ; it returned PT24000000H :/
            (tu/query-ra
-            '[:table [a] [{a (- #time/date "2021-12-24" #time/date "2021-12-23")}]]))))
+            '[:table [a] [{a (date-diff #time/date "2021-12-24" #time/date "2021-12-23" "HOUR")}]]))))
 
 (t/deftest test-incorrect-relation-params
   (t/is

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -265,9 +265,9 @@
       :clj "P1M"}
 
      ;; HACK to return durations, see #431
-     {:sql "DATE '2021-12-24' - DATE '2021-12-23'"
+     {:sql "DATE_DIFF(DATE '2021-12-24', DATE '2021-12-23', HOUR)"
       :json-type JsonNodeType/STRING
-      :clj "PT24H"}
+      :clj "P0DT24H"}
 
      ;; arrays
 

--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -1453,8 +1453,8 @@
                                                                    :xt/valid-from app-from
                                                                    :xt/valid-to app-to}]
                                                            :for-valid-time :all-time})
-                                              (where (= (- #inst "1970-01-08" #inst "1970-01-01")
-                                                        (- app-to app-from)))))
+                                              (where (= (date-diff #inst "1970-01-08" #inst "1970-01-01" "DAY")
+                                                        (date-diff app-to app-from "DAY")))))
                                       (map (fn [{:keys [id app-from app-to]}]
                                              [:delete-docs {:from :docs, :valid-from app-from, :valid-to app-to}
                                               id]))))]

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
@@ -354,7 +354,7 @@ SELECT *
                xt$valid_to,
                xt$system_from,
                xt$system_to)
- WHERE (x.xt$valid_to - x.xt$valid_from) = (DATE '1970-01-08' - DATE '1970-01-01')
+ WHERE DATE_DIFF(x.xt$valid_to, x.xt$valid_from, DAY) = DATE_DIFF(DATE '1970-01-08', DATE '1970-01-01', DAY)
 ----
 1
 145
@@ -368,7 +368,7 @@ statement ok
 DELETE
 FROM Prop_Owner
 FOR ALL VALID_TIME AS x
-WHERE (x.xt$valid_to - x.xt$valid_from) = (DATE '1970-01-08' - DATE '1970-01-01')
+WHERE DATE_DIFF(x.xt$valid_to, x.xt$valid_from, DAY) = DATE_DIFF(DATE '1970-01-08', DATE '1970-01-01', DAY)
 
 query IIITTTT rowsort
 SELECT *


### PR DESCRIPTION
See #3124 

## Assumptions

The following is based on my understanding of the issue & the SQL spec, namely:
- From the SQL EBNF, we also expect an interval qualifier to be passed through - ie, subtracting two datetime should look like this: `(DATETIME_1 - DATETIME_2) DAY`.
- We use the interval qualifier to:
  - Decide which interval type we want to return - as mentioned in the description of the issue, either `:year-month` or `month-day-nano`.
  - Decide what to calculate the difference between temporal values with.
  - Decide how to truncate/display the outputted interval.

## Implementation 

**Implemented in this PR:** 
- Codegen with variable number of arguments, function called `date-diff`. 
  - Takes two datetime values, and additionally either:
    - `start-field` - calculate difference in start-field and convert to truncated interval based on start-field  - ie, called for `(DATEDIFF dt1 dt2 "HOUR")`
    -  `start-field` & `precision` - calculate difference in start-field, with an extra precision provided for seconds - `ie, called for (DATEDIFF dt1 dt2 "SECOND (1, 3)")`. Convert to truncated interval based on start-field with appropriate second precision.
    -  `start-field` & `end-field` - calculate difference between the two in end-field and convert to truncated interval with least significant field being end-field and most significant field being start-field. ie, called for `(DATEDIFF dt1 dt2 "DAY TO SECOND")`
    -  `start-field`, `end-field` & `precision` - calculate difference between the two in end-field and convert to truncated interval, with appropriate provided precision for seconds ie, called for `(DATEDIFF dt1 dt2 "DAY TO SECOND (6)")`
  - Return type depends on the 'interval qualifier' - if qualifier starts with YEAR or MONTH, then return a `:year-month` interval, else `:month-day-nano`.
  - We do some additional validation in the codegen call:
    - If `precision` is provided, we check it has a valid value.
    - If using a multi field interval qualifier, we check the units are valud (ie, second field isnt larger than first field, only allowed multi field values used)
    - We keep the check from the previous implementation around infinite timestamps. 
  - Using `between` from `ChronoUnit` to calculate the difference between the two timestamps, and then return the result as a `PeriodDuration`.
      - Which ChronoUnit we use depends on the 'interval qualifier' - for example, if the qualifier is "YEAR", we use `ChronoUnit/YEARS` to calculate the difference in years.
      - In cases with multiple field interval qualifiers, we calculate period and duration accordingly - truncating the value based on the smallest time field value in the interval.
      - When precision is provided with `SECOND`, we also calculate in nanos and truncate to appropriate precision.
      - When only time based fields entered (ie, single field like `HOUR, SECOND` or multi field like `HOUR TO SECOND`), we return _everything_ in the Duration, calculated by our least significant field in the interval
  - We implement for other types `date`, `timestamp-tz` (and all other combinations of said types, ie for two dates, two timestamps with timezones, mixed types including timestamp-local, etc) using a set of codegen casts.
- SQL planning and parsing for `DATE_DIFF`, creating variable argument s-expressions as appropriate based on the provided interval qualifier structure.
- Numerous tests around behaviour:
  - Numerous tests around behaviour, various values, validations et al within `expression-test`. 
  - SQL planning and SQL query tests within `sql-test`.
- Fixing up previous tests that include `date`-`date` (in both XTQL and SQL)  

**Differences between DATE_DIFF and SQL spec**:
Some changes were also made between spec and the final result here, namely:
- Changing the syntax to a function call, `DATE_DIFF`. This was done for a few different reasons:
  - Ambiguity in the syntax - it was parsing as an `<interval primary>` with a `<numerical value function>` rather than the `<interval value expression>` we expected   
  - Better matching the experience of calling the underlying function from XTQL - when implementing the codegen we similarly implemented as a function called `date-diff`.  
- Slight differences in how we output/handle intervals:
  - `YEAR TO MONTH`, or `YEAR`, will be shown/handled in terms of months, due to how we display/pass around `interval/year-month` internally.  
  - As a result of using `Duration` - we will always display time based date differences in terms of `HOURS`, `MINUTES` and `SECONDS`, regardless of specified interval qualifier. E.G, if using `(DATE_DIFF dt1 dt2 "SECOND")`, and the result is MORE than 60 seconds, such as 66 seconds, will be outputted as `1 minute 6 seconds` in the PeriodDuration.
    
## TODO

Still have to write up docs around `DATE_DIFF` - likely it's own section in `temporal.adoc` given the general complexity/size of the options here (rather than part of one of the tables on there). Given the current size of PR and how long it has taken to get into a reviewable state, I'm inclined to open a ticket and do it as a followup push on `2.x`. 