### PR TITLE
Add infix regex operators to SQL #3213

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -877,7 +877,7 @@
     {:return-type :bool
      :->call-code (fn [[haystack-code needle-code]]
                     `(boolean (re-find ~(if re-literal
-                                          (Pattern/compile re-literal flag-int)
+                                          `(Pattern/compile ~re-literal ~flag-int)
                                           `(Pattern/compile (resolve-string ~needle-code) ~flag-int))
                                        (resolve-string ~haystack-code))))}))
 

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -708,6 +708,19 @@
     [:regex_like_predicate ^:z rvp [:regex_like_predicate_part_2 "NOT" "LIKE_REGEX" ^:z cp "FLAG" ^:z flag]]
     (list 'not (list 'like-regex (expr rvp) (expr cp) (expr flag)))
 
+    ;; Treating postgres infix regex operators as alisases for LIKE_REGEX
+    [:postgres_regex_predicate ^:z rvp [:postgres_regex_operator "~"] ^:z cp]
+    (list 'like-regex (expr rvp) (expr cp) "")
+
+    [:postgres_regex_predicate ^:z rvp [:postgres_regex_operator "~*"] ^:z cp]
+    (list 'like-regex (expr rvp) (expr cp) "i")
+
+    [:postgres_regex_predicate ^:z rvp [:postgres_regex_operator "!~"] ^:z cp]
+    (list 'not (list 'like-regex (expr rvp) (expr cp) ""))
+
+    [:postgres_regex_predicate ^:z rvp [:postgres_regex_operator "!~*"] ^:z cp]
+    (list 'not (list 'like-regex (expr rvp) (expr cp) "i"))
+    
     [:character_substring_function "SUBSTRING" ^:z cve "FROM" ^:z sp "FOR" ^:z sl]
     ;;=>
     (list 'substring (expr cve) (expr sp) (expr sl))

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -1899,6 +1899,7 @@ subquery
     | in_predicate
     | like_predicate
     | regex_like_predicate
+    | postgres_regex_predicate
     | null_predicate
     | quantified_comparison_predicate
     | exists_predicate
@@ -2001,6 +2002,18 @@ regex_like_predicate
 
 regex_like_predicate_part_2
     : [ 'NOT' ] 'LIKE_REGEX' xquery_pattern [ 'FLAG' xquery_option_flag ]
+    ;
+
+(* Postgres infix regex predicates *)
+postgres_regex_predicate
+    : character_value_expression postgres_regex_operator xquery_pattern
+    ;
+
+postgres_regex_operator
+    : '~'
+    | '~*'
+    | '!~'
+    | '!~*'
     ;
 
 (*  8.8        <null predicate> *)

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -553,6 +553,7 @@
 
       "" "" "i" true
       "A" "a" "i" true
+      "ABCD" "a" "i" true
       "a\nB\nc" "^B$" "" false
       "a\nB\nc" "^B$" "m" true
       "a\nB\nc" "^b$" "m" false

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -537,6 +537,53 @@
   (t/is (= [{:match true}]
            (xt/q tu/*node* "SELECT ('ABC' LIKE_REGEX 'a' FLAG 'i') as match FROM (VALUES 1) AS x"))))
 
+(t/deftest test-postgres-regex-expr
+  (t/are [sql expected] (= expected (plan-expr sql))
+
+    "foo.a ~ foo.b" '(like-regex x1 x2 "")
+    "foo.a ~* foo.b" '(like-regex x1 x2 "i")
+
+    "foo.a !~ foo.b" '(not (like-regex x1 x2 ""))
+    "foo.a !~* foo.b" '(not (like-regex x1 x2 "i"))))
+
+(defn pg-regex-query [val op pattern]
+  (let [query (format "SELECT ('%s' %s '%s') as match FROM (VALUES 1) AS x" val op pattern)
+        [{:keys [match]}] (xt/q tu/*node* query)]
+    match))
+
+(t/deftest test-postgres-regex-query
+  (t/testing "postgres case sensitive match regex"
+    (t/are [expected val op pattern] (= expected (pg-regex-query val op pattern))
+      true "abcd" "~" "abcd"
+      true "abcd" "~" "a.c"
+      false "abcd" "~" "x"
+      false "abcd" "~" "A"
+      false "ABCD" "~" "a"))
+
+  (t/testing "postgres case insensitive match regex"
+    (t/are [expected val op pattern] (= expected (pg-regex-query val op pattern))
+      true "abcd" "~*" "abcd"
+      true "abcd" "~*" "a.c"
+      false "abcd" "~*" "x"
+      true "abcd" "~*" "A"
+      true "ABCD" "~*" "a"))
+
+  (t/testing "postgres case sensitive not match regex"
+    (t/are [expected val op pattern] (= expected (pg-regex-query val op pattern))
+      false "abcd" "!~" "abcd"
+      false "abcd" "!~" "a.c"
+      true "abcd" "!~" "x"
+      true "abcd" "!~" "A"
+      true "ABCD" "!~" "a"))
+
+  (t/testing "postgres case insensitive not match regex"
+    (t/are [expected val op pattern] (= expected (pg-regex-query val op pattern))
+      false "abcd" "!~*" "abcd"
+      false "abcd" "!~*" "a.c"
+      true "abcd" "!~*" "x"
+      false "abcd" "!~*" "A"
+      false "ABCD" "!~*" "a")))
+
 (t/deftest test-upper-expr
   (t/is (= '(upper x1) (plan-expr "UPPER(foo.a)"))))
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -530,6 +530,13 @@
     "foo.a NOT LIKE_REGEX foo.b" '(not (like-regex x1 x2 ""))
     "foo.a NOT LIKE_REGEX foo.b FLAG 'i'" '(not (like-regex x1 x2 "i"))))
 
+(t/deftest test-like-regex-query-case-insensitive
+  (t/is (= [{:match false}]
+           (xt/q tu/*node* "SELECT ('ABC' LIKE_REGEX 'a') as match FROM (VALUES 1) AS x")))
+
+  (t/is (= [{:match true}]
+           (xt/q tu/*node* "SELECT ('ABC' LIKE_REGEX 'a' FLAG 'i') as match FROM (VALUES 1) AS x"))))
+
 (t/deftest test-upper-expr
   (t/is (= '(upper x1) (plan-expr "UPPER(foo.a)"))))
 


### PR DESCRIPTION
**Github Action Runs**: [Here](https://github.com/danmason/xtdb/actions?query=branch%3Ainfix-regex-operators-3213++)
**Linked Issue:** Resolves #3213 

- Adds the infix regex operators from postgres - see [here](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP).
  - Essentially - these are parsed in the grammar and plan to use the existing `like_regex` function (which already can handle being non case sensitive.
  - Adds some tests under `sql_test` for the planning and usage of these. 
- Fixes a small issue within the implementation to `like_regex`:
  - Discovered while in `sql_test` - Seemed to essentially treat the compiled pattern as if it was a clojure string regex, could see that from the codegen, so it was disregarding the tags (such as saying the pattern should be case insensitive) 
  - Seemed to come as a result from compiling the pattern ahead of time - so fixed this by constructing/compiling the pattern as part of the executed code.
  - Added a test around `like_regex` using case insensitive tag at the `sql_test` level to verify this as fixed. 