### PR TITLE
Simplify and move `->merge-plan` and `->merge-tasks` to Kotlin 

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -55,15 +55,15 @@
 
         is-valid-ptr (ArrowBufPointer.)]
 
-    (doseq [{:keys [^bytes path segments nodes]} (trie/->merge-plan segments
-                                                                    {:path-pred (when path-filter
-                                                                                  (let [path-len (alength path-filter)]
-                                                                                    (fn [^bytes page-path]
-                                                                                      (let [len (min path-len (alength page-path))]
-                                                                                        (Arrays/equals path-filter 0 len
-                                                                                                       page-path 0 len)))))})
+    (doseq [{:keys [^bytes path mp-nodes]} (trie/->merge-plan segments
+                                                              {:path-pred (when path-filter
+                                                                            (let [path-len (alength path-filter)]
+                                                                              (fn [^bytes page-path]
+                                                                                (let [len (min path-len (alength page-path))]
+                                                                                  (Arrays/equals path-filter 0 len
+                                                                                                 page-path 0 len)))))})
 
-            :let [data-rdrs (trie/load-data-pages (map :data-rel segments) nodes)
+            :let [data-rdrs (mapv trie/load-data-page mp-nodes)
                   merge-q (PriorityQueue. (Comparator/comparing (util/->jfn :ev-ptr) (EventRowPointer/comparator)))
                   path (if (or (nil? path-filter)
                                (> (alength path) (alength path-filter)))

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -15,7 +15,7 @@
            (org.apache.arrow.vector.types.pojo Field FieldType)
            (xtdb Compactor IBufferPool)
            xtdb.bitemporal.IPolygonReader
-           (xtdb.trie EventRowPointer HashTrieKt IDataRel MergePlanTask)
+           (xtdb.trie EventRowPointer HashTrieKt IDataRel MergePlanTask CompactorSegment)
            xtdb.vector.IRelationWriter
            xtdb.vector.IRowCopier
            xtdb.vector.IVectorWriter
@@ -118,10 +118,10 @@
         (.add table-metadatas (.openTableMetadata metadata-mgr (trie/->table-meta-file-path table-path trie-key))))
 
       (let [segments (mapv (fn [{:keys [trie] :as _table-metadata} data-rel]
-                             {:trie trie, :data-rel data-rel})
+                             (CompactorSegment. data-rel trie))
                            table-metadatas
                            data-rels)
-            schema (->log-data-rel-schema (map :data-rel segments))]
+            schema (->log-data-rel-schema (map #(.getDataRel ^CompactorSegment %) segments))]
 
         (util/with-open [data-rel-wtr (trie/open-log-data-wtr allocator schema)
                          recency-wtr (open-recency-wtr allocator)]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -21,7 +21,7 @@
            (java.io Closeable)
            java.nio.ByteBuffer
            (java.nio.file Path)
-           (java.util Comparator HashMap Iterator LinkedList Map PriorityQueue)
+           (java.util Comparator HashMap Iterator LinkedList Map PriorityQueue ArrayList)
            (java.util.function IntPredicate)
            (java.util.stream IntStream)
            (org.apache.arrow.memory ArrowBuf BufferAllocator)
@@ -316,47 +316,48 @@
 
 (defn- ->merge-tasks
   "segments :: [Segment]
-    Segment :: {:keys [trie-key table-metadata page-idx-pred]} ;; for Arrow tries
-             | {:keys [trie live-rel]} ;; for live tries"
+    Segment :: {:keys [meta-file trie-key table-metadata page-idx-pred]} ;; for Arrow tries
+             | {:keys [trie live-rel]} ;; for live tries
+
+   return :: (seq {:keys [path leaves]})"
   [segments path-pred]
+  (let [result (ArrayList.)]
+    (->> (trie/->merge-plan segments {:path-pred path-pred})
+         (run! (fn [{:keys [path mp-nodes]}]
+                 (let [^MutableRoaringBitmap cumulative-iid-bitmap (MutableRoaringBitmap.)
+                       leaves (ArrayList.)]
+                   (loop [[{:keys [segment] trie-node :node} & more-mp-nodes] mp-nodes
+                          node-taken? false]
+                     (if segment
+                       (if-not trie-node
+                         (recur more-mp-nodes node-taken?)
 
-  (->> (trie/->merge-plan segments {:path-pred path-pred})
-       (into [] (keep (fn [{:keys [path segments nodes]}]
-                        (let [^MutableRoaringBitmap cumulative-iid-bitmap (MutableRoaringBitmap.)]
-                          (loop [[trie-node & more-nodes] nodes
-                                 [segment & more-segs] segments
-                                 node-taken? false,
-                                 leaves []]
-                            (if segment
-                              (if-not trie-node
-                                (recur more-nodes more-segs node-taken? leaves)
+                         (condp = (class trie-node)
+                           ArrowHashTrie$Leaf
+                           (let [{:keys [^IntPredicate page-idx-pred ^ITableMetadata table-metadata]} segment
+                                 page-idx (.getDataPageIndex ^ArrowHashTrie$Leaf trie-node)
+                                 take-node? (.test page-idx-pred page-idx)]
 
-                                (condp = (class trie-node)
-                                  ArrowHashTrie$Leaf
-                                  (let [{:keys [^IntPredicate page-idx-pred ^ITableMetadata table-metadata]} segment
-                                        page-idx (.getDataPageIndex ^ArrowHashTrie$Leaf trie-node)
-                                        take-node? (.test page-idx-pred page-idx)]
-                                    (when take-node?
-                                      (.or cumulative-iid-bitmap (.iidBloomBitmap table-metadata page-idx)))
+                             (when take-node?
+                               (.or cumulative-iid-bitmap (.iidBloomBitmap table-metadata page-idx)))
 
-                                    (recur more-nodes more-segs (or node-taken? take-node?)
-                                           (cond-> leaves
-                                             (or take-node?
-                                                 (when node-taken?
-                                                   (when-let [iid-bitmap (.iidBloomBitmap table-metadata page-idx)]
-                                                     (MutableRoaringBitmap/intersects cumulative-iid-bitmap iid-bitmap))))
-                                             (conj [:arrow segment page-idx]))))
+                             (when (or take-node?
+                                       (when node-taken?
+                                         (when-let [iid-bitmap (.iidBloomBitmap table-metadata page-idx)]
+                                           (MutableRoaringBitmap/intersects cumulative-iid-bitmap iid-bitmap))))
+                               (.add leaves [:arrow segment page-idx]))
 
-                                  LiveHashTrie$Leaf
-                                  (let [^LiveHashTrie$Leaf trie-node trie-node
-                                        {:keys [^RelationReader live-rel, trie]} segment]
-                                    (recur more-nodes more-segs true
-                                           (conj leaves
-                                                 [:live (-> live-rel
-                                                            (.select (.mergeSort trie-node trie)))])))))
+                             (recur more-mp-nodes (or node-taken? take-node?)))
 
-                              (when node-taken?
-                                {:path path, :leaves leaves})))))))))
+                           LiveHashTrie$Leaf
+                           (let [^LiveHashTrie$Leaf trie-node trie-node
+                                 {:keys [^RelationReader live-rel, trie]} segment]
+                             (.add leaves [:live (.select live-rel (.mergeSort trie-node trie))])
+                             (recur more-mp-nodes true))))
+
+                       (when node-taken?
+                         (.add result {:path path, :leaves (vec leaves)}))))))))
+    result))
 
 (defmethod ig/prep-key ::scan-emitter [_ opts]
   (merge opts

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -18,7 +18,8 @@
            org.apache.arrow.vector.types.UnionMode
            (org.apache.arrow.vector.types.pojo ArrowType$Union Schema)
            xtdb.IBufferPool
-           (xtdb.trie MergePlanNode ArrowHashTrie$Leaf HashTrie$Node ITrieWriter LiveHashTrie LiveHashTrie$Leaf)
+           (xtdb.trie IDataRel MergePlanNode ArrowHashTrie$Leaf HashTrie$Node ITrieWriter LiveHashTrie LiveHashTrie$Leaf
+                      CompactorSegment)
            (xtdb.vector IVectorReader RelationReader)
            xtdb.watermark.ILiveTableWatermark))
 
@@ -346,11 +347,6 @@
 
       (mapv :file-path !current-trie-keys))))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(definterface IDataRel
-  (^org.apache.arrow.vector.types.pojo.Schema getSchema [])
-  (^xtdb.vector.RelationReader loadPage [trie-leaf]))
-
 (deftype ArrowDataRel [^ArrowBuf buf
                        ^VectorSchemaRoot root
                        ^VectorLoader loader
@@ -401,6 +397,6 @@
         live-table-wm (conj (->LiveDataRel (.liveRelation live-table-wm)))))))
 
 (defn load-data-page [^MergePlanNode merge-plan-node]
-  (let [{:keys [^IDataRel data-rel]} (.getSegment merge-plan-node)
+  (let [^IDataRel data-rel (.getDataRel ^CompactorSegment (.getSegment merge-plan-node))
         trie-leaf (.getNode merge-plan-node)]
     (.loadPage data-rel trie-leaf)))

--- a/core/src/main/kotlin/xtdb/metadata/Metadata.kt
+++ b/core/src/main/kotlin/xtdb/metadata/Metadata.kt
@@ -7,5 +7,5 @@ interface ITableMetadata {
    fun metadataReader() : IVectorReader
    fun columnNames() : Set<String>
    fun rowIndex(columnName: String, pageIdx: Int) : Long
-   fun iidBloomBitmap(pageIdx: Int) : ImmutableRoaringBitmap
+   fun iidBloomBitmap(pageIdx: Int) : ImmutableRoaringBitmap?
 }

--- a/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
@@ -31,16 +31,12 @@ class ArrowHashTrie(private val nodesVec: DenseUnionVector) :
         private val count = iidBranchVec.getElementEndIndex(branchVecIdx) - startIdx
 
         override val iidChildren: Array<Node?>
-            get() {
-                val startIdx = startIdx
-
-                return Array(count) { childBucket ->
-                    val childIdx = childBucket + startIdx
-                    if (iidBranchElVec.isNull(childIdx))
-                        null
-                    else
-                        forIndex(conjPath(path, childBucket.toByte()), iidBranchElVec[childIdx])
-                }
+            get() = Array(count) { childBucket ->
+                val childIdx = childBucket + startIdx
+                if (iidBranchElVec.isNull(childIdx))
+                    null
+                else
+                    forIndex(conjPath(path, childBucket.toByte()), iidBranchElVec[childIdx])
             }
 
         override val recencies = null

--- a/core/src/main/kotlin/xtdb/trie/HashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/HashTrie.kt
@@ -1,7 +1,15 @@
 package xtdb.trie
 
+import clojure.lang.Keyword
+import com.carrotsearch.hppc.ObjectStack
 import org.apache.arrow.memory.util.ArrowBufPointer
+import org.roaringbitmap.buffer.MutableRoaringBitmap
+import xtdb.metadata.ITableMetadata
+import xtdb.trie.HashTrie.Node
+import xtdb.vector.RelationReader
 import java.util.*
+import java.util.function.IntPredicate
+import java.util.function.Predicate
 import java.util.stream.Stream
 
 internal typealias RecencyArray = LongArray
@@ -14,7 +22,7 @@ fun conjPath(path: ByteArray, idx: Byte): ByteArray {
     return childPath
 }
 
-interface HashTrie<N : HashTrie.Node<N>> {
+interface HashTrie<N : Node<N>> {
     val rootNode: N?
 
     val leaves get() = rootNode?.leaves ?: emptyList()
@@ -63,4 +71,105 @@ interface HashTrie<N : HashTrie.Node<N>> {
             return 0
         }
     }
+}
+data class MergePlanNode(val segment: Map<*,*>, val node: Node<*>?)
+data class MergePlanTask(val mpNodes: List<MergePlanNode>, val path: ByteArray)
+
+private val trieKey = Keyword.intern("trie")
+@Suppress("UNUSED_EXPRESSION")
+fun toMergePlan(segments: List<Map<Keyword, Any>?>, pathPred: Predicate<ByteArray>?) : ArrayList<MergePlanTask> {
+    val result: ArrayList<MergePlanTask> = ArrayList()
+    val stack : ObjectStack<MergePlanTask> = ObjectStack()
+
+    val initialMpNodes = ArrayList<MergePlanNode>()
+    for (segment in segments){
+        val trie = segment?.get(trieKey) as HashTrie<*>?
+        if (trie != null) segment?.let { MergePlanNode(it, trie.rootNode) }?.let { initialMpNodes.add(it) }
+    }
+
+    if (initialMpNodes.size > 0) stack.push(MergePlanTask(initialMpNodes, ByteArray(0)))
+
+    while (!stack.isEmpty) {
+        val mergePlanTask = stack.pop()
+        val mpNodes = mergePlanTask.mpNodes
+        when {
+            mpNodes.any { it.node is ArrowHashTrie.RecencyBranch} -> {
+                val newMpNodes = ArrayList<MergePlanNode>()
+                for (mpNode in mergePlanTask.mpNodes){
+                    // TODO filter by recencies #3166
+                    if (mpNode.node?.recencies != null) {
+                        for(i in 0 until mpNode.node.recencies!!.size) {
+                            newMpNodes.add(MergePlanNode(mpNode.segment, mpNode.node.recencyNode(i)))
+                        }
+                    } else {
+                        newMpNodes.add(mpNode)
+                    }
+                }
+                stack.push(MergePlanTask(newMpNodes, mergePlanTask.path))
+            }
+            pathPred?.test(mergePlanTask.path)?.not() == true ->  null
+            mpNodes.any { it.node is ArrowHashTrie.IidBranch } -> {
+                val nodeChildren = mpNodes.map { it.node?.iidChildren }
+                // do these in reverse order so that they're on the stack in path-prefix order
+                for (bucketIdx in HashTrie.LEVEL_WIDTH - 1 downTo 0) {
+                    val newMpNodes = ArrayList<MergePlanNode>()
+                    for (i in nodeChildren.indices) {
+                        val children : Array<out Node<*>?>? = nodeChildren.get(i)
+                        if (children != null) {
+                            children.get(bucketIdx)?.also { newMpNodes.add(MergePlanNode(mpNodes.get(i).segment, it)) }
+                        } else {
+                            newMpNodes.add(mpNodes.get(i))
+                        }
+                    }
+                    if (newMpNodes.size > 0) stack.push(MergePlanTask(newMpNodes, conjPath(mergePlanTask.path, bucketIdx.toByte())))
+                }
+            }
+            else ->  result.add(mergePlanTask)
+        }
+    }
+    return result
+}
+
+abstract class Leaf()
+data class ArrowLeaf(val segment: Any, val pageIdx: Int) : Leaf()
+data class LiveLeaf(val liveRel: RelationReader) : Leaf()
+
+data class MergeTask(val leaves: List<Leaf>, val path: ByteArray)
+
+private val pageIdxPredKey = Keyword.intern("page-idx-pred")
+private val tableMetadataKey = Keyword.intern("table-metadata")
+private val liveRelKey= Keyword.intern("live-rel")
+
+fun toMergeTasks(segments: List<Map<Keyword, Any>?>, pathPred: Predicate<ByteArray>?) : ArrayList<Any> {
+    val result = ArrayList<Any>()
+    for (mergePlanTask in toMergePlan(segments, pathPred)) {
+        var nodeTaken = false
+        val cumulativeIidBitmap = MutableRoaringBitmap()
+        val leaves = ArrayList<Leaf>()
+        for(mpNode in mergePlanTask.mpNodes) when (mpNode.node) {
+            is ArrowHashTrie.Leaf -> {
+                val pageIdxPred = mpNode.segment.get(pageIdxPredKey) as IntPredicate
+                val tableMetadata = mpNode.segment.get(tableMetadataKey) as ITableMetadata
+                val pageIdx = mpNode.node.dataPageIndex
+                val takeNode = pageIdxPred.test(pageIdx)
+                if (takeNode) {
+                    val iidBloomBitmap = tableMetadata.iidBloomBitmap(pageIdx)
+                    cumulativeIidBitmap.or(iidBloomBitmap)
+                    leaves.add(ArrowLeaf(mpNode.segment, pageIdx))
+                } else if (nodeTaken && tableMetadata.iidBloomBitmap(pageIdx)?.let { MutableRoaringBitmap.intersects( it, cumulativeIidBitmap ) }!!) {
+                    leaves.add(ArrowLeaf(mpNode.segment, pageIdx))
+                }
+
+                (nodeTaken or takeNode).also { nodeTaken = it }
+            }
+            is LiveHashTrie.Leaf -> {
+                val liveRel = mpNode.segment.get(liveRelKey) as RelationReader
+                val trie = mpNode.segment.get(trieKey) as LiveHashTrie
+                leaves.add(LiveLeaf(liveRel.select(mpNode.node.mergeSort(trie))))
+                nodeTaken = true
+            }
+        }
+        if (nodeTaken) result.add(MergeTask(leaves, mergePlanTask.path))
+    }
+    return result
 }


### PR DESCRIPTION
We first rewrite `->merge-plan` (in Clojure) with some optimisations and then move the functions `->merge-plan` and `->merge-tasks` to Kotlin.

TODO:
- [x] Kotlin review
  - Is expression chaining (`let`, `also` ....) the way to go?
- [x] Best practices for the Clojure boundary. Should everything that is used on the Kotlin side be `data classes`?