### PR TITLE
Add `NEST_ONE`, `NEST_MANY` to SQL, #3299

### DIFF
--- a/core/src/main/clojure/xtdb/sql/analyze.clj
+++ b/core/src/main/clojure/xtdb/sql/analyze.clj
@@ -839,6 +839,8 @@
      ag)
 
     :subquery (projected-columns (r/$ ag 1))
+    :nest_one_subquery [[{:identifier "xt$nest_one"}]]
+    :nest_many_subquery [[{:identifier "xt$nest_many"}]]
 
     ::r/inherit))
 
@@ -1097,9 +1099,11 @@
 
 (defn subquery-type [ag]
   (r/zcase ag
-    (:query_expression
-     :in_value_list)
+    (:query_expression :in_value_list)
     {:type :scalar_subquery :single? true}
+
+    :nest_one_subquery {:type :nest_one_subquery :single? true}
+    :nest_many_subquery {:type :nest_many_subquery}
 
     :array_value_constructor_by_query
     {:type :table_subquery :single? true}

--- a/core/src/main/resources/xtdb/sql/parser/sql.ebnf
+++ b/core/src/main/resources/xtdb/sql/parser/sql.ebnf
@@ -200,6 +200,7 @@ field_definition : field_name data_type ;
     | window_function
     | nested_window_function
     | scalar_subquery
+    | nest_subquery
     | case_expression
     | cast_specification
     | field_reference
@@ -919,6 +920,11 @@ fetch_first_clause
 (*  7.15 <subquery> *)
 
 <scalar_subquery> : subquery ;
+
+<nest_subquery> : nest_one_subquery | nest_many_subquery  ;
+nest_one_subquery : <'NEST_ONE'> subquery ;
+nest_many_subquery : <'NEST_MANY'> subquery ;
+
 <row_subquery> : subquery ;
 <table_subquery> : subquery ;
 subquery : <left_paren> query_expression <right_paren> ;

--- a/docs/src/content/docs/reference/main/sql/queries.adoc
+++ b/docs/src/content/docs/reference/main/sql/queries.adoc
@@ -47,11 +47,87 @@ predicate :: <value> <binary_op> <value>
 
 value :: <predicate>
        | <function> ( [ <arg> [ , ... ] ])
-       | <query>
+       | (<query>)
+       | NEST_ONE(<query>)
+       | NEST_MANY(<query>)
 ----
 
 * Temporarily, column names in XTDB SQL must be qualified - e.g. `SELECT u.first_name, u.last_name FROM users u`
 * Predicates and functions are taken from the XT 'standard library'.
+
+== Nested sub-queries
+
+Nested sub-queries allow you to easily create tree-shaped results, using `NEST_MANY` and `NEST_ONE`:
+
+* For example, if you have a one-to-many relationship (e.g. customers -> orders), you can write a query that, for each customer, returns an array of their orders as nested objects:
++
+--
+[source,sql]
+----
+SELECT c.xt$id AS customer_id, c.name,
+       NEST_MANY(SELECT o.xt$id AS order_id, o.value
+                 FROM orders o
+                 WHERE o.customer_id = c.xt$id
+                 ORDER BY o.xt$id)
+         AS orders
+FROM customers c"
+----
+
+=>
+
+[source,json]
+----
+[
+  {
+    "customerId": 0,
+    "name": "bob",
+    "orders": [ { "orderId": 0, "value": 26.20 }, { "orderId": 1, "value": 8.99 } ]
+  },
+  {
+    "customerId": 1,
+    "name": "alice",
+    "orders": [ { "orderId": 2, "value": 12.34 } ]
+  }
+]
+----
+--
+* In the other direction (many-to-one) - for each order, additionally return details about the customer - use `NEST_ONE` to get a single nested object:
++
+--
+[source,sql]
+----
+SELECT o.xt$id AS order_id, o.value,
+       NEST_ONE(SELECT c.name FROM customers c
+                WHERE c.xt$id = o.customer_id)
+         AS customer
+FROM orders o
+ORDER BY o.xt$id
+----
+
+=>
+
+[source,json]
+----
+[
+  {
+    "orderId": 0,
+    "value": 26.20,
+    "customer": { "name": "bob" }
+  },
+  {
+    "order-id": 1,
+    "value": 8.99,
+    "customer": { "name": "bob" }
+  },
+  {
+    "order-id": 2,
+    "value": 12.34,
+    "customer": { "name": "alice" }
+  }
+]
+----
+--
+
 
 [NOTE]
 ====

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
@@ -1,0 +1,23 @@
+[:rename
+ {x1 customer_id, x2 name, x9 orders}
+ [:project
+  [x1 x2 x9]
+  [:group-by
+   [x1 x2 xt$row_number_0 {x9 (array_agg x8)}]
+   [:apply
+    :left-outer-join
+    {x1 ?x11}
+    [:map
+     [{xt$row_number_0 (row-number)}]
+     [:rename
+      {xt$id x1, name x2}
+      [:scan {:table customers} [xt$id name]]]]
+    [:project
+     [{x8 {:order_id x4, :value x5}}]
+     [:project
+      [x4 x5]
+      [:rename
+       {xt$id x4, value x5, customer_id x6}
+       [:scan
+        {:table orders}
+        [xt$id value {customer_id (= customer_id ?x11)}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
@@ -1,0 +1,17 @@
+[:rename
+ {x1 order_id, x2 value, x8 customer}
+ [:project
+  [x1 x2 x8]
+  [:apply
+   :single-join
+   {x3 ?x9}
+   [:rename
+    {xt$id x1, value x2, customer_id x3}
+    [:scan {:table orders} [xt$id value customer_id]]]
+   [:project
+    [{x8 {:name x5}}]
+    [:project
+     [x5]
+     [:rename
+      {name x5, xt$id x6}
+      [:scan {:table customers} [name {xt$id (= xt$id ?x9)}]]]]]]]]


### PR DESCRIPTION
Added to grammar, analysis and planner - but tbh largely just reused the existing sub-query mechanism. Main difference is the addition of the `:group-by` and `:project` in `plan/interpret-subquery`.

TODO: 
- [x] docs