### PR TITLE
Add support for information_schema and pg_catalog

### DIFF
--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -1,0 +1,212 @@
+(ns xtdb.information-schema
+  (:require xtdb.metadata
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr]
+            [xtdb.vector.writer :as vw])
+  (:import
+   (org.apache.arrow.vector VectorSchemaRoot)
+   (org.apache.arrow.vector.types.pojo Schema Field)
+   xtdb.operator.IRelationSelector
+   (xtdb.vector RelationReader IVectorWriter IRelationWriter)
+   (xtdb ICursor)
+   (xtdb.metadata IMetadataManager)
+   (xtdb.watermark Watermark)))
+
+;;TODO add temporal cols
+
+(defn schema-info->col-rows [schema-info]
+  (for [table-entry schema-info
+        [idx col] (map-indexed #(vector %1 %2) (val table-entry))
+        :let [table (key table-entry)
+              name (key col)
+              ^Field col-field (val col)
+              col-types (or (seq (.getChildren col-field)) [col-field])]]
+
+    {:idx idx ;; no guarentee of order/stability of idx for a given col
+     :table table
+     :name name
+     :type (map #(types/arrow-type->col-type (.getType ^Field %)) col-types)}))
+
+(def info-tables-raw {"tables" {"table_catalog" (types/col-type->field "table_catalog" :utf8)
+                                "table_schema" (types/col-type->field "table_schema" :utf8)
+                                "table_name" (types/col-type->field "table_name" :utf8)
+                                "table_type" (types/col-type->field "table_type" :utf8)}
+                      "columns" {"table_catalog" (types/col-type->field "table_catalog" :utf8)
+                                 "table_schema" (types/col-type->field "table_schema" :utf8)
+                                 "table_name" (types/col-type->field "table_name" :utf8)
+                                 "column_name" (types/col-type->field "column_name" :utf8)
+                                 "data_type" (types/col-type->field "data_type" [:list :utf8])}
+                      "schemata" {"catalog_name" (types/col-type->field "catalog_name" :utf8)
+                                  "schema_name" (types/col-type->field "schema_name" :utf8)
+                                  "schema_owner" (types/col-type->field "schema_owner" :utf8)}})
+
+(def info-tables (update-keys info-tables-raw #(str "information_schema$" %)))
+(def info-table-cols (update-vals info-tables-raw (comp set keys)))
+
+(def pg-catalog-tables-raw
+  {"pg_tables" {"schemaname" (types/col-type->field "schemaname" :utf8)
+                "tablename" (types/col-type->field "tablename" :utf8)
+                "tableowner" (types/col-type->field "tableowner" :utf8)
+                "tablespace" (types/col-type->field "tablespace" :null)}
+   "pg_views" {"schemaname" (types/col-type->field "schemaname" :utf8)
+               "viewname" (types/col-type->field "viewname" :utf8)
+               "viewowner" (types/col-type->field "viewowner" :utf8)}
+   "pg_matviews" {"schemaname" (types/col-type->field "schemaname" :utf8)
+                  "matviewname" (types/col-type->field "matviewname" :utf8)
+                  "matviewowner" (types/col-type->field "matviewowner" :utf8)}
+   "pg_attribute" {"attrelid" (types/col-type->field "attrelid" :i32)
+                   "attname" (types/col-type->field "attname" :utf8)
+                   "atttypid" (types/col-type->field "atttypid" :i32)
+                   "attlen" (types/col-type->field "attlen" :i16)
+                   "attnum" (types/col-type->field "attnum" :i16)}
+   "pg_namespace" {"oid" (types/col-type->field "oid" :i32)
+                   "nspname" (types/col-type->field "nspname" :utf8)
+                   "nspowner" (types/col-type->field "nspowner" :i32)
+                   "nspacl" (types/col-type->field "nspacl" :null)}})
+
+(def pg-catalog-tables (update-keys pg-catalog-tables-raw #(str "pg_catalog$" %)))
+(def pg-catalog-table-cols (update-vals pg-catalog-tables-raw (comp set keys)))
+
+(def derived-tables (merge info-tables pg-catalog-tables))
+
+(def schemas [{"catalog_name" "default"
+               "schema_name" "pg_catalog"
+               "schema_owner" "default"}
+              {"catalog_name" "default"
+               "schema_name" "public"
+               "schema_owner" "default"}
+              {"catalog_name" "default"
+               "schema_name" "information_schema"
+               "schema_owner" "default"}])
+
+(def pg-namespaces (map (fn [{:strs [schema_owner schema_name] :as schema}]
+                          (-> schema
+                              (assoc "nspowner" (hash schema_owner))
+                              (assoc "oid" (hash schema_name))))
+                        schemas))
+
+(defn tables [^IRelationWriter rel-wtr schema-info]
+  (doseq [table (keys schema-info)]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "table_catalog" (.writeObject col-wtr "default")
+        "table_name" (.writeObject col-wtr table)
+        "table_schema" (.writeObject col-wtr "public")
+        "table_type" (.writeObject col-wtr "BASE TABLE")))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(defn pg-tables [^IRelationWriter rel-wtr schema-info]
+  (doseq [table (keys schema-info)]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "schemaname" (.writeObject col-wtr "public")
+        "tablename" (.writeObject col-wtr table)
+        "tableowner" (.writeObject col-wtr "default")
+        "tablespace" (.writeObject col-wtr nil)))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(defn columns [^IRelationWriter rel-wtr col-rows]
+  (doseq [{:keys [table name type]} col-rows]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "table_catalog" (.writeObject col-wtr "default")
+        "table_name" (.writeObject col-wtr table)
+        "table_schema" (.writeObject col-wtr "public")
+        "column_name" (.writeObject col-wtr name)
+        "data_type" (let [el-wtr (.listElementWriter col-wtr)]
+                      (.startList col-wtr)
+                      (doseq [type-el type]
+                        (.writeObject el-wtr type-el))
+                      (.endList col-wtr))))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(defn pg-attribute [^IRelationWriter rel-wtr col-rows]
+  (doseq [{:keys [idx table name _type]} col-rows]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "attrelid" (.writeInt col-wtr (hash table))
+        "attname" (.writeObject col-wtr name)
+        "atttypid" (.writeInt col-wtr 114) ;; = json - avoiding circular dep on pgwire.clj
+        "attlen" (.writeShort col-wtr -1)
+        "attnum" (.writeShort col-wtr idx)))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(defn schemata [^IRelationWriter rel-wtr]
+  (doseq [{:strs [catalog_name schema_name schema_owner]} schemas]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "catalog_name" (.writeObject col-wtr catalog_name)
+        "schema_name" (.writeObject col-wtr schema_name)
+        "schema_owner" (.writeObject col-wtr schema_owner)))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(defn pg-namespace [^IRelationWriter rel-wtr]
+  (doseq [{:strs [oid schema_name nspowner]} pg-namespaces]
+    (.startRow rel-wtr)
+    (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
+      (case col
+        "oid" (.writeInt col-wtr oid)
+        "nspname" (.writeObject col-wtr schema_name)
+        "nspowner" (.writeInt col-wtr nspowner)
+        "nspacl" (.writeObject col-wtr nil)))
+    (.endRow rel-wtr))
+  (.syncRowCount rel-wtr)
+  rel-wtr)
+
+(deftype InformationSchemaCursor [^:unsynchronized-mutable ^RelationReader out-rel vsr]
+  ICursor
+  (tryAdvance [this c]
+    (boolean
+     (when-let [out-rel out-rel]
+       (try
+         (set! (.out-rel this) nil)
+         (.accept c out-rel)
+         true
+         (finally
+           (util/close vsr)
+           (.close out-rel))))))
+
+  (close [_]
+    (util/close vsr)
+    (some-> out-rel .close)))
+
+(defn ->cursor [allocator derived-table-schema table col-names col-preds params ^IMetadataManager metadata-mgr ^Watermark wm]
+  (util/with-close-on-catch [root (VectorSchemaRoot/create (Schema. (or (vals (select-keys derived-table-schema col-names)) [])) allocator)]
+    (let [schema-info (merge-with merge
+                                  (.allColumnFields metadata-mgr)
+                                  (some-> (.liveIndex wm)
+                                          (.allColumnFields)))
+          out-rel-wtr (vw/root->writer root)
+          out-rel (vw/rel-wtr->rdr (case table
+                                     "information_schema$tables" (tables out-rel-wtr schema-info)
+                                     "information_schema$columns" (columns out-rel-wtr (schema-info->col-rows schema-info))
+                                     "information_schema$schemata" (schemata out-rel-wtr)
+                                     "pg_catalog$pg_tables" (pg-tables out-rel-wtr schema-info)
+                                     "pg_catalog$pg_views" out-rel-wtr
+                                     "pg_catalog$pg_matviews" out-rel-wtr
+                                     "pg_catalog$pg_attribute" (pg-attribute out-rel-wtr (schema-info->col-rows schema-info))
+                                     "pg_catalog$pg_namespace" (pg-namespace out-rel-wtr)
+                                     (throw (UnsupportedOperationException. (str "Information Schema table does not exist: " table)))))]
+
+      ;;TODO reuse relation selector code from tri cursor
+      (InformationSchemaCursor. (reduce (fn [^RelationReader rel ^IRelationSelector col-pred]
+                                          (.select rel (.select col-pred allocator rel params)))
+                                        (-> out-rel
+                                            (vr/with-absent-cols allocator col-names))
+                                        (vals col-preds)) root))))

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -116,7 +116,7 @@ vertical_bar
 (*  5.2     <token> and <separator> *)
 
 regular_identifier
-    : !#'(?i)(\b(NULL|WITH|SELECT|FROM|WHERE|GROUP|HAVING|ORDER|OFFSET|FETCH|LIMIT|PARTITION|ROWS|RANGE|GROUPS|UNION|EXCEPT|INTERSECT|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_DATE|LOCALTIME|LOCALTIMESTAMP|END_OF_TIME)\b)' #'[a-zA-Z][a-zA-Z0-9_$]*'
+: !#'(?i)(\b(NULL|WITH|SELECT|FROM|WHERE|GROUP|HAVING|ORDER|OFFSET|FETCH|LIMIT|PARTITION|ROWS|RANGE|GROUPS|UNION|EXCEPT|INTERSECT|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_DATE|LOCALTIME|LOCALTIMESTAMP|END_OF_TIME)\b)' #'[a-zA-Z][a-zA-Z0-9_$]*'
     ;
 
 large_object_length_token
@@ -370,8 +370,14 @@ boolean_literal
     | delimited_identifier
     ;
 
+schema_name
+    : 'INFORMATION_SCHEMA'
+    | 'PG_CATALOG'
+    | 'PUBLIC'
+    ;
+
 <table_name>
-    : !#'(?i)(\b(SYSTEM_TIME|VALID_TIME)\b)' identifier
+    : [ schema_name <period> ] !#'(?i)(\b(SYSTEM_TIME|VALID_TIME)\b)' identifier
     ;
 
 <column_name>
@@ -637,7 +643,7 @@ identifier_chain
 (*  6.7        <column reference> *)
 
 column_reference
-    : basic_identifier_chain
+    : [ schema_name <period> ] basic_identifier_chain
     ;
 
 (*  6.9        <set function specification> *)

--- a/pgwire-server/src/main/clojure/xtdb/pgwire.clj
+++ b/pgwire-server/src/main/clojure/xtdb/pgwire.clj
@@ -129,7 +129,7 @@
   ^bytes [s]
   (.getBytes (str s) StandardCharsets/UTF_8))
 
-(def ^:private oids
+(def oids
   "A map of postgres type (that we may support to some extent) to numeric oid.
   Mapping to oid is useful for result descriptions, as well as to determine the semantics of received parameters."
   {:undefined 0

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -1,0 +1,223 @@
+(ns xtdb.information-schema-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-allocator tu/with-node)
+
+(def test-data [[:put-docs :beanie {:xt/id :foo, :col1 "foo1"}]
+                [:put-docs :beanie {:xt/id :bar, :col1 123}]
+                [:put-docs :baseball {:xt/id :baz, :col1 123 :col2 456}]])
+
+(deftest test-info-schema-columns
+  (xt/submit-tx tu/*node* test-data)
+
+  (t/is (= #{{:table-catalog "default",
+              :table-schema "public",
+              :table-name "beanie",
+              :column-name "col1",
+              :data-type ["utf8" "i64"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "xt$txs",
+              :column-name "xt$tx_time",
+              :data-type ["[:timestamp-tz :micro \"UTC\"]"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "xt$txs",
+              :column-name "xt$id",
+              :data-type ["i64"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "beanie",
+              :column-name "xt$id",
+              :data-type ["keyword"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "baseball",
+              :column-name "col2",
+              :data-type ["i64"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "xt$txs",
+              :column-name "xt$error",
+              :data-type ["transit"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "baseball",
+              :column-name "col1",
+              :data-type ["i64"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "baseball",
+              :column-name "xt$id",
+              :data-type ["keyword"]}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "xt$txs",
+              :column-name "xt$committed?",
+              :data-type ["bool"]}}
+           (set (tu/query-ra '[:scan
+                               {:table information_schema$columns}
+                               [table_catalog table_schema table_name column_name data_type]]
+                             {:node tu/*node*})))))
+
+(deftest test-info-schema-tables
+  (xt/submit-tx tu/*node* test-data)
+
+  (t/is (= #{{:table-catalog "default",
+              :table-schema "public",
+              :table-name "beanie",
+              :table-type "BASE TABLE"}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "xt$txs",
+              :table-type "BASE TABLE"}
+             {:table-catalog "default",
+              :table-schema "public",
+              :table-name "baseball",
+              :table-type "BASE TABLE"}}
+           (set (tu/query-ra '[:scan {:table information_schema$tables} [table_catalog table_schema table_name table_type]]
+                             {:node tu/*node*})))))
+
+(deftest test-pg-attribute
+  (xt/submit-tx tu/*node* test-data)
+
+  (t/is (=
+         #{{:attrelid 159967295, :atttypid 114, :attname "col2", :attlen -1}
+           {:attrelid 93927094, :atttypid 114, :attname "xt$id", :attlen -1}
+           {:attrelid 499408916, :atttypid 114, :attname "xt$id", :attlen -1}
+           {:attrelid 159967295, :atttypid 114, :attname "xt$id", :attlen -1}
+           {:attrelid 93927094, :atttypid 114, :attname "xt$tx_time", :attlen -1}
+           {:attrelid 93927094, :atttypid 114, :attname "xt$committed?", :attlen -1}
+           {:attrelid 159967295, :atttypid 114, :attname "col1", :attlen -1}
+           {:attrelid 93927094, :atttypid 114, :attname "xt$error", :attlen -1}
+           {:attrelid 499408916, :atttypid 114, :attname "col1", :attlen -1}}
+           (set (tu/query-ra '[:scan
+                               {:table pg_catalog$pg_attribute}
+                               [attrelid attname atttypid attlen]]
+                             {:node tu/*node*})))))
+
+(deftest test-pg-tables
+  (xt/submit-tx tu/*node* test-data)
+
+  (t/is (= #{{:tablespace nil,
+              :schemaname "public",
+              :tableowner "default",
+              :tablename "xt$txs"}
+             {:tablespace nil,
+              :schemaname "public",
+              :tableowner "default",
+              :tablename "baseball"}
+             {:tablespace nil,
+              :schemaname "public",
+              :tableowner "default",
+              :tablename "beanie"}}
+           (set (tu/query-ra '[:scan
+                               {:table pg_catalog$pg_tables}
+                               [schemaname tablename tableowner tablespace]]
+                             {:node tu/*node*})))))
+
+(deftest test-pg-views
+  (t/is (= []
+           (tu/query-ra '[:scan
+                          {:table pg_catalog$pg_views}
+                          [schemaname viewname viewowner]]
+                        {:node tu/*node*}))))
+
+(deftest test-mat-views
+  (t/is (= []
+           (tu/query-ra '[:scan
+                          {:table pg_catalog$pg_matviews}
+                          [schemaname matviewname matviewowner]]
+                        {:node tu/*node*}))))
+
+(deftest test-sql-query
+  (xt/submit-tx tu/*node* [[:put-docs :beanie {:xt/id :foo, :col1 "foo1"}]
+                           [:put-docs :beanie {:xt/id :bar, :col1 123}]
+                           [:put-docs :baseball {:xt/id :baz, :col1 123 :col2 456}]])
+
+  (t/is (= [{:column-name "xt$id"}]
+           (xt/q tu/*node*
+                 "SELECT information_schema.columns.column_name FROM information_schema.columns LIMIT 1")))
+
+  (t/is (= #{{:attrelid 159967295, :attname "col2"}
+             {:attrelid 159967295, :attname "xt$id"}}
+           (set
+            (xt/q tu/*node*
+                  "SELECT pg_attribute.attname, pg_attribute.attrelid FROM pg_attribute LIMIT 2"))))
+
+  (t/is (= [{:table-name "baseball",
+             :data-type ["keyword"],
+             :column-name "xt$id",
+             :table-catalog "default",
+             :table-schema "public"}]
+           (xt/q tu/*node*
+                 "SELECT * FROM information_schema.columns AS c LIMIT 1"))))
+
+(deftest test-selection-and-projection
+  (xt/submit-tx tu/*node* [[:put-docs :beanie {:xt/id :foo, :col1 "foo1"}]
+                           [:put-docs :beanie {:xt/id :bar, :col1 123}]
+                           [:put-docs :baseball {:xt/id :baz, :col1 123 :col2 456}]])
+
+  (t/is (=
+         #{{:table-name "xt$txs", :table-schema "public"}
+           {:table-name "beanie", :table-schema "public"}
+           {:table-name "baseball", :table-schema "public"}}
+         (set (tu/query-ra '[:scan {:table information_schema$tables} [table_name table_schema]]
+                           {:node tu/*node*})))
+        "Only requested cols are projected")
+
+  (t/is (=
+         #{{:table-name "baseball", :table-schema "public"}}
+         (set (tu/query-ra '[:scan {:table information_schema$tables} [table_schema {table_name (= table_name "baseball")}]]
+                           {:node tu/*node*})))
+        "col-preds work")
+
+  (t/is (=
+         #{{:table-name "beanie", :table-schema "public"}}
+         (set (tu/query-ra '[:scan {:table information_schema$tables} [table_schema {table_name (= table_name ?tn)}]]
+                           {:node tu/*node* :params {'?tn "beanie"}})))
+        "col-preds with params work")
+
+
+  ;;TODO although this doesn't error, not sure this exctly works, adding a unknown col = null didn't work
+  ;;I think another complication could be that these tables don't necesasrily have a primary/unique key due to
+  ;;lack of xtid
+  (t/is
+   (=
+    #{{:table-name "baseball"}
+      {:table-name "beanie"}
+      {:table-name "xt$txs"}}
+    (set (tu/query-ra '[:scan {:table information_schema$tables} [table_name unknown_col]]
+                      {:node tu/*node*})))
+   "cols that don't exist don't error/projected as nulls/absents"))
+
+(deftest test-pg-namespace
+  (t/is (=
+         #{{:nspowner 722480637,
+            :oid -1980112537,
+            :nspacl nil,
+            :nspname "information_schema"}
+           {:nspowner 722480637,
+            :oid -2125819141,
+            :nspacl nil,
+            :nspname "pg_catalog"}
+           {:nspowner 722480637,
+            :oid 1106696632,
+            :nspacl nil,
+            :nspname "public"}}
+         (set (tu/query-ra '[:scan {:table pg_catalog$pg_namespace} [oid nspname nspowner nspacl]]
+                           {:node tu/*node*})))))
+(deftest test-schemata
+  (t/is (= #{{:catalog-name "default",
+              :schema-name "information_schema",
+              :schema-owner "default"}
+             {:catalog-name "default",
+              :schema-name "pg_catalog",
+              :schema-owner "default"}
+             {:catalog-name "default",
+              :schema-name "public",
+              :schema-owner "default"}}
+           (set (tu/query-ra '[:scan {:table information_schema$schemata} [catalog_name schema_name schema_owner]]
+                             {:node tu/*node*})))))

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-aliased-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-aliased-table.edn
@@ -1,0 +1,1 @@
+[:scan {:table information_schema$columns} [column_name]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-field.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-field.edn
@@ -1,0 +1,7 @@
+[:rename
+ {x3 my_field}
+ [:project
+  [{x3 (. x1 :my_field)}]
+  [:rename
+   {column_name x1}
+   [:scan {:table information_schema$columns} [column_name]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-fully-qualified.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-fully-qualified.edn
@@ -1,0 +1,1 @@
+[:scan {:table information_schema$columns} [column_name]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-implict-pg_catalog.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-implict-pg_catalog.edn
@@ -1,0 +1,1 @@
+[:scan {:table pg_catalog$pg_attribute} [attname]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-qualified-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-qualified-col-ref.edn
@@ -1,0 +1,1 @@
+[:scan {:table pg_catalog$pg_attribute} [attname]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-unqualified-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-unqualified-col-ref.edn
@@ -1,0 +1,1 @@
+[:scan {:table pg_catalog$pg_attribute} [attname]]


### PR DESCRIPTION
Commit contains an initial pass at adding information_schema and pg_catalog tables. These tables describe the state of the database and its schema.

Tables are available under their respective schemas in SQL, which are modeled as namespaces in the table names at the plan level e.g. pg_catalog$pg_tables.

Currently we implement only a subset of the tables and their respective columns, these can and will be expanded on over time as requirements from tooling etc. come in. Furthermore we take some liberties with regards to the values of contained in certain information_schema table, such as DATA_TYPE returning a list of types, due to XTDBs polymorphic nature.

Additionally we deviate from the SQL spec grammar with regards to schema qualified column references, due to the need to disambiguate between a field reference and a schema qualified column ref, as they are currently syntatically identical. This will need re-addressing if we move away from known/static schema names.

Commit also contains a small refactoring of table_primary planning.