### PR TITLE
Add generic `length` function to EE 

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1388,12 +1388,13 @@
   {:return-type :i32
    :->call-code #(do `(count ~@%))})
 
-(defn count-non-empty [m]
-  (reduce
-   (fn [^Integer non-empty [_x ^IValueReader y]]
-     (if (.isNull y) non-empty (Math/addExact non-empty 1)))
-   0
-   m))
+(defn count-non-empty [m] 
+  (loop [n 0, xs (vals m)]
+    (if (seq xs)
+      (if (.isAbsent ^IValueReader (first xs))
+        (recur n (rest xs))
+        (recur (inc n) (rest xs)))
+      n)))
 
 (defmethod codegen-call [:length :struct] [_] 
   {:return-type :i32

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -704,6 +704,9 @@
     [:octet_length_expression _ ^:z nve]
     (list 'octet-length (expr nve))
 
+    [:generic_length_expression "LENGTH" ^:z nve]
+    (list 'length (expr nve)) 
+
     [:character_overlay_function _ ^:z target _ ^:z placing _ ^:z pos _ ^:z len]
     (list 'overlay (expr target) (expr placing) (expr pos) (expr len))
 

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -935,6 +935,17 @@ binary_position_expression
 <length_expression>
     : char_length_expression
     | octet_length_expression
+    | generic_length_expression
+    ;
+
+generic_length_expression
+    : 'LENGTH' <left_paren> length_value_expression <right_paren>
+    ;
+
+<length_value_expression>
+    : character_value_expression
+    | string_value_expression
+    | array_value_expression
     ;
 
 char_length_expression
@@ -944,6 +955,8 @@ char_length_expression
 octet_length_expression
     : 'OCTET_LENGTH' <left_paren> string_value_expression <right_paren>
     ;
+
+
 
 extract_expression
     : 'EXTRACT' <left_paren> extract_field 'FROM' extract_source <right_paren>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -138,6 +138,7 @@ export default defineConfig({
                 { label: 'String functions', link: '/reference/main/stdlib/string' },
                 { label: 'Temporal functions', link: '/reference/main/stdlib/temporal' },
                 { label: 'Aggregate functions', link: '/reference/main/stdlib/aggregates' },
+                { label: 'Other functions', link: '/reference/main/stdlib/other'}
               ]
             },
           ]

--- a/docs/src/content/docs/reference/main/stdlib/other.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/other.adoc
@@ -1,0 +1,28 @@
+---
+title: Other Functions
+---
+
+== Length
+
+A generic function to calculate the length of values. 
+
+[source,clojure]
+----
+(length <expr>)
+----
+
+
+[source,sql]
+----
+LENGTH(<expr>)
+----
+
+Where `<expr>` is one of the following:
+
+* A **string** - returns the number of utf8 characters in the string
+** Acts as an alias for the `CHAR_LENGTH` function - see in link:string[String Functions]
+* A **varbinary** - returns the number of bytes in the varbinary
+** Acts as an alias for `OCTET_LENGTH` function - see in link:string[String Functions]
+* A **list** - returns the number of elements in the list
+* A **set** - returns the number of elements in the set
+* A **struct** - returns the number of *non-absent* fields in the struct

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -445,7 +445,17 @@
       (t/is (= 0 (length {})))
       (t/is (= 1 (length {:a 1})))
       (t/is (= 3 (length {:a 1 :b 2 :c 3})))
-      (t/is (= 2 (length {:a 1 :b 2 :c nil}))))))
+      (t/is (= 3 (length {:a 1 :b 2 :c nil}))))))
+
+(t/deftest test-struct-length-handles-absents
+  (with-open [rel (tu/open-rel [(-> (types/col-type->field "x" [:struct '{xa [:union #{:i8 :absent :null}]
+                                                                          xb [:union #{:i8 :absent :null}]}])
+                                    (tu/open-vec [{:xa 42}
+                                                  {:xa 42 :xb 41}
+                                                  {:xb 41}
+                                                  {:xa nil :xb nil}]))])] 
+    (t/is (= {:res [1 2 1 2], :res-type :i32}
+             (run-projection rel '(length x))))))
 
 (t/deftest test-like
   (t/are [s ptn expected-result]

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -418,6 +418,35 @@
       "😀")
     (t/is (= nil (len nil :null)))))
 
+(t/deftest test-length
+  (letfn [(length [test-val] (project1 (list 'length 'a) {:a test-val}))]
+    (t/testing "calling length on strings"
+      (t/is (= 5 (length "hello")))
+      (t/is (= 0 (length "")))
+      (t/is (= 1 (length "a")))
+      (t/is (= 1 (length "😀"))))
+    
+    (t/testing "calling length on varbinary"
+      (t/is (= 0 (length (byte-array []))))
+      (t/is (= 2 (length (byte-array [-33 -44]))))
+      (t/is (= 1 (length (byte-array [-33])))))
+    
+    (t/testing "calling length on lists"
+      (t/is (= 0 (length [])))
+      (t/is (= 1 (length [""])))
+      (t/is (= 4 (length ["a" 1 3 :5]))))
+    
+    (t/testing "calling length on sets"
+      (t/is (= (length #{}) 0))
+      (t/is (= (length #{:a}) 1))
+      (t/is (= (length #{"1" "2"}) 2)))
+    
+    (t/testing "calling length on structs"
+      (t/is (= 0 (length {})))
+      (t/is (= 1 (length {:a 1})))
+      (t/is (= 3 (length {:a 1 :b 2 :c 3})))
+      (t/is (= 2 (length {:a 1 :b 2 :c nil}))))))
+
 (t/deftest test-like
   (t/are [s ptn expected-result]
       (= expected-result (project1 '(like a b) {:a s, :b ptn}))


### PR DESCRIPTION
See #3125 

Implements `length` within the expression engine:
- Implemented for a number of different types:
  - `utf8` string - calls through to codegen for `char-length`
  -  `varbinary` - calls through to codegen for `octet-length`
  -  `list` - calls through to codegen for `cardinality`
  - `set` - returns the number of elements in the set, using `count` (as it is passed a **Set**)
  -  `struct` returns the number of *non-absent* fields in the struct.
- Numerous tests in expression-test.
- Added to SQL parser/planning:
  - Handles a couple of literals/expressions in the grammar - particularly, `character_value_expression`, `string_value_expression` & `array_value_expression` 
  - Adds a number of tests to sql-test.
- Adds docs around this:
  - Created a new page, "Other Functions", under stdlib.
  - Goes through usages and what expressions are supported by `length`  