### PR TITLE
Testing parameter support in table temporal filters #3068

### DIFF
--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -1338,7 +1338,35 @@
                                      :for-system-time :all-time})
                        tx1 nil)))
 
-            "for all sys time"))))
+            "for all sys time")))
+  
+  (t/testing "testing temporal fns with params"
+    (t/is (= #{{:id :matthew, :app-from (time/->zdt #inst "2015"), :app-to nil}
+               {:id :luke, :app-from (time/->zdt #inst "2021"), :app-to (time/->zdt #inst "2022")}}
+             (set (xt/q tu/*node*
+                        '(from :docs {:bind [{:xt/id id} {:xt/valid-from app-from
+                                                          :xt/valid-to app-to}]
+                                      :for-valid-time (in $arg-from $arg-to)})
+                        {:args {:arg-from #inst "2021"
+                                :arg-to #inst "2023"}}))))
+    
+    (t/is (= #{{:id :matthew}}
+             (set (xt/q tu/*node*
+                        '(unify (from :docs {:bind [{:xt/id id}]
+                                             :for-valid-time (at $arg-t1)})
+                                (from :docs {:bind [{:xt/id id}]
+                                             :for-valid-time (at $arg-t2)}))
+                        {:args {:arg-t1 #inst "2018"
+                                :arg-t2 #inst "2024"}}))))
+    
+    (t/is (= #{{:id :matthew, :app-from (time/->zdt #inst "2015"), :app-to nil}
+               {:id :luke, :app-from (time/->zdt #inst "2021"), :app-to (time/->zdt #inst "2022")}}
+             (set (xt/q tu/*node*
+                        '(from :docs {:bind [{:xt/id id} {:xt/valid-from app-from
+                                                          :xt/valid-to app-to}]
+                                      :for-valid-time (in $arg-from $arg-to)})
+                        {:args {:arg-from #inst "2021"
+                                :arg-to #inst "2023"}}))))))
 
 (t/deftest test-for-valid-time-with-current-time-2493
   (xt/submit-tx tu/*node* [[:put-docs {:into :docs, :valid-to #inst "2040"}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of-system-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of-system-time.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo, :for-system-time [:at ?_0]} [bar]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo, :for-valid-time [:at ?_0]} [bar]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-between.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo, :for-valid-time [:between ?_0 ?_1]} [bar]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-from-to.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-from-to.edn
@@ -1,0 +1,1 @@
+[:scan {:table foo, :for-valid-time [:in ?_0 ?_1]} [bar]]


### PR DESCRIPTION
**Issue:** #3068
**Github Action Runs**: See [**here**](https://github.com/danmason/xtdb/actions?query=branch%3Aparams-in-table-temporal-filters++)

RE: support of parameters within table temporal filters:
- We already supported it from the logical planner.
- In SQL:
  - Seems like we also already supported it from the SQL grammar/planner - have added a few tests to `sql_test` to demonstrate.
- In XTQL:
  - Similarly seems like we also supported it when params passed in with `$param`.
 
As such, this PR doesn't change anything inside either XTQL or SQL, but adds some tests around the parameter behavior to both xtql-test and sql-test to confirm the above.