### PR TITLE
Updates to SQL generated column names.

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -1003,7 +1003,7 @@
                                    apply-mode columns independent-relation dependent-relation]
   (let [independent-projection (relation-columns independent-relation)
         smap (set/map-invert columns)
-        row-number-sym '$row_number$
+        row-number-sym 'xt$row_number
         columns (remove-unused-correlated-columns columns dependent-relation)
         post-group-by-projection (remove symbol? post-group-by-projection)]
     (cond->> [:group-by (vec (concat independent-projection

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -23,7 +23,7 @@
   (symbol (str table lp/relation-id-delimiter table-id lp/relation-prefix-delimiter column)))
 
 (defn unqualified-projection-symbol [{:keys [identifier ^long index] :as _projection}]
-  (symbol (or identifier (str "$column_" (inc index) "$"))))
+  (symbol (or identifier (str "xt$column_" (inc index)))))
 
 (defn qualified-projection-symbol [{:keys [qualified-column original-index] :as projection}]
   (let [{derived-column :ref table :table} (meta projection)]

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -42,9 +42,12 @@
 (defn- table-reference-symbol [correlation-name id]
   (symbol (str correlation-name lp/relation-id-delimiter id)))
 
-(defn- aggregate-symbol [prefix z]
+(def agg-in-prefix "xt$agg_in")
+(def agg-out-prefix "xt$agg_out")
+
+(defn- aggregate-symbol [agg-prefix z]
   (let [query-id (sem/id (sem/scope-element z))]
-    (symbol (str "$" prefix lp/relation-id-delimiter query-id lp/relation-prefix-delimiter (sem/id z) "$"))))
+    (symbol (str agg-prefix lp/relation-id-delimiter query-id lp/relation-prefix-delimiter (sem/id z)))))
 
 (defn- exists-symbol [qe]
   (id-symbol "subquery" (sem/id qe) "$exists$"))
@@ -866,15 +869,15 @@
 
     [:aggregate_function _]
     ;;=>
-    (aggregate-symbol "agg_out" z)
+    (aggregate-symbol agg-out-prefix z)
 
     [:aggregate_function "COUNT" [:asterisk "*"]]
     ;;=>
-    (aggregate-symbol "agg_out" z)
+    (aggregate-symbol agg-out-prefix z)
 
     [:aggregate_function _ _]
     ;;=>
-    (aggregate-symbol "agg_out" z)
+    (aggregate-symbol agg-out-prefix z)
 
     [:subquery ^:z qe]
     ;;=>
@@ -1107,7 +1110,7 @@
     (w/prewalk
       (fn [node]
         (when (and (symbol? node)
-                   (str/starts-with? (str node) "$agg_out"))
+                   (str/starts-with? (str node) agg-out-prefix))
           (vswap! column-refs conj node))
         node
         node)
@@ -1393,33 +1396,33 @@
         group-by (for [aggregate aggregates]
                    (r/zmatch aggregate
                      [:aggregate_function [:general_set_function [:computational_operation sf] ^:z ve]]
-                     {:in {(aggregate-symbol "agg_in" aggregate) (expr ve)}
-                      :out {(aggregate-symbol "agg_out" aggregate)
+                     {:in {(aggregate-symbol agg-in-prefix aggregate) (expr ve)}
+                      :out {(aggregate-symbol agg-out-prefix aggregate)
                             (-> sf
                                 (str/lower-case)
                                 (str/replace "_" "-")
                                 (symbol)
-                                (list (aggregate-symbol "agg_in" aggregate)))}}
+                                (list (aggregate-symbol agg-in-prefix aggregate)))}}
 
                      [:aggregate_function [:general_set_function [:computational_operation sf] [:set_quantifier sq] ^:z ve]]
-                     {:in {(aggregate-symbol "agg_in" aggregate) (expr ve)}
-                      :out {(aggregate-symbol "agg_out" aggregate)
+                     {:in {(aggregate-symbol agg-in-prefix aggregate) (expr ve)}
+                      :out {(aggregate-symbol agg-out-prefix aggregate)
                             (-> sf
                                 (str/lower-case)
                                 (str/replace "_" "-")
                                 (str "-" (str/lower-case sq))
                                 (symbol)
-                                (list (aggregate-symbol "agg_in" aggregate)))}}
+                                (list (aggregate-symbol agg-in-prefix aggregate)))}}
 
                      [:aggregate_function "COUNT" [:asterisk "*"]]
-                     {:in {(aggregate-symbol "agg_in" aggregate) 1}
-                      :out {(aggregate-symbol "agg_out" aggregate)
-                            (list 'count (aggregate-symbol "agg_in" aggregate))}}
+                     {:in {(aggregate-symbol agg-in-prefix aggregate) 1}
+                      :out {(aggregate-symbol agg-out-prefix aggregate)
+                            (list 'count (aggregate-symbol agg-in-prefix aggregate))}}
 
                      [:aggregate_function [:array_aggregate_function "ARRAY_AGG" ^:z ve]]
-                     {:in {(aggregate-symbol "agg_in" aggregate) (expr ve)}
-                      :out {(aggregate-symbol "agg_out" aggregate)
-                            (list 'array-agg (aggregate-symbol "agg_in" aggregate))}}
+                     {:in {(aggregate-symbol agg-in-prefix aggregate) (expr ve)}
+                      :out {(aggregate-symbol agg-out-prefix aggregate)
+                            (list 'array-agg (aggregate-symbol agg-in-prefix aggregate))}}
 
                      (throw (err/illegal-arg :xtdb.sql/parse-error
                                              {::err/message "unknown aggregation function"}))))]

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -50,15 +50,15 @@
     (symbol (str agg-prefix lp/relation-id-delimiter query-id lp/relation-prefix-delimiter (sem/id z)))))
 
 (defn- exists-symbol [qe]
-  (id-symbol "subquery" (sem/id qe) "$exists$"))
+  (id-symbol "xt$subquery" (sem/id qe) "exists"))
 
 (defn- subquery-reference-symbol [qe]
-  (table-reference-symbol "subquery" (sem/id qe)))
+  (table-reference-symbol "xt$subquery" (sem/id qe)))
 
 (defn- subquery-projection-symbols [qe]
   (let [subquery-id (sem/id qe)]
     (vec (for [projection (first (sem/projected-columns qe))]
-           (id-symbol "subquery" subquery-id (unqualified-projection-symbol projection))))))
+           (id-symbol "xt$subquery" subquery-id (unqualified-projection-symbol projection))))))
 
 (defn- subquery-array-symbol
   "When you have a ARRAY ( subquery ) expression, use this to reference the projected column

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -610,3 +610,12 @@
               (when-let [cause (.getCause e)]
                 (unroll cause))))]
     (or (unroll e) e)))
+
+(defn seeded-gensym
+  ([] (seeded-gensym "" 0))
+  ([^long count-start] (seeded-gensym "" count-start))
+  ([suffix ^long count-start]
+   (let [ctr (atom (dec count-start))]
+     (fn gensym-seed
+       ([] (symbol (str "gensym" suffix (swap! ctr inc))))
+       ([prefix] (symbol (str prefix suffix (swap! ctr inc))))))))

--- a/core/src/main/clojure/xtdb/xtql.clj
+++ b/core/src/main/clojure/xtdb/xtql.clj
@@ -38,15 +38,6 @@
 
 (def ^:dynamic *gensym* gensym)
 
-(defn seeded-gensym
-  ([] (seeded-gensym "" 0))
-  ([count-start] (seeded-gensym "" count-start))
-  ([suffix count-start]
-   (let [ctr (atom (dec count-start))]
-     (fn gensym-seed
-       ([] (symbol (str "gensym" suffix (swap! ctr inc))))
-       ([prefix] (symbol (str prefix suffix (swap! ctr inc))))))))
-
 (defprotocol ExprPlan
   (plan-expr [expr])
   (required-vars [expr]))
@@ -906,7 +897,7 @@
 
 (def compile-query
   (-> (fn [query table-info]
-        (let [{:keys [ra-plan]} (binding [*gensym* (seeded-gensym "_" 0)
+        (let [{:keys [ra-plan]} (binding [*gensym* (util/seeded-gensym "_" 0)
                                           *table-info* table-info]
                                   (plan-query query))]
 
@@ -1034,7 +1025,7 @@
        (:ra-plan (plan-query (.query query)))]]]))
 
 (defn compile-dml [query {:keys [table-info] :as tx-opts}]
-  (let [ra-plan (binding [*gensym* (seeded-gensym "_" 0)
+  (let [ra-plan (binding [*gensym* (util/seeded-gensym "_" 0)
                           *table-info* table-info]
                   (plan-dml query tx-opts))
         [dml-op dml-op-opts plan] ra-plan]

--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -436,7 +436,7 @@
                decode-json*))))
 
 (deftest testing-sql-query-with-args-3167
-  (t/is (= [{".column-1/" 1, ".column-2/" 3}]
+  (t/is (= [{"xt/column-1" 1, "xt/column-2" 3}]
            (-> (http/request {:accept "application/jsonl"
                               :as :string
                               :request-method :post

--- a/src/test/resources/xtdb/sql/plan_test_expectations/all-as-expression-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/all-as-expression-in-select.edn
@@ -1,5 +1,5 @@
 [:rename
- {x7 $column_1$}
+ {x7 xt$column_1}
  [:project
   [x7]
   [:map

--- a/src/test/resources/xtdb/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
@@ -1,5 +1,5 @@
 [:rename
- {x2 $column_1$}
+ {x2 xt$column_1}
  [:project
   [{x2 4}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
@@ -3,11 +3,11 @@
  [:project
   [x5]
   [:group-by
-   [x1 $row_number$ {x5 (sum x3)}]
+   [x1 xt$row_number {x5 (sum x3)}]
    [:apply
     :left-outer-join
     {x1 ?x7}
     [:map
-     [{$row_number$ (row-number)}]
+     [{xt$row_number (row-number)}]
      [:rename {z x1} [:scan {:table tab0} [z]]]]
     [:table [x3] [{x3 1} {x3 2} {x3 3} {x3 ?x7}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
@@ -1,5 +1,5 @@
 [:rename
- {x5 $column_1$}
+ {x5 xt$column_1}
  [:project
   [x5]
   [:group-by

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
@@ -3,11 +3,11 @@
  [:project
   [x5]
   [:group-by
-   [x1 xt$row_number {x5 (sum x3)}]
+   [x1 xt$row_number_0 {x5 (sum x3)}]
    [:apply
     :left-outer-join
     {x1 ?x7}
     [:map
-     [{xt$row_number (row-number)}]
+     [{xt$row_number_0 (row-number)}]
      [:rename {z x1} [:scan {:table tab0} [z]]]]
     [:table [x3] [{x3 1} {x3 2} {x3 3} {x3 ?x7}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
@@ -1,5 +1,5 @@
 [:rename
- {x5 $column_1$}
+ {x5 xt$column_1}
  [:project
   [x5]
   [:apply

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-10.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:group-by
   [{x3 (sum x1)}]
   [:rename {length x1} [:scan {:table movie} [length]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:order-by
   [[x3 {:direction :asc, :null-ordering :nulls-last}]]
   [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 films, x3 $column_2$}
+ {x1 films, x3 xt$column_2}
  [:project
   [x1 x3]
   [:unnest

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 films, x3 $column_2$, x4 $column_3$}
+ {x1 films, x3 xt$column_2, x4 xt$column_3}
  [:project
   [x1 x3 x4]
   [:unnest

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-32.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-32.edn
@@ -1,3 +1,3 @@
 [:rename
- {x1 $column_1$, x2 $column_2$}
+ {x1 xt$column_1, x2 xt$column_2}
  [:table [x1 x2] [{x1 1, x2 2} {x1 3, x2 4}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-33.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-33.edn
@@ -1,1 +1,1 @@
-[:rename {x1 $column_1$} [:table [x1] [{x1 1} {x1 2}]]]
+[:rename {x1 xt$column_1} [:table [x1] [{x1 1} {x1 2}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
@@ -1,5 +1,5 @@
 [:rename
- {x7 $column_1$, x8 $column_2$, x9 $column_3$}
+ {x7 xt$column_1, x8 xt$column_2, x9 xt$column_3}
  [:project
   [{x7 (case (+ x1 1) x2 111 x3 222 x4 333 x5 444 555)}
    {x8

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
@@ -1,5 +1,5 @@
 [:rename
- {x4 $column_1$}
+ {x4 xt$column_1}
  [:project
   [{x4 (nullif x1 x2)}]
   [:rename {a x1, b x2} [:scan {:table t1} [a b]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 name, x8 $column_2$}
+ {x1 name, x8 xt$column_2}
  [:project
   [x1 x8]
   [:select

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
@@ -5,11 +5,11 @@
   [:select
    (< 1000000 x6)
    [:group-by
-    [x1 xt$row_number {x6 (sum x3)}]
+    [x1 xt$row_number_0 {x6 (sum x3)}]
     [:left-outer-join
      [{x1 x4}]
      [:map
-      [{xt$row_number (row-number)}]
+      [{xt$row_number_0 (row-number)}]
       [:rename {custkey x1} [:scan {:table customer} [custkey]]]]
      [:rename
       {totalprice x3, custkey x4}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
@@ -5,11 +5,11 @@
   [:select
    (< 1000000 x6)
    [:group-by
-    [x1 $row_number$ {x6 (sum x3)}]
+    [x1 xt$row_number {x6 (sum x3)}]
     [:left-outer-join
      [{x1 x4}]
      [:map
-      [{$row_number$ (row-number)}]
+      [{xt$row_number (row-number)}]
       [:rename {custkey x1} [:scan {:table customer} [custkey]]]]
      [:rename
       {totalprice x3, custkey x4}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
@@ -3,11 +3,11 @@
  [:project
   [x1 x11]
   [:group-by
-   [x1 x2 x3 xt$row_number {x11 (count x10)}]
+   [x1 x2 x3 xt$row_number_0 {x11 (count x10)}]
    [:left-outer-join
     [{x2 x8}]
     [:map
-     [{xt$row_number (row-number)}]
+     [{xt$row_number_0 (row-number)}]
      [:anti-join
       [(or (= x3 x5) (nil? x3) (nil? x5))]
       [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
@@ -3,11 +3,11 @@
  [:project
   [x1 x11]
   [:group-by
-   [x1 x2 x3 $row_number$ {x11 (count x10)}]
+   [x1 x2 x3 xt$row_number {x11 (count x10)}]
    [:left-outer-join
     [{x2 x8}]
     [:map
-     [{$row_number$ (row-number)}]
+     [{xt$row_number (row-number)}]
      [:anti-join
       [(or (= x3 x5) (nil? x3) (nil? x5))]
       [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 name, x11 $column_2$}
+ {x1 name, x11 xt$column_2}
  [:project
   [x1 x11]
   [:group-by

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
@@ -5,11 +5,11 @@
   [:select
    (= x6 x11)
    [:group-by
-    [x1 x2 x4 x5 x6 $row_number$ {x11 (min x8)}]
+    [x1 x2 x4 x5 x6 xt$row_number {x11 (min x8)}]
     [:left-outer-join
      [{x2 x9}]
      [:map
-      [{$row_number$ (row-number)}]
+      [{xt$row_number (row-number)}]
       [:mega-join
        [{x2 x5}]
        [[:rename {name x1, id x2} [:scan {:table students} [name id]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
@@ -5,11 +5,11 @@
   [:select
    (= x6 x11)
    [:group-by
-    [x1 x2 x4 x5 x6 xt$row_number {x11 (min x8)}]
+    [x1 x2 x4 x5 x6 xt$row_number_0 {x11 (min x8)}]
     [:left-outer-join
      [{x2 x9}]
      [:map
-      [{xt$row_number (row-number)}]
+      [{xt$row_number_0 (row-number)}]
       [:mega-join
        [{x2 x5}]
        [[:rename {name x1, id x2} [:scan {:table students} [name id]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
@@ -7,11 +7,11 @@
    [:map
     [{x17 (+ x15 1)}]
     [:group-by
-     [x1 x2 x3 x4 x6 x7 x8 xt$row_number {x15 (avg x10)}]
+     [x1 x2 x3 x4 x6 x7 x8 xt$row_number_0 {x15 (avg x10)}]
      [:left-outer-join
       [(or (= x2 x11) (and (= x12 x3) (> x4 x13)))]
       [:map
-       [{xt$row_number (row-number)}]
+       [{xt$row_number_0 (row-number)}]
        [:mega-join
         [{x2 x7}]
         [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
@@ -7,11 +7,11 @@
    [:map
     [{x17 (+ x15 1)}]
     [:group-by
-     [x1 x2 x3 x4 x6 x7 x8 $row_number$ {x15 (avg x10)}]
+     [x1 x2 x3 x4 x6 x7 x8 xt$row_number {x15 (avg x10)}]
      [:left-outer-join
       [(or (= x2 x11) (and (= x12 x3) (> x4 x13)))]
       [:map
-       [{$row_number$ (row-number)}]
+       [{xt$row_number (row-number)}]
        [:mega-join
         [{x2 x7}]
         [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
@@ -1,5 +1,5 @@
 [:rename
- {x6 $column_1$}
+ {x6 xt$column_1}
  [:project
   [x6]
   [:apply

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:single-join
   []
   [:rename {} [:scan {:table t2} []]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
@@ -1,5 +1,5 @@
 [:rename
- {x7 $column_1$}
+ {x7 xt$column_1}
  [:project
   [x7]
   [:apply

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
@@ -1,5 +1,5 @@
 [:rename
- {x6 $column_1$}
+ {x6 xt$column_1}
  [:project
   [x6]
   [:mega-join

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -1,5 +1,5 @@
 [:rename
- {x7 $column_1$}
+ {x7 xt$column_1}
  [:project
   [x7]
   [:group-by

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -3,10 +3,10 @@
  [:project
   [x7]
   [:group-by
-   [x1 x2 xt$row_number {x7 (array-agg x4)}]
+   [x1 x2 xt$row_number_0 {x7 (array-agg x4)}]
    [:mega-join
     [{x1 x5}]
     [[:map
-      [{xt$row_number (row-number)}]
+      [{xt$row_number_0 (row-number)}]
       [:rename {b x1, a x2} [:scan {:table a} [b {a (= a 42)}]]]]
      [:rename {b1 x4, b2 x5} [:scan {:table b} [b1 b2]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -3,10 +3,10 @@
  [:project
   [x7]
   [:group-by
-   [x1 x2 $row_number$ {x7 (array-agg x4)}]
+   [x1 x2 xt$row_number {x7 (array-agg x4)}]
    [:mega-join
     [{x1 x5}]
     [[:map
-      [{$row_number$ (row-number)}]
+      [{xt$row_number (row-number)}]
       [:rename {b x1, a x2} [:scan {:table a} [b {a (= a 42)}]]]]
      [:rename {b1 x4, b2 x5} [:scan {:table b} [b1 b2]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-current-time-111.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-current-time-111.edn
@@ -1,16 +1,16 @@
 [:rename
  {x1 a,
-  x8 $column_7$,
-  x13 $column_12$,
-  x5 $column_4$,
-  x9 $column_8$,
-  x12 $column_11$,
-  x10 $column_9$,
-  x4 $column_3$,
-  x6 $column_5$,
-  x11 $column_10$,
-  x7 $column_6$,
-  x3 $column_2$}
+  x8 xt$column_7,
+  x13 xt$column_12,
+  x5 xt$column_4,
+  x9 xt$column_8,
+  x12 xt$column_11,
+  x10 xt$column_9,
+  x4 xt$column_3,
+  x6 xt$column_5,
+  x11 xt$column_10,
+  x7 xt$column_6,
+  x3 xt$column_2}
  [:project
   [x1
    {x3 (current-time)}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
@@ -1,5 +1,5 @@
 [:rename
- {x6 $column_1$}
+ {x6 xt$column_1}
  [:project
   [{x6 (and (< x3 x2) (> x4 x1))}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 col1, x5 $column_2$}
+ {x1 col1, x5 xt$column_2}
  [:single-join
   []
   [:rename {col1 x1} [:scan {:table t1} [col1]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 col1, x3 $column_2$}
+ {x1 col1, x3 xt$column_2}
  [:project
   [x1 {x3 ?_0}]
   [:rename {col1 x1} [:scan {:table t1} [col1]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:project
   [{x3 1}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:project
   [{x3 1}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-system-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-system-time.edn
@@ -1,5 +1,5 @@
 [:rename
- {x3 $column_1$}
+ {x3 xt$column_1}
  [:project
   [{x3 1}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
@@ -1,5 +1,5 @@
 [:rename
- {x7 $column_1$}
+ {x7 xt$column_1}
  [:project
   [x7]
   [:apply

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -38,12 +38,12 @@
        x20
        x22
        x23
-       $row_number$
+       xt$row_number
        {x38 (min x25)}]
       [:left-outer-join
        [{x1 x26}]
        [:map
-        [{$row_number$ (row-number)}]
+        [{xt$row_number (row-number)}]
         [:mega-join
          [{x20 x22} {x12 x19} {x1 x14} {x11 x15}]
          [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -38,12 +38,12 @@
        x20
        x22
        x23
-       xt$row_number
+       xt$row_number_0
        {x38 (min x25)}]
       [:left-outer-join
        [{x1 x26}]
        [:map
-        [{xt$row_number (row-number)}]
+        [{xt$row_number_0 (row-number)}]
         [:mega-join
          [{x20 x22} {x12 x19} {x1 x14} {x11 x15}]
          [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -9,11 +9,11 @@
     [:map
      [{x14 (* 0.2 x12)}]
      [:group-by
-      [x1 x2 x3 x5 x6 x7 xt$row_number {x12 (avg x9)}]
+      [x1 x2 x3 x5 x6 x7 xt$row_number_0 {x12 (avg x9)}]
       [:left-outer-join
        [{x5 x10}]
        [:map
-        [{xt$row_number (row-number)}]
+        [{xt$row_number_0 (row-number)}]
         [:mega-join
          [{x2 x5}]
          [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -9,11 +9,11 @@
     [:map
      [{x14 (* 0.2 x12)}]
      [:group-by
-      [x1 x2 x3 x5 x6 x7 $row_number$ {x12 (avg x9)}]
+      [x1 x2 x3 x5 x6 x7 xt$row_number {x12 (avg x9)}]
       [:left-outer-join
        [{x5 x10}]
        [:map
-        [{$row_number$ (row-number)}]
+        [{xt$row_number (row-number)}]
         [:mega-join
          [{x2 x5}]
          [[:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -18,11 +18,11 @@
        [:map
         [{x24 (* 0.5 x22)}]
         [:group-by
-         [x9 x10 x11 xt$row_number {x22 (sum x17)}]
+         [x9 x10 x11 xt$row_number_0 {x22 (sum x17)}]
          [:left-outer-join
           [{x10 x18} {x9 x19}]
           [:map
-           [{xt$row_number (row-number)}]
+           [{xt$row_number_0 (row-number)}]
            [:semi-join
             [{x10 x13}]
             [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -18,11 +18,11 @@
        [:map
         [{x24 (* 0.5 x22)}]
         [:group-by
-         [x9 x10 x11 $row_number$ {x22 (sum x17)}]
+         [x9 x10 x11 xt$row_number {x22 (sum x17)}]
          [:left-outer-join
           [{x10 x18} {x9 x19}]
           [:map
-           [{$row_number$ (row-number)}]
+           [{xt$row_number (row-number)}]
            [:semi-join
             [{x10 x13}]
             [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
@@ -1,5 +1,5 @@
 [:rename
- {x2 $column_1$}
+ {x2 xt$column_1}
  [:project
   [{x2 4}]
   [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
@@ -1,5 +1,5 @@
 [:rename
- {x2 $column_1$}
+ {x2 xt$column_1}
  [:project
   [{x2 4}]
   [:rename


### PR DESCRIPTION
**Github Action Runs**: [Here](https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Agenerated-column-names++)
**Linked Issue:** Resolves #3156 

- Updates the format of generated projection columns from `$column_idx$` to `xt$column_idx`.
- Updates `$row_number$` to `xt$row_number` and using a seeded-gensym to ensure uniqueness.
- Updates aggregate symbol and it's usages - pulls agg_in and agg_out to separate vars for ease of future updates and consistensy.
- Rename `subquery` symbol to start with `xt$subquery`
- Moves `seeded-gensym` to util to make it shared between XTQL and SQL.