### PR TITLE
Copy row removal

### DIFF
--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -77,7 +77,7 @@
       (let [row-count (.rowCount in-rel)]
         (util/with-close-on-catch [^StructVector struct-vec (-> ^Field (apply types/->field (str col-name) #xt.arrow/type :struct false
                                                                               (for [^IVectorReader col in-rel]
-                                                                                (.getField col)))
+                                                                                (types/field-with-name (.getField col) (.getName col))))
                                                                 (.createVector allocator))]
 
           ;; TODO can we quickly set all of these to 1?

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -22,6 +22,7 @@
            (java.io Closeable)
            java.nio.ByteBuffer
            (java.nio.file Path)
+           (com.carrotsearch.hppc IntArrayList)
            (java.util ArrayList Comparator HashMap Iterator LinkedList Map PriorityQueue)
            (java.util.function IntPredicate Predicate)
            (java.util.stream IntStream)
@@ -38,7 +39,8 @@
            xtdb.operator.IRelationSelector
            (xtdb.trie ArrowHashTrie$Leaf EventRowPointer HashTrie HashTrieKt LiveHashTrie$Leaf MergePlanNode MergePlanTask)
            (xtdb.util TemporalBounds TemporalBounds$TemporalColumn)
-           (xtdb.vector IRelationWriter IRowCopier IVectorReader IVectorWriter RelationReader RelationWriter)
+           (xtdb.vector IRelationWriter IRowCopier IVectorReader IVectorWriter RelationReader RelationWriter
+                        IMultiVectorRelationFactory IVectorIndirection$Selection IndirectMultiVectorReader)
            (xtdb.watermark ILiveTableWatermark IWatermarkSource Watermark)))
 
 (s/def ::table symbol?)
@@ -117,30 +119,40 @@
     (with-open [^Watermark wm (.openWatermark wm-src wm-tx)]
       (.allTableColNames scan-emitter wm))))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn- ->content-consumer [^IRelationWriter out-rel, ^RelationReader leaf-rel, col-names]
-  (let [op-rdr (.readerForName leaf-rel "op")
-        put-rdr (.legReader op-rdr :put)
+(defn temporal-column? [col-name]
+  (contains? #{"xt$system_from" "xt$system_to" "xt$valid_from" "xt$valid_to"}
+             (util/str->normal-form-str col-name)))
 
-        row-copiers (object-array
-                     (for [[col-name col-writer] out-rel
-                           :let [normalized-name (util/str->normal-form-str col-name)
-                                 copier (case normalized-name
-                                          "xt$iid"
-                                          (.rowCopier (.readerForName leaf-rel "xt$iid")
-                                                      col-writer)
+(defn rels->multi-vector-rel-factory ^xtdb.vector.IMultiVectorRelationFactory [leaf-rels, ^BufferAllocator allocator, col-names]
+  (let [put-rdrs (mapv (fn [^RelationReader rel]
+                         [(.rowCount rel) (-> (.readerForName rel "op") (.legReader :put))])
+                       leaf-rels)
+        reader-indirection (IntArrayList.)
+        vector-indirection (IntArrayList.)]
+    (letfn [(->indirect-multi-vec [col-name reader-selection vector-selection]
+              (let [normalized-name (util/str->normal-form-str col-name)
+                    readers (ArrayList.)]
+                (if (= normalized-name "xt$iid")
+                  (doseq [^RelationReader leaf-rel leaf-rels]
+                    (.add readers (-> (.readerForName leaf-rel "xt$iid") (.withName col-name))))
 
-                                          ("xt$system_from" "xt$system_to" "xt$valid_from" "xt$valid_to") nil
-                                          (some-> (.structKeyReader put-rdr normalized-name)
-                                                  (.rowCopier col-writer)))]
-                           :when copier]
-                       copier))]
+                  (doseq [[row-count ^IVectorReader put-rdr] put-rdrs]
+                    (if-let [rdr (some-> (.structKeyReader put-rdr normalized-name)
+                                         (.withName col-name))]
+                      (.add readers rdr)
+                      (.add readers (vr/->absent-col col-name allocator row-count)))))
+                (IndirectMultiVectorReader. readers reader-selection vector-selection)))]
+      (reify IMultiVectorRelationFactory
+        (accept [_ rdrIdx vecIdx]
+          (.add reader-indirection rdrIdx)
+          (.add vector-indirection vecIdx))
+        (realize [_]
+          (let [reader-selection (IVectorIndirection$Selection. (.toArray reader-indirection))
+                vector-selection (IVectorIndirection$Selection. (.toArray vector-indirection))]
+            (RelationReader/from (mapv #(->indirect-multi-vec % reader-selection vector-selection) col-names))))))))
 
-    (reify IRowConsumer
-      (accept [_ idx _valid-from _valid-to _sys-from _sys-to]
-        (dotimes [i (alength row-copiers)]
-          (let [^IRowCopier copier (aget row-copiers i)]
-            (.copyRow copier idx)))))))
+(defn- ->content-rel-factory ^xtdb.vector.IMultiVectorRelationFactory [leaf-rdrs allocator content-col-names]
+  (rels->multi-vector-rel-factory leaf-rdrs allocator content-col-names))
 
 (defn- ->bitemporal-consumer ^xtdb.bitemporal.IRowConsumer [^IRelationWriter out-rel, col-names]
   (letfn [(writer-for [normalised-col-name]
@@ -217,7 +229,7 @@
 
     :live (first leaf-args)))
 
-(defrecord LeafPointer [ev-ptr content-consumer])
+(defrecord LeafPointer [ev-ptr rel-idx])
 
 (deftype TrieCursor [^BufferAllocator allocator, ^Iterator merge-tasks, ^IRelationWriter out-rel
                      ^Path table-path, col-names, ^Map col-preds,
@@ -227,53 +239,56 @@
   (tryAdvance [_ c]
     (if (.hasNext merge-tasks)
       (let [{:keys [leaves path]} (.next merge-tasks)
-            is-valid-ptr (ArrowBufPointer.)
-            ^IRelationSelector iid-pred (get col-preds "xt$iid")
-            merge-q (PriorityQueue. (Comparator/comparing (util/->jfn #(.ev_ptr ^LeafPointer %)) (EventRowPointer/comparator)))
-            calculate-polygon (bitemp/polygon-calculator temporal-bounds)
-            bitemp-consumer (->bitemporal-consumer out-rel col-names)]
+            is-valid-ptr (ArrowBufPointer.)]
+        (with-open [out-rel (vw/->rel-writer allocator)]
+          (let [^IRelationSelector iid-pred (get col-preds "xt$iid")
+                merge-q (PriorityQueue. (Comparator/comparing (util/->jfn #(.ev_ptr ^LeafPointer %)) (EventRowPointer/comparator)))
+                calculate-polygon (bitemp/polygon-calculator temporal-bounds)
+                bitemp-consumer (->bitemporal-consumer out-rel col-names)
+                leaf-rdrs (for [leaf leaves
+                                :let [^RelationReader data-rdr (merge-task-data-reader buffer-pool vsr-cache table-path leaf)]]
+                            (cond-> data-rdr
+                              iid-pred (.select (.select iid-pred allocator data-rdr params))))
+                [temporal-cols content-cols] ((juxt filter remove) temporal-column? col-names)
+                content-rel-factory (->content-rel-factory leaf-rdrs allocator content-cols)]
 
-        (.clear out-rel)
-
-        (doseq [leaf leaves
-                :let [^RelationReader data-rdr (merge-task-data-reader buffer-pool vsr-cache table-path leaf)
-                      ^RelationReader leaf-rdr (cond-> data-rdr
-                                                 iid-pred (.select (.select iid-pred allocator data-rdr params)))
-                      ev-ptr (EventRowPointer. leaf-rdr path)]]
-          (when (.isValid ev-ptr is-valid-ptr path)
-            (.add merge-q (->LeafPointer ev-ptr (->content-consumer out-rel leaf-rdr col-names)))))
-
-        (loop []
-          (when-let [^LeafPointer q-obj (.poll merge-q)]
-            (let [^EventRowPointer ev-ptr (.ev_ptr q-obj),
-                  ^IRowConsumer content-consumer (.content_consumer q-obj)]
-              (when-let [^Polygon polygon (calculate-polygon ev-ptr)]
-                (when (= :put (.getOp ev-ptr))
-                  (let [sys-from (.getSystemFrom ev-ptr)
-                        idx (.getIndex ev-ptr)]
-                    (dotimes [i (.getValidTimeRangeCount polygon)]
-                      (let [valid-from (.getValidFrom polygon i)
-                            valid-to (.getValidTo polygon i)
-                            sys-to (.getSystemTo polygon i)]
-                        (when (and (.inRange temporal-bounds valid-from valid-to sys-from sys-to)
-                                   (not (= valid-from valid-to))
-                                   (not (= sys-from sys-to)))
-                          (.startRow out-rel)
-                          (.accept content-consumer idx valid-from valid-to sys-from sys-to)
-                          (.accept bitemp-consumer idx valid-from valid-to sys-from sys-to)
-                          (.endRow out-rel)))))))
-
-              (.nextIndex ev-ptr)
+            (doseq [[idx leaf-rdr] (map-indexed vector leaf-rdrs)
+                    :let [ev-ptr (EventRowPointer. leaf-rdr path)]]
               (when (.isValid ev-ptr is-valid-ptr path)
-                (.add merge-q q-obj))
-              (recur))))
+                (.add merge-q (->LeafPointer ev-ptr idx))))
 
-        (let [^RelationReader rel (reduce (fn [^RelationReader rel ^IRelationSelector col-pred]
-                                            (.select rel (.select col-pred allocator rel params)))
-                                          (-> (vw/rel-wtr->rdr out-rel)
-                                              (vr/with-absent-cols allocator col-names))
-                                          (vals (dissoc col-preds "xt$iid")))]
-          (.accept c rel))
+            (loop []
+              (when-let [^LeafPointer q-obj (.poll merge-q)]
+                (let [^EventRowPointer ev-ptr (.ev_ptr q-obj)]
+                  (when-let [^Polygon polygon (calculate-polygon ev-ptr)]
+                    (when (= :put (.getOp ev-ptr))
+                      (let [sys-from (.getSystemFrom ev-ptr)
+                            idx (.getIndex ev-ptr)]
+                        (dotimes [i (.getValidTimeRangeCount polygon)]
+                          (let [valid-from (.getValidFrom polygon i)
+                                valid-to (.getValidTo polygon i)
+                                sys-to (.getSystemTo polygon i)]
+                            (when (and (.inRange temporal-bounds valid-from valid-to sys-from sys-to)
+                                       (not (= valid-from valid-to))
+                                       (not (= sys-from sys-to)))
+                              (.startRow out-rel)
+                              (.accept content-rel-factory (.rel-idx q-obj) idx)
+                              (.accept bitemp-consumer idx valid-from valid-to sys-from sys-to)
+                              (.endRow out-rel)))))))
+
+                  (.nextIndex ev-ptr)
+                  (when (.isValid ev-ptr is-valid-ptr path)
+                    (.add merge-q q-obj))
+                  (recur))))
+
+            (let [^RelationReader rel (cond-> (.realize content-rel-factory)
+                                        (or (empty? (seq content-cols)) (seq temporal-cols))
+                                        (vr/concat-rels (vw/rel-wtr->rdr out-rel)))
+                  ^RelationReader rel (reduce (fn [^RelationReader rel ^IRelationSelector col-pred]
+                                                (.select rel (.select col-pred allocator rel params)))
+                                              rel
+                                              (vals (dissoc col-preds "xt$iid")))]
+              (.accept c rel))))
         true)
 
       false))

--- a/core/src/main/clojure/xtdb/vector/reader.clj
+++ b/core/src/main/clojure/xtdb/vector/reader.clj
@@ -2,10 +2,13 @@
   (:require [clojure.set :as set]
             [xtdb.types :as types])
   (:import clojure.lang.MapEntry
+           (com.carrotsearch.hppc IntArrayList)
+           (java.util ArrayList)
            (org.apache.arrow.memory BufferAllocator)
            (org.apache.arrow.vector ValueVector VectorSchemaRoot)
            xtdb.api.query.IKeyFn
-           (xtdb.vector IVectorReader RelationReader ValueVectorReadersKt)))
+           (xtdb.vector IVectorReader RelationReader ValueVectorReadersKt IMultiVectorRelationFactory
+                        IVectorIndirection$Selection IndirectMultiVectorReader)))
 
 (defn vec->reader ^IVectorReader [^ValueVector v]
   (ValueVectorReadersKt/from v))
@@ -23,11 +26,14 @@
                          (.createVector allocator))
                  (.setValueCount row-count))))
 
+(defn- available-col-names [^RelationReader rel]
+  (into #{} (map #(.getName ^IVectorReader %)) rel))
+
 ;; we don't allocate anything here, but we need it because BaseValueVector
 ;; (a distant supertype of NullVector) thinks it needs one.
 (defn with-absent-cols ^xtdb.vector.RelationReader [^RelationReader rel, ^BufferAllocator allocator, col-names]
   (let [row-count (.rowCount rel)
-        available-col-names (into #{} (map #(.getName ^IVectorReader %)) rel)]
+        available-col-names (available-col-names rel)]
     (rel-reader (concat rel
                         (->> (set/difference col-names available-col-names)
                              (map #(->absent-col % allocator row-count))))
@@ -45,3 +51,11 @@
                                      (when (some? v)
                                        (MapEntry/create k v))))))))
            (range (.rowCount rel))))))
+
+(defn concat-rels [^RelationReader rel1 ^RelationReader rel2]
+  (cond (empty? (seq rel1)) rel2
+        (empty? (seq rel2)) rel1
+        :else (do
+                (assert (= (.rowCount rel1) (.rowCount rel2)))
+                (assert (empty? (set/intersection (available-col-names rel1) (available-col-names rel2))))
+                (RelationReader/from (into (seq rel1) (seq rel2))))))

--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -983,7 +983,7 @@ public class ValueVectorReader implements IVectorReader {
 
         @Override
         public IValueReader valueReader(IVectorPosition pos) {
-            var legReaders = legs.stream().collect(Collectors.toMap(l -> l, l -> DuvReader.this.legReader(l).valueReader(pos)));
+            var legReaders = legs.stream().collect(Collectors.toMap(l -> l, l -> this.legReader(l).valueReader(pos)));
 
             return new IValueReader() {
                 @Override

--- a/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
+++ b/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
@@ -513,4 +513,3 @@ private object WriterForVectorVisitor : VectorVisitor<IVectorWriter, FieldChange
 @JvmOverloads
 fun writerFor(vec: ValueVector, notify: FieldChangeListener? = null): IVectorWriter =
     vec.accept(WriterForVectorVisitor, notify)
-

--- a/core/src/main/kotlin/xtdb/vector/IMultiVectorRelationFactory.kt
+++ b/core/src/main/kotlin/xtdb/vector/IMultiVectorRelationFactory.kt
@@ -1,0 +1,7 @@
+package xtdb.vector
+
+@Suppress("unused")
+interface IMultiVectorRelationFactory {
+    fun accept(relIdx: Int, vecIdx: Int)
+    fun realize(): RelationReader
+}

--- a/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
+++ b/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
@@ -1,0 +1,259 @@
+package xtdb.vector
+
+import clojure.lang.IFn
+import clojure.lang.Keyword
+import clojure.lang.RT
+import org.apache.arrow.memory.util.ArrowBufPointer
+import org.apache.arrow.memory.util.hash.ArrowBufHasher
+import org.apache.arrow.vector.NullVector
+import org.apache.arrow.vector.ValueVector
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.Field
+import xtdb.api.query.IKeyFn
+import xtdb.toLeg
+import xtdb.util.requiringResolve
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+
+class IndirectMultiVectorReader(
+    private val readers: List<IVectorReader?>,
+    private val readerIndirection: IVectorIndirection,
+    private val vectorIndirections: IVectorIndirection,
+) : IVectorReader {
+
+    private val name = readers.filterNotNull().first().name
+    private val fields: List<Field?> = readers.map { it?.field }
+    private val legReaders = ConcurrentHashMap<Keyword, IVectorReader>()
+    private val vectorField by lazy (LazyThreadSafetyMode.PUBLICATION){
+        MERGE_FIELDS.applyTo(RT.seq(fields.filterNotNull())) as Field
+    }
+
+    companion object {
+        private val MERGE_FIELDS: IFn = requiringResolve("xtdb.types/merge-fields")
+    }
+
+    init {
+        assert(readers.any { it != null })
+    }
+
+    private fun unsupported(): RuntimeException {
+        throw UnsupportedOperationException("IndirectMultiVectoReader")
+    }
+
+    private fun safeReader(idx: Int): IVectorReader {
+        return readers[readerIndirection[idx]] ?: throw unsupported()
+    }
+
+    override fun valueCount(): Int {
+        return readerIndirection.valueCount()
+    }
+
+    override fun getName(): String {
+        return name
+    }
+
+    override fun withName(colName: String): IVectorReader {
+        return RenamedVectorReader(this, colName)
+    }
+
+    override fun getField(): Field {
+        return vectorField
+    }
+
+    override fun hashCode(idx: Int, hasher: ArrowBufHasher): Int {
+        return safeReader(idx).hashCode(vectorIndirections[idx], hasher)
+    }
+
+    override fun isNull(idx: Int): Boolean {
+        val readerIdx = readerIndirection[idx]
+        return readerIdx < 0 || readers[readerIdx] == null || readers[readerIdx]!!.isNull(vectorIndirections[idx])
+    }
+
+    override fun getBoolean(idx: Int): Boolean = safeReader(idx).getBoolean(vectorIndirections[idx])
+
+    override fun getByte(idx: Int): Byte = safeReader(idx).getByte(vectorIndirections[idx])
+
+    override fun getShort(idx: Int): Short = safeReader(idx).getShort(vectorIndirections[idx])
+
+    override fun getInt(idx: Int): Int = safeReader(idx).getInt(vectorIndirections[idx])
+
+    override fun getLong(idx: Int): Long = safeReader(idx).getLong(vectorIndirections[idx])
+
+    override fun getFloat(idx: Int): Float = safeReader(idx).getFloat(vectorIndirections[idx])
+
+    override fun getDouble(idx: Int): Double = safeReader(idx).getDouble(vectorIndirections[idx])
+
+    override fun getBytes(idx: Int): ByteBuffer = safeReader(idx).getBytes(vectorIndirections[idx])
+
+    override fun getPointer(idx: Int): ArrowBufPointer = safeReader(idx).getPointer(vectorIndirections[idx])
+
+    override fun getPointer(idx: Int, reuse: ArrowBufPointer): ArrowBufPointer =
+        safeReader(idx).getPointer(vectorIndirections[idx], reuse)
+
+    override fun getObject(idx: Int): Any? = safeReader(idx).getObject(vectorIndirections[idx])
+
+    override fun getObject(idx: Int, keyFn: IKeyFn<*>?): Any? =
+        safeReader(idx).getObject(vectorIndirections[idx], keyFn)
+
+    override fun structKeyReader(colName: String) =
+        IndirectMultiVectorReader( readers.map { it?.structKeyReader(colName) }, readerIndirection, vectorIndirections )
+
+    override fun structKeys() = readers.filterNotNull().flatMap { it.structKeys() }.toSet()
+
+    override fun listElementReader(): IVectorReader = IndirectMultiVectorReader(
+        readers.map { it?.listElementReader() }, readerIndirection, vectorIndirections
+    )
+
+    override fun getListStartIndex(idx: Int): Int = safeReader(idx).getListStartIndex(vectorIndirections[idx])
+
+    override fun getListCount(idx: Int): Int = safeReader(idx).getListCount(vectorIndirections[idx])
+
+    override fun mapKeyReader(): IVectorReader =
+        IndirectMultiVectorReader(readers.map { it?.mapKeyReader() }, readerIndirection, vectorIndirections)
+
+    override fun mapValueReader(): IVectorReader =
+        IndirectMultiVectorReader(readers.map { it?.mapValueReader() }, readerIndirection, vectorIndirections)
+
+    override fun getLeg(idx: Int): Keyword {
+        val reader = safeReader(idx)
+        return when (val type = fields[readerIndirection[idx]]!!.fieldType.type) {
+            is ArrowType.Union -> reader.getLeg(vectorIndirections[idx])
+            else -> type.toLeg()
+        }
+    }
+
+    override fun legReader(legKey: Keyword): IVectorReader {
+        return legReaders.computeIfAbsent(legKey) {
+            val validReaders = readers.zip(fields).map { (reader, field) ->
+                if (reader == null) null
+                else when (field!!.fieldType.type) {
+                    is ArrowType.Union -> reader.legReader(legKey)
+                    else -> {
+                        if (field.fieldType.type.toLeg() == legKey) reader
+                        else null
+                    }
+                }
+            }
+
+            IndirectMultiVectorReader(
+                validReaders,
+                object : IVectorIndirection {
+                    override fun valueCount(): Int {
+                        return readerIndirection.valueCount()
+                    }
+
+                    override fun getIndex(idx: Int): Int {
+                        val readerIdx = readerIndirection[idx]
+                        if (validReaders[readerIdx] != null) return readerIdx;
+                        return -1
+                    }
+                }, vectorIndirections
+            )
+        }
+    }
+
+    override fun legs(): List<Keyword> {
+        return fields.flatMapIndexed { index: Int, field: Field? ->
+            if (field != null) {
+                when (val type = field.fieldType.type) {
+                    is ArrowType.Union -> readers[index]!!.legs()
+                    else -> listOf(type.toLeg())
+                }
+            } else {
+                emptyList()
+            }
+        }.toSet().toList()
+    }
+
+    override fun copyTo(vector: ValueVector): IVectorReader {
+        val writer = writerFor(vector)
+        val copier = rowCopier(writer)
+
+        for (i in 0 until valueCount()) {
+            copier.copyRow(i)
+        }
+
+        writer.syncValueCount();
+        return ValueVectorReader.from(vector);
+    }
+
+    override fun transferTo(vector: ValueVector): IVectorReader {
+        throw unsupported()
+    }
+
+    override fun rowCopier(writer: IVectorWriter): IRowCopier {
+        val rowCopiers = readers.map { it?.rowCopier(writer) ?: ValueVectorReader(NullVector()).rowCopier(writer) }
+        return IRowCopier { sourceIdx -> rowCopiers[readerIndirection[sourceIdx]].copyRow(vectorIndirections[sourceIdx]) }
+    }
+
+    private fun indirectVectorPosition(pos: IVectorPosition): IVectorPosition {
+        return object : IVectorPosition {
+            override var position: Int
+                get() = vectorIndirections[pos.position]
+                set(@Suppress("UNUSED_PARAMETER") value) {
+                    throw unsupported()
+                }
+        }
+    }
+
+    override fun valueReader(pos: IVectorPosition): IValueReader {
+        val indirectPos = indirectVectorPosition(pos)
+        val valueReaders = readers.map { it?.valueReader(indirectPos) }.toTypedArray()
+
+        return object : IValueReader {
+            private fun valueReader(): IValueReader {
+                return valueReaders[readerIndirection[pos.position]]!!
+            }
+
+            override val leg: Keyword?
+                get() = valueReader().leg
+
+            override val isNull: Boolean
+                get() = valueReader().isNull
+
+            override fun readBoolean(): Boolean {
+                return valueReader().readBoolean()
+            }
+
+            override fun readByte(): Byte {
+                return valueReader().readByte()
+            }
+
+            override fun readShort(): Short {
+                return valueReader().readShort()
+            }
+
+            override fun readInt(): Int {
+                return valueReader().readInt()
+            }
+
+            override fun readLong(): Long {
+                return valueReader().readLong()
+            }
+
+            override fun readFloat(): Float {
+                return valueReader().readFloat()
+            }
+
+            override fun readDouble(): Double {
+                return valueReader().readDouble()
+            }
+
+            override fun readBytes(): ByteBuffer {
+                return valueReader().readBytes()
+            }
+
+            override fun readObject(): Any? {
+                return valueReader().readObject()
+            }
+        }
+    }
+
+    override fun close() {
+        readers.map { it?.close() }
+    }
+
+    override fun toString(): String {
+        return "(IndirectMultiVectorReader ".plus(readers.map { it.toString() }.toString()).plus(")")
+    }
+}

--- a/core/src/test/kotlin/xtdb/vector/IndirectMultiVectorReaderTest.kt
+++ b/core/src/test/kotlin/xtdb/vector/IndirectMultiVectorReaderTest.kt
@@ -1,0 +1,306 @@
+package xtdb.vector
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.complex.DenseUnionVector
+import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.vector.IVectorIndirection.Selection
+import org.apache.arrow.vector.types.Types.MinorType.DENSEUNION as DENSEUNION_TYPE
+import org.apache.arrow.vector.types.pojo.ArrowType.Bool.INSTANCE as BOOL_TYPE
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct.INSTANCE as STRUCT_TYPE
+
+fun <T> cycle(list: List<T>): Sequence<T> {
+    return sequence {
+        while (true) {
+            yieldAll(list)
+        }
+    }
+}
+
+class IndirectMultiVectorReaderTest {
+    private lateinit var alloc: RootAllocator
+
+    @BeforeEach
+    fun setUp() {
+        alloc = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        alloc.close()
+    }
+
+    @Test
+    fun testMonomorphicSimpleVectors() {
+        val intVec1 = IntVector("my-int", alloc)
+        val intVec2 = IntVector("my-int", alloc)
+        for (i in 0..4) {
+            if (i % 2 == 0) intVec1.setSafe(i / 2, i)
+            else intVec2.setSafe(i / 2, i)
+        }
+        intVec1.valueCount = 2
+        intVec2.valueCount = 2
+
+        val rdr1 = ValueVectorReader.intVector(intVec1)
+        val rdr2 = ValueVectorReader.intVector(intVec2)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1, rdr2),
+            Selection(intArrayOf(0, 1, 0, 1)),
+            Selection(intArrayOf(0, 0, 1, 1))
+        )
+        val r = 0..3
+        assertEquals(r.toList(), r.map { indirectRdr.getInt(it) })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(r.toList(), r.map { valueRdr.readInt().also { pos.getPositionAndIncrement() } })
+
+        val resVec = IntVector("my-int", alloc)
+        val vectorWriter = writerFor(resVec)
+        val rowCopier = indirectRdr.rowCopier(vectorWriter)
+        r.map { rowCopier.copyRow(it) }
+        vectorWriter.syncValueCount()
+        assertEquals(r.toList(), r.map { resVec[it] })
+
+        rdr1.close()
+        rdr2.close()
+        vectorWriter.close()
+    }
+
+    private fun readMaps(valueReader: IValueReader): Any? {
+        return when (val o = valueReader.readObject()) {
+            is Map<*, *> -> o.mapValues { readMaps(it.value as IValueReader) }
+            else -> o
+        }
+    }
+
+    @Test
+    fun testMonomorphicStructVectors() {
+        val fooField = Field("foo", FieldType.notNullable(BOOL_TYPE), null)
+        val barField = Field("bar", FieldType.notNullable(BOOL_TYPE), null)
+        val structField = Field("my-struct", FieldType(false, STRUCT_TYPE, null, null), listOf(fooField, barField))
+        val structVec1 = structField.createVector(alloc) as StructVector
+        val structVec2 = structField.createVector(alloc) as StructVector
+        val structVec1Writer = StructVectorWriter(structVec1, null)
+        val structVec2Writer = StructVectorWriter(structVec2, null)
+
+        val m1 = mapOf("foo" to false, "bar" to true)
+        val m2 = mapOf("foo" to true, "bar" to false)
+
+        for (i in 0..4) {
+            if (i % 2 == 0) structVec1Writer.writeObject(m1)
+            else structVec2Writer.writeObject(m2)
+        }
+        structVec1Writer.syncValueCount()
+        structVec2Writer.syncValueCount()
+
+        val rdr1 = ValueVectorReader.structVector(structVec1)
+        val rdr2 = ValueVectorReader.structVector(structVec2)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1, rdr2),
+            Selection(intArrayOf(0, 1, 0, 1)),
+            Selection(intArrayOf(0, 0, 1, 1))
+        )
+        val r = 0..3
+        val expected = cycle(listOf(m1, m2)).take(4).toList()
+        assertEquals(expected, r.map { indirectRdr.getObject(it) })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(expected, r.map { readMaps(valueRdr).also { pos.getPositionAndIncrement() } })
+
+        val resVec = structField.createVector(alloc) as StructVector
+        val vectorWriter = writerFor(resVec)
+        val rowCopier = indirectRdr.rowCopier(vectorWriter)
+        r.map { rowCopier.copyRow(it) }
+        vectorWriter.syncValueCount()
+        val resRdr = ValueVectorReader.structVector(resVec)
+        assertEquals(expected, r.map { resRdr.getObject(it) })
+
+        rdr1.close()
+        rdr2.close()
+        vectorWriter.close()
+    }
+
+    @Test
+    fun testPolymorphicSimpleVectors() {
+        val intVec = IntVector("my-int-or-str", alloc)
+        val stringVec = VarCharVector("my-int-or-str", alloc)
+        val stringVecWriter = writerFor(stringVec)
+        intVec.setSafe(0, 0)
+        intVec.setSafe(1, 1)
+        stringVecWriter.writeObject("first")
+        stringVecWriter.writeObject("second")
+        intVec.valueCount = 2
+        stringVecWriter.syncValueCount()
+
+        val rdr1 = ValueVectorReader.intVector(intVec)
+        val rdr2 = ValueVectorReader.varCharVector(stringVec)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1, rdr2),
+            Selection(intArrayOf(0, 1, 0, 1)),
+            Selection(intArrayOf(0, 0, 1, 1))
+        )
+        val r = 0..3
+        val expected = listOf(0, "first", 1, "second")
+        assertEquals(expected, r.map { indirectRdr.getObject(it) })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(expected, r.map { valueRdr.readObject().also { pos.getPositionAndIncrement() } })
+
+        val duvField = Field("my-duv", FieldType(false, DENSEUNION_TYPE.type, null, null), null)
+        val resVec = duvField.createVector(alloc) as DenseUnionVector
+        val vectorWriter = writerFor(resVec)
+        val rowCopier = indirectRdr.rowCopier(vectorWriter)
+        r.map { rowCopier.copyRow(it) }
+        vectorWriter.syncValueCount()
+        val resRdr = ValueVectorReader.denseUnionVector(resVec)
+        assertEquals(expected, r.map { resRdr.getObject(it) })
+
+        rdr1.close()
+        rdr2.close()
+        vectorWriter.close()
+    }
+
+    @Test
+    fun testPolymorphicSimpleAndComplexVectors() {
+        val intVec = IntVector("my-int-or-str", alloc)
+        val stringVec = VarCharVector("my-int-or-str", alloc)
+        val stringVecWriter = writerFor(stringVec)
+        val duvField = Field("my-duv", FieldType(false, DENSEUNION_TYPE.type, null, null), null)
+        val duvVec = duvField.createVector(alloc) as DenseUnionVector
+        val duvVectorWriter = writerFor(duvVec)
+
+
+        intVec.setSafe(0, 0)
+        stringVecWriter.writeObject("first")
+        duvVectorWriter.writeObject(2)
+        intVec.setSafe(1, 3)
+        stringVecWriter.writeObject("fourth")
+        duvVectorWriter.writeObject("fifth")
+
+        intVec.valueCount = 2
+        stringVecWriter.syncValueCount()
+        duvVectorWriter.syncValueCount()
+
+        val rdr1 = ValueVectorReader.intVector(intVec)
+        val rdr2 = ValueVectorReader.varCharVector(stringVec)
+        val rdr3 = ValueVectorReader.denseUnionVector(duvVec)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1, rdr2, rdr3),
+            Selection(intArrayOf(0, 1, 2, 0, 1, 2)),
+            Selection(intArrayOf(0, 0, 0, 1, 1, 1))
+        )
+        val r = 0..5
+        val expected = listOf(0, "first", 2, 3, "fourth", "fifth")
+        assertEquals(expected, r.map { indirectRdr.getObject(it) })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(expected, r.map { valueRdr.readObject().also { pos.getPositionAndIncrement() } })
+
+        val resVec = duvField.createVector(alloc) as DenseUnionVector
+        val vectorWriter = writerFor(resVec)
+        val rowCopier = indirectRdr.rowCopier(vectorWriter)
+        r.map { rowCopier.copyRow(it) }
+        vectorWriter.syncValueCount()
+        val resRdr = ValueVectorReader.denseUnionVector(resVec)
+        assertEquals(expected, r.map { resRdr.getObject(it) })
+
+        rdr1.close()
+        rdr2.close()
+        rdr3.close()
+        vectorWriter.close()
+    }
+
+    @Test
+    fun testAbsentVectors() {
+        val duvField = Field("my-duv", FieldType(false, DENSEUNION_TYPE.type, null, null), null)
+        val duvVec1 = duvField.createVector(alloc) as DenseUnionVector
+        val duvVec2 = duvField.createVector(alloc) as DenseUnionVector
+        val duvVectorWriter1 = writerFor(duvVec1)
+        val duvVectorWriter2 = writerFor(duvVec2)
+
+        duvVectorWriter1.writeObject(0)
+        duvVectorWriter2.writeObject("first")
+        duvVectorWriter1.populateWithAbsents(2)
+        duvVectorWriter2.writeObject(3)
+        duvVectorWriter1.writeObject("fourth")
+        duvVectorWriter2.populateWithAbsents(3)
+
+        val rdr1 = ValueVectorReader.denseUnionVector(duvVec1)
+        val rdr2 = ValueVectorReader.denseUnionVector(duvVec2)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1, rdr2),
+            Selection(intArrayOf(0, 1, 0, 1, 0, 1)),
+            Selection(intArrayOf(0, 0, 1, 1, 2, 2))
+        )
+        val r = 0..5
+        val expected = listOf(0, "first", null, 3, "fourth", null)
+        assertEquals(expected, r.map {
+            if (indirectRdr.isNull(it)) null
+            else indirectRdr.getObject(it)
+        })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(expected, r.map {
+            val res =
+                if (valueRdr.isNull) null
+                else valueRdr.readObject()
+            pos.getPositionAndIncrement()
+            res
+        })
+
+        val resVec = duvField.createVector(alloc) as DenseUnionVector
+        val vectorWriter = writerFor(resVec)
+        val rowCopier = indirectRdr.rowCopier(vectorWriter)
+        r.map { rowCopier.copyRow(it) }
+        vectorWriter.syncValueCount()
+        val resRdr = ValueVectorReader.denseUnionVector(resVec)
+        assertEquals(expected, r.map { resRdr.getObject(it) })
+
+        rdr1.close()
+        rdr2.close()
+        vectorWriter.close()
+    }
+
+    @Test
+    fun testSingleLeggedDUVs() {
+        val duvField = Field("my-duv", FieldType(false, DENSEUNION_TYPE.type, null, null), null)
+        val duvVec1 = duvField.createVector(alloc) as DenseUnionVector
+        val duvVectorWriter1 = writerFor(duvVec1)
+
+        duvVectorWriter1.writeObject(0)
+        duvVectorWriter1.writeObject(1)
+
+        val rdr1 = ValueVectorReader.denseUnionVector(duvVec1)
+        val indirectRdr = IndirectMultiVectorReader(
+            listOf(rdr1),
+            Selection(intArrayOf(0, 0)),
+            Selection(intArrayOf(0, 1))
+        )
+
+        val r = 0..1
+        val expected = listOf(0, 1)
+        assertEquals(expected, r.map { indirectRdr.getObject(it) })
+
+        val pos = IVectorPosition.build(0)
+        val valueRdr = indirectRdr.valueReader(pos)
+        assertEquals(expected, r.map {
+            val res = valueRdr.readInt()
+            pos.getPositionAndIncrement()
+            res
+        })
+
+        rdr1.close()
+    }
+}


### PR DESCRIPTION
Previously we were copying data in scan to a new relation that was then passed out of scan. We now create views over the existing content columns. For temporal columns we still copy to a new relation because of the resolution of the polygons.
The main new class is a `IndirectMultiVectorReader` which is a view over multiple `IVectorReader`s. It should behave like a `DuvReader` in case the underlying vectors don't have a monomorphic type and otherwise like a reader as returned by `getField`. 

Todo:
- [x] check performance
    - [x] TPC-H (SF 0.4) - hot and cold run
         - ~75s on main (uncompacted - with background tasks)
         - ~66.5s with copy row removal (uncompacted - with background tasks)
    - [x] Auctionmark 30sec run - number of get-item calls
         - ~72k calls on main (with one thread failure)
         - ~67k calls with copy row removal (with two thread failures)
         - failures are related to #3280
- [x] Review
