### PR TITLE
Add table/schema privilege function parsing, always returning true.

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -737,6 +737,12 @@
               "SYMMETRIC" 'between-symmetric
               "ASYMMETRIC" 'between)]
       (list 'not (list f (expr rvp-1) (expr rvp-2) (expr rvp-3))))
+    
+    ;; Various table access control functions - always return true for now, since we lack the concept.
+    [:has_table_privilege_predicate "HAS_TABLE_PRIVILEGE" _table _privilege] true
+    [:has_table_privilege_predicate "HAS_TABLE_PRIVILEGE" _user _table _privilege] true
+    [:has_schema_privilege_predicate "HAS_SCHEMA_PRIVILEGE" _schema _privilege] true
+    [:has_schema_privilege_predicate "HAS_SCHEMA_PRIVILEGE" _user _schema _privilege] true
 
     [:extract_expression "EXTRACT" [:primary_datetime_field [:non_second_primary_datetime_field extract-field]] "FROM" ^:z es]
     ;;=>

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -1894,6 +1894,7 @@ subquery
     | quantified_comparison_predicate
     | exists_predicate
     | period_predicate
+    | postgres_access_privilege_predicate
     ;
 
 (*  8.2        <comparison predicate> *)
@@ -2135,6 +2136,44 @@ period_immediately_succeeds_predicate_part_2
 
 search_condition
     : boolean_value_expression
+    ;
+
+(*  postgres access privilege predicates *)
+
+<postgres_access_privilege_predicate>
+    : has_table_privilege_predicate
+    | has_schema_privilege_predicate
+    ;
+
+has_table_privilege_predicate
+    : [ <pg_catalog_reference> ] 'HAS_TABLE_PRIVILEGE' <left_paren> user_string <comma> table_string <comma> privilege_string <right_paren>
+    | [ <pg_catalog_reference> ] 'HAS_TABLE_PRIVILEGE' <left_paren> table_string <comma> privilege_string <right_paren>
+    ;
+
+has_schema_privilege_predicate
+    : [ <pg_catalog_reference> ] 'HAS_SCHEMA_PRIVILEGE' <left_paren> user_string <comma> schema_string <comma> privilege_string <right_paren>
+    | [ <pg_catalog_reference> ] 'HAS_SCHEMA_PRIVILEGE' <left_paren> schema_string <comma> privilege_string <right_paren>
+    ;
+
+(* Sometimes specified as pg_catalog.fn, so add parsing for that *)
+pg_catalog_reference
+    : 'PG_CATALOG' <period>
+    ;
+
+user_string
+    : character_value_expression
+    ;
+
+table_string
+    : character_value_expression
+    ;
+
+schema_string
+    : character_value_expression
+    ;
+
+privilege_string
+    : character_value_expression
     ;
 
 (*  10 Additional common elements *)

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1896,35 +1896,19 @@
 
 (t/deftest test-postgres-access-control-functions
   ;; These current functions should always should return true
+  (t/are [sql expected] (= expected (plan-expr sql))
+    "has_table_privilege('xtdb','docs', 'select')" true
+    "has_table_privilege('docs', 'select')" true
+    "pg_catalog.has_table_privilege('docs', 'select')" true
 
-  (t/testing "has table privilege"
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT has_table_privilege('xtdb','docs', 'select') FROM (VALUES 1) AS x")))
+    "has_schema_privilege('xtdb', 'public', 'select')" true
+    "has_schema_privilege('public', 'select')" true
+    "pg_catalog.has_schema_privilege('public', 'select')" true
 
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT has_table_privilege('docs', 'select') FROM (VALUES 1) AS x")))
+    "has_table_privilege(current_user, 'docs', 'select')" true
+    "has_schema_privilege(current_user, 'public', 'select')" true)
 
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT pg_catalog.has_table_privilege('docs', 'select') FROM (VALUES 1) AS x"))))
-
-  (t/testing "has schema privilege"
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT has_schema_privilege('xtdb', 'public', 'select') FROM (VALUES 1) AS x")))
-
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT has_schema_privilege('public', 'select') FROM (VALUES 1) AS x")))
-
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT pg_catalog.has_schema_privilege('public', 'select') FROM (VALUES 1) AS x"))))
-
-  (t/testing "current_user passed in"
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT pg_catalog.has_table_privilege(current_user, 'docs', 'select') FROM (VALUES 1) AS x")))
-    
-    (t/is (= [{:xt/column-1 true}]
-             (xt/q tu/*node* "SELECT pg_catalog.has_schema_privilege(current_user, 'public', 'select') FROM (VALUES 1) AS x"))))
-
-  (t/testing "example query"
+  (t/testing "example SQL query"
     (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :x 3}]])
 
     (t/is (= [{:x 3}]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1893,3 +1893,39 @@
   
   (t/is (= [{:xt/column-1 "public"}]
            (xt/q tu/*node* "SELECT current_schema FROM (VALUES 1) AS x"))))
+
+(t/deftest test-postgres-access-control-functions
+  ;; These current functions should always should return true
+
+  (t/testing "has table privilege"
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT has_table_privilege('xtdb','docs', 'select') FROM (VALUES 1) AS x")))
+
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT has_table_privilege('docs', 'select') FROM (VALUES 1) AS x")))
+
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT pg_catalog.has_table_privilege('docs', 'select') FROM (VALUES 1) AS x"))))
+
+  (t/testing "has schema privilege"
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT has_schema_privilege('xtdb', 'public', 'select') FROM (VALUES 1) AS x")))
+
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT has_schema_privilege('public', 'select') FROM (VALUES 1) AS x")))
+
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT pg_catalog.has_schema_privilege('public', 'select') FROM (VALUES 1) AS x"))))
+
+  (t/testing "current_user passed in"
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT pg_catalog.has_table_privilege(current_user, 'docs', 'select') FROM (VALUES 1) AS x")))
+    
+    (t/is (= [{:xt/column-1 true}]
+             (xt/q tu/*node* "SELECT pg_catalog.has_schema_privilege(current_user, 'public', 'select') FROM (VALUES 1) AS x"))))
+
+  (t/testing "example query"
+    (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :x 3}]])
+
+    (t/is (= [{:x 3}]
+             (xt/q tu/*node* "SELECT docs.x FROM docs WHERE has_table_privilege('docs', 'select') ")))))


### PR DESCRIPTION
**Github Action Runs**: [Here](https://github.com/danmason/xtdb/actions?query=branch%3Apostgres-table-access-functions-3216++)
**Linked Issue:** Resolves #3216 

Adds initial support for some of the table access control/"Access Privilege Inquiry Functions" to our SQL:
- Works with or without `pg_catalog.` specified the function call.
  - If it is, we essentially handle it in the parser and discard it prior to planning.
- Currently implementing:
  - All the arities for `has_table_privilege`
  - All the arities for `has_schema_privilege` 
- Always returning true from the planner.