### PR TITLE
Docs SQL reorg

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -38,33 +38,10 @@ export default defineConfig({
             { label: 'Quickstart', link: '/intro/getting-started' },
             { label: 'SQL basics', link: '/quickstart/insert-and-query' },
             { label: 'Query the past', link: '/quickstart/query-the-past' },
-	    { label: 'Set Valid-Time', link: '/quickstart/set-valid-time' },
+	    { label: 'Control the timeline', link: '/quickstart/control-the-timeline' },
 
 	  ]
 	},
-        {
-          label: 'Background',
-          collapsed: true,
-          items: [
-            { label: 'Mission', link: '/intro/why-xtdb' },
-            { label: 'XTDB at a glance', link: '/intro/what-is-xtdb' },
-            { label: 'How XTDB works', link: '/intro/data-model' },
-            // { label: 'Architecture', link: '/intro/architecture' },
-            // { label: 'Bitemporality', link: '/intro/bitemporality' }
-
-            { label: 'Community', link: '/intro/community' },
-            { label: 'Roadmap', link: '/intro/roadmap' },
-
-            {
-              label: 'XTQL',
-              collapsed: true,
-              items: [
-                { label: 'Overview', link: '/intro/what-is-xtql' },
-                { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
-               ]
-            },
-          ],
-        },
 
 /*        {
           label: 'Tutorials',
@@ -78,6 +55,9 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Setting up a cluster on AWS', link: '/guides/starting-with-aws' },
+            { label: 'XTQL Overview', link: '/intro/what-is-xtql' },
+            { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
+
           ],
         },
 
@@ -130,6 +110,7 @@ export default defineConfig({
             { label: 'Overview', link: '/drivers' },
             {
               label: 'HTTP + JSON',
+              collapsed: true,
               items: [
                 { label: 'Getting started', link: '/drivers/http/getting-started' },
                 { label: 'HTTP (OpenAPI) ↗', link: '/drivers/http/openapi/index.html', attrs: { target: '_blank' } },
@@ -138,6 +119,7 @@ export default defineConfig({
 
             {
               label: 'Java',
+              collapsed: true,
               items: [
                 { label: 'Getting started', link: '/drivers/java/getting-started' },
                 // TODO broken atm
@@ -147,6 +129,7 @@ export default defineConfig({
 
             {
               label: 'Kotlin',
+              collapsed: true,
               items: [
                 { label: 'Getting started', link: '/drivers/kotlin/getting-started' },
                 { label: 'KDoc ↗', link: '/drivers/kotlin/kdoc/index.html', attrs: { target: '_blank' } }
@@ -155,16 +138,14 @@ export default defineConfig({
 
             {
               label: 'Clojure',
+              collapsed: true,
               items: [
                 { label: 'Getting started', link: '/drivers/clojure/getting-started' },
                 { label: 'Codox ↗', link: '/drivers/clojure/codox/index.html', attrs: { target: '_blank' } },
                 { label: 'Configuration cookbook', link: '/drivers/clojure/configuration' },
                 { label: 'Transactions cookbook', link: '/drivers/clojure/txs' },
-                { label: 'Clojure Tutorials',
-		  items: [
-			   { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
-                  ]
-		},
+                { label: 'Tutorial: Learn XTQL Today', link: '/tutorials/learn-xtql-today-with-clojure' },
+
               ]
             },
 
@@ -202,6 +183,21 @@ export default defineConfig({
               ]
             },
           ]
+        },
+	{
+          label: 'Appendices',
+          collapsed: true,
+          items: [
+            { label: 'Mission', link: '/intro/why-xtdb' },
+            { label: 'XTDB at a glance', link: '/intro/what-is-xtdb' },
+            { label: 'How XTDB works', link: '/intro/data-model' },
+            // { label: 'Architecture', link: '/intro/architecture' },
+            // { label: 'Bitemporality', link: '/intro/bitemporality' }
+
+            { label: 'Community', link: '/intro/community' },
+            { label: 'Roadmap', link: '/intro/roadmap' },
+
+          ],
         },
       ],
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,45 +29,143 @@ export default defineConfig({
 
         { label: '← 1.x (stable release) docs', link: 'https://v1-docs.xtdb.com', attrs: { target: '_blank' } },
 
+        { label: 'Overview', link: '/index.html' },
+
         {
-          label: 'Introduction',
-          collapsed: false,
+	  label: 'Getting Started',
+	  collapsed: false,
+	  items: [
+            { label: 'Basic Setup', link: '/intro/getting-started' },
+	  ]
+	},
+        {
+          label: 'Background',
+          collapsed: true,
           items: [
-            { label: 'Overview', link: '/' },
-            { label: 'Why XTDB?', link: '/intro/why-xtdb' },
-            { label: 'Getting started', link: '/intro/getting-started' },
-            {
-              label: 'What is XTDB?',
-              items: [
-                { label: 'At a glance', link: '/intro/what-is-xtdb' },
-                { label: 'What is XTQL?', link: '/intro/what-is-xtql' },
-                { label: 'Data model', link: '/intro/data-model' },
-                // { label: 'Architecture', link: '/intro/architecture' },
-                // { label: 'Bitemporality', link: '/intro/bitemporality' }
-              ]
-            },
+            { label: 'Mission', link: '/intro/why-xtdb' },
+            { label: 'XTDB at a glance', link: '/intro/what-is-xtdb' },
+            { label: 'How XTDB works', link: '/intro/data-model' },
+            // { label: 'Architecture', link: '/intro/architecture' },
+            // { label: 'Bitemporality', link: '/intro/bitemporality' }
+
             { label: 'Community', link: '/intro/community' },
             { label: 'Roadmap', link: '/intro/roadmap' },
+
+            {
+              label: 'XTQL',
+              collapsed: true,
+              items: [
+                { label: 'Overview', link: '/intro/what-is-xtql' },
+                { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
+               ]
+            },
           ],
         },
 
-        {
+/*        {
           label: 'Tutorials',
           collapsed: true,
           items: [
-            { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
           ],
         },
-
+*/
         {
           label: 'Guides',
           collapsed: true,
           items: [
             { label: 'Setting up a cluster on AWS', link: '/guides/starting-with-aws' },
-            { label: 'XTQL Walkthrough', link: '/guides/xtql-walkthrough' },
           ],
         },
 
+        {
+          label: 'Reference',
+          collapsed: true,
+          items: [
+            { label: 'Overview', link: '/reference/main' },
+
+            {
+              label: 'SQL',
+              collapsed: true,
+              items: [
+                { label: 'Transactions', link: '/reference/main/sql/txs' },
+                { label: 'Queries', link: '/reference/main/sql/queries' },
+              ]
+            },
+
+{
+              label: 'XTQL',
+              collapsed: true,
+              items: [
+                { label: 'Transactions', link: '/reference/main/xtql/txs' },
+                { label: 'Queries', link: '/reference/main/xtql/queries' },
+              ]
+            },
+
+            { label: 'Data Types', link: '/reference/main/data-types' },
+
+            {
+              label: 'Standard Library',
+              collapsed: true,
+              items: [
+                { label: 'Overview', link: '/reference/main/stdlib' },
+                { label: 'Predicates', link: '/reference/main/stdlib/predicates' },
+                { label: 'Numeric functions', link: '/reference/main/stdlib/numeric' },
+                { label: 'String functions', link: '/reference/main/stdlib/string' },
+                { label: 'Temporal functions', link: '/reference/main/stdlib/temporal' },
+                { label: 'Aggregate functions', link: '/reference/main/stdlib/aggregates' },
+                { label: 'Other functions', link: '/reference/main/stdlib/other'}
+              ]
+            },
+          ]
+        },
+
+        {
+          label: 'Drivers',
+          collapsed: true,
+          items: [
+            { label: 'Overview', link: '/drivers' },
+            {
+              label: 'HTTP + JSON',
+              items: [
+                { label: 'Getting started', link: '/drivers/http/getting-started' },
+                { label: 'HTTP (OpenAPI) ↗', link: '/drivers/http/openapi/index.html', attrs: { target: '_blank' } },
+              ]
+            },
+
+            {
+              label: 'Java',
+              items: [
+                { label: 'Getting started', link: '/drivers/java/getting-started' },
+                // TODO broken atm
+                // { label: 'Javadoc ↗', link: '/drivers/java/javadoc/index.html', attrs: {target: '_blank'} }
+              ]
+            },
+
+            {
+              label: 'Kotlin',
+              items: [
+                { label: 'Getting started', link: '/drivers/kotlin/getting-started' },
+                { label: 'KDoc ↗', link: '/drivers/kotlin/kdoc/index.html', attrs: { target: '_blank' } }
+              ]
+            },
+
+            {
+              label: 'Clojure',
+              items: [
+                { label: 'Getting started', link: '/drivers/clojure/getting-started' },
+                { label: 'Codox ↗', link: '/drivers/clojure/codox/index.html', attrs: { target: '_blank' } },
+                { label: 'Configuration cookbook', link: '/drivers/clojure/configuration' },
+                { label: 'Transactions cookbook', link: '/drivers/clojure/txs' },
+                { label: 'Clojure Tutorials',
+		  items: [
+			   { label: 'Learn XTQL Today, with Clojure', link: '/tutorials/learn-xtql-today-with-clojure' },
+                  ]
+		},
+              ]
+            },
+
+          ]
+        },
         {
           label: 'Configuration',
           collapsed: true,
@@ -97,85 +195,6 @@ export default defineConfig({
               items: [
                 { label: 'Overview', link: '/config/modules' },
                 { label: 'HTTP Server', link: '/config/modules/http-server' }
-              ]
-            },
-          ]
-        },
-
-        {
-          label: 'Reference',
-          collapsed: true,
-          items: [
-            { label: 'Overview', link: '/reference/main' },
-
-            {
-              label: 'XTQL',
-              collapsed: true,
-              items: [
-                { label: 'Transactions', link: '/reference/main/xtql/txs' },
-                { label: 'Queries', link: '/reference/main/xtql/queries' },
-              ]
-            },
-
-            {
-              label: 'SQL',
-              collapsed: true,
-              items: [
-                { label: 'Transactions', link: '/reference/main/sql/txs' },
-                { label: 'Queries', link: '/reference/main/sql/queries' },
-              ]
-            },
-
-            { label: 'Data Types', link: '/reference/main/data-types' },
-
-            {
-              label: 'Standard Library',
-              collapsed: true,
-              items: [
-                { label: 'Overview', link: '/reference/main/stdlib' },
-                { label: 'Predicates', link: '/reference/main/stdlib/predicates' },
-                { label: 'Numeric functions', link: '/reference/main/stdlib/numeric' },
-                { label: 'String functions', link: '/reference/main/stdlib/string' },
-                { label: 'Temporal functions', link: '/reference/main/stdlib/temporal' },
-                { label: 'Aggregate functions', link: '/reference/main/stdlib/aggregates' },
-                { label: 'Other functions', link: '/reference/main/stdlib/other'}
-              ]
-            },
-          ]
-        },
-
-        {
-          label: 'Drivers',
-          collapsed: true,
-          items: [
-            { label: 'Overview', link: '/drivers' },
-
-            {
-              label: 'Clojure',
-              items: [
-                { label: 'Getting started', link: '/drivers/clojure/getting-started' },
-                { label: 'Configuration cookbook', link: '/drivers/clojure/configuration' },
-                { label: 'Transactions cookbook', link: '/drivers/clojure/txs' },
-                { label: 'Codox ↗', link: '/drivers/clojure/codox/index.html', attrs: { target: '_blank' } }
-              ]
-            },
-
-            {
-              label: 'Kotlin',
-              items: [
-                { label: 'Getting started', link: '/drivers/kotlin/getting-started' },
-                { label: 'KDoc ↗', link: '/drivers/kotlin/kdoc/index.html', attrs: { target: '_blank' } }
-              ]
-            },
-
-            { label: 'HTTP (OpenAPI) ↗', link: '/drivers/http/openapi/index.html', attrs: { target: '_blank' } },
-
-            {
-              label: 'Java',
-              items: [
-                { label: 'Getting started', link: '/drivers/java/getting-started' },
-                // TODO broken atm
-                // { label: 'Javadoc ↗', link: '/drivers/java/javadoc/index.html', attrs: {target: '_blank'} }
               ]
             },
           ]

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -76,7 +76,7 @@ export default defineConfig({
               ]
             },
 
-{
+            {
               label: 'XTQL',
               collapsed: true,
               items: [

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,13 +29,17 @@ export default defineConfig({
 
         { label: '← 1.x (stable release) docs', link: 'https://v1-docs.xtdb.com', attrs: { target: '_blank' } },
 
-        { label: 'Overview', link: '/index.html' },
+        { label: 'Introduction', link: '/index.html' },
 
         {
 	  label: 'Getting Started',
 	  collapsed: false,
 	  items: [
-            { label: 'Basic Setup', link: '/intro/getting-started' },
+            { label: 'Quickstart', link: '/intro/getting-started' },
+            { label: 'SQL basics', link: '/quickstart/insert-and-query' },
+            { label: 'Query the past', link: '/quickstart/query-the-past' },
+	    { label: 'Set Valid-Time', link: '/quickstart/set-valid-time' },
+
 	  ]
 	},
         {

--- a/docs/public/xtsql.py
+++ b/docs/public/xtsql.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+
+# MIT License
+
+# Copyright (c) 2023-2024 Håkan Råberg and Steven Deobald
+
+# Copyright (c) 2024 JUXT Ltd
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import base64
+from datetime import date, datetime, time
+import json
+import urllib.request
+
+end_of_time = "9999-12-31T23:59:59.999999Z"
+
+def parse_iso_datetime(date_string):
+    """
+    Attempts to parse a date_string with varying levels of granularity, from just a year
+    to a full timestamp with microseconds, accepting both 'T' and ' ' as separators between
+    date and time components.
+    """
+    # print(date_string)
+
+    # Normalize the datetime string to use a space separator
+    date_string = date_string.replace('T', ' ')
+
+    # List of datetime formats in decreasing order of granularity
+    # Note the use of optional parts with regex-like syntax in strptime is not possible,
+    # so we list the formats explicitly.
+    datetime_formats = [
+        "%Y-%m-%d %H:%M:%S.%f%z",  # Full timestamp with microseconds and timezone
+        "%Y-%m-%d %H:%M:%S.%fZ",   # Timestamp without timezone Z
+        "%Y-%m-%d %H:%M:%S.%f",    # Timestamp without timezone
+        "%Y-%m-%d %H:%M:%SZ",      # Timestamp without microseconds Z
+        "%Y-%m-%d %H:%M:%S",       # Timestamp without microseconds
+        "%Y-%m-%d %H:%MZ",         # Without seconds Z
+        "%Y-%m-%d %H:%M",          # Without seconds
+        "%Y-%m-%d %HZ",            # Only date and hour Z
+        "%Y-%m-%d %H",             # Only date and hour
+        "%Y-%m-%d",                # Only date
+        "%Y-%m",                   # Only year and month
+        "%Y"                       # Only year
+    ]
+
+    for fmt in datetime_formats:
+        try:
+            # Attempt to parse the string with the current format
+            return datetime.strptime(date_string, fmt)
+        except ValueError:
+            # If parsing fails, move on to the next format
+            continue
+
+    # If no format matches, return max datetime
+    return datetime.max
+
+def remove_none_and_empty_dict_values(d):
+    def is_empty_dict(val):
+        if isinstance(val, dict) and not val:
+            return True
+        return False
+
+    keys_to_delete = [key for key, value in d.items() if value is None or is_empty_dict(value)]
+    for key in keys_to_delete:
+        del d[key]
+
+    for key, value in list(d.items()):
+        if isinstance(value, dict):
+            remove_none_and_empty_dict_values(value)
+            if is_empty_dict(value):
+                del d[key]
+
+    return d
+
+class AbstractXtdb:
+    def _from_json_ld(self, obj):
+        match obj.get('@type', None):
+            case 'xt:timestamp':
+                return parse_iso_datetime(obj['@value'])
+            case 'xt:timestamptz':
+                return parse_iso_datetime(obj['@value'].replace("[UTC]", ""))
+            case 'xt:date':
+                return date.fromisoformat(obj['@value'])
+            case _:
+                return obj.get('@graph', obj)
+
+    def _to_json_ld(self, obj):
+        match obj:
+            case datetime():
+                 return {'@value': datetime.isoformat(obj), '@type': 'xt:timestamp'}
+            case date():
+                 return {'@value': date.isoformat(obj), '@type': 'xt:date'}
+            case _:
+                 raise TypeError
+
+class Xtdb(AbstractXtdb):
+    """
+    An XTDB client for the HTTP API
+    Attributes
+    ----------
+    url : str
+        HTTP URL of an XTDB Server
+    """
+    def __init__(self, url='http://localhost:3000', accept='application/json',
+                 txtimeout=None):
+        """
+        Parameters
+        ----------
+        url : str, default='http://localhost:3000/'
+            HTTP URL of an XTDB instance
+        accept : str, default='application/json'
+            Accept header content type
+        """
+        super().__init__()
+        self.url = url
+        self.accept = accept
+        self.txtimeout = txtimeout
+
+    def sql_query(self, q, p=[], m=False, accept=None, explain=None,
+                  basis_at_tx_id=None, basis_at_system_time=None):
+        """Executes a read-only SQL statement
+        The SQL statement is sent to the `/query` endpoint at `Xtdb.url` over HTTP.
+        Parameters
+        ----------
+        q : str
+            SQL statement or query to execute
+        p : array_like, default=[]
+            An array of positional SQL parameters
+        Raises
+        ------
+        TypeError
+            Internal error if attempting to translate an unknown type
+            to LD-JSON.
+        """
+        if accept is None:
+            accept = self.accept
+        headers = {'Accept': accept,
+                   'Content-Type': 'application/json'}
+
+        if p == []:
+            args_value = []
+        else:
+            args_value = json.dumps(p, default=self._to_json_ld)
+
+        payload = {"query": {"sql": q[:-1]},
+                   "queryOpts": {# "args": args_value,
+                                 "txTimeout": self.txtimeout,
+                                 "keyFn": "SNAKE_CASE_STRING",
+                                 "explain": explain,
+                                 "basis": {"currentTime": basis_at_system_time,
+                                           "atTx": {"txId": basis_at_tx_id,
+                                                    "systemTime": basis_at_system_time}}}}
+
+        payload = remove_none_and_empty_dict_values(payload)
+
+        #print(payload)
+        url = self.url + '/query'
+
+        data = json.dumps(payload).encode('utf-8')
+        # print(data)
+
+        req = urllib.request.Request(url, data, headers, method='POST')
+        with urllib.request.urlopen(req) as response:
+            response_body = response.read().decode('utf-8')
+            json_strings = response_body.strip().split('\n')
+            json_array = [json.loads(json_str, object_hook=self._from_json_ld)
+                          for json_str in json_strings if json_str]
+
+            return json_array
+
+    def sql_tx(self, q, p=[], m=False, accept=None):
+        """Executes a transactional SQL statement
+        The SQL statement is sent to the `/tx` endpoint at `Xtdb.url` over HTTP.
+        Parameters
+        ----------
+        q : str
+            SQL statement to execute
+        p : array_like, default=[]
+            An array of positional SQL parameters
+        Raises
+        ------
+        TypeError
+            Internal error if attempting to translate an unknown type
+            to LD-JSON.
+        """
+        if accept is None:
+            accept = self.accept
+        headers = {'Accept': accept,
+                   'Content-Type': 'application/json'}
+
+        if p == []:
+            args_value = []
+        else:
+            args_value = json.dumps(p, default=self._to_json_ld)
+
+        # TODO afterTx, atTx
+
+        payload = {"txOps":[{"sql": q[:-1]}]}
+
+        url = self.url + '/tx'
+
+        data = json.dumps(payload).encode('utf-8')
+
+        req = urllib.request.Request(url, data, headers, method='POST')
+        with urllib.request.urlopen(req) as response:
+            response_body = response.read().decode('utf-8')
+            json_strings = response_body.strip().split('\n')
+            json_array = [json.loads(json_str, object_hook=self._from_json_ld)
+                          for json_str in json_strings if json_str]
+
+            return json_array
+
+    def sql_status(self, accept=None):
+        """Calls the `/status` endpoint of the connected XTDB server.
+        """
+        if accept is None:
+            accept = self.accept
+        headers = {'Accept': accept}
+
+        url = self.url + '/status'
+
+        req = urllib.request.Request(url, headers=headers, method='GET')
+        with urllib.request.urlopen(req) as response:
+            response_body = response.read().decode('utf-8')
+            json_strings = response_body.strip().split('\n')
+            json_array = [json.loads(json_str, object_hook=self._from_json_ld)
+                          for json_str in json_strings if json_str]
+
+            return json_array
+
+# end of client functionality
+
+# beginning of console functionality
+
+"""XTDB Console
+This script provides a prompt (->) at which the user can enter raw SQL
+commands to send to XTDB.
+"""
+
+import cmd
+import json
+# import xtdb
+import pprint
+import urllib.error
+import re
+import time
+# import edn_format
+
+def markdownSimpleTable(data):
+    # Ensure there is data to process
+    if not data:
+        return "No data provided."
+
+    # Collect keys in order while avoiding duplicates
+    seen_keys = set()
+    ordered_keys = []
+    for item in data:
+        for key in item.keys():
+            if key not in seen_keys:
+                seen_keys.add(key)
+                ordered_keys.append(key)
+
+    # Calculate Padding For Each Column Based On Header and Data Length
+    rowsPadding = {}
+    for index, key in enumerate(ordered_keys):
+        padCount = max(len(str(item.get(key, ""))) + 1 for item in data) + 2  # Adjusted for added space
+        headerPadCount = len(key) + 2
+        rowsPadding[index] = max(padCount, headerPadCount)
+
+    # Render Markdown Header
+    header_row = '|' + '|'.join((' ' + key).ljust(rowsPadding[index]) for index, key in enumerate(ordered_keys)) + '|'
+    separator_row = '|' + '|'.join('-' * rowsPadding[index] for index in range(len(ordered_keys))) + '|'
+    rows = [header_row, separator_row]
+
+    # Render Tabular Data
+    for item in data:
+        row = '|' + '|'.join((' ' + str(item.get(key, ""))).ljust(rowsPadding[index]) for index, key in enumerate(ordered_keys)) + '|'
+        rows.append(row)
+
+    # Convert Tabular String Rows Into String
+    tableString = "\n".join(rows)
+    return tableString
+
+def prepare_for_tabulate(data, special_key='xt$id'):
+    # return data
+    # Check if the special key exists in any of the dictionaries
+    if any(special_key in row for row in data):
+        # Sort keys alphanumerically, but put special_key first
+        sorted_keys = sorted({key for row in data for key in row if key != special_key})
+        sorted_keys.insert(0, special_key)  # Insert the special_key at the beginning
+    else:
+        # Just sort keys alphanumerically if special_key doesn't exist
+        sorted_keys = sorted({key for row in data for key in row})
+
+    # Reorder the dictionaries according to sorted_keys
+    reordered_data = [{key: row.get(key) for key in sorted_keys} for row in data]
+
+    return reordered_data
+
+def pretty_format(item, nonestr='NULL', emptystr='\'\''):
+    if isinstance(item, dict):
+        return {k: pretty_format(v, nonestr, emptystr) for k, v in item.items()}
+    else:
+        if item is None:
+            return nonestr
+        elif item == '':
+            return emptystr
+        elif isinstance (item, str):
+            return '\'' + item + '\''
+        else:
+            return item
+
+# def json_ld_to_edn_string(obj):
+#    if isinstance(obj, dict):
+#        # Check for special types first
+#        match obj.get('@type', None):
+#            case 'xt:keyword':
+#                return edn_format.Keyword(obj['@value'])
+#            case 'xt:symbol':
+#                return edn_format.Symbol(obj['@value'])
+#            case _:
+#                # Recursively process and convert nested dictionaries or lists
+#                return {k: json_ld_to_edn_string(v) for k, v in obj.items() if k != '@type'}
+#    elif isinstance(obj, list):
+#        # Recursively process each item in the list
+#        return [json_ld_to_edn_string(item) for item in obj]
+#    else:
+#        # Return the object as is if it's not a dict or list (base case)
+#        return obj
+
+class XtdbConsole(cmd.Cmd):
+    """
+    An XTDB console for processing SQL statements, files, or prompts.
+    Running multiple statements (separated by `;`) is not supported.
+    Attributes
+    ----------
+    url : str
+        HTTP URL of an XTDB server
+    accept : str, optional
+        accept header content type (defaults to 'application/json')
+    prompt : str, optional
+        initial prompt (defaults to '->')
+    nested_prompt : str, optional
+        prompt for multi-line SQL statements (defaults to '..')
+    """
+    def __init__(self, url, accept='application/json', prompt='-> ', nested_prompt='.. '):
+        super().__init__()
+        self.url = url
+        self.accept = accept
+        self.prompt = prompt
+        self.default_prompt = prompt
+        self.nested_prompt = nested_prompt
+        self.timer = False
+        self.txtimeout = "PT1S"
+        self.basis_at_tx_id = -1
+        self.basis_at_system_time = end_of_time
+        self.tabulate = True
+        self.lines = []
+        self.was_error = False
+
+    def emptyline(self):
+        pass
+
+    def do_timer(self, arg):
+        'Sets or shows timer.'
+        if arg:
+            self.timer = arg == 'on'
+        if self.timer:
+            print('on')
+        else:
+            print('off')
+
+    def complete_txtimeout(self, text, line, begidx, endidx):
+        return [x for x in ['off']
+                if x.startswith(text)]
+
+    def do_txtimeout(self, arg):
+        'Sets or shows request `txTimeout`.'
+        if arg:
+            self.txtimeout = arg
+        if self.txtimeout:
+            print(self.txtimeout)
+
+    def do_basis_at_tx_id(self, arg):
+        'Sets or shows current TxId used for the time-travel `basis` at which queries are run.'
+        if arg:
+            self.basis_at_tx_id = int(arg)
+        if self.basis_at_tx_id:
+            print(self.basis_at_tx_id)
+        # TODO clear_basis?
+        # TODO print json toggle (off by default)
+
+    def do_basis_at_system_time(self, arg):
+        'Sets or shows current systemTime used for the time-travel `basis` at which queries are run.'
+        if arg:
+            self.basis_at_system_time = parse_iso_datetime(arg).strftime('%Y-%m-%dT%H:%M:%S.%f') + 'Z'
+        if self.basis_at_system_time:
+            print(self.basis_at_system_time)
+
+    def do_clear_basis(self, arg):
+        'Clear current `basis` settings.'
+        self.basis_at_system_time = end_of_time
+        self.basis_at_tx_id = -1
+        print('basis cleared')
+
+    def do_recent_transactions(self, arg):
+        'Show the 10 most recent transactions by running `SELECT * FROM xt$txs ORDER BY xt$txs.xt$id DESC LIMIT 20;`'
+        result = Xtdb(self.url, self.accept,
+                           self.txtimeout).sql_query('SELECT * FROM xt$txs ORDER BY xt$txs.xt$id DESC LIMIT 20;')
+        if self.tabulate:
+                result2 = [pretty_format(item) for item in result]
+                print(markdownSimpleTable(prepare_for_tabulate(result2)))
+        else:
+            pprint.pprint(result)
+
+    def do_tabulate(self, arg):
+        'Sets or shows table printer setting.'
+        if arg:
+            self.tabulate = arg == 'on'
+        if self.tabulate:
+            print('on')
+        else:
+            print('off')
+
+    def do_status(self, arg):
+        'Calls the `/status` endpoint of the connected XTDB server.'
+        result = Xtdb(self.url, self.accept).sql_status()
+        if self.tabulate:
+            print(markdownSimpleTable(result))
+        else:
+            pprint.pprint(result)
+
+    def complete_accept(self, text, line, begidx, endidx):
+        return [x for x in ['application/json']
+                if x.startswith(text)]
+
+    def do_accept(self, arg):
+        'Sets or shows the accepted mime type.'
+        if arg:
+            self.accept = re.sub('=\s*', '', arg)
+        print(self.accept)
+
+    def do_url(self, arg):
+        'Sets or shows the database URL.'
+        if arg:
+            self.url = re.sub('=\s*', '', arg)
+        print(self.url)
+
+    def do_quit(self, arg):
+        'Quits the console.'
+        return 'stop'
+
+    def default(self, line):
+        start_time = None
+        if line == 'EOF':
+            return 'stop'
+
+        self.lines.append(line)
+
+        if not line.strip().endswith(';'):
+            self.prompt = self.nested_prompt
+            return
+
+        try:
+            sql = '\n'.join(self.lines)
+            self.lines = []
+            self.prompt = self.default_prompt
+            start_time = time.time()
+
+            explain = sql.upper().startswith("EXPLAIN ")
+            explain = True if explain else None
+            sql = sql[8:] if explain else sql
+
+            # Initial conditions for setting values to None or their actual value
+            basis_at_tx_id_condition = self.basis_at_tx_id == -1
+            basis_at_system_time_condition = self.basis_at_system_time == end_of_time
+            # Determine if either value should not be None based on initial conditions
+            either_value_not_none = not basis_at_tx_id_condition or not basis_at_system_time_condition
+            # Apply logic to ensure both are not None if either is not None
+            if either_value_not_none:
+                basis_at_tx_id = self.basis_at_tx_id if not basis_at_tx_id_condition else -1
+                basis_at_system_time = self.basis_at_system_time if not basis_at_system_time_condition else end_of_time
+            else:
+                # If both should be None based on their specific conditions
+                basis_at_tx_id = None if basis_at_tx_id_condition else self.basis_at_tx_id
+                basis_at_system_time = None if basis_at_system_time_condition else self.basis_at_system_time
+
+            # TODO consider WITH ROLLBACK SET BEGIN COMMIT VALUES START
+
+            # TODO figure out insertion of "" and escaped \' edge cases
+
+            dml_operations = ("INSERT", "UPDATE", "DELETE", "ERASE")
+
+            if sql.upper().startswith(dml_operations):
+                result = Xtdb(self.url, self.accept, self.txtimeout).sql_tx(sql)
+            else:
+                result = Xtdb(self.url, self.accept,
+                                   self.txtimeout).sql_query(sql,
+                                                             explain=explain,
+                                                             basis_at_tx_id=basis_at_tx_id,
+                                                             basis_at_system_time=basis_at_system_time)
+
+            if explain:
+                #print('Generated query plan (printed using `edn_format`):')
+                print(result[0]['plan'])
+                #print(edn_format.dumps(json_ld_to_edn_string(result[0]['plan']),
+                #                       keyword_keys=True,
+                #                       indent=2))
+            elif self.tabulate:
+                result2 = [pretty_format(item) for item in result]
+                print(markdownSimpleTable(prepare_for_tabulate(result2)))
+            else:
+                pprint.pprint(result)
+
+        except urllib.error.HTTPError as e:
+            self.was_error = True
+            if e.code != 400:
+                print('%s %s' % (e.code, e.reason))
+            body = e.read().decode('utf-8')
+            if body:
+               # print(body)
+               # TODO if no xtdb.error/message, print the whole body
+                print(json.loads(body)["@value"]["xtdb.error/message"])
+        except urllib.error.URLError as e:
+            self.was_error = True
+            print(self.url)
+            print(e.reason)
+        if start_time and self.timer:
+            print('Elapsed: %f ms' % (time.time() - start_time))
+
+def main():
+    import argparse
+    import sys
+    import pathlib
+
+    print("XTDB v2.0 -- SQL Console")
+    print("Copyright © 2021-2024, JUXT LTD.")
+    print()
+    print("Type 'help' for commands")
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('sql', nargs='*', help='SQL statement or file')
+    parser.add_argument('--url', default='http://localhost:3000')
+    args = parser.parse_args()
+
+    prompt = '-> '
+    nested_prompt = '.. '
+    if not sys.stdin.isatty():
+        prompt = ''
+        nested_prompt = ''
+    try:
+        console = XtdbConsole(args.url, prompt=prompt, nested_prompt=nested_prompt)
+        if args.sql:
+            for sql in args.sql:
+                path = pathlib.Path(sql)
+                if path.is_file():
+                    sql = path.read_text()
+
+                if not sql.strip().endswith(';'):
+                    sql += ';'
+
+                console.default(sql)
+
+                if console.was_error:
+                    sys.exit(1)
+        else:
+            console.cmdloop()
+            if sys.stdin.isatty():
+                print()
+    except KeyboardInterrupt:
+        print()
+
+if __name__ == '__main__':
+    main()

--- a/docs/public/xtsql.py
+++ b/docs/public/xtsql.py
@@ -505,6 +505,8 @@ class XtdbConsole(cmd.Cmd):
                                                              basis_at_tx_id=basis_at_tx_id,
                                                              basis_at_system_time=basis_at_system_time)
 
+            print()
+
             if explain:
                 #print('Generated query plan (printed using `edn_format`):')
                 print(result[0]['plan'])
@@ -516,6 +518,8 @@ class XtdbConsole(cmd.Cmd):
                 print(markdownSimpleTable(prepare_for_tabulate(result2)))
             else:
                 pprint.pprint(result)
+
+            print()
 
         except urllib.error.HTTPError as e:
             self.was_error = True
@@ -542,13 +546,14 @@ def main():
     print("Copyright © 2021-2024, JUXT LTD.")
     print()
     print("Type 'help' for commands")
+    print()
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('sql', nargs='*', help='SQL statement or file')
     parser.add_argument('--url', default='http://localhost:3000')
     args = parser.parse_args()
 
-    prompt = '-> '
+    prompt = 'xtdb-> '
     nested_prompt = '.. '
     if not sys.stdin.isatty():
         prompt = ''

--- a/docs/src/content/docs/concepts/key-concepts.adoc
+++ b/docs/src/content/docs/concepts/key-concepts.adoc
@@ -50,12 +50,12 @@ In addition to any user-defined columns asserted for a given row, XTDB maintains
 
 These columns are:
 
-- `system_time_from`
-- `system_time_to`
-- `valid_time_from`
-- `valid_time_to`
+- `xt$system_from`
+- `xt$system_to`
+- `xt$valid_from`
+- `xt$valid_to`
 
-The values of these columns are maintained automatically and the respective pairs of columns always form 'closed-open' periods (i.e. inclusive of 'from', exclusive of 'to').
+The columns are not visible unless explicitly queried. The values of these columns are maintained automatically and the respective pairs of columns always form 'closed-open' periods (i.e. inclusive of 'from', exclusive of 'to').
 
 'System time' represents the audit history of all changes to records and captures the time that information entered the system. 'Valid time' is a user-managed dimension and can be used for a variety of purposes (out of order updates, backfilling data, domain modeling etc.).
 

--- a/docs/src/content/docs/drivers.adoc
+++ b/docs/src/content/docs/drivers.adoc
@@ -4,7 +4,7 @@ title: XTDB Client Language Drivers
 
 XTDB is accessible through our HTTP API and Java, Kotlin and Clojure drivers - drivers for JavaScript, Python and many more will be available in due course.
 
-* link:/drivers/http/openapi/index.html[OpenAPI HTTP specification^]
-* link:/drivers/clojure/getting-started[Clojure]
+* link:/drivers/http/getting-started.html[HTTP + JSON]
 * link:/drivers/java/getting-started[Java]
 * link:/drivers/kotlin/getting-started[Kotlin]
+* link:/drivers/clojure/getting-started[Clojure]

--- a/docs/src/content/docs/drivers/http/getting-started.adoc
+++ b/docs/src/content/docs/drivers/http/getting-started.adoc
@@ -1,0 +1,8 @@
+---
+title: Getting started (HTTP + JSON)
+---
+
+== Connecting through HTTP
+
+1. Firstly, to run the XTDB server, check out the general link:/intro/getting-started[getting started guide].
+2. Refer to the link:/drivers/http/openapi/index.html[OpenAPI] documentation

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -14,13 +14,8 @@ title: Welcome to XTDB!
 </div>
 ++++
 
-XTDB is an immutable database, queryable with both link:/reference/main/sql/queries.html[SQL] and link:/intro/what-is-xtql.html[XTQL], that reduces the time and cost of building and maintaining safe systems of record.
-It is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^].
+XTDB is an immutable database that reduces the time and cost of building and maintaining safe systems of record.
 
-You can quickly try inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
+To start learning how to use XTDB with SQL, link:/intro/getting-started[click here].
 
-Alternatively, to get up-and-running locally, check out the link:/intro/getting-started[getting started] page.
-
-XTDB is distributed as a Docker image and is accessible over link:localhost:4322/intro/getting-started[HTTP] and via client drivers: link:/drivers/java/getting-started[Java], link:/drivers/kotlin/getting-started[Kotlin], link:/drivers/Clojure/getting-started[Clojure], and more link:/intro/roadmap.html[coming soon]!
-
-For help and support, join link:/intro/community[the community].
+XTDB is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^]. For help and support, join link:/intro/community[the community].

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -14,18 +14,13 @@ title: Welcome to XTDB!
 </div>
 ++++
 
-XTDB is a bitemporal, dynamic database, queryable with SQL and XTQL, that reduces the time and cost of building and maintaining safe systems of record.
+XTDB is an immutable database, queryable with both link:/reference/main/sql/queries.html[SQL] and link:/intro/what-is-xtql.html[XTQL], that reduces the time and cost of building and maintaining safe systems of record.
 It is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^].
 
-To quickly get up-and-running, check out our link:/intro/getting-started[getting started] guide.
+You can quickly try inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
 
-For the time being, XTDB is accessible through our HTTP API and Java, Kotlin and Clojure drivers - drivers for JavaScript, Python and many more will be available in due course.
+Alternatively, to get up-and-running locally, check out the link:/intro/getting-started[getting started] page.
 
-Next up:
+XTDB is distributed as a Docker image and is accessible over link:localhost:4322/intro/getting-started[HTTP] and via client drivers: link:/drivers/java/getting-started[Java], link:/drivers/kotlin/getting-started[Kotlin], link:/drivers/Clojure/getting-started[Clojure], and more link:/intro/roadmap.html[coming soon]!
 
-* Find out link:/intro/what-is-xtdb[what makes XTDB great].
-* Find out more about link:/intro/what-is-xtql[XTQL].
-* Find out how to configure the XTDB link:/config/tx-log[transaction-log] and link:/config/storage[storage].
-* Check out the link:/reference/main[XTDB reference documentation].
-* Learn more about the individual link:/drivers[client drivers].
-* For help and support, visit the link:/intro/community[XTDB community].
+For help and support, join link:/intro/community[the community].

--- a/docs/src/content/docs/index.adoc
+++ b/docs/src/content/docs/index.adoc
@@ -16,6 +16,6 @@ title: Welcome to XTDB!
 
 XTDB is an immutable database that reduces the time and cost of building and maintaining safe systems of record.
 
-To start learning how to use XTDB with SQL, link:/intro/getting-started[click here].
+To begin learning about the novel features of XTDB with SQL, take a look at the link:/intro/getting-started[Quickstart].
 
 XTDB is free-to-use and open-source, under the https://opensource.org/license/mpl-2-0/[MPL license^]. For help and support, join link:/intro/community[the community].

--- a/docs/src/content/docs/intro/data-model.adoc
+++ b/docs/src/content/docs/intro/data-model.adoc
@@ -1,8 +1,8 @@
 ---
-title: The XTDB Data Model
+title: How XTDB Works
 ---
 
-XTDB is a 'bitemporal' and 'dynamic' relational database with columnar foundations. This makes is uniquely capable at handling evolving, semi-structured data - the kind of data that developers might ordinarily handle using manual copies of "documents" or "diffs" and JSONB columns.
+XTDB is a database built on top of columnar storage (using link:https://arrow.apache.org/[Apache Arrow]) and is designed to handle evolving, semi-structured data via SQL natively, avoiding the need for workarounds like JSONB columns and audit tables.
 
 In XTDB all data, including nested data, is able to be stored in tables without classic constraints or restrictions in the range of types or shapes, and without any upfront schema definitions. This is more akin to a document database than a classic SQL database.
 
@@ -37,7 +37,7 @@ In addition to `xt$id`, which is the only mandatory column, 2 pairs of system-ma
 As implied by the nature of these columns, no rows written into XTDB are ever mutated directly, and only new rows can be inserted. The only exceptions to this principle are:
 
 . the existence of the `ERASE` operation, which can permanently delete entire rows for explicit data retention policies, and,
-. the need to 'close' the `xt$system-to` period for the now-superseded row
+. the need to 'close' the `xt$system_to` period for the now-superseded row
 
 == How temporal columns are maintained
 

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -59,19 +59,4 @@ Next up, you probably want to start by inserting data, running your first querie
 
 link:/quickstart/insert-and-query[Let's INSERT some data]!
 
-== Option B: Exploring via HTTP
-
-Alternatively, to learn how to use the HTTP API and discover a few of XTDB's novel capabilities using curl or another REST client of choice check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see all the options available.
-
-== Option C: Connecting via a client driver
-
-Official client drivers are provided for a range of languages to make working with XTDB more ergonomic than working directly with HTTP and JSON.
-
-[.lang-icons.right]
-image:{icon}/java.svg[Clojure,link={java}#_connecting_through_http]
-image:{icon}/kotlin.svg[Clojure,link={kotlin}#_connecting_through_http]
-image:{icon}/clojure.svg[Clojure,link={clojure}#_connecting_through_http]
-
-For more details, check out the relevant instructions for your language:
-
-More client drivers are link:/intro/roadmap.html[coming soon]!
+XTDB also has an link:/drivers/http/getting-started[HTTP + JSON] API and link:/drivers[client drivers] are provided for a range of languages to make working with XTDB more ergonomic than working directly with HTTP directly.

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -8,7 +8,7 @@ title: Quickstart
 
 == Try Online
 
-If you want to avoid starting your own server locally, you can instantly play with inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
+If you want to avoid running your own XTDB server locally, you can instantly play with inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
 
 == Docker Install
 
@@ -37,7 +37,7 @@ To work with XTDB interactively right away, you can run raw SQL commands using t
 [source,bash]
 ----
 # any recent version of Python should work, no Python knowledge required
-curl -s https://docs.xtdb.com/xtsql.py && \
+curl -s https://docs.xtdb.com/xtsql.py -O && \
   python xtsql.py --url=http://localhost:3000
 ----
 
@@ -48,9 +48,10 @@ In addition to running SQL statements, `xtsql` supports a number of built-in com
 [source,text]
 ----
 -> status
+
 | latestCompletedTx | latestSubmittedTx |
 |-------------------|-------------------|
-| None              | None              |
+| NULL              | NULL              |
 ----
 
 If that returns a table like the above, then everything should be up and running.
@@ -59,4 +60,4 @@ Next up, you probably want to start by inserting data, running your first querie
 
 link:/quickstart/insert-and-query[Let's INSERT some data]!
 
-XTDB also has an link:/drivers/http/getting-started[HTTP + JSON] API and link:/drivers[client drivers] are provided for a range of languages to make working with XTDB more ergonomic than working directly with HTTP directly.
+Note that `xtsql` is just a lightweight wrapper around XTDB's link:/drivers/http/getting-started[HTTP + JSON] API, and that link:/drivers[client drivers] are also provided for a range of languages to make working with XTDB more ergonomic than working with HTTP directly.

--- a/docs/src/content/docs/intro/getting-started.adoc
+++ b/docs/src/content/docs/intro/getting-started.adoc
@@ -1,77 +1,77 @@
 ---
-title: Getting started
+title: Quickstart
 ---
 :icon: /images/icons
 :clojure: /drivers/clojure/getting-started.html
 :java: /drivers/java/getting-started.html
 :kotlin: /drivers/kotlin/getting-started.html
 
-XTDB can run in-process (in a JVM), or through traditional client-server connections.
+== Try Online
 
-== Client/Server
+If you want to avoid starting your own server locally, you can instantly play with inserting data and querying XTDB right now using the link:https://fiddle.xtdb.com/[XT fiddle] website.
 
-You can start an XTDB server using the 'standalone' Docker image:
+== Docker Install
 
-[source,shell]
+XTDB is built for traditional client-server interactions over HTTP. You can start an XTDB server using the following Docker image:
+
+[source,bash]
 ----
-docker pull ghcr.io/xtdb/xtdb-standalone-ea
-
-docker run -tip 3000:3000 ghcr.io/xtdb/xtdb-standalone-ea
+docker run --pull=always -tip 3000:3000 ghcr.io/xtdb/xtdb-standalone-ea
 ----
 
 This starts a server on http://localhost:3000.
-By default, your data will be saved in a local directory in the Docker image, but you can also attach a host volume in the usual Docker way, to preserve your data on your host machine:
-
-[source,sh]
-----
-docker run \
-  -tip 3000:3000 \
-  -v /path/to/host/dir:/var/lib/xtdb \
-  ghcr.io/xtdb/xtdb-standalone-ea
-----
-
-=== Connecting through HTTP
+By default your data will only be stored transiently using a local directory within the Docker image, but you can attach a host volume to preserve your data across container restarts, e.g. by adding `-v /tmp/xtdb-data-dir:/var/lib/xtdb`.
 
 You can then connect to your XTDB server using cURL, or similar tools.
-For example, to check its status:
+For example, to check the status of the server:
 
-[source,shell]
+[source,bash]
 ----
 curl http://localhost:3000/status
 ----
 
-To run your first query:
+== Run the `xtsql` interactive console
 
-[source,shell]
+To work with XTDB interactively right away, you can run raw SQL commands using the `xtsql.py` terminal console:
+
+[source,bash]
 ----
-sql="SELECT t1.doc.foo[1]
-     FROM (VALUES ({'foo':['Hello', 'world!']})) AS t1(doc)"; \
-curl -X POST localhost:3000/query \
-     -H "Content-Type: application/json" -H "Accept: application/jsonl" \
-     -d "{\"query\": {\"sql\": \"${sql}\"}}"
+# any recent version of Python should work, no Python knowledge required
+curl -s https://docs.xtdb.com/xtsql.py && \
+  python xtsql.py --url=http://localhost:3000
 ----
 
-From here, check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see what else is available.
+=== Confirm connectivity
 
-=== Connecting from a client library
+In addition to running SQL statements, `xtsql` supports a number of built-in commands, e.g. type 'status' and hit Enter to confirm XTDB is running and that you are connected:
 
-If you're running on the JVM, you can use the JVM client library to connect to this node.
+[source,text]
+----
+-> status
+| latestCompletedTx | latestSubmittedTx |
+|-------------------|-------------------|
+| None              | None              |
+----
+
+If that returns a table like the above, then everything should be up and running.
+
+Next up, you probably want to start by inserting data, running your first queries, and learning about XTDB's novel capabilities:
+
+link:/quickstart/insert-and-query[Let's INSERT some data]!
+
+== Option B: Exploring via HTTP
+
+Alternatively, to learn how to use the HTTP API and discover a few of XTDB's novel capabilities using curl or another REST client of choice check out the link:/drivers/http/openapi/index.html[HTTP OpenAPI docs] to see all the options available.
+
+== Option C: Connecting via a client driver
+
+Official client drivers are provided for a range of languages to make working with XTDB more ergonomic than working directly with HTTP and JSON.
 
 [.lang-icons.right]
-image:{icon}/clojure.svg[Clojure,link={clojure}#_connecting_through_http]
 image:{icon}/java.svg[Clojure,link={java}#_connecting_through_http]
 image:{icon}/kotlin.svg[Clojure,link={kotlin}#_connecting_through_http]
+image:{icon}/clojure.svg[Clojure,link={clojure}#_connecting_through_http]
 
 For more details, check out the relevant instructions for your language:
 
-== In process (JVM)
-
-If you're running a JVM (17+), you can also use XTDB directly, in-process, using the same API interface as the remote client.
-In-process XTDB is particularly useful for testing and interactive development - you can start an in-memory node quickly and with little hassle, which makes it a great tool for unit tests and REPL experimentation.
-
-[.lang-icons.right]
-image:{icon}/clojure.svg[Clojure,link={clojure}#_in_process]
-image:{icon}/java.svg[Clojure,link={java}#_in_process]
-image:{icon}/kotlin.svg[Clojure,link={kotlin}#_in_process]
-
-For more details, check out the relevant instructions for your language:
+More client drivers are link:/intro/roadmap.html[coming soon]!

--- a/docs/src/content/docs/intro/why-xtdb.adoc
+++ b/docs/src/content/docs/intro/why-xtdb.adoc
@@ -1,15 +1,19 @@
 ---
-title: Why XTDB?
+title: Mission
 ---
 
-== The Mission
+XTDB is an immutable, time-travel database designed for building complex applications, and to support developers with features that are essential for meeting common regulatory compliance requirements.
+
+Temporal querying has been identified as a hard problem in SQL database for decades, and XTDB is the first ground-up realization of the 'bitemporal model', but XTDB's temporal powers have benefits for all kinds of applications - not just advanced scenarios in specific domains.
+
+== Time Matters
 
 At link:https://juxt.pro/[JUXT], the company behind XTDB, our mission is *to simplify how the world makes software*.
 
 Experience has made clear to us that no single piece of software infrastructure is more central to the success of an IT system than a well-designed database.
 However, we believe existing database technologies (Postgres, SQL Server, MongoDB etc.) are far from "finished" and that many important problems still remain unsolved across the database industry. Instead, these problems are left for users of such databases to work around and solve ad-hoc in their application code.
 
-For XTDB, the biggest source of complexity in application code we hope to address is *time*, and therefore XTDB is a database built for the hard problems of: accurate record keeping (with full ACID transaction support), time-travel queries (XT stands for "across time"), and data evolution. These problems are most acute wherever an organization is handling *regulated data*.
+One of the biggest sources of complexity in application code we hope to address is *time*, and therefore XTDB is a database built for the hard problems of: accurate record keeping (with full ACID transaction support), time-travel queries (XT stands for "across time"), and data evolution. These problems are most acute wherever an organization is handling *regulated data*.
 
 == The Problems
 
@@ -26,6 +30,16 @@ In support of this mission, XTDB solves 4 distinct problems we see with existing
 . *Challenging data integration & evolution* - strict schema definitions, update-in-place mutations, and poor support for semi-structured data are all impediments to using relational databases as integration points.
 . *Difficulty of managing SQL with an ad hoc bitemporal schema* - composing SQL is unnecessarily hard and is a common source of developer friction. Bitemporal versioning makes it harder still.
 
-== The Solution: XTDB
+== The Solution
 
 We have designed XTDB to solve each of these problems in a cohesive way that we believe can reduce the time & costs required for organizations to build and maintain link:https://www.juxt.pro/blog/kent-beck-podcast/[*safe*] systems of record and their associated APIs.
+
+For the everyday application developer who is not working on regulated systems and is less concerned about the nuanced understanding and implications of bitemporal modelling, it is sufficient to simply be aware that the model underpins three distinct layers of capabilities, which the documentation explains in depth. In order of significance:
+
+. *Basis* - using a timestamp as a stable basis for querying prior database states - an essential safety net for developers and organizations alike - and the key to consistent downstreaming processing (e.g. creating a businss KPI report without ETL)
+. *System-Time* - a pair of hidden timestamp columns built-in to every table, maintained automatically, that can be used to retrieve old versions of data
+. *Valid-Time* - an advanced versioning mechanism that is helpful for scheduling changes across data, and critical for time-aware applications where system-time alone is not enough
+
+First and foremost, XTDB is built to reduce the risks and impact of data loss, update anomalies and brittle database designs. It achieves this goal primarily by always recording the history of all changes (particularly UPDATEs and DELETEs which are normally destructive operations), and by restricting the scope of concurrent database usage, such that an auditable, linear sequence of all changes is retained.
+
+Beyond the obvious auditing and debugging benefits of retaining change data and prior database states, XTDB's history-preserving capability presents a robust & stable source of truth - a _basis_ - within a wider IT architecture that is unlike anything that most databases can offer.

--- a/docs/src/content/docs/quickstart/control-the-timeline.adoc
+++ b/docs/src/content/docs/quickstart/control-the-timeline.adoc
@@ -19,7 +19,7 @@ Note that valid-time as provided by XTDB is specifically about the validity (or 
 
 === INSERT into the past
 
-We can specify the `xt$valid_from` column during an INSERT statement to record when the organization (not necessarily this particular database!) first became aware of `carol`:
+We can specify the `xt$valid_from` column during an INSERT statement to record when the _organization_ (i.e. thinking beyond this particular database!) first became aware of `carol`:
 
 [source,sql]
 ----
@@ -29,7 +29,7 @@ INSERT INTO people (xt$id, name, favorite_color, xt$valid_from)
 
 === What did you know?
 
-We can now show that we knew `carol` existed in the company records before the database was even created:
+We can now show that we knew `carol` existed in the company records before this database was even created:
 
 [source,sql]
 ----
@@ -45,3 +45,9 @@ The 'bitemporal' combination of valid-time and system-time columns allows us to 
 SELECT people.xt$id, people.xt$valid_from, people.xt$system_from
   FROM people FOR ALL VALID_TIME FOR ALL SYSTEM_TIME;
 ----
+
+== Next steps!
+
+You have now learned the essentials of using XTDB!
+
+Looking for more? Please have a browse around the docs, try building something, and feel very welcome to say link:https://discuss.xtdb.com/[hello] 👋

--- a/docs/src/content/docs/quickstart/control-the-timeline.adoc
+++ b/docs/src/content/docs/quickstart/control-the-timeline.adoc
@@ -1,5 +1,5 @@
 ---
-title: Set Valid-Time
+title: Control the timeline
 ---
 
 Everything demonstrated so far only scratches the surface of what XTDB can do, given that XTDB is a full SQL implementation with all the implications that has, however there is one further aspect where XTDB is very different to most databases: ubiquitous 'Valid-Time' versioning.

--- a/docs/src/content/docs/quickstart/insert-and-query.adoc
+++ b/docs/src/content/docs/quickstart/insert-and-query.adoc
@@ -1,0 +1,73 @@
+---
+title: SQL Basics
+---
+
+XTDB implements a SQL API that closely follows the ISO standard specifications and draws inspiration from Postgres where needed, however unlike most SQL systems XTDB does not require an explicit schema to be declared upfront.
+
+The only caveat is that each record in XTDB must contain a user-provided `xt$id` primary key column, but other columns are fully dynamic - meaning each row in XTDB has the flexibility of a document in a document database.
+
+Note: `xt$` is a reserved prefix convention for namepacing system-mandated columns and other XTDB-specific database objects.
+
+=== Insert a row into a new table
+
+To run your first INSERT transaction, simply enter the following into `xtsql`:
+
+[source,sql]
+----
+INSERT INTO people (xt$id, name) VALUES (6, 'fred');
+----
+
+Here the `people` table has not been defined anywhere beforehand - the table is created dynamically during the INSERT statement, along with any supplied columns and inferrable type information.
+
+=== Query for that same row
+
+Querying this data back again is a simple matter of:
+
+[source,sql]
+----
+SELECT * FROM people;
+----
+
+=== Evolve the table
+
+If we now INSERT another row with a slightly different shape, XTDB will gracefully evolve the schema of the `people` table to reflect the union of all the records it contains:
+
+[source,sql]
+----
+INSERT INTO people (xt$id, name, likes)
+  VALUES (9, 'bob', ['fishing', 3.14, {'dynamic':'data'}]);
+----
+
+Re-running our `SELECT * FROM people` you should now see:
+
+[source,text]
+----
+| xt$id | likes                                   | name    |
+|-------|-----------------------------------------|---------|
+| 6     | None                                    | 'fred'  |
+| 9     | ['fishing', 3.14, {'dynamic': 'data'}]  | 'bob'   |
+----
+
+=== Handling ‘documents’
+
+XTDB is designed to work with JSON-like nested data as a first-class concept (i.e. highly flexible but not restricted to JSON or JSONB types). This means you can easily store deeply-nested document structures:
+
+[source,sql]
+----
+UPDATE people
+SET info = {'phone_numbers': [{'loc': 'home',
+                               'tel': '123-456-7890'},
+                              {'loc': 'work',
+                               'tel': '098-765-4321'}]}
+  WHERE people.name = 'fred';
+----
+
+And you can then query this nested data intuitively:
+
+[source,sql]
+----
+SELECT people.info.phone_numbers[2].tel FROM people
+  WHERE people.name = 'fred';
+----
+
+Pretty neat! But what if we made a mistake somewhere and wanted to undo a change? The thing that makes XTDB _most_ interesting is the approach to immutability and time-travel, read on...

--- a/docs/src/content/docs/quickstart/insert-and-query.adoc
+++ b/docs/src/content/docs/quickstart/insert-and-query.adoc
@@ -55,10 +55,10 @@ XTDB is designed to work with JSON-like nested data as a first-class concept (i.
 [source,sql]
 ----
 UPDATE people
-SET info = {'phone_numbers': [{'loc': 'home',
-                               'tel': '123-456-7890'},
-                              {'loc': 'work',
-                               'tel': '098-765-4321'}]}
+SET info = {'contact': [{'loc': 'home',
+                         'tel': '123'},
+                        {'loc': 'work',
+                         'tel': '456'}]}
   WHERE people.name = 'fred';
 ----
 
@@ -66,7 +66,7 @@ And you can then query this nested data intuitively:
 
 [source,sql]
 ----
-SELECT people.info.phone_numbers[2].tel FROM people
+SELECT people.info.contact[2].tel FROM people
   WHERE people.name = 'fred';
 ----
 

--- a/docs/src/content/docs/quickstart/query-the-past.adoc
+++ b/docs/src/content/docs/quickstart/query-the-past.adoc
@@ -1,0 +1,151 @@
+---
+title: Query the past
+---
+
+XTDB automatically records all versions and changes to individual rows across your database. This is useful on many levels for building reliably information systems, and it all starts with a link:https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying[log].
+
+=== A log of transactions
+
+Like other clients of an XTDB server, `xtsql` operates by sending stateless JSON payloads over HTTP. This transport layer offers many operational advantages, but it also means transactions are inherently non-interactive (i.e. there is no stateful connection/session in place).
+
+Consequently, transactions in XTDB are durable (link:https://en.wikipedia.org/wiki/ACID[ACID]) requests which are processed serially and asynchronously, i.e. if you wait a few milliseconds for the processing of a newly submitted to finish, you can generally then read that same data in your next query (a.k.a. "read your writes"). However, `xtsql` (and all XTDB language drivers) will implicitly wait for any recently submitted transactions to be processed before subsequent queries are executed, and to achieve this, all transactions are uniquely identified with an `xt$id`.
+
+For convenience, you can easily see history and of prior transactions within `xtsql` by using the `recent_transactions` command:
+
+[source,text]
+----
+| xt$id | xt$committed? | xt$error | xt$tx_time                        |
+|-------|---------------|----------|-----------------------------------|
+| 0     | True          | NULL     | 2024-03-13 18:38:37.398210+00:00  |
+----
+
+You can see this table directly by running
+
+[source,sql]
+----
+SELECT * FROM xt$txs;
+----
+
+=== Basis: re-run queries against past states without explicit snapshots
+
+Unlike in typical SQL database, `UPDATE` and `DELETE` operations in XTDB are non-destructive, meaning previous versions of records are retained automatically and previous states of the entire database can be readily accessed.
+
+For example, despite having seemingly just updated the original version of the `fred` record from the initial step (`SELECT * FROM people` will only show the 'current' version of everything by default), the original version can be retrieved using a couple of methods.
+
+The simplest way to observe the prior version of the `fred` record is to re-run the exact same query against an earlier 'basis'.
+
+A basis is like a pointer to a snapshot of a previous version of the entire database state, except unlike snapshots in other systems there is no copying or explicit snapshot creation required.
+
+A basis is stable and allows you to re-run unmodified queries indefinitely. This is useful for debugging, auditing, and exposing application data for processing in downstream systems (generating reports, analytics etc.)
+
+Within `xtsql`, changing the basis can be accomplished by defining a timestamp using the `basis_at_system_time` command:
+
+[source,text]
+----
+-> basis_at_system_time
+9999-12-31T23:59:59.999999Z
+----
+
+Without a parameter supplied, the default value returned implies that the basis is not set. To set the basis, simply use some prefix of a valid ISO8601 timestamp string as a parameter to the `basis_at_system_time` command:
+
+[source,text]
+----
+-> basis_at_system_time 2020
+2020-01-01T00:00:00.000000Z
+----
+
+With the basis now set to 2020, try re-running the `SELECT * FROM people` query and see that no results are returned.
+
+Now try setting the basis to a timestamp shortly after our initial transaction (the timestamp shown here is for illustration only, you should refer to the output of `recent_transactions`):
+
+[source,text]
+----
+-> basis_at_system_time 2024-03-13 18:39
+2024-03-13T18:39:00.000000Z
+----
+
+When you re-run the `SELECT * FROM people` query again, this time you should see the original version of the `fred` row and also the `bob` row won't be visible.
+
+To clear the basis and reset the query behaviour to 'current' you can run the `clear_basis` command (which resets `xtsql` back to using the default 9999-12-31 timestamp):
+
+[source,text]
+----
+-> clear_basis
+basis cleared
+----
+
+Welcome back to the present! You should now be able to see the latest versions of `fred` and `bob` by re-running the query once again.
+
+=== System-Time Columns: automatic time-versioning of rows without audit tables
+
+The mechanism underpinning the basis concept is called 'System Time'.
+
+Normally a SQL database will irreversibly lose access to prior states of data after transactions containing `UPDATE` or `DELETE` statements are committed. System-time versioning is a standard defined in link:https://en.wikipedia.org/wiki/SQL:2011[SQL:2011], but unlike other implementations, XTDB has it baked into the core of the database engine such that all data is versioned by default and all modification operations are non-destructive.
+
+This minimises the circumstances where developers need to reach for backups or ETL integrations with other warehousing systems in order to recover data. It also provides an opportunity to avoid complicating application schemas with "soft delete" columns and audit tables.
+
+The system-time columns `xt$system_from` and `xt$system_to` are hidden from view by default but, when specified, can be found on every table within regular SQL - and can also be combined with the previously described capability to query at a prior basis (if desirable):
+
+[source,sql]
+----
+SELECT people.*, people.xt$system_from, people.xt$system_to
+  FROM people;
+----
+
+The full system-time history for a set of records in a table can be retrieved by specifying `FOR ALL SYSTEM_TIME` after each table reference:
+
+[source,sql]
+----
+SELECT people.*, people.xt$system_from, people.xt$system_to
+  FROM people FOR ALL SYSTEM_TIME;
+----
+
+You can also run queries against individual tables at specific timestamps using `FOR SYSTEM_TIME AS_OF <timestamp>` and use temporal period operators (`OVERLAPS`, `PRECEDES` etc.) to interrogate audit trails - see the link:/reference/main/sql/queries[SQL reference documentation].
+
+=== A delta of changes to a table since a given system-time
+
+[source,sql]
+----
+SELECT people.*, people.xt$system_from, people.xt$system_to
+  FROM people FOR SYSTEM_TIME BETWEEN DATE '2020-01-01' AND CURRENT_TIMESTAMP;
+----
+
+=== Restore a deleted row
+
+Let's first delete `fred`:
+
+[source,sql]
+----
+DELETE FROM people where people.name = 'fred';
+----
+
+Now `SELECT * FROM people` should only show `bob`. Here's how we can get `fred` back:
+
+[source,sql]
+----
+INSERT INTO people (xt$id, name, likes)
+SELECT people.xt$id, people.name, people.likes
+  FROM people FOR ALL SYSTEM_TIME
+  WHERE people.xt$id = 6
+  ORDER BY people.xt$system_to DESC
+  LIMIT 1;
+----
+
+=== ERASE as hard-delete
+
+Sometimes you do really want to forget the past though, and where data does need to be erased ("hard deleted"), an `ERASE` operation is provided:
+
+[source,sql]
+----
+ERASE FROM people WHERE people.xt$id = 6;
+----
+
+The ERASE is effective as soon as the transaction is committed.
+
+Under the hood, the relevant data is guaranteed to be fully erased only once all background index processing has completed and the changes have been written to the remote object storage.
+
+=== Your basic training is almost complete!
+
+With everything covered so far, you are already well-versed in the main benefits of XTDB.
+
+Really there is only one more topic left to examine before you are familiar with all the novel SQL functionality XTDB has to offer, read on...

--- a/docs/src/content/docs/quickstart/query-the-past.adoc
+++ b/docs/src/content/docs/quickstart/query-the-past.adoc
@@ -2,18 +2,20 @@
 title: Query the past
 ---
 
-XTDB automatically records all versions and changes to individual rows across your database. This is useful on many levels for building reliably information systems, and it all starts with a link:https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying[log].
+XTDB automatically records all versions and changes to individual rows across your database. This is widely useful for building reliable information systems, and it all starts with a link:https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying[log].
 
 === A log of transactions
 
-Like other clients of an XTDB server, `xtsql` operates by sending stateless JSON payloads over HTTP. This transport layer offers many operational advantages, but it also means transactions are inherently non-interactive (i.e. there is no stateful connection/session in place).
+The `xtsql` console behaves as an ordinary client of an XTDB server, and it operates by sending stateless JSON payloads over HTTP as the transport layer. HTTP as a transport layer offers many operational advantages, but it also means transactions are inherently non-interactive (i.e. there is no stateful connection/session in place).
 
-Consequently, transactions in XTDB are durable (link:https://en.wikipedia.org/wiki/ACID[ACID]) requests which are processed serially and asynchronously, i.e. if you wait a few milliseconds for the processing of a newly submitted to finish, you can generally then read that same data in your next query (a.k.a. "read your writes"). However, `xtsql` (and all XTDB language drivers) will implicitly wait for any recently submitted transactions to be processed before subsequent queries are executed, and to achieve this, all transactions are uniquely identified with an `xt$id`.
+Consequently, transactions in XTDB are durable (link:https://en.wikipedia.org/wiki/ACID[ACID]) requests which are processed serially and asynchronously, i.e. if you wait a few milliseconds for the processing of a newly submitted to finish, you can generally then read that same data in your next query (a.k.a. "read your writes"). However, `xtsql` and all XTDB language drivers will, by default, implicitly wait for any recently submitted transactions to be processed before subsequent queries are executed. To achieve this, all transactions are uniquely identified with an `xt$id`.
 
 For convenience, you can easily see history and of prior transactions within `xtsql` by using the `recent_transactions` command:
 
 [source,text]
 ----
+-> recent_transactions
+
 | xt$id | xt$committed? | xt$error | xt$tx_time                        |
 |-------|---------------|----------|-----------------------------------|
 | 0     | True          | NULL     | 2024-03-13 18:38:37.398210+00:00  |
@@ -30,11 +32,11 @@ SELECT * FROM xt$txs;
 
 Unlike in typical SQL database, `UPDATE` and `DELETE` operations in XTDB are non-destructive, meaning previous versions of records are retained automatically and previous states of the entire database can be readily accessed.
 
-For example, despite having seemingly just updated the original version of the `fred` record from the initial step (`SELECT * FROM people` will only show the 'current' version of everything by default), the original version can be retrieved using a couple of methods.
+For example, despite having _seemingly_ just updated the original version of the `fred` record that was inserted initially (`SELECT * FROM people` will only show the 'current' version of everything by default), the original version was not lost can be retrieved using a couple of methods.
 
 The simplest way to observe the prior version of the `fred` record is to re-run the exact same query against an earlier 'basis'.
 
-A basis is like a pointer to a snapshot of a previous version of the entire database state, except unlike snapshots in other systems there is no copying or explicit snapshot creation required.
+A basis is like a pointer to a snapshot of a previous version of the entire database state, except unlike snapshots in other systems in XTDB there is no copying or explicit snapshot creation required.
 
 A basis is stable and allows you to re-run unmodified queries indefinitely. This is useful for debugging, auditing, and exposing application data for processing in downstream systems (generating reports, analytics etc.)
 
@@ -43,6 +45,7 @@ Within `xtsql`, changing the basis can be accomplished by defining a timestamp u
 [source,text]
 ----
 -> basis_at_system_time
+
 9999-12-31T23:59:59.999999Z
 ----
 
@@ -51,6 +54,7 @@ Without a parameter supplied, the default value returned implies that the basis 
 [source,text]
 ----
 -> basis_at_system_time 2020
+
 2020-01-01T00:00:00.000000Z
 ----
 
@@ -82,9 +86,9 @@ The mechanism underpinning the basis concept is called 'System Time'.
 
 Normally a SQL database will irreversibly lose access to prior states of data after transactions containing `UPDATE` or `DELETE` statements are committed. System-time versioning is a standard defined in link:https://en.wikipedia.org/wiki/SQL:2011[SQL:2011], but unlike other implementations, XTDB has it baked into the core of the database engine such that all data is versioned by default and all modification operations are non-destructive.
 
-This minimises the circumstances where developers need to reach for backups or ETL integrations with other warehousing systems in order to recover data. It also provides an opportunity to avoid complicating application schemas with "soft delete" columns and audit tables.
+This minimises the circumstances where developers need to reach for backups or ETL integrations with other warehousing systems in order to recover data. It also helps avoid complicating application schemas with things like "soft delete" columns and audit tables.
 
-The system-time columns `xt$system_from` and `xt$system_to` are hidden from view by default but, when specified, can be found on every table within regular SQL - and can also be combined with the previously described capability to query at a prior basis (if desirable):
+The system-time columns `xt$system_from` and `xt$system_to` are hidden from view by default but, when specified, can be accessed on every table using regular SQL:
 
 [source,sql]
 ----
@@ -92,7 +96,9 @@ SELECT people.*, people.xt$system_from, people.xt$system_to
   FROM people;
 ----
 
-The full system-time history for a set of records in a table can be retrieved by specifying `FOR ALL SYSTEM_TIME` after each table reference:
+More details about these columns and how they are maintained by the system can be found in the link:/intro/data-model[How XTDB Works] section.
+
+The full system-time history for a set of records in a table can be retrieved by specifying `FOR ALL SYSTEM_TIME` after the table reference:
 
 [source,sql]
 ----
@@ -123,8 +129,8 @@ Now `SELECT * FROM people` should only show `bob`. Here's how we can get `fred` 
 
 [source,sql]
 ----
-INSERT INTO people (xt$id, name, likes)
-SELECT people.xt$id, people.name, people.likes
+INSERT INTO people (xt$id, name, info)
+SELECT people.xt$id, people.name, people.info
   FROM people FOR ALL SYSTEM_TIME
   WHERE people.xt$id = 6
   ORDER BY people.xt$system_to DESC

--- a/docs/src/content/docs/quickstart/set-valid-time.adoc
+++ b/docs/src/content/docs/quickstart/set-valid-time.adoc
@@ -1,0 +1,47 @@
+---
+title: Set Valid-Time
+---
+
+Everything demonstrated so far only scratches the surface of what XTDB can do, given that XTDB is a full SQL implementation with all the implications that has, however there is one further aspect where XTDB is very different to most databases: ubiquitous 'Valid-Time' versioning.
+
+=== Valid-Time is for advanced time-travel
+
+In addition to system-time versioning, SQL:2011 also defines 'application-time' versioning. XTDB applies this versioning to all tables and refers to it as valid-time.
+
+Valid-time is a key tool for developers who need to offer time-travel functionality within their applications. It is a rigourously defined model that can help avoid cluttering schemas and queries with bespoke `updated_at`, `deleted_at` and `effective_from` columns (...and all the various TRIGGERs that typically live alongside those).
+
+Developers who try to build useful functionality on top of system-time directly will likely encounter issues with migrations, backfill, and out-of-order ingestion. Valid-time solves these challenges head-on whilst also enabling other advanced usage scenarios:
+
+. *corrections* - curate a timeline of versions with an ability to correct data - an essential capability for applications where recording the full context behind critical decisions is needed
+. *global scheduling* - control exactly when data is visible to as-of-now queries by loading data with future valid-time timestamps, without needing to complicate your schema or queries - data will 'appear' and 'disappear' automatically as wall-clock time progresses
+
+Note that valid-time as provided by XTDB is specifically about the validity (or "effective from" time) of a given row in the table, and not _necessarily_ (unless you carefully map it 1:1) some other domain conception of time.
+
+=== INSERT into the past
+
+We can specify the `xt$valid_from` column during an INSERT statement to record when the organization (not necessarily this particular database!) first became aware of `carol`:
+
+[source,sql]
+----
+INSERT INTO people (xt$id, name, favorite_color, xt$valid_from)
+  VALUES (2, 'carol', 'blue', DATE '2024-01-01');
+----
+
+=== What did you know?
+
+We can now show that we knew `carol` existed in the company records before the database was even created:
+
+[source,sql]
+----
+SELECT * FROM people FOR VALID_TIME AS OF DATE '2024-02-01';
+----
+
+=== When did you know it?
+
+The 'bitemporal' combination of valid-time and system-time columns allows us to readily prove an auditable history about what we claimed to have known in the past:
+
+[source,sql]
+----
+SELECT people.xt$id, people.xt$valid_from, people.xt$system_from
+  FROM people FOR ALL VALID_TIME FOR ALL SYSTEM_TIME;
+----

--- a/docs/src/content/docs/reference/main.adoc
+++ b/docs/src/content/docs/reference/main.adoc
@@ -4,6 +4,6 @@ title: XTDB reference guide
 
 In the query-language reference guide, you can find:
 
-* Specifications for XTQL link:/reference/main/xtql/txs[transactions] and link:/reference/main/xtql/queries[queries].
 * Specifications for SQL link:/reference/main/sql/txs[transactions] and link:/reference/main/sql/queries[queries].
+* Specifications for XTQL link:/reference/main/xtql/txs[transactions] and link:/reference/main/xtql/queries[queries].
 * Details of the XTDB link:/reference/main/stdlib[standard library] of functions.


### PR DESCRIPTION
1. Moved a few headings around
2. Add a SQL Quickstart
3. The canonical xtsql.py is hosted under `public`