### PR TITLE
Improved test results reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           arguments: test
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload build reports
         if: success() || failure() # i.e. not cancelled
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Test
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: test
+          arguments: test --continue
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: success() || failure() # always run even if the previous step fails

--- a/lang/test-harness/src/test/clojure/drivers/python_test.clj
+++ b/lang/test-harness/src/test/clojure/drivers/python_test.clj
@@ -4,6 +4,7 @@
             [clojure.java.shell :refer [sh]]))
 
 (def project-root (str @tu/root-path "/lang/python/"))
+(def report-path (str project-root "/build/test-results/test/TEST-python-test.xml"))
 
 (defn poetry-install [f]
   ;; Install dependencies
@@ -17,8 +18,7 @@
 (deftest python-test
   (let [out (sh "poetry"
                 "run" "pytest"
-                ; TODO: Figure out where to put this
-                ; (str "--junitxml=" report-path)
+                (str "--junitxml=" report-path)
                 :dir project-root)]
     (is (= 0 (:exit out))
         (:out out))))


### PR DESCRIPTION
While looking into how to integrate the python test results into the JUnit report I found [this project](https://github.com/marketplace/actions/junit-report-action).

This PR provides these things:
- A test report with individual test results inside github (see below for what that looks like)
- Adds some dummy failures to show this off (TODO: remove)
- Adds a `testReport` command that runs all the tests and combines their results into one html report
  - Not so sure about replacing the `test` command with this one but might be useful if we want to keep the current reports
  - This report doesn't contain the individual python test results (couldn't figure that out yet)

---

Clicking on the `🔴` on the commit looks like this:
<img width="647" alt="Screenshot 2024-04-17 at 14 46 21" src="https://github.com/xtdb/xtdb/assets/8889986/1a9ae6ad-bf8f-4fc1-afcd-00fedeac6f0a">

And clicking "details" next to the JUnit Test Report looks like this:
<img width="1241" alt="Screenshot 2024-04-17 at 14 46 45" src="https://github.com/xtdb/xtdb/assets/8889986/fbb9d7ee-8951-445e-8fca-68064da65958">