### PR TITLE
SQL+JSON-first docs refactor (still WIP)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,20 +34,12 @@ export default defineConfig({
           collapsed: false,
           items: [
             { label: 'Overview', link: '/' },
-            { label: 'Why XTDB?', link: '/intro/why-xtdb' },
             { label: 'Getting started', link: '/intro/getting-started' },
-            {
-              label: 'What is XTDB?',
-              items: [
-                { label: 'At a glance', link: '/intro/what-is-xtdb' },
-                { label: 'What is XTQL?', link: '/intro/what-is-xtql' },
-                { label: 'Data model', link: '/intro/data-model' },
-                // { label: 'Architecture', link: '/intro/architecture' },
-                // { label: 'Bitemporality', link: '/intro/bitemporality' }
-              ]
-            },
+            { label: 'What is XTDB', link: '/intro/what-is-xtdb' },
+            { label: 'Data model', link: '/intro/data-model' },
             { label: 'Community', link: '/intro/community' },
             { label: 'Roadmap', link: '/intro/roadmap' },
+            { label: 'Mission', link: '/intro/why-xtdb' },
           ],
         },
 
@@ -63,6 +55,8 @@ export default defineConfig({
           label: 'Guides',
           collapsed: true,
           items: [
+ 	    { label: 'SQL over HTTP', link: '/guides/sql-over-http' },
+
             { label: 'Setting up a cluster on AWS', link: '/guides/starting-with-aws' },
             { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
           ],
@@ -107,11 +101,11 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/reference/main' },
-
             {
               label: 'XTQL',
               collapsed: true,
               items: [
+                { label: 'What is XTQL?', link: '/intro/what-is-xtql' },     
                 { label: 'Transactions', link: '/reference/main/xtql/txs' },
                 { label: 'Queries', link: '/reference/main/xtql/queries' },
               ]

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,9 +45,15 @@ export default defineConfig({
 
         {
           label: 'Tutorials',
-          collapsed: true,
+//          collapsed: true,
           items: [
-            { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
+  	    { label: 'SQL over HTTP', link: '/tutorials/sql-over-http' },
+	    { label: 'XTQL',
+	      collapsed: true,
+	      items: [
+                { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
+		],
+            },
           ],
         },
 
@@ -55,45 +61,20 @@ export default defineConfig({
           label: 'Guides',
           collapsed: true,
           items: [
- 	    { label: 'SQL over HTTP', link: '/guides/sql-over-http' },
-
-            { label: 'Setting up a cluster on AWS', link: '/guides/starting-with-aws' },
-            { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
+	    { label: 'Deployment',
+	      collapsed: true,
+	      items: [
+	        { label: 'Setting up a cluster on AWS', link: '/guides/starting-with-aws' },
+		],
+            },
+	    { label: 'XTQL',
+	      collapsed: true,	    
+	      items: [
+            
+                { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
+	      ]
+	     },
           ],
-        },
-
-        {
-          label: 'Configuration',
-          collapsed: true,
-          items: [
-            { label: 'Overview', link: '/config' },
-
-            {
-              label: 'Transaction Log',
-              items: [
-                { label: 'Overview', link: '/config/tx-log' },
-                { label: 'Kafka', link: '/config/tx-log/kafka' },
-              ],
-            },
-
-            {
-              label: 'Storage',
-              items: [
-                { label: 'Overview', link: '/config/storage' },
-                { label: 'AWS S3', link: '/config/storage/s3' },
-                { label: 'Azure Blob Storage', link: '/config/storage/azure' },
-                { label: 'Google Cloud Storage', link: '/config/storage/google-cloud' }
-              ]
-            },
-
-            {
-              label: 'Optional Modules',
-              items: [
-                { label: 'Overview', link: '/config/modules' },
-                { label: 'HTTP Server', link: '/config/modules/http-server' }
-              ]
-            },
-          ]
         },
 
         {
@@ -101,24 +82,10 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/reference/main' },
-            {
-              label: 'XTQL',
-              collapsed: true,
-              items: [
-                { label: 'What is XTQL?', link: '/intro/what-is-xtql' },     
-                { label: 'Transactions', link: '/reference/main/xtql/txs' },
-                { label: 'Queries', link: '/reference/main/xtql/queries' },
-              ]
-            },
 
-            {
-              label: 'SQL',
-              collapsed: true,
-              items: [
-                { label: 'Transactions', link: '/reference/main/sql/txs' },
-                { label: 'Queries', link: '/reference/main/sql/queries' },
-              ]
-            },
+            { label: 'SQL Transactions', link: '/reference/main/sql/txs' },
+	    
+            { label: 'SQL Queries', link: '/reference/main/sql/queries' },
 
             { label: 'Data Types', link: '/reference/main/data-types' },
 
@@ -135,6 +102,51 @@ export default defineConfig({
                 { label: 'Other functions', link: '/reference/main/stdlib/other'}
               ]
             },
+
+	    {
+              label: 'XTQL',
+              collapsed: true,
+              items: [
+                { label: 'What is XTQL?', link: '/intro/what-is-xtql' },     
+                { label: 'Transactions', link: '/reference/main/xtql/txs' },
+                { label: 'Queries', link: '/reference/main/xtql/queries' },
+              ]
+            },
+
+	    {
+	      label: 'Advanced Configuration',
+	      collapsed: true,
+	      items: [
+		{ label: 'Overview', link: '/config' },
+
+		{
+		  label: 'Transaction Log',
+		  items: [
+		    { label: 'Overview', link: '/config/tx-log' },
+		    { label: 'Kafka', link: '/config/tx-log/kafka' },
+		  ],
+		},
+
+		{
+		  label: 'Storage',
+		  items: [
+		    { label: 'Overview', link: '/config/storage' },
+		    { label: 'AWS S3', link: '/config/storage/s3' },
+		    { label: 'Azure Blob Storage', link: '/config/storage/azure' },
+		    { label: 'Google Cloud Storage', link: '/config/storage/google-cloud' }
+		  ]
+		},
+
+		{
+		  label: 'Optional Modules',
+		  items: [
+		    { label: 'Overview', link: '/config/modules' },
+		    { label: 'HTTP Server', link: '/config/modules/http-server' }
+		  ]
+		},
+	      ]
+	    },
+
           ]
         },
 
@@ -143,9 +155,36 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/drivers' },
+	    {
+	      label: 'HTTP',
+	      items: [
+	        { label: 'Getting started', link:'/drivers/http/getting-started'},
+                { label: 'HTTP (OpenAPI) ↗', link: '/drivers/http/openapi/index.html', attrs: { target: '_blank' } },
+		]
+            },
+
+            {
+              label: 'Java',
+              collapsed: true,	      
+              items: [
+                { label: 'Getting started', link: '/drivers/java/getting-started' },
+                // TODO broken atm
+                // { label: 'Javadoc ↗', link: '/drivers/java/javadoc/index.html', attrs: {target: '_blank'} }
+              ]
+            },
+
+            {
+              label: 'Kotlin',
+              collapsed: true,	      
+              items: [
+                { label: 'Getting started', link: '/drivers/kotlin/getting-started' },
+                { label: 'KDoc ↗', link: '/drivers/kotlin/kdoc/index.html', attrs: { target: '_blank' } }
+              ]
+            },
 
             {
               label: 'Clojure',
+              collapsed: true,	      
               items: [
                 { label: 'Getting started', link: '/drivers/clojure/getting-started' },
                 { label: 'Configuration cookbook', link: '/drivers/clojure/configuration' },
@@ -153,25 +192,7 @@ export default defineConfig({
                 { label: 'Codox ↗', link: '/drivers/clojure/codox/index.html', attrs: { target: '_blank' } }
               ]
             },
-
-            {
-              label: 'Kotlin',
-              items: [
-                { label: 'Getting started', link: '/drivers/kotlin/getting-started' },
-                { label: 'KDoc ↗', link: '/drivers/kotlin/kdoc/index.html', attrs: { target: '_blank' } }
-              ]
-            },
-
-            { label: 'HTTP (OpenAPI) ↗', link: '/drivers/http/openapi/index.html', attrs: { target: '_blank' } },
-
-            {
-              label: 'Java',
-              items: [
-                { label: 'Getting started', link: '/drivers/java/getting-started' },
-                // TODO broken atm
-                // { label: 'Javadoc ↗', link: '/drivers/java/javadoc/index.html', attrs: {target: '_blank'} }
-              ]
-            },
+	    
           ]
         },
       ],

--- a/docs/src/content/docs/concepts/key-concepts.adoc
+++ b/docs/src/content/docs/concepts/key-concepts.adoc
@@ -50,12 +50,12 @@ In addition to any user-defined columns asserted for a given row, XTDB maintains
 
 These columns are:
 
-- `system_time_from`
-- `system_time_to`
-- `valid_time_from`
-- `valid_time_to`
+- `xt$system_from`
+- `xt$system_to`
+- `xt$valid_from`
+- `xt$valid_to`
 
-The values of these columns are maintained automatically and the respective pairs of columns always form 'closed-open' periods (i.e. inclusive of 'from', exclusive of 'to').
+The columns are not visible unless explicitly queried. The values of these columns are maintained automatically and the respective pairs of columns always form 'closed-open' periods (i.e. inclusive of 'from', exclusive of 'to').
 
 'System time' represents the audit history of all changes to records and captures the time that information entered the system. 'Valid time' is a user-managed dimension and can be used for a variety of purposes (out of order updates, backfilling data, domain modeling etc.).
 

--- a/docs/src/content/docs/drivers.adoc
+++ b/docs/src/content/docs/drivers.adoc
@@ -5,6 +5,6 @@ title: XTDB Client Language Drivers
 XTDB is accessible through our HTTP API and Java, Kotlin and Clojure drivers - drivers for JavaScript, Python and many more will be available in due course.
 
 * link:/drivers/http/openapi/index.html[OpenAPI HTTP specification^]
-* link:/drivers/clojure/getting-started[Clojure]
 * link:/drivers/java/getting-started[Java]
 * link:/drivers/kotlin/getting-started[Kotlin]
+* link:/drivers/clojure/getting-started[Clojure]

--- a/docs/src/content/docs/drivers/http/getting-started.adoc
+++ b/docs/src/content/docs/drivers/http/getting-started.adoc
@@ -1,0 +1,7 @@
+---
+title: Getting started (HTTP)
+---
+
+1. Firstly, to run the XTDB server, check out the general link:/intro/getting-started[getting started guide].
+2. Then, run through the link:/guides/sql-over-http[SQL over HTTP] usage guide to get familiar with the 3 endpoints
+3. Discover the full range of capabilities via the link:drivers/http/openapi/index[OpenAPI] documentation

--- a/docs/src/content/docs/guides/sql-over-http.adoc
+++ b/docs/src/content/docs/guides/sql-over-http.adoc
@@ -1,0 +1,73 @@
+---
+title: SQL over HTTP
+---
+
+Assuming you have successfully started an XTDB server, this guide walks through the basic HTTP API usage. The examples should be runnable using any language, and cURL commands are also provided for convenience
+
+== Status
+
+To confirm XTDB is running:
+
+`GET` to `localhost:3000/status`
+
+If that returns, everything should be up and running.
+
+== Transact
+
+To run your first transaction, send the following:
+
+`POST` to `localhost:3000/tx`
+
+[source,json]
+----
+{
+  "txOps": [{"sql": "INSERT INTO people (xt$id, name) VALUES (6, 'fred')"}]
+}
+----
+
+Note that the `people` doesn't have to be defined beforehand - the table is created dynamically during the INSERT along with any supplied columns and types.
+
+(TODO cURL tabs)
+
+Transactions are durable and processed asynchronously. If you wait a few milliseconds for the processing to finish, you can query then that data.
+
+== Query
+
+`POST` to `localhost:3000/query`
+
+[source,json]
+----
+{
+  "query": {"sql": "SELECT * FROM people"}}
+}
+----
+
+You can also ensure that the query reflects our transaction (after it has been either committed or aborted) by supplying the 'basis' map returned from our transations to the `queryOpts`:
+
+`POST` to `localhost:3000/query`
+
+[source,json]
+----
+{
+  "query": {"sql": "SELECT * FROM people"},
+  "queryOpts": {"basis": {"txId": 7806,
+                          "systemTime":"2024-03-04T14:31:03.728415Z"}}
+}
+----
+
+== Working with documents
+
+XTDB is designed to work with JSON-like nested data as a first-class concept. Which means you can send the following transaction:
+
+`POST` to `localhost:3000/tx`
+
+[source,json]
+----
+{
+  "txOps": [{"sql": "INSERT INTO people (xt$id, name, info)
+                     VALUES (6, 'fred', {'height': 172,
+                                         'age': 29,
+                                         'likes': ['apples'])"}]
+}
+----
+

--- a/docs/src/content/docs/guides/sql-over-http.adoc
+++ b/docs/src/content/docs/guides/sql-over-http.adoc
@@ -71,3 +71,28 @@ XTDB is designed to work with JSON-like nested data as a first-class concept. Wh
 }
 ----
 
+== Basis allows you to re-run queries
+
+Re-run the previous query with the basis map supplied and see that the results are the same:
+
+`POST` to `localhost:3000/query`
+
+[source,json]
+----
+{
+  "query": {"sql": "SELECT * FROM people"},
+  "queryOpts": {"basis": {"txId": 7806,
+                          "systemTime":"2024-03-04T14:31:03.728415Z"}}
+}
+----
+
+A basis map is like a pointer to a snapshot of a previous version of the entire database state, except unlike snapshots in other systems there is no copying or explicit snapshot creation required.
+
+If you re-run the previous query with the previous basis (returned by the first transaction), you _won't_ see the new version of Fred's record.
+
+A basis is stable and allows you to re-run unmodified queries indefinitely. This is useful for debugging, auditing, and exposing application data for processing in downstream systems (generating reports, analytics etc.)
+
+
+== System-Time Columns
+
+...

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -14,12 +14,14 @@ title: Welcome to XTDB!
 </div>
 ++++
 
-XTDB is an immutable database, queryable with both SQL and XTQL, that reduces the time and cost of building and maintaining safe systems of record.
+XTDB is an immutable database, queryable with both link:/reference/main/sql/queries.html[SQL] and link:/intro/what-is-xtql.html[XTQL], that reduces the time and cost of building and maintaining safe systems of record.
 It is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^].
 
-To quickly get up-and-running, check out our link:/intro/getting-started[getting started] guide.
+You can quickly try inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
 
-XTDB is accessible over HTTP and via client drivers: Java, Kotlin and Clojure.
+Alternatively, to get up-and-running locally, check out our link:/intro/getting-started[getting started] guide.
+
+XTDB is distributed as a Docker image and is accessible over link:localhost:4322/intro/getting-started[HTTP] or via client drivers: link:/drivers/java/getting-started[Java], link:/drivers/kotlin/getting-started[Kotlin], link:/drivers/Clojure/getting-started[Clojure], and more link:/intro/roadmap.html[coming soon]!
 
 Next up:
 
@@ -28,5 +30,5 @@ Next up:
 * Find out more about link:/intro/what-is-xtql[XTQL].
 * Check out the link:/reference/main[XTDB reference documentation].
 * Get familiar with the individual link:/drivers[client drivers].
-* Learn about XTDB's link:/config/tx-log[transaction-log] and link:/config/storage[storage] configurations.
+* Learn about XTDB's link:/config/tx-log[transaction-log] and link:/config/storage[storage] advanced configuration options.
 * For help and support, visit the link:/intro/community[XTDB community].

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -23,7 +23,8 @@ For the time being, XTDB is accessible through our HTTP API and Java, Kotlin and
 
 Next up:
 
-* Discover link:/intro/what-is-xtdb[What makes XTDB great].
+* Read link:/intro/what-is-xtdb[why we built XTDB].
+* Discover all the things that link:/intro/what-is-xtdb[makes XTDB great].
 * Find out more about link:/intro/what-is-xtql[XTQL].
 * Check out the link:/reference/main[XTDB reference documentation].
 * Get familiar with the individual link:/drivers[client drivers].

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -19,7 +19,7 @@ It is free-to-use and open-source, under the https://opensource.org/license/mpl-
 
 To quickly get up-and-running, check out our link:/intro/getting-started[getting started] guide.
 
-For the time being, XTDB is accessible through our HTTP API and Java, Kotlin and Clojure drivers - drivers for JavaScript, Python and many more will be available in due course.
+XTDB is accessible over HTTP and via client drivers: Java, Kotlin and Clojure.
 
 Next up:
 

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -14,7 +14,7 @@ title: Welcome to XTDB!
 </div>
 ++++
 
-XTDB is a bitemporal, dynamic database, queryable with SQL and XTQL, that reduces the time and cost of building and maintaining safe systems of record.
+XTDB is an immutable database, queryable with both SQL and XTQL, that reduces the time and cost of building and maintaining safe systems of record.
 It is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^].
 
 To quickly get up-and-running, check out our link:/intro/getting-started[getting started] guide.
@@ -23,9 +23,9 @@ For the time being, XTDB is accessible through our HTTP API and Java, Kotlin and
 
 Next up:
 
-* Find out link:/intro/what-is-xtdb[what makes XTDB great].
+* Discover link:/intro/what-is-xtdb[What makes XTDB great].
 * Find out more about link:/intro/what-is-xtql[XTQL].
-* Find out how to configure the XTDB link:/config/tx-log[transaction-log] and link:/config/storage[storage].
 * Check out the link:/reference/main[XTDB reference documentation].
-* Learn more about the individual link:/drivers[client drivers].
+* Get familiar with the individual link:/drivers[client drivers].
+* Learn about XTDB's link:/config/tx-log[transaction-log] and link:/config/storage[storage] configurations.
 * For help and support, visit the link:/intro/community[XTDB community].

--- a/docs/src/content/docs/intro/data-model.adoc
+++ b/docs/src/content/docs/intro/data-model.adoc
@@ -2,7 +2,7 @@
 title: The XTDB Data Model
 ---
 
-XTDB is a 'bitemporal' and 'dynamic' relational database with columnar foundations. This makes is uniquely capable at handling evolving, semi-structured data - the kind of data that developers might ordinarily handle using manual copies of "documents" or "diffs" and JSONB columns.
+XTDB is a database built on top of columnar storage (using link:https://arrow.apache.org/[Apache Arrow]) and is designed to handle semi-structured data via SQL natively, avoiding the need for workarounds like JSONB columns.
 
 In XTDB all data, including nested data, is able to be stored in tables without classic constraints or restrictions in the range of types or shapes, and without any upfront schema definitions. This is more akin to a document database than a classic SQL database.
 

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -46,9 +46,7 @@ To run your first query:
 ----
 sql="SELECT t1.doc.foo[1]
      FROM (VALUES ({'foo':['Hello', 'world!']})) AS t1(doc)"; \
-curl -X POST localhost:3000/query \
-     -H "Content-Type: application/json" -H "Accept: application/jsonl" \
-     -d "{\"query\": {\"sql\": \"${sql}\"}}"
+curl --json "{\"query\": {\"sql\": \"${sql}\"}}" localhost:3000/query
 ----
 
 From here, check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see what else is available.

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -6,11 +6,7 @@ title: Getting started
 :java: /drivers/java/getting-started.html
 :kotlin: /drivers/kotlin/getting-started.html
 
-XTDB is built for traditional client-server interactions over HTTP, but can also be run in-process (in a JVM) where desirable.
-
-== Client/Server
-
-You can start an XTDB server using the 'standalone' Docker image:
+XTDB is built for traditional client-server interactions over HTTP. You can start an XTDB server using the 'standalone' Docker image:
 
 [source,shell]
 ----
@@ -30,8 +26,6 @@ docker run \
   ghcr.io/xtdb/xtdb-standalone-ea
 ----
 
-=== Connecting through HTTP
-
 You can then connect to your XTDB server using cURL, or similar tools.
 For example, to check its status:
 
@@ -40,26 +34,11 @@ For example, to check its status:
 curl http://localhost:3000/status
 ----
 
-To run your first query:
+To learn how to use the HTTP API, follow our introductory guide.
 
-[source,shell]
-----
-sql="SELECT t1.doc.foo[1]
-     FROM (VALUES ({'foo':['Hello', 'world!']})) AS t1(doc)"; \
-curl --json "{\"query\": {\"sql\": \"${sql}\"}}" localhost:3000/query
-----
+You can also check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see all the options available.
 
-To insert a document:
-
-[source,shell]
-----
-sql="INSERT INTO t2 (xt\$id, foo) VALUES (123, 'bar')"; \
-curl --json "{\"txOps\": [{\"sql\": \"${sql}\"}]}" localhost:3000/query
-----
-
-From here, check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see what else is available.
-
-=== Connecting from a client library
+== Connecting from a client library
 
 If you're running on the JVM, you can use the JVM client library to connect to this node.
 
@@ -71,6 +50,8 @@ image:{icon}/kotlin.svg[Clojure,link={kotlin}#_connecting_through_http]
 For more details, check out the relevant instructions for your language:
 
 == In process (JVM)
+
+XTDB can also be run in-process (in a JVM) where desirable.
 
 If you're running a JVM (17+), you can also use XTDB directly, in-process, using the same API interface as the remote client.
 In-process XTDB is particularly useful for testing and interactive development - you can start an in-memory node quickly and with little hassle, which makes it a great tool for unit tests and REPL experimentation.

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -6,7 +6,7 @@ title: Getting started
 :java: /drivers/java/getting-started.html
 :kotlin: /drivers/kotlin/getting-started.html
 
-XTDB can run in-process (in a JVM), or through traditional client-server connections.
+XTDB is built for traditional client-server interactions over HTTP, but can also be run in-process (in a JVM) where desirable.
 
 == Client/Server
 
@@ -47,6 +47,14 @@ To run your first query:
 sql="SELECT t1.doc.foo[1]
      FROM (VALUES ({'foo':['Hello', 'world!']})) AS t1(doc)"; \
 curl --json "{\"query\": {\"sql\": \"${sql}\"}}" localhost:3000/query
+----
+
+To insert a document:
+
+[source,shell]
+----
+sql="INSERT INTO t2 (xt\$id, foo) VALUES (123, 'bar')"; \
+curl --json "{\"txOps\": [{\"sql\": \"${sql}\"}]}" localhost:3000/query
 ----
 
 From here, check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see what else is available.

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -34,13 +34,13 @@ For example, to check its status:
 curl http://localhost:3000/status
 ----
 
-To learn how to use the HTTP API, follow our introductory guide.
+To learn how to use the HTTP API and discover a few of XTDB's novel capabilities, follow the link:/tutorials/sql-over-http[introductory tutorial].
 
 You can also check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see all the options available.
 
-== Connecting from a client library
+== Connecting via a client driver
 
-If you're running on the JVM, you can use the JVM client library to connect to this node.
+Official client drivers are provived for a range of languages to make working with XTDB more ergonomic than working directly with HTTP and JSON.
 
 [.lang-icons.right]
 image:{icon}/clojure.svg[Clojure,link={clojure}#_connecting_through_http]
@@ -49,16 +49,4 @@ image:{icon}/kotlin.svg[Clojure,link={kotlin}#_connecting_through_http]
 
 For more details, check out the relevant instructions for your language:
 
-== In process (JVM)
-
-XTDB can also be run in-process (in a JVM) where desirable.
-
-If you're running a JVM (17+), you can also use XTDB directly, in-process, using the same API interface as the remote client.
-In-process XTDB is particularly useful for testing and interactive development - you can start an in-memory node quickly and with little hassle, which makes it a great tool for unit tests and REPL experimentation.
-
-[.lang-icons.right]
-image:{icon}/clojure.svg[Clojure,link={clojure}#_in_process]
-image:{icon}/java.svg[Clojure,link={java}#_in_process]
-image:{icon}/kotlin.svg[Clojure,link={kotlin}#_in_process]
-
-For more details, check out the relevant instructions for your language:
+More client drivers are link:/intro/roadmap.html[coming soon]!

--- a/docs/src/content/docs/intro/why-xtdb.adoc
+++ b/docs/src/content/docs/intro/why-xtdb.adoc
@@ -6,14 +6,14 @@ XTDB is an immutable, time-travel database designed for building complex applica
 
 Temporal querying has been identified as a hard problem in SQL database for decades, and XTDB is the first ground-up realization of the 'bitemporal model', but XTDB's temporal powers have benefits for all kinds of applications - not just advanced scenarios in specific domains.
 
-== The Mission
+== Time Matters
 
 At link:https://juxt.pro/[JUXT], the company behind XTDB, our mission is *to simplify how the world makes software*.
 
 Experience has made clear to us that no single piece of software infrastructure is more central to the success of an IT system than a well-designed database.
 However, we believe existing database technologies (Postgres, SQL Server, MongoDB etc.) are far from "finished" and that many important problems still remain unsolved across the database industry. Instead, these problems are left for users of such databases to work around and solve ad-hoc in their application code.
 
-For XTDB, the biggest source of complexity in application code we hope to address is *time*, and therefore XTDB is a database built for the hard problems of: accurate record keeping (with full ACID transaction support), time-travel queries (XT stands for "across time"), and data evolution. These problems are most acute wherever an organization is handling *regulated data*.
+One of the biggest sources of complexity in application code we hope to address is *time*, and therefore XTDB is a database built for the hard problems of: accurate record keeping (with full ACID transaction support), time-travel queries (XT stands for "across time"), and data evolution. These problems are most acute wherever an organization is handling *regulated data*.
 
 == The Problems
 
@@ -30,7 +30,7 @@ In support of this mission, XTDB solves 4 distinct problems we see with existing
 . *Challenging data integration & evolution* - strict schema definitions, update-in-place mutations, and poor support for semi-structured data are all impediments to using relational databases as integration points.
 . *Difficulty of managing SQL with an ad hoc bitemporal schema* - composing SQL is unnecessarily hard and is a common source of developer friction. Bitemporal versioning makes it harder still.
 
-== The Solution: XTDB
+== The Solution
 
 We have designed XTDB to solve each of these problems in a cohesive way that we believe can reduce the time & costs required for organizations to build and maintain link:https://www.juxt.pro/blog/kent-beck-podcast/[*safe*] systems of record and their associated APIs.
 

--- a/docs/src/content/docs/intro/why-xtdb.adoc
+++ b/docs/src/content/docs/intro/why-xtdb.adoc
@@ -2,6 +2,10 @@
 title: Why XTDB?
 ---
 
+XTDB is an immutable, time-travel database designed for building complex applications, and to support developers with features that are essential for meeting common regulatory compliance requirements.
+
+Temporal querying has been identified as a hard problem in SQL database for decades, and XTDB is the first ground-up realization of the 'bitemporal model', but XTDB's temporal powers have benefits for all kinds of applications - not just advanced scenarios in specific domains.
+
 == The Mission
 
 At link:https://juxt.pro/[JUXT], the company behind XTDB, our mission is *to simplify how the world makes software*.
@@ -29,3 +33,14 @@ In support of this mission, XTDB solves 4 distinct problems we see with existing
 == The Solution: XTDB
 
 We have designed XTDB to solve each of these problems in a cohesive way that we believe can reduce the time & costs required for organizations to build and maintain link:https://www.juxt.pro/blog/kent-beck-podcast/[*safe*] systems of record and their associated APIs.
+
+For the everyday application developer who is not working on regulated systems and is less concerned about the nuanced understanding and implications of bitemporal modelling, it is sufficient to simply be aware that the model underpins three distinct layers of capabilities, which the documentation explains in depth. In order of significance:
+
+. *Basis* - using a timestamp as a stable basis for querying prior database states - an essential safety net for developers and organizations alike - and the key to consistent downstreaming processing (e.g. creating a businss KPI report without ETL)
+. *System-Time* - a pair of hidden timestamp columns built-in to every table, maintained automatically, that can be used to retrieve old versions of data
+. *Valid-Time* - an advanced versioning mechanism that is helpful for scheduling changes across data, and critical for time-ware applications where system-time alone is not enough
+
+First and foremost, XTDB is built to reduce the risks and impact of data loss, update anomalies and brittle database designs. It achieves this goal primarily by always recording the history of all changes (particularly UPDATEs and DELETEs which are normally destructive operations), and by restricting the scope of concurrent database usage, such that an auditable, linear sequence of all changes is retained.
+
+Beyond the obvious auditing and debugging benefits of retaining change data and prior database states, XTDB's history-preserving capability presents a robust & stable source of truth - a _basis_ - within a wider IT architecture that is unlike anything that most databases can offer.
+

--- a/docs/src/content/docs/intro/why-xtdb.adoc
+++ b/docs/src/content/docs/intro/why-xtdb.adoc
@@ -1,5 +1,5 @@
 ---
-title: Why XTDB?
+title: Mission
 ---
 
 XTDB is an immutable, time-travel database designed for building complex applications, and to support developers with features that are essential for meeting common regulatory compliance requirements.

--- a/docs/src/content/docs/tutorials/sql-over-http.adoc
+++ b/docs/src/content/docs/tutorials/sql-over-http.adoc
@@ -2,7 +2,7 @@
 title: SQL over HTTP
 ---
 
-Assuming you have successfully started an XTDB server, this guide walks through the basic HTTP API usage. The examples should be runnable using any language, and cURL commands are also provided for convenience
+Assuming you have successfully started an XTDB server, this tutorial walks through basic HTTP API usage and showcases a few of the novel features of XTDB. The examples should be easily translatable to any language (or you could use one of the many supported link:/drivers[client drivers]), and cURL commands are also provided for convenience.
 
 == Status
 


### PR DESCRIPTION
- [ ] sql+json as default/first throughout
- [ ] promote transactions and queries to top-level - xtql as standalone section
- [ ] remove xtql from overview
- [ ] http reference page as parent to openapi page
- [ ] add intro text to openapi page
- [ ] sql only api docs