### PR TITLE
Eager watermarks

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -406,7 +406,7 @@
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
         (let [query-str (.getObject query-rdr tx-op-idx)
-              tables-with-cols (scan/tables-with-cols tx-opts wm-src scan-emitter)]
+              tables-with-cols (scan/tables-with-cols wm-src scan-emitter)]
           ;; TODO handle error
           (zmatch (sql/compile-query query-str (assoc tx-opts :table-info tables-with-cols))
             [:insert query-opts inner-query]
@@ -481,7 +481,7 @@
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
         (let [xtql-op (.form ^ClojureForm (.getObject op-rdr tx-op-idx))
-              tables-with-cols (scan/tables-with-cols tx-opts wm-src scan-emitter)]
+              tables-with-cols (scan/tables-with-cols wm-src scan-emitter)]
           (when-not (instance? TxOp$XtqlOp xtql-op)
             (throw (UnsupportedOperationException. "unknown XTQL DML op")))
 
@@ -582,7 +582,7 @@
                                                    (.getDataVector))
 
                   wm-src (reify IWatermarkSource
-                           (openWatermark [_ _tx]
+                           (openWatermark [_]
                              (Watermark. nil (.openWatermark live-idx-tx))))
 
                   tx-opts {:basis {:at-tx tx-key, :current-time system-time}
@@ -654,7 +654,7 @@
     (li/force-flush! live-idx tx-key expected-last-chunk-tx-id))
 
   IWatermarkSource
-  (openWatermark [_ tx-key] (.openWatermark live-idx tx-key))
+  (openWatermark [_] (.openWatermark live-idx))
 
   (latestCompletedTx [_] (.latestCompletedTx live-idx))
   (latestCompletedChunkTx [_] (.latestCompletedChunkTx live-idx))

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -59,7 +59,7 @@
   (^xtdb.indexer.live_index.ILiveTable liveTable [^String tableName])
   (^xtdb.indexer.live_index.ILiveIndexTx startTx [^xtdb.api.TransactionKey txKey])
 
-  (^xtdb.watermark.Watermark openWatermark [^xtdb.api.TransactionKey txKey])
+  (^xtdb.watermark.Watermark openWatermark [])
 
   (^void close []))
 
@@ -318,7 +318,7 @@
         AutoCloseable
         (close [_]))))
 
-  (openWatermark [this tx-key]
+  (openWatermark [this]
     (let [wm-read-stamp (.readLock wm-lock)]
       (try
         (doto ^Watermark (.-shared-wm this) .retain)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -114,11 +114,9 @@
         (apply-constraint for-system-time (.getSystemFrom bounds) (.getSystemTo bounds))))
     bounds))
 
-(defn tables-with-cols [{:keys [basis after-tx]} ^IWatermarkSource wm-src ^IScanEmitter scan-emitter]
-  (let [{:keys [at-tx]} basis
-        wm-tx (or at-tx after-tx)]
-    (with-open [^Watermark wm (.openWatermark wm-src wm-tx)]
-      (.allTableColNames scan-emitter wm))))
+(defn tables-with-cols [^IWatermarkSource wm-src ^IScanEmitter scan-emitter]
+  (with-open [^Watermark wm (.openWatermark wm-src)]
+    (.allTableColNames scan-emitter wm)))
 
 (defn temporal-column? [col-name]
   (contains? #{"xt$system_from" "xt$system_to" "xt$valid_from" "xt$valid_to"}

--- a/core/src/main/kotlin/xtdb/watermark/IWatermark.kt
+++ b/core/src/main/kotlin/xtdb/watermark/IWatermark.kt
@@ -38,5 +38,5 @@ class Watermark(
 }
 
 interface IWatermarkSource {
-    fun openWatermark(afterTx: TransactionKey?): Watermark
+    fun openWatermark(): Watermark
 }

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -189,7 +189,7 @@
 
             (.commit live-index-tx)
 
-            (with-open [wm (.openWatermark live-index tx-key)]
+            (with-open [wm (.openWatermark live-index)]
               (let [live-index-wm (.liveIndex wm)
                     live-table-before (live-table-wm->data (.liveTable live-index-wm table-name))]
 


### PR DESCRIPTION
This PR adds eager watermarks which are taken on commit in the indexing thread. The `tx-key` on `openWatermark` is pointless now as it was previously only used to check if an existing watermark was able to satisfy the `tx-key`. The waiting on the correct tx-key is still the callers responsibility.

This should also fix #3315.

I checked against Auctionmark a couldn't see any significant slow down:
![Selection_028](https://github.com/xtdb/xtdb/assets/23086133/2bb5084e-cb42-40b1-b82b-a79d4a9a3467)

Left with eager Watermark , right as previously (with one failure thread as per #3315).

TPC-H ingest of ScaleFactor 0.3 took
- 52secs on `main`
- 55secs on this

Todo:
- [x] remove `tx-key` from `openWatermark`