### PR TITLE
Add `current` SQL session variables to SQL and EE, use hardcoded values #3215

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1041,6 +1041,17 @@
    :->call-code (fn [[code]]
                   `(ByteBuffer/wrap (.getBytes (.toLowerCase (resolve-string ~code)) StandardCharsets/UTF_8)))})
 
+;; SQL Session Variable functions.
+;; We currently return hard-coded values for these functions, as we do not currently have any of these concepts.
+(defmethod codegen-call [:current_user] [_]
+  {:return-type :utf8 :->call-code (fn [_] `(ByteBuffer/wrap (.getBytes "xtdb" StandardCharsets/UTF_8)))})
+
+(defmethod codegen-call [:current_database] [_]
+  {:return-type :utf8 :->call-code (fn [_] `(ByteBuffer/wrap (.getBytes "xtdb" StandardCharsets/UTF_8)))})
+
+(defmethod codegen-call [:current_schema] [_]
+  {:return-type :utf8 :->call-code (fn [_] `(ByteBuffer/wrap (.getBytes "public" StandardCharsets/UTF_8)))})
+
 (defn- allocate-concat-out-buffer ^ByteBuffer [bufs]
   (loop [i (int 0)
          capacity (int 0)]

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -824,6 +824,10 @@
     [:concatenation ^:z nve1 _ ^:z nve2]
     (list 'concat (expr nve1) (expr nve2))
 
+    [:session_variable_function "CURRENT_USER"] '(current-user)
+    [:session_variable_function "CURRENT_SCHEMA"] '(current-schema)
+    [:session_variable_function "CURRENT_DATABASE"] '(current-database)
+
     [:character_position_expression _ ^:z needle _ ^:z haystack]
     (list 'position (expr needle) (expr haystack))
 

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -116,7 +116,7 @@ vertical_bar
 (*  5.2     <token> and <separator> *)
 
 regular_identifier
-: !#'(?i)(\b(NULL|WITH|SELECT|FROM|WHERE|GROUP|HAVING|ORDER|OFFSET|FETCH|LIMIT|PARTITION|ROWS|RANGE|GROUPS|UNION|EXCEPT|INTERSECT|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_DATE|LOCALTIME|LOCALTIMESTAMP|END_OF_TIME)\b)' #'[a-zA-Z][a-zA-Z0-9_$]*'
+: !#'(?i)(\b(NULL|WITH|SELECT|FROM|WHERE|GROUP|HAVING|ORDER|OFFSET|FETCH|LIMIT|PARTITION|ROWS|RANGE|GROUPS|UNION|EXCEPT|INTERSECT|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_DATE|LOCALTIME|LOCALTIMESTAMP|END_OF_TIME|CURRENT_USER|CURRENT_SCHEMA|CURRENT_DATABASE)\b)' #'[a-zA-Z][a-zA-Z0-9_$]*'
     ;
 
 large_object_length_token
@@ -1128,6 +1128,7 @@ binary_concatenation
     | fold
     | trim_function
     | character_overlay_function
+    | session_variable_function
     ;
 
 character_substring_function
@@ -1163,6 +1164,13 @@ trim_specification
 character_overlay_function
     : 'OVERLAY' <left_paren> character_value_expression 'PLACING' character_value_expression 'FROM' start_position [ 'FOR' string_length ] [ 'USING' char_length_units ] <right_paren>
     ;
+
+session_variable_function 
+    : 'CURRENT_USER'
+    | 'CURRENT_SCHEMA'
+    | 'CURRENT_DATABASE'
+    ;
+
 
 <binary_value_function>
     : binary_substring_function

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1882,3 +1882,14 @@
 
     (t/is (= [{:xt/column-1 ["one"]}]
              (xt/q tu/*node* "SELECT ARRAY(select b.b1 from b where b.b2 = 42) FROM a where a.a = 42")))))
+
+(t/deftest test-postgres-session-variables
+  ;; These currently return hard-coded values.
+  (t/is (= [{:xt/column-1 "xtdb"}]
+           (xt/q tu/*node* "SELECT current_user FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:xt/column-1 "xtdb"}]
+           (xt/q tu/*node* "SELECT current_database FROM (VALUES 1) AS x")))
+  
+  (t/is (= [{:xt/column-1 "public"}]
+           (xt/q tu/*node* "SELECT current_schema FROM (VALUES 1) AS x"))))


### PR DESCRIPTION
**Github Action Runs**: [Here](https://github.com/danmason/xtdb/actions?query=branch%3Apg-session-variables++)
**Linked Issue:** Resolves #3215 

- Adds `CURRENT_USER`, `CURRENT_DATABASE` and `CURRENT_SCHEMA` to SQL grammar as `session_variable_function`.
- Adds planning for these into SQL planner.
- Adds functions to handle these within the expression engine, returning the suggested hardcoded results.
- Adds a test under `sql_test` that these return from the query. 