### PR TITLE
Casting between durations <--> MDN intervals #3196

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -447,6 +447,19 @@
                             (duration->nano))
                       (with-conversion :nano tgt-tsunit)))})
 
+
+(defn duration->mdn-interval [^Duration d]
+  (let [days-in-duration (.toDays d)]
+    (PeriodDuration. (Period/ofDays days-in-duration)
+                     (.minusDays d days-in-duration))))
+
+(defmethod expr/codegen-cast [:duration :interval] [{[_ d-unit] :source-type}]
+  {:return-type [:interval :month-day-nano]
+   :->call-code (fn [[d]]
+                  `(-> ~(with-conversion d d-unit :nano)
+                       (Duration/ofNanos)
+                       (duration->mdn-interval)))})
+
 ;;;; SQL:2011 Operations involving datetimes and intervals
 (defn- recall-with-cast
   ([expr cast1 cast2] (recall-with-cast expr cast1 cast2 expr/codegen-call))

--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -18,14 +18,20 @@
 
 ;;;; units
 
+(defn multiply-for-conversion ^long [^long ts ^long quotient]
+  (Math/multiplyExact ts quotient))
+
+(defn divide-for-conversion ^long [^long ts ^long quotient]
+  (quot ts quotient))
+
 (defn- with-conversion [form from-unit to-unit]
   (if (= from-unit to-unit)
     form
     (let [from-hz (types/ts-units-per-second from-unit)
           to-hz (types/ts-units-per-second to-unit)]
       (if (> to-hz from-hz)
-        `(Math/multiplyExact ~form ~(quot to-hz from-hz))
-        `(quot ~form ~(quot from-hz to-hz))))))
+        `(multiply-for-conversion ~form ~(quot to-hz from-hz))
+        `(divide-for-conversion ~form ~(quot from-hz to-hz))))))
 
 (defn- with-arg-unit-conversion [unit1 unit2 ->ret-type ->call-code]
   (if (= unit1 unit2)

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -192,6 +192,9 @@
     [:duration_type "DURATION" [:unsigned_integer fractional-precision]]
     (cast-temporal-with-precision e :duration fractional-precision)
 
+    [:interval_type "INTERVAL"]
+    (list 'cast e [:interval :month-day-nano])
+
     [:character_string_type "VARCHAR"]
     (list 'cast e :utf8)
 

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -501,7 +501,7 @@ with_or_without_time_zone
     ;
 
 interval_type
-    : 'INTERVAL' interval_qualifier
+    : 'INTERVAL' [ interval_qualifier ]
     ;
 
 row_type

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -308,6 +308,19 @@
                               #"The minimum fractional seconds precision is 0."
                               (test-cast #xt/interval-mdn ["P4M8D" "PT0S"] [:duration :nano] {:precision -1}))))))
 
+
+(t/deftest cast-duration-to-interval
+  (letfn [(test-cast
+            [src-value tgt-type]
+            (-> (tu/query-ra [:project [{'res `(~'cast ~src-value ~tgt-type)}]
+                              [:table [{}]]]
+                             {:basis {}})
+                first :res))]
+
+    (t/is (= #xt/interval-mdn ["P0D" "PT3H1.11S"] (test-cast #time/duration "PT3H1.11S" :interval)))
+    (t/is (= #xt/interval-mdn ["P1D" "PT1H1.11S"] (test-cast #time/duration "PT25H1.11S" :interval)))
+    (t/is (= #xt/interval-mdn ["P35D" "PT2H1.11S"] (test-cast #time/duration "P35DT2H1.11S" :interval)))))
+
 (def ^:private instant-gen
   (->> (tcg/tuple (tcg/choose (.getEpochSecond #time/instant "2020-01-01T00:00:00Z")
                               (.getEpochSecond #time/instant "2040-01-01T00:00:00Z"))

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -269,6 +269,45 @@
         (t/testing "duration"
           (t/is (= "PT13M56.123S" (test-cast #time/duration "PT13M56.123S" :utf8))))))))
 
+(t/deftest cast-interval-to-duration
+  (letfn [(test-cast
+            ([src-value tgt-type] (test-cast src-value tgt-type nil))
+            ([src-value tgt-type cast-opts]
+             (-> (tu/query-ra [:project [{'res `(~'cast ~src-value ~tgt-type ~cast-opts)}]
+                               [:table [{}]]]
+                              {:basis {}})
+                 first :res)))]
+
+    (t/testing "cannot cast year-month interval to duration"
+      (t/is (thrown-with-msg? UnsupportedOperationException
+                              #"Cannot cast a year-month interval to a duration"
+                              (test-cast #xt/interval-ym "P12M" [:duration :micro]))))
+
+    (t/testing "cannot cast day-time interval to duration"
+      (t/is (thrown-with-msg? UnsupportedOperationException
+                              #"Cannot cast a day-time interval to a duration"
+                              (test-cast #xt/interval-dt ["P1D" "PT0S"] [:duration :micro]))))
+
+    (t/testing "cannot cast month-day-nano interval to duration when months > 0"
+      (t/is (thrown-with-msg? RuntimeException
+                              #"Cannot cast month-day-nano intervals when month component is non-zero."
+                              (test-cast #xt/interval-mdn ["P4M8D" "PT0S"] [:duration :micro]))))
+
+    (t/testing "casting month-day-nano intervals -> duration"
+      (t/is (= #time/duration "PT25H1S" (test-cast #xt/interval-mdn ["P1D" "PT1H1S"] [:duration :second])))
+      (t/is (= #time/duration "PT3H1M1S" (test-cast #xt/interval-mdn ["P0D" "PT3H1M1S"] [:duration :second])))
+      (t/is (= #time/duration "PT25H1.111111S" (test-cast #xt/interval-mdn ["P1D" "PT1H1.111111111S"] [:duration :micro]))))
+
+    (t/testing "casting month-day-nano intervals -> duration with precision"
+      (t/is (= #time/duration "PT25H1.11S" (test-cast #xt/interval-mdn ["P1D" "PT1H1.111111111S"] [:duration :milli] {:precision 2})))
+      (t/is (= #time/duration "PT25H1.1111111S" (test-cast #xt/interval-mdn ["P1D" "PT1H1.111111111S"] [:duration :nano] {:precision 7})))
+      (t/is (thrown-with-msg? IllegalArgumentException
+                              #"The maximum fractional seconds precision is 9."
+                              (test-cast #xt/interval-mdn ["P4M8D" "PT0S"] [:duration :nano] {:precision 10})))
+      (t/is (thrown-with-msg? IllegalArgumentException
+                              #"The minimum fractional seconds precision is 0."
+                              (test-cast #xt/interval-mdn ["P4M8D" "PT0S"] [:duration :nano] {:precision -1}))))))
+
 (def ^:private instant-gen
   (->> (tcg/tuple (tcg/choose (.getEpochSecond #time/instant "2020-01-01T00:00:00Z")
                               (.getEpochSecond #time/instant "2040-01-01T00:00:00Z"))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -869,6 +869,13 @@
   (t/is (= [{:string "PT13M56.123S"}]
            (xt/q tu/*node* "SELECT CAST(docs.duration AS VARCHAR) as string FROM docs"))))
 
+(t/deftest test-cast-interval-to-duration
+  (t/is (= [{:duration #time/duration "PT13M56S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56' MINUTE TO SECOND AS DURATION) as duration FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:duration #time/duration "PT13M56.123456789S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56.123456789' MINUTE TO SECOND AS DURATION(9)) as duration FROM (VALUES 1) AS x"))))
+
 (t/deftest test-expr-in-equi-join
   (t/is
     (=plan-file

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -876,6 +876,18 @@
   (t/is (= [{:duration #time/duration "PT13M56.123456789S"}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56.123456789' MINUTE TO SECOND AS DURATION(9)) as duration FROM (VALUES 1) AS x"))))
 
+(t/deftest test-cast-duration-to-interval
+  (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :duration #time/duration "PT26H13M56S"}]])
+
+  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT2H13M56S"]}]
+           (xt/q tu/*node* "SELECT CAST(docs.duration AS INTERVAL) as itvl FROM docs")))
+
+  (t/is (= [{:itvl #xt/interval-mdn ["P5D" "PT2H"]}]
+           (xt/q tu/*node* "SELECT CAST((TIMESTAMP '2021-10-26T14:00:00' - TIMESTAMP '2021-10-21T12:00:00') AS INTERVAL) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:itvl #xt/interval-mdn ["P370D" "PT2H"]}]
+           (xt/q tu/*node* "SELECT CAST((TIMESTAMP '2021-10-26T14:00:00' - TIMESTAMP '2020-10-21T12:00:00') AS INTERVAL) as itvl FROM (VALUES 1) AS x"))))
+
 (t/deftest test-expr-in-equi-join
   (t/is
     (=plan-file


### PR DESCRIPTION
**Issue:** #3196
**Github Action Runs**: See [**here**](
https://github.com/danmason/xtdb/actions?query=branch%3Acast-intervals-and-durations-3196+)

Handles casting between Intervals and Duration:
- For both - we implicitly assume 1 day == 24 hours
- For `interval-->duration`:
  - Based on the ticket, only a `month-day-nano` interval can be converted to a duration - attempting to cast from a `day-time` or `year-month` interval throws an unsupported operation exception. 
  - We ONLY convert a `month-day-nano` **if** total months == 0.
  - When converting to a duration we also consider `precision` (if passed in). We use an appropriate return type (defaults to `micro`), and truncate duration accordingly. 
- For `duration-->interval`:
  - We **always** return a `month-day-nano` interval.
  - This interval will only ever have `days` - `month` will always = 0.
  - We add appropriate SQL planning/parsing for this.
  - We assume no interval qualifier is specified - casting to an interval looks like `CAST(foo.duration AS INTERVAL)`
- Add a number of appropriate tests to `temporal_test` and `sql_test`.

We also make a small change to the `with-conversion` function in `temporal.clj`:
- Separating out certain calls into their own function so we can type hint parameters and the result.
- This prevents certain unexpected `arithmetic exception: integer overflow` being thrown due to unclear types/reflection.

 