### PR TITLE
Fiddle tweaks

### DIFF
--- a/docs/src/components/fiddle.astro
+++ b/docs/src/components/fiddle.astro
@@ -1,6 +1,6 @@
 ---
 import Play from 'astro-heroicons/solid/Play.astro';
-import Pencil from 'astro-heroicons/solid/Pencil.astro';
+import ArrowTopRightOnSquare from 'astro-heroicons/solid/ArrowTopRightOnSquare.astro';
 
 const { magicContext } = Astro.props;
 
@@ -28,13 +28,11 @@ function gensym() {
                 </div>
             </div>
             <div class="flex-grow" />
-            <div data-id="open-in-fiddle"
-                 class="px-2 bg-gray-300 hover:bg-gray-400/70 dark:bg-gray-600 dark:hover:bg-gray-700 cursor-pointer rounded-md">
-                <div class="flex flex-row items-center gap-1">
-                    <Pencil class="size-4" />
-                    Edit in xt-fiddle
-                </div>
-            </div>
+            <span data-id="open-in-fiddle"
+                 class="cursor-pointer underline">
+                 Open in xt-fiddle
+                 <ArrowTopRightOnSquare class="size-3" />
+            </span>
         </div>
         <div class="bg-gray-100 dark:bg-gray-800 rounded-md overflow-x-auto"
              data-id="results" />

--- a/docs/src/components/fiddle/editor.ts
+++ b/docs/src/components/fiddle/editor.ts
@@ -29,13 +29,13 @@ let themeObj = {
         borderBottom: "1px solid var(--teal-color)",
         color: "inherit"
     },
-    // only show cursor when focused
+    // Always show the cursor
     ".cm-cursor": {
-        visibility: "hidden"
+        display: "block",
     },
-    "&.cm-focused .cm-cursor": {
-        visibility: "visible"
-    }
+    ".cm-cursorLayer": {
+        animation: "steps(1) cm-blink 1.2s infinite",
+    },
 }
 
 let darkThemeObj = structuredClone(themeObj);

--- a/docs/src/components/fiddle/editor.ts
+++ b/docs/src/components/fiddle/editor.ts
@@ -82,7 +82,8 @@ interface Params {
 
 export function makeEditor({ initialText, parent }: Params) {
     const view = new EditorView({
-        doc: Text.of(initialText.split("\n")),
+        doc: initialText,
+        selection: { anchor: initialText.length },
         extensions: extensions,
         parent: parent,
     });


### PR DESCRIPTION
- Always show the cursor & place it at the end of the text by default

To try:
- Add a separate "edit" button that just selects the editor
- Change the wording of the "edit in xt-fiddle" button (open in xt-fiddle?)