### PR TITLE
Casting to and from intervals

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -498,6 +498,17 @@
     (->multi-field-interval-call expr)
     (->single-field-interval-call expr)))
 
+(defn interval->iso-string [^PeriodDuration x]
+  (let [period-str (.toString (.getPeriod x))
+        duration-str (.toString (.getDuration x))]
+    (str period-str (str/replace duration-str #"^PT" "T"))))
+
+(defmethod expr/codegen-cast [:interval :utf8] [_]
+  {:return-type :utf8
+   :->call-code (fn [[pd]]
+                  `(-> (interval->iso-string ~pd)
+                       (string->byte-buffer)))})
+
 ;;;; SQL:2011 Operations involving datetimes and intervals
 (defn- recall-with-cast
   ([expr cast1 cast2] (recall-with-cast expr cast1 cast2 expr/codegen-call))

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -301,6 +301,9 @@
     [:interval_type "INTERVAL"]
     (list 'cast e [:interval :month-day-nano])
 
+    [:interval_type "INTERVAL" q]
+    (list 'cast e :interval (interval-qualifier->map q))
+
     [:character_string_type "VARCHAR"]
     (list 'cast e :utf8)
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -934,6 +934,21 @@
          #"Cannot cast integer to a multi field interval"
          (xt/q tu/*node* "SELECT CAST(2 AS INTERVAL YEAR TO MONTH) as itvl FROM (VALUES 1) AS x"))))
 
+(t/deftest test-cast-string-to-interval
+  (t/is (= [{:itvl #xt/interval-mdn ["P3D" "PT11H10M"]}]
+           (xt/q tu/*node* "SELECT CAST('3 11:10' AS INTERVAL DAY TO MINUTE) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:itvl #xt/interval-ym "P24M"}]
+           (xt/q tu/*node* "SELECT CAST('2' AS INTERVAL YEAR) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:itvl #xt/interval-ym "P22M"}]
+           (xt/q tu/*node* "SELECT CAST('1-10' AS INTERVAL YEAR TO MONTH) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (thrown-with-msg?
+         IllegalArgumentException
+         #"Interval end field must have less significance than the start field."
+         (xt/q tu/*node* "SELECT CAST('11:10' AS INTERVAL MINUTE TO HOUR) as itvl FROM (VALUES 1) AS x"))))
+
 (t/deftest test-expr-in-equi-join
   (t/is
     (=plan-file

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -922,6 +922,18 @@
   (t/is (= [{:itvl #xt/interval-mdn ["P370D" "PT2H"]}]
            (xt/q tu/*node* "SELECT CAST((TIMESTAMP '2021-10-26T14:00:00' - TIMESTAMP '2020-10-21T12:00:00') AS INTERVAL) as itvl FROM (VALUES 1) AS x"))))
 
+(t/deftest test-cast-int-to-interval
+  (t/is (= [{:itvl #xt/interval-mdn ["P3D" "PT0S"]}]
+           (xt/q tu/*node* "SELECT CAST(3 AS INTERVAL DAY) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:itvl #xt/interval-ym "P24M"}]
+           (xt/q tu/*node* "SELECT CAST(2 AS INTERVAL YEAR) as itvl FROM (VALUES 1) AS x")))
+  
+  (t/is (thrown-with-msg?
+         IllegalArgumentException
+         #"Cannot cast integer to a multi field interval"
+         (xt/q tu/*node* "SELECT CAST(2 AS INTERVAL YEAR TO MONTH) as itvl FROM (VALUES 1) AS x"))))
+
 (t/deftest test-expr-in-equi-join
   (t/is
     (=plan-file

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -949,6 +949,25 @@
          #"Interval end field must have less significance than the start field."
          (xt/q tu/*node* "SELECT CAST('11:10' AS INTERVAL MINUTE TO HOUR) as itvl FROM (VALUES 1) AS x"))))
 
+(t/deftest test-cast-interval-to-string
+  (t/is (= [{:string "P2YT0S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '2' YEAR AS VARCHAR) as string FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:string "P22MT0S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '1-10' YEAR TO MONTH AS VARCHAR) as string FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:string "P-22MT0S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '-1-10' YEAR TO MONTH AS VARCHAR) as string FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:string "P1DT0S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '1' DAY AS VARCHAR) as string FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:string "P1DT10H10M10S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '1 10:10:10' DAY TO SECOND AS VARCHAR) as string FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:string "P0DT10M10.111111111S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '10:10.111111111' MINUTE TO SECOND(9) AS VARCHAR) as string FROM (VALUES 1) AS x"))))
+
 (t/deftest test-expr-in-equi-join
   (t/is
     (=plan-file


### PR DESCRIPTION
Initial cut of #2308 
**Test Runs:** [**Here**](https://github.com/danmason/xtdb/actions?query=branch%3Acasting-to-and-from-intervals++)

Implements the following: 
- Handling interval qualifier in the plan and returning a map of relevant info - useful as cast opts/literal args. 
- Adding cast to Interval with interval qualifier to SQL plan.
- Adding int -> interval with single field interval qualifier casting.
- Adding string -> interval with interval qualifier casting - calling down to single field interval / multi field interval respectively.
- Adding interval -> ISO 8601 string casting
- Adds numerous tests around all of the above.

Above will likely change within our follow up work on intervals - leaving out casting between interval types here.