### PR TITLE
Enable `getLeg` on base ValueVectorReader

### DIFF
--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -9,6 +9,7 @@ import org.apache.arrow.vector.holders.NullableIntervalDayHolder;
 import org.apache.arrow.vector.holders.NullableIntervalMonthDayNanoHolder;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import xtdb.Types;
 import xtdb.api.query.IKeyFn;
 import xtdb.types.IntervalDayTime;
 import xtdb.types.IntervalMonthDayNano;
@@ -185,12 +186,12 @@ public class ValueVectorReader implements IVectorReader {
 
     @Override
     public Keyword getLeg(int idx) {
-        throw unsupported();
+        return Types.toLeg(vector.getField().getFieldType().getType());
     }
 
     @Override
     public List<Keyword> legs() {
-        throw unsupported();
+        return List.of(Types.toLeg(vector.getField().getFieldType().getType()));
     }
 
     @Override

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -58,6 +58,20 @@
              (set (tu/query-ra '[:scan {:table xt_docs} [xt$id]]
                                {:node node}))))))
 
+(t/deftest test-chunk-boundary-different-struct-types
+  (with-open [node (xtn/start-node {:indexer {:rows-per-chunk 20}})]
+    (xt/submit-tx node (for [i (range 20)]
+                         [:put-docs :xt_docs {:xt/id i :foo {:bar 42}}]))
+
+    (xt/submit-tx node (for [i (range 20 40)]
+                         [:put-docs :xt_docs {:xt/id i :foo {:bar "forty-two"}}]))
+
+    (t/is (= #{{:bar 42} {:bar "forty-two"}}
+             (set (tu/query-ra
+                   '[:project [{bar (. foo :bar) }]
+                     [:scan {:table xt_docs} [foo]]]
+                   {:node node}))))))
+
 (t/deftest test-smaller-page-limit
   (with-open [node (xtn/start-node {:indexer {:page-limit 16}})]
     (xt/submit-tx node (for [i (range 20)] [:put-docs :xt_docs {:xt/id i}]))


### PR DESCRIPTION
So the problem is that IMVR might have monomorphic struct vectors in the underlying vectors. For example `[:struct {"bar" :i64}]` and `[:stuct {"bar" :utf8}]`. From the point of view of IMVR the "bar" attribute type is a union. The expression engine than might call `getLeg` on the "bar" `IValueReader`'s, but at that point the value readers are primitive `IValueReader`'s.

Options were:
1. Just return the primitive `getLeg` name in every base vector. Implemented here.
2. Do something more complicated in the `IValueReader` of IMVR. The problem is that an `getObject` call needs to be modified quite heavily in the case of struct readers. So I opted for 1.

Happy to consider other options, as `getLeg` calls should "normally" only be called on unions. 