### PR TITLE
Add AGE(dt, dt) function to EE and SQL.

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -1031,6 +1031,10 @@
     ;;=>
     (list 'date_trunc dtps (expr dte))
 
+    [:age_function "AGE" [:age_source ^:z dt1] [:age_source ^:z dt2]]
+    ;;=>
+    (list 'age (expr dt1) (expr dt2))
+
     (expr-varargs z)))
 
 ;; Logical plan.

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -1297,6 +1297,7 @@ interval_primary
 <interval_value_function>
     : interval_absolute_value_function
     | date_trunc_interval_function
+    | age_function
     ;
 
 interval_absolute_value_function
@@ -2583,6 +2584,15 @@ date_trunc_interval_source
 
 <date_trunc_time_zone>
     : <quote> time_zone_region <quote>
+
+(* AGE function *)
+age_function
+    : 'AGE' <left_paren> age_source <comma> age_source <right_paren>
+    ;
+
+age_source
+    : datetime_value_expression
+    ;
 
 (* ARROW_TABLE <table primary>, based on SQL:2016 JSON_TABLE *)
 

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -281,4 +281,8 @@ a| Returns true iff `p1` starts after `p2` ends
 
 | `(extract "field" interval)` | `EXTRACT('field', interval)`
 | Extracts the given field from the interval. Field must be one of `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE` or `SECOND`.
+
+| `(age date-time date-time)` | `AGE(date_time, date_time)` 
+| Returns an **interval** representing the difference between two date-times - subtracting the second value from the first. Works for any combination of **date times**, **date times with time zone identifiers**, or **dates**.
+
 |===


### PR DESCRIPTION
**Related Issue:** #3198 
**GH Action Runs:** [Here](https://github.com/danmason/xtdb/actions?query=branch%3Aadd-age-fn-3198++)

Adds the `Age(dt, dt)` function, returning a **month-day-nano** interval representing the time between the two dates:
- Adds to the expression engine.
- Adds into SQL parsing, planning.
- Adds it under `temporal.adoc` docs.
- Adds numerous tests to both temporal-test and sql-test to check behaviour.