### PR TITLE
Add more caching to the MetadataManager

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api(kotlin("stdlib-jdk8"))
     api("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.6.0")
 
-    implementation("com.github.ben-manes.caffeine", "caffeine", "3.1.8")
+    api("com.github.ben-manes.caffeine", "caffeine", "3.1.8")
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -8,16 +8,14 @@
             [xtdb.trie :as trie]
             [xtdb.util :as util])
   (:import (java.time LocalTime)
-           xtdb.IBufferPool
            (xtdb.metadata IMetadataManager ITableMetadata)))
 
 (t/use-fixtures :once tu/with-allocator)
 
 (defn with-table-metadata [node meta-file-path f]
-  (let [^IBufferPool buffer-pool (tu/component node :xtdb/buffer-pool)
-        ^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)]
-    (util/with-open [{meta-rdr :rdr} (trie/open-meta-file buffer-pool meta-file-path)]
-      (f (.tableMetadata metadata-mgr meta-rdr meta-file-path)))))
+  (let [^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)]
+    (util/with-open [table-metadata (.openTableMetadata metadata-mgr meta-file-path)]
+      (f table-metadata))))
 
 (t/deftest test-find-gt-ivan
   (with-open [node (xtn/start-node {:indexer {:rows-per-chunk 10}})]


### PR DESCRIPTION
`open-meta-files` was loading buffers and VSR's over and over again for the metadata. This change adds a cache to the MetadataManager that keeps some of these longer around. The cache is currently defaulting to 128 in size, which (assuming Metadata files are roughly the same size) accounts for roughly ~1G of data. 

We add a `TableMetadata` defrecord which implements `ITableMetadata` and also contains the trie, arrow buffer and metadata relation reader on top of previously calculated metadata. This gets cached. The last one, either MetadataManager evicting the particular `TableMetadata` or a query using the `TableMetadata`, closes the referenced objects. One thing to note is that previously we were caching `table-metadata-idxs` indefinitely and without bound, they now also get removed one things get evicted from the `MetadataManager`.