### PR TITLE
Updates to string<-->temporal casting: Handling durations, changes to Varchar

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -187,6 +187,11 @@
      (let [fp (parse-long fractional-precision)]
        (list 'cast-tstz e {:precision fp :unit (if (<= fp 6) :micro :nano)}))
 
+    [:duration_type "DURATION"]
+    (list 'cast e [:duration :micro])
+    [:duration_type "DURATION" [:unsigned_integer fractional-precision]]
+    (cast-temporal-with-precision e :duration fractional-precision)
+
     [:character_string_type "VARCHAR"]
     (list 'cast e :utf8)
 

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -190,9 +190,6 @@
     [:character_string_type "VARCHAR"]
     (list 'cast e :utf8)
 
-    [:character_string_type "VARCHAR" [:character_length [:unsigned_integer length]]]
-    (list 'cast e :utf8 {:length (parse-long length)})
-
     (throw (err/illegal-arg :xtdb.sql/parse-error
                             {::err/message (str "Cannot build cast for: " (pr-str cast-spec))
                              :cast-spec cast-spec}))))

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -388,13 +388,18 @@ correlation_name
     ;
 
 character_string_type
-    : 'CHARACTER' [ <left_paren> character_length <right_paren> ]
+    : 'VARCHAR'
+    ;
+
+(* Currently unsupported character_string_type 
+    | 'VARCHAR'  [ <left_paren> character_length <right_paren> ] 
+    | 'CHARACTER' [ <left_paren> character_length <right_paren> ]
     | 'CHAR' [ <left_paren> character_length <right_paren> ]
     | 'CHARACTER' 'VARYING' <left_paren> character_length <right_paren>
     | 'CHAR' 'VARYING' <left_paren> character_length <right_paren>
-    | 'VARCHAR' [ <left_paren> character_length <right_paren> ]
     | character_large_object_type
-    ;
+*) 
+    
 
 character_large_object_type
     : 'CHARACTER' 'LARGE' 'OBJECT' [ <left_paren> character_large_object_length <right_paren> ]

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -385,6 +385,7 @@ correlation_name
     | datetime_type
     | interval_type
     | character_string_type
+    | duration_type 
     ;
 
 character_string_type
@@ -399,7 +400,6 @@ character_string_type
     | 'CHAR' 'VARYING' <left_paren> character_length <right_paren>
     | character_large_object_type
 *) 
-    
 
 character_large_object_type
     : 'CHARACTER' 'LARGE' 'OBJECT' [ <left_paren> character_large_object_length <right_paren> ]
@@ -418,6 +418,9 @@ binary_large_object_string_type
     : 'BINARY' 'LARGE' 'OBJECT' [ <left_paren> large_object_length <right_paren> ]
     | 'BLOB' [ <left_paren> large_object_length <right_paren> ]
     ;
+
+duration_type
+    : 'DURATION' [ <left_paren> time_precision <right_paren> ]
 
 <numeric_type>
     : exact_numeric_type

--- a/docs/src/content/docs/reference/main/data-types.adoc
+++ b/docs/src/content/docs/reference/main/data-types.adoc
@@ -106,6 +106,11 @@ TIMEZONE]`
 |`-- TBD`
 |`:keyword`
 
+|`DURATION`
+| Duration of time
+|TBD
+|`#time/duration "PT1H3M5S"`
+
 |===
 
 ////

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -255,10 +255,7 @@
           (t/is (= "2022-08-01T05:34:56.789" (test-cast #time/date-time "2022-08-01T05:34:56.789" :utf8))))
 
         (t/testing "tstz"
-          (t/is (= "2022-08-01T05:34:56.789Z[UTC]" (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789Z[UTC]" :utf8))))
-
-        (t/testing "with string length limit"
-          (t/is (= "2022" (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789Z[UTC]" :utf8 {:length 4}))))))))
+          (t/is (= "2022-08-01T05:34:56.789Z[UTC]" (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789Z[UTC]" :utf8))))))))
 
 (def ^:private instant-gen
   (->> (tcg/tuple (tcg/choose (.getEpochSecond #time/instant "2020-01-01T00:00:00Z")

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -230,6 +230,13 @@
           (t/is (thrown-with-msg? RuntimeException
                                   #"'2022-08-01T05:34:56.789' has invalid format for type timestamp with timezone"
                                   (test-cast "2022-08-01T05:34:56.789" [:timestamp-tz :second "UTC"]))))
+        
+        (t/testing "duration"
+          (t/is (= #time/duration "PT13M56.123456S" (test-cast "PT13M56.123456S" [:duration :micro])))
+          (t/is (= #time/duration "PT13M56S" (test-cast "PT13M56.123456S" [:duration :second])))
+          (t/is (thrown-with-msg? RuntimeException
+                                  #"'2022-08-01T00:00:00Z' has invalid format for type duration"
+                                  (test-cast "2022-08-01T00:00:00Z" [:duration :micro]))))
 
         (t/testing "with precision"
           (t/is (= #time/date-time "2022-08-01T05:34:56" (test-cast "2022-08-01T05:34:56.1234" [:timestamp-local :micro] {:precision 0})))
@@ -237,6 +244,7 @@
           (t/is (= #time/zoned-date-time "2022-08-01T05:34:56.12Z[UTC]" (test-cast  "2022-08-01T05:34:56.123456Z" [:timestamp-tz :micro "UTC"] {:precision 2})))
           (t/is (= #time/zoned-date-time "2022-08-01T04:04:56.12345678Z[UTC]" (test-cast "2022-08-01T05:34:56.123456789+01:30" [:timestamp-tz :nano "UTC"] {:precision 8})))
           (t/is (= #time/time "05:34:56.1234567" (test-cast "05:34:56.123456789" [:time-local :nano] {:precision 7})))
+          (t/is (= #time/duration "PT13M56.1234567S" (test-cast "PT13M56.123456789S" [:duration :nano] {:precision 7})))
           (t/is (thrown-with-msg? IllegalArgumentException
                                   #"The minimum fractional seconds precision is 0."
                                   (test-cast "05:34:56.123456789" [:time-local :nano] {:precision -1})))
@@ -255,7 +263,10 @@
           (t/is (= "2022-08-01T05:34:56.789" (test-cast #time/date-time "2022-08-01T05:34:56.789" :utf8))))
 
         (t/testing "tstz"
-          (t/is (= "2022-08-01T05:34:56.789Z[UTC]" (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789Z[UTC]" :utf8))))))))
+          (t/is (= "2022-08-01T05:34:56.789Z[UTC]" (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789Z[UTC]" :utf8))))
+        
+        (t/testing "duration"
+          (t/is (= "PT13M56.123S" (test-cast #time/duration "PT13M56.123S" :utf8))))))))
 
 (def ^:private instant-gen
   (->> (tcg/tuple (tcg/choose (.getEpochSecond #time/instant "2020-01-01T00:00:00Z")

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -812,6 +812,12 @@
   (t/is (= [{:time #time/time "12:00:01"}]
            (xt/q tu/*node* "SELECT CAST('12:00:01' AS TIME) as time FROM (VALUES 1) AS x")))
   
+  (t/is (= [{:duration #time/duration "PT13M56.123456S"}]
+           (xt/q tu/*node* "SELECT CAST('PT13M56.123456789S' AS DURATION) as duration FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:duration #time/duration "PT13M56.123456789S"}]
+           (xt/q tu/*node* "SELECT CAST('PT13M56.123456789S' AS DURATION(9)) as duration FROM (VALUES 1) AS x")))
+
   (t/is (= [{:time #time/time "12:00:01.1234"}]
            (xt/q tu/*node* "SELECT CAST('12:00:01.123456' AS TIME(4)) as time FROM (VALUES 1) AS x")))
   
@@ -837,7 +843,12 @@
            (xt/q tu/*node* "SELECT CAST(DATE '2021-10-21' AS VARCHAR) as string FROM (VALUES 1) AS x")))
 
   (t/is (= [{:string "12:00:01"}]
-           (xt/q tu/*node* "SELECT CAST(TIME '12:00:01' AS VARCHAR) as string FROM (VALUES 1) AS x"))))
+           (xt/q tu/*node* "SELECT CAST(TIME '12:00:01' AS VARCHAR) as string FROM (VALUES 1) AS x")))
+  
+  ;; We do not have a literal for Duration, so insert one into the table and query & cast it out
+  (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :duration #time/duration "PT13M56.123S"}]])
+  (t/is (= [{:string "PT13M56.123S"}]
+           (xt/q tu/*node* "SELECT CAST(docs.duration AS VARCHAR) as string FROM docs"))))
 
 (t/deftest test-expr-in-equi-join
   (t/is

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -837,10 +837,7 @@
            (xt/q tu/*node* "SELECT CAST(DATE '2021-10-21' AS VARCHAR) as string FROM (VALUES 1) AS x")))
 
   (t/is (= [{:string "12:00:01"}]
-           (xt/q tu/*node* "SELECT CAST(TIME '12:00:01' AS VARCHAR) as string FROM (VALUES 1) AS x")))
-  
-  (t/is (= [{:string "2021"}]
-           (xt/q tu/*node* "SELECT CAST(TIMESTAMP '2021-10-21T12:34:01Z' AS VARCHAR(4)) as string FROM (VALUES 1) AS x"))))
+           (xt/q tu/*node* "SELECT CAST(TIME '12:00:01' AS VARCHAR) as string FROM (VALUES 1) AS x"))))
 
 (t/deftest test-expr-in-equi-join
   (t/is


### PR DESCRIPTION
**Github Action Runs**: [**Link**](https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Atemporal-casting-changes++)
Resolving some of the extra actions from #3123 

- VARCHAR changes:
  - Only handling `varchar` (without `(n)` specified).
  - Commenting out unused parts of `character string type`
- `String <--> Duration`
  - Added `duration_type` as a cast target in the SQL grammar, add plan for it. 
  - Handled in the EE.
  - Handling `precision` being specified as well (ie, `DURATION (9)`).
  - Adds `Duration` as a data type in the data type table.