### PR TITLE
Updates to interval comparison/equality #2307

### DIFF
--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -710,6 +710,25 @@
     "ABS(foo.a)" '(abs x1)
     "ABS(1 YEAR)" '(abs (single-field-interval 1 "YEAR" 2 0))))
 
+(t/deftest test-interval-comparison
+  (t/is (= [{:gt true}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 4' DAY TO HOUR > INTERVAL '3 1' DAY TO HOUR) as gt FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:lt false}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 4' DAY TO HOUR < INTERVAL '3 1' DAY TO HOUR) as lt FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:gte true}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 4' DAY TO HOUR >= INTERVAL '3 1' DAY TO HOUR) as gte FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:lte false}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 4' DAY TO HOUR <= INTERVAL '3 1' DAY TO HOUR) as lte FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:eq false}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 4' DAY TO HOUR = INTERVAL '3 1' DAY TO HOUR) as eq FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:eq true}]
+           (xt/q tu/*node* "SELECT (INTERVAL '3 1' DAY TO HOUR = INTERVAL '3 1' DAY TO HOUR) as eq FROM (VALUES 1) AS x"))))
+
 (deftest test-array-construction
   (t/are [sql expected]
     (= expected (plan-expr sql))


### PR DESCRIPTION
**Issue:** #2307
**Github Action Runs**: See [**here**](https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Acompare-intervals+)

Within this PR, there's a number of updates & additions to comparison/equality between intervals. In particular:
- Can compare only within same typed interval - if differing intervals are compared, we throw an unsupported operation exception.
- If attempting to compare a `:day-time` interval - we throw an unsupported operation exception.
- For `year-month` intervals:
  - Convert to total months & compare that.
- For `month-day-nano` intervals:
  - Will throw a runtime error if either has `months > 0` (we have a few other places where in general we handle MDNs that way, so shall stick with it).
  - Otherwise, convert to a total of the MDN in `nanosseconds` and compare that.

Some notes:
- Currently, `single_field_interval` does return `day-time` when the field is not `YEAR`/`MONTH` so we will have the case that one cannot compare between those.