### PR TITLE
`date` - `date` returning an integer of days elapsed.

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -392,8 +392,9 @@
 (defmethod expr/codegen-call [:- :timestamp-tz :timestamp-local] [{[[_ x-unit] y] :arg-types, :as expr}]
   (-> expr (recall-with-cast [:timestamp-local x-unit] y)))
 
-(defmethod expr/codegen-call [:- :date :date] [expr]
-  (-> expr (recall-with-cast [:timestamp-local :micro] [:timestamp-local :micro])))
+(defmethod expr/codegen-call [:- :date :date] [_expr]
+  ;; FIXME this assumes date-unit :day
+  {:return-type :i32 :->call-code (fn [[x y]] `(Math/subtractExact ~x ~y))})
 
 (doseq [t [:timestamp-tz :timestamp-local]]
   (defmethod expr/codegen-call [:- :date t] [{[_ t2] :arg-types, :as expr}]

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -72,6 +72,8 @@ Examples:
 
 | `(- duration duration)` | `duration - duration` | duration
 | `(- interval interval)` | `interval - interval` | interval
+| `(- date date)` | `date - date` | integer (number of days elapsed)
+
 
 | `(* duration num)`
 

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -370,10 +370,16 @@
 
       (t/is (nil? (test-arithmetic '- time/end-of-time #xt/interval-mdn ["P0D" "PT1H15M43.342S"]))))
 
-    (t/testing "(- datetime datetime)"
-      (t/is (= #time/duration "PT24H"
-               (test-arithmetic '- #time/date "2022-08-01" #time/date "2022-07-31")))
+    (t/testing "(- date date)"
+      (t/is (= 1 (test-arithmetic '- #time/date "2022-08-01" #time/date "2022-07-31")))
 
+      (t/is (= 3 (test-arithmetic '- #time/date "2001-10-01" #time/date "2001-09-28")))
+
+      (t/is (= 1 (test-arithmetic '- #time/date "2001-03-01" #time/date "2001-02-28" )))
+
+      (t/is (= 2 (test-arithmetic '- #time/date "2000-03-01" #time/date "2000-02-28"))))
+
+    (t/testing "(- datetime datetime)" 
       (t/is (= #time/duration "PT1H15M43.342S"
                (test-arithmetic '- #time/date "2022-08-01" #time/date-time "2022-07-31T22:44:16.658")))
 

--- a/src/test/clojure/xtdb/operator/table_test.clj
+++ b/src/test/clojure/xtdb/operator/table_test.clj
@@ -111,11 +111,6 @@
                            [:table [{x50 false}]]]]
                         {:params {'?x53 "RAIL"}}))))
 
-(t/deftest test-date-subtraction-bug-435
-  (t/is (= [{:a #time/duration "PT24H"}] ; it returned PT24000000H :/
-           (tu/query-ra
-            '[:table [a] [{a (- #time/date "2021-12-24" #time/date "2021-12-23")}]]))))
-
 (t/deftest test-incorrect-relation-params
   (t/is
    (thrown-with-msg? RuntimeException #"Table param must be of type struct list"

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -264,10 +264,9 @@
       :json-type JsonNodeType/STRING
       :clj "P1M"}
 
-     ;; HACK to return durations, see #431
      {:sql "DATE '2021-12-24' - DATE '2021-12-23'"
-      :json-type JsonNodeType/STRING
-      :clj "PT24H"}
+      :json-type JsonNodeType/NUMBER
+      :clj 1}
 
      ;; arrays
 

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
@@ -354,7 +354,7 @@ SELECT *
                xt$valid_to,
                xt$system_from,
                xt$system_to)
- WHERE (x.xt$valid_to - x.xt$valid_from) = (DATE '1970-01-08' - DATE '1970-01-01')
+ WHERE (x.xt$valid_to - x.xt$valid_from) = (TIMESTAMP '1970-01-08 00:00:00' - TIMESTAMP '1970-01-01 00:00:00')
 ----
 1
 145
@@ -368,7 +368,7 @@ statement ok
 DELETE
 FROM Prop_Owner
 FOR ALL VALID_TIME AS x
-WHERE (x.xt$valid_to - x.xt$valid_from) = (DATE '1970-01-08' - DATE '1970-01-01')
+WHERE (x.xt$valid_to - x.xt$valid_from) = (TIMESTAMP '1970-01-08 00:00:00' - TIMESTAMP '1970-01-01 00:00:00')
 
 query IIITTTT rowsort
 SELECT *


### PR DESCRIPTION
Resolves #3197 