### PR TITLE
Casting between string and temporals - #3123

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -135,11 +135,12 @@
             (form->expr struct env)
             (rest args))))
 
-(defmethod parse-list-form 'cast [[_ expr target-type] env]
+(defmethod parse-list-form 'cast [[_ expr target-type cast-opts] env]
   {:op :call
    :f :cast
    :args [(form->expr expr env)]
-   :target-type target-type})
+   :target-type target-type
+   :cast-opts cast-opts})
 
 (defmethod parse-list-form ::default [[f & args] env]
   {:op :call
@@ -1203,8 +1204,8 @@
   (defmethod codegen-cast [:utf8 col-type] [_]
     {:return-type col-type, :->call-code #(do `(~parse-sym (buf->str ~@%)))}))
 
-(defmethod codegen-call [:cast :any] [{[source-type] :arg-types, :keys [target-type]}]
-  (codegen-cast {:source-type source-type, :target-type target-type}))
+(defmethod codegen-call [:cast :any] [{[source-type] :arg-types, :keys [target-type cast-opts]}]
+  (codegen-cast {:source-type source-type, :target-type target-type :cast-opts cast-opts}))
 
 (defmethod codegen-expr :struct [{:keys [entries]} opts]
   (let [emitted-vals (->> entries

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -384,6 +384,7 @@ correlation_name
     | boolean_type
     | datetime_type
     | interval_type
+    | character_string_type
     ;
 
 character_string_type
@@ -391,7 +392,7 @@ character_string_type
     | 'CHAR' [ <left_paren> character_length <right_paren> ]
     | 'CHARACTER' 'VARYING' <left_paren> character_length <right_paren>
     | 'CHAR' 'VARYING' <left_paren> character_length <right_paren>
-    | 'VARCHAR' <left_paren> character_length <right_paren>
+    | 'VARCHAR' [ <left_paren> character_length <right_paren> ]
     | character_large_object_type
     ;
 


### PR DESCRIPTION
**Issue:** #3123 
**Github Action Runs**: See [**here**](https://github.com/danmason/xtdb/actions?query=branch%3Acasting-string-to-temporals-3123++)

- Within the expression engine, implements casting between **utf8 strings** and **temporal** values. Temporal values supported:
  - Time without timezone
  - Timestamp with timezone
  - Timestamp without timezone
  - Date
- When casting to a temporal type  - ensure we handle `precision` being provided, changing type accordingly (and defaulting to micros otherwise)
- When casting to a VARCHAR, can optionally pass `(n)` to truncate the output string.
- Using the inbuilt Java temporal classes - ensures we both parse and output in terms of ISO specified strings. 
- Has some custom exception handling to present a decently formatted message when failing to parse a temporal string.
- Add necessary parts to the EBNF and SQL Planner to be able to convert between these types.
- Adds a number of tests around the casting behavior to both `temporal_test` and `sql_test`.

For reviewers - see the comments on the PR for a few caveats/questions on behavior.

## TODOs

Summarized from discussions on Slack, stuff to do:
- [x] Updates to units when casting to temporal types.
  - Default to `micro` as the unit when casting to temporal types.
  - Allow specification of `fractional-precision` , handle within the expression engine.
    - More than 6 we use nano as the unit
    - 6 or less we use micro as the unit
    - Truncate accordingly based on precision specified.
- [x] Updates to casting to VARCHAR:
  - Allow `n` to be provided, truncate accordingly.
  - Allow VARCHAR without `n` specified - do not truncate in that case.
- [x] Can probably clear up handling of and mentions of `Duration` here  (as both something to cast from and something to cast to), and drop from the issue.
- [x] Returning of `runtime exceptions` when failing to parse a temporal string - stops indexer from halting