### PR TITLE
Compactor runs as a background task, #2652

### DIFF
--- a/core/src/main/kotlin/xtdb/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/Compactor.kt
@@ -87,6 +87,7 @@ internal fun IntArray.recencyPartitions(
     return res.mapValuesTo(sortedMapOf()) { it.value.toArray() }
 }
 
+@Suppress("unused")
 @JvmOverloads
 fun writeRelation(
     trieWriter: ITrieWriter,
@@ -99,7 +100,8 @@ fun writeRelation(
     val iidReader = relation.readerForName("xt\$iid")
 
     fun writeSubtree(depth: Int, sel: Selection): Int =
-        if (sel.size <= pageLimit) {
+        if (Thread.interrupted()) throw InterruptedException()
+        else if (sel.size <= pageLimit) {
             for (idx in sel) rowCopier.copyRow(idx)
 
             val pos = trieWriter.writeLeaf()


### PR DESCRIPTION
resolves #2652

This PR creates tasks that compact index files in the background. By default it uses half the machine threads to do so (although we can adapt this over time as required).

* We calculate the available jobs every time any thread has finished, so that they're as up-to-date as they can be. It turned out to be cheap enough to calculate this in practice, relative to the cost of the compaction job itself
  * Had we not done this (i.e. had we kept the list of available jobs from last time in a queue), in a multi-node setup, you'd likely end up with more re-work.
  * There's still a slight race condition here, that another node is currently working on the same job - we assume that there will likely be enough distinct jobs to accept this risk. If two nodes _do_ work on the same job, they'll both write the same file to object-storage at the end.
  * We check that threads on the same node don't pick up the same job.
* `compactAll` is now only used as a test util - this awaits a steady state where there are no active tasks and no available jobs.
* Given that compaction effectively runs much more frequently now, we pretty much get a new L1 file every time there's a new L0 file. We'll certainly want to GC these (#3195), but I wonder whether it's also worth us holding off creating these for a little while after the block's created so that we don't create as many quickly-superseded L1 files?
* I've tested this against longer TPC-H runs, but we could use some better automated tests in this area, to take multiple nodes into account.