### PR TITLE
Handle `routine_invocation` - use for `has_table_privilege` and `has_schema_privilege`.

### DIFF
--- a/core/src/main/clojure/xtdb/sql/parser.clj
+++ b/core/src/main/clojure/xtdb/sql/parser.clj
@@ -296,7 +296,7 @@
   (sql-parser "IN ( col0 * col0 )" :in_predicate_part_2)
 
   (sql-parser "INTERVAL '3 4' DAY TO HOUR" :interval_literal)
-  (sql-parser "DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40')" :datetime_value_function)
+  (sql-parser "SELECT DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40') FROM Foo" :directly_executable_statement)
   (sql-parser "DATE_TRUNC('day', TIMESTAMP '2001-02-16 20:38:40', 'Australia/Sydney')" :datetime_value_function)
   (sql-parser "DATE_TRUNC('hour', INTERVAL '3 4' DAY TO HOUR)" :interval_value_function)
 

--- a/core/src/main/clojure/xtdb/sql/parser.clj
+++ b/core/src/main/clojure/xtdb/sql/parser.clj
@@ -277,6 +277,8 @@
 
 
   (sql-parser "SELECT * FROMfoo" :directly_executable_statement)
+  (sql-parser "SELECT pg_catalog.HAS_TABLE_PRIVILEGE(current_user, 'foo', 'bar') FROM foo" :directly_executable_statement)
+  (sql-parser "SELECT has_table_privilege(current_user, 'foo', 'bar') FROM foo" :directly_executable_statement)
 
   (println (failure->str (sql-parser "* FROMfoo" :term)))
 

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -1050,11 +1050,11 @@
     ;;=>
     (list 'age (expr dt1) (expr dt2))
 
-    [:routine_invocation [:regular_identifier routine-name] sql-args]
+    [:routine_invocation [:routine_identifier routine-name] sql-args]
     ;;=>
     (routine-invocation nil routine-name sql-args)
     
-    [:routine_invocation [:schema_name schema-name] [:regular_identifier routine-name] sql-args]
+    [:routine_invocation [:schema_name schema-name] [:routine_identifier routine-name] sql-args]
     ;;=>
     (routine-invocation schema-name routine-name sql-args)
 

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -380,9 +380,9 @@ schema_name
     : [ schema_name <period> ] !#'(?i)(\b(SYSTEM_TIME|VALID_TIME)\b)' identifier
     ;
 
-<qualified_identifier>
-    : identifier
-    ;
+(* Following the lead of regular_identifier here, filtering known function calls *)
+routine_identifier
+    : !#'(?i)(\b(RANK|DENSE_RANK|PERCENT_RANK|CUME_DIST|ROW_NUMBER|NTILE|LEAD|LAG|FIRST_VALUE|LAST_VALUE|NTH_VALUE|VALUE_OF|NULLIF|COALESCE|CAST|POSITION|LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|OCTET_LENGTH|EXTRACT|CARDINALITY|ARRAY_MAX_CARDINALITY|ABS|MOD|LN|EXP|POWER|SQRT|FLOOR|CEIL|CEILING|SUBSTRING|UPPER|LOWER|TRIM|OVERLAY|CURRENT_TIME|LOCALTIME|CURRENT_TIMESTAMP|LOCALTIMESTAMP|END_OF_TIME|TRIM_ARRAY|ARRAY|USING|PERIOD|AVG|MAX|MIN|SUM|EVERY|ANY|SOME|COUNT|STDDEV_POP|STDDEV_SAMP|VAR_SAMP|VAR_POP|ARRAY_AGG|SIN|COS|TAN|SINH|COSH|TANH|ASIN|ACOS|ATAN|LOG|LOG10|LEAST|GREATEST|OBJECT|DATE_TRUNC|AGE|ARROW_TABLE)\b)' #'[a-zA-Z][a-zA-Z0-9_$]*'
 
 <column_name>
     : identifier
@@ -2192,7 +2192,7 @@ routine_invocation
     ;
 
 <routine_name> 
-    : [ schema_name <period> ] <qualified_identifier>
+    : [ schema_name <period> ] routine_identifier
     ;
 
 sql_argument_list 

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -380,6 +380,10 @@ schema_name
     : [ schema_name <period> ] !#'(?i)(\b(SYSTEM_TIME|VALID_TIME)\b)' identifier
     ;
 
+<qualified_identifier>
+    : identifier
+    ;
+
 <column_name>
     : identifier
     ;
@@ -584,6 +588,7 @@ field_definition
     | field_reference
     | collection_value_constructor
     | array_element_reference
+    | routine_invocation
     ;
 
 <collection_value_constructor>
@@ -1894,7 +1899,6 @@ subquery
     | quantified_comparison_predicate
     | exists_predicate
     | period_predicate
-    | postgres_access_privilege_predicate
     ;
 
 (*  8.2        <comparison predicate> *)
@@ -2138,44 +2142,6 @@ search_condition
     : boolean_value_expression
     ;
 
-(*  postgres access privilege predicates *)
-
-<postgres_access_privilege_predicate>
-    : has_table_privilege_predicate
-    | has_schema_privilege_predicate
-    ;
-
-has_table_privilege_predicate
-    : [ <pg_catalog_reference> ] 'HAS_TABLE_PRIVILEGE' <left_paren> user_string <comma> table_string <comma> privilege_string <right_paren>
-    | [ <pg_catalog_reference> ] 'HAS_TABLE_PRIVILEGE' <left_paren> table_string <comma> privilege_string <right_paren>
-    ;
-
-has_schema_privilege_predicate
-    : [ <pg_catalog_reference> ] 'HAS_SCHEMA_PRIVILEGE' <left_paren> user_string <comma> schema_string <comma> privilege_string <right_paren>
-    | [ <pg_catalog_reference> ] 'HAS_SCHEMA_PRIVILEGE' <left_paren> schema_string <comma> privilege_string <right_paren>
-    ;
-
-(* Sometimes specified as pg_catalog.fn, so add parsing for that *)
-pg_catalog_reference
-    : 'PG_CATALOG' <period>
-    ;
-
-user_string
-    : character_value_expression
-    ;
-
-table_string
-    : character_value_expression
-    ;
-
-schema_string
-    : character_value_expression
-    ;
-
-privilege_string
-    : character_value_expression
-    ;
-
 (*  10 Additional common elements *)
 
 (*  10.1 <interval qualifier> *)
@@ -2218,6 +2184,23 @@ non_second_primary_datetime_field
 
 <interval_leading_field_precision>
     : unsigned_integer
+    ;
+
+(*  10.4 <routine_invocation> *)
+routine_invocation
+    : routine_name sql_argument_list
+    ;
+
+<routine_name> 
+    : [ schema_name <period> ] <qualified_identifier>
+    ;
+
+sql_argument_list 
+    : <left_paren> [ sql_argument [ { <comma> sql_argument } ] ] <right_paren>
+    ;
+
+<sql_argument> 
+    : value_expression
     ;
 
 (*  10.9 <aggregate function> *)

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1906,7 +1906,10 @@
     "pg_catalog.has_schema_privilege('public', 'select')" true
 
     "has_table_privilege(current_user, 'docs', 'select')" true
-    "has_schema_privilege(current_user, 'public', 'select')" true)
+    "has_schema_privilege(current_user, 'public', 'select')" true
+    
+    "HAS_TABLE_PRIVILEGE('xtdb','docs', 'select')" true
+    "PG_CATALOG.HAS_TABLE_PRIVILEGE('xtdb','docs', 'select')" true)
 
   (t/testing "example SQL query"
     (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :x 3}]])


### PR DESCRIPTION
**Github Action Runs**: [Here](https://github.com/danmason/xtdb/actions?query=branch%3Aroutine-invocation-3216++)
**Linked Issue:** Resolves #3216 

Adds handling for `routine_invocation` and updates `has_table_privilege` and `has_schema_privilege` to use it.