### PR TITLE
add `execute-tx` (#3344)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 if git diff --cached -G"<<no-commit>>" --no-ext-diff --exit-code; then
     exit 0
 else
-    echo "WARNING: <<no-commit>> present in staged diff, lines marked with this should not be commited."
+    echo "WARNING: <<no-commit>> present in staged diff, lines marked with this should not be committed."
     echo "If you are sure you want to continue, please skip this pre-commit hook using the --no-verify or -n option"
     echo "Aborting commit."
     exit 1

--- a/api/src/main/kotlin/xtdb/JsonSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonSerde.kt
@@ -10,7 +10,11 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
+import kotlinx.serialization.modules.polymorphic
+import xtdb.api.TransactionAborted
+import xtdb.api.TransactionCommitted
 import xtdb.api.TransactionKey
+import xtdb.api.TransactionResult
 import xtdb.util.kebabToCamelCase
 import java.io.InputStream
 import java.io.OutputStream

--- a/api/src/main/kotlin/xtdb/api/IXtdb.kt
+++ b/api/src/main/kotlin/xtdb/api/IXtdb.kt
@@ -58,6 +58,23 @@ interface IXtdb : AutoCloseable {
     fun submitTx(vararg ops: TxOp) = submitTx(TxOptions(), *ops)
 
     /**
+     * Executes the transaction - this method will block until the receiving node has indexed the transaction.
+     *
+     * @param txOpts options for the transaction
+     * @param ops XTQL/SQL transaction operations.
+     * @return the result of the executed transaction.
+     */
+    fun executeTx(txOpts: TxOptions, vararg ops: TxOp): TransactionResult
+
+    /**
+     * Executes the transaction - this method will block until the receiving node has indexed the transaction.
+     *
+     * @param ops XTQL/SQL transaction operations.
+     * @return the result of the executed transaction.
+     */
+    fun executeTx(vararg ops: TxOp) = executeTx(TxOptions(), *ops)
+
+    /**
      * @suppress
      */
     override fun close()

--- a/api/src/main/kotlin/xtdb/api/TransactionResult.kt
+++ b/api/src/main/kotlin/xtdb/api/TransactionResult.kt
@@ -1,0 +1,117 @@
+package xtdb.api
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+import xtdb.AnySerde
+import xtdb.InstantSerde
+import xtdb.util.requiringResolve
+import java.time.Instant
+
+@Serializable(with = Serde::class)
+sealed interface TransactionResult : TransactionKey
+
+internal class Serde : JsonContentPolymorphicSerializer<TransactionResult>(TransactionResult::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<TransactionResult> =
+        if (element.jsonObject["committed"]?.jsonPrimitive?.boolean ?: throw SerializationException("Missing committed")) {
+            TransactionCommitted.serializer()
+        } else {
+            TransactionAborted.serializer()
+        }
+}
+
+@Serializable(with = CommittedSerde::class)
+interface TransactionCommitted : TransactionResult
+
+internal fun txCommitted(txId: Long, systemTime: Instant) =
+    requiringResolve("xtdb.serde/->tx-committed").invoke(txId, systemTime) as TransactionCommitted
+
+internal class CommittedSerde : KSerializer<TransactionCommitted> {
+    override val descriptor = buildClassSerialDescriptor("xtdb.api.TransactionCommitted") {
+        element<Long>("txId")
+        element("systemTime", InstantSerde.descriptor)
+        element<Boolean>("committed")
+    }
+
+    override fun deserialize(decoder: Decoder): TransactionCommitted {
+        var txId: Long? = null
+        var systemTime: Instant? = null
+        decoder.decodeStructure(descriptor) {
+            loop@ while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    CompositeDecoder.DECODE_DONE -> break@loop
+                    0 -> txId = decodeLongElement(descriptor, 0)
+                    1 -> systemTime = decodeSerializableElement(descriptor, 1, InstantSerde)
+                    2 -> Unit
+                    else -> throw SerializationException("Unknown index $index")
+                }
+            }
+        }
+
+        return txCommitted(
+            txId ?: throw SerializationException("Missing txId"),
+            systemTime ?: throw SerializationException("Missing systemTime")
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: TransactionCommitted) =
+        encoder.encodeStructure(descriptor) {
+            encodeLongElement(descriptor, 0, value.txId)
+            encodeSerializableElement(descriptor, 1, InstantSerde, value.systemTime)
+            encodeBooleanElement(descriptor, 2, true)
+        }
+}
+
+@Serializable(with = AbortedSerde::class)
+interface TransactionAborted : TransactionResult {
+    val error: Throwable
+}
+
+internal fun txAborted(txId: Long, systemTime: Instant, error: Throwable) =
+    requiringResolve("xtdb.serde/->tx-aborted").invoke(txId, systemTime, error) as TransactionAborted
+
+internal class AbortedSerde : KSerializer<TransactionAborted> {
+    override val descriptor = buildClassSerialDescriptor("xtdb.api.TransactionAborted") {
+        element<Long>("txId")
+        element("systemTime", InstantSerde.descriptor)
+        element<Boolean>("committed")
+        element("error", AnySerde.descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): TransactionAborted {
+        var txId: Long? = null
+        var systemTime: Instant? = null
+        var error: Throwable? = null
+
+        decoder.decodeStructure(descriptor) {
+            loop@ while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    CompositeDecoder.DECODE_DONE -> break@loop
+                    0 -> txId = decodeLongElement(descriptor, 0)
+                    1 -> systemTime = decodeSerializableElement(descriptor, 1, InstantSerde)
+                    2 -> Unit
+                    3 -> error = decodeSerializableElement(descriptor, 3, AnySerde) as? Throwable
+                    else -> throw SerializationException("Unknown index $index")
+                }
+            }
+        }
+        return txAborted(
+            txId ?: throw SerializationException("Missing txId"),
+            systemTime ?: throw SerializationException("Missing systemTime"),
+            error ?: throw SerializationException("Missing error")
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: TransactionAborted) =
+        encoder.encodeStructure(descriptor) {
+            encodeLongElement(descriptor, 0, value.txId)
+            encodeSerializableElement(descriptor, 1, InstantSerde, value.systemTime)
+            encodeBooleanElement(descriptor, 2, false)
+            encodeSerializableElement(descriptor, 3, AnySerde, value.error)
+        }
+}

--- a/api/src/main/resources/data_readers.clj
+++ b/api/src/main/resources/data_readers.clj
@@ -1,4 +1,5 @@
-{xt/tx-key xtdb.serde/tx-key-read-fn
+{xt/tx-key xtdb.serde/map->TxKey
+ xt/tx-result xtdb.serde/tx-result-read-fn
  xt/tx-opts xtdb.serde/tx-opts-read-fn
  xt/clj-form xtdb.api/->ClojureForm
  xt/illegal-arg xtdb.serde/iae-reader

--- a/api/src/test/kotlin/xtdb/JsonSerdeTest.kt
+++ b/api/src/test/kotlin/xtdb/JsonSerdeTest.kt
@@ -40,6 +40,12 @@ import xtdb.api.txKey
 import java.time.*
 import java.util.*
 
+internal fun String.trimJson() =
+    trimIndent()
+        .replace(": ", ":")
+        .replace(", ", ",")
+        .replace(Regex("\n\\s*"), "")
+
 class JsonSerdeTest {
 
     private fun Any?.assertRoundTrip(expectedJson: String) {
@@ -123,13 +129,6 @@ class JsonSerdeTest {
     fun `round-trips sets`() {
         emptySet<Any>().assertRoundTrip("""{"@type":"xt:set","@value":[]}""")
         setOf(4L, 5L, 6.0).assertRoundTrip("""{"@type":"xt:set","@value":[4,5,6.0]}""")
-    }
-
-    private fun String.trimJson(): String {
-        return this.trimIndent()
-            .replace(": ", ":")
-            .replace(", ", ",")
-            .replace(Regex("\n\\s+"), "")
     }
 
     @Test

--- a/api/src/test/kotlin/xtdb/api/TransactionResultTest.kt
+++ b/api/src/test/kotlin/xtdb/api/TransactionResultTest.kt
@@ -1,0 +1,74 @@
+package xtdb.api
+
+import clojure.lang.Keyword
+import kotlinx.serialization.encodeToString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.JSON_SERDE
+import xtdb.trimJson
+import java.time.Instant
+
+class TransactionResultTest {
+
+    private val testError = xtdb.RuntimeException(Keyword.intern("xtdb.error", "error-key"), "test")
+
+    @Test
+    fun testTransactionResultSerialization() {
+        val committed = txCommitted(1, Instant.ofEpochMilli(0))
+
+        assertEquals(
+            """{"txId":1,"systemTime":"1970-01-01T00:00:00Z","committed":true}""".trimJson(),
+            JSON_SERDE.encodeToString(committed)
+        )
+
+        val aborted = txAborted(1, Instant.ofEpochMilli(0), testError)
+        assertEquals(
+            """
+            {
+              "txId": 1,
+              "systemTime": "1970-01-01T00:00:00Z",
+              "committed": false,
+              "error": {
+                  "@type":"xt:error",
+                  "@value":{"xtdb.error/message":"test",
+                  "xtdb.error/class":"xtdb.RuntimeException",
+                  "xtdb.error/error-key":"xtdb.error/error-key","xtdb.error/data":{}
+                }
+              }
+            }
+            """.trimJson(),
+            JSON_SERDE.encodeToString(aborted)
+        )
+    }
+
+    @Test
+    fun testTransactionResultDeserialization() {
+        val committed = txCommitted(1, Instant.ofEpochMilli(0))
+        assertEquals(
+            committed,
+            JSON_SERDE.decodeFromString<TransactionResult>("""{"txId":1,"systemTime":"1970-01-01T00:00:00Z","committed":true}""")
+        )
+
+        val aborted = txAborted(1, Instant.ofEpochMilli(0), testError)
+        assertEquals(
+            aborted,
+            JSON_SERDE.decodeFromString<TransactionResult>(
+                """
+                {
+                  "txId": 1,
+                  "systemTime": "1970-01-01T00:00:00Z",
+                  "committed": false,
+                  "error": {
+                      "@type":"xt:error",
+                      "@value":{"xtdb.error/message":"test",
+                      "xtdb.error/class":"xtdb.RuntimeException",
+                      "xtdb.error/error-key":"xtdb.error/error-key","xtdb.error/data":{}
+                    }
+                  }
+                }
+                """
+            )
+        )
+    }
+
+}

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -236,7 +236,7 @@
         ;; TODO confirm/expand API that we expose to tx-fns
         sci-ctx (sci/init {:bindings {'q (tx-fn-q q-src wm-src tx-opts)
                                       'sleep (fn [^long n] (Thread/sleep n))
-                                      '*current-tx* (serde/tx-key-write-fn tx-key)}
+                                      '*current-tx* tx-key}
                            :namespaces {'xt xt-sci-ns}})]
 
     (reify OpIndexer

--- a/core/src/test/kotlin/xtdb/api/XtdbTest.kt
+++ b/core/src/test/kotlin/xtdb/api/XtdbTest.kt
@@ -37,7 +37,7 @@ internal class XtdbTest {
 
     @Test
     fun startsInMemoryNode() {
-        node.submitTx(putDocs("foo", mapOf("xt\$id" to "jms")))
+        node.executeTx(putDocs("foo", mapOf("xt\$id" to "jms")))
 
         assertEquals(
             listOf(mapOf("id" to "jms")),
@@ -60,7 +60,7 @@ internal class XtdbTest {
 
     @Test
     fun `test query opts`() {
-        node.submitTx(putDocs("docs2", mapOf("xt\$id" to 1, "foo" to "bar")))
+        node.executeTx(putDocs("docs2", mapOf("xt\$id" to 1, "foo" to "bar")))
 
         assertEquals(
             listOf(mapOf("myFoo" to "bar")),

--- a/docs/src/content/docs/drivers/clojure/txs.adoc
+++ b/docs/src/content/docs/drivers/clojure/txs.adoc
@@ -4,7 +4,7 @@ title: Transactions cookbook
 :txs: /reference/main/xtql/txs
 :codox: /drivers/clojure/codox
 
-This document provides examples for EDN transaction operations, to be submitted to link:{codox}/xtdb.api.html#var-submit-tx[`xtdb.api/submit-tx`^].
+This document provides examples for EDN transaction operations, to be submitted to link:{codox}/xtdb.api.html#var-execute-tx[`xtdb.api/execute-tx`^] or link:{codox}/xtdb.api.html#var-submit-tx[`xtdb.api/submit-tx`^].
 
 Main article: link:{txs}[Transactions]
 

--- a/docs/src/content/docs/reference/main/sql/txs.adoc
+++ b/docs/src/content/docs/reference/main/sql/txs.adoc
@@ -2,12 +2,13 @@
 title: SQL Transactions
 ---
 
-SQL transactions are submitted through `xtdb.api/submit-tx`.
+SQL transactions are submitted through `xtdb.api/execute-tx` and `xtdb.api/submit-tx`.
 
 * `(xt/submit-tx <node> <tx-ops> <opts>?)`: returns the transaction key of the submitted transaction.
 ** `tx-ops`: vector of link:#tx-ops[transaction operations].
 ** `opts` (map):
 *** `:default-all-valid-time?` (boolean, default false): whether to default to all valid time if not explicitly specified in the query.
+* `(xt/execute-tx <node> <tx-ops> <opts>?)` : additionally awaits for the transaction to be processed, and returns `{:committed? true|false, :error err}` alongside the transaction key.
 
 [#tx-ops]
 == Transaction operations
@@ -20,12 +21,14 @@ e.g.
 ----
 (require '[xtdb.api :as xt])
 
-(xt/submit-tx node [[:sql "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')"]
+(xt/execute-tx node [[:sql "INSERT INTO users (xt$id, name) VALUES ('jms', 'James')"]
 
-                    ;; with args - pass multiple vectors if required.
-                    [:sql "INSERT INTO users (xt$id, name) VALUES (?, ?)"
-                     ["jms", "James"]
-                     ["jdt", "Jeremy"]]])
+                     ;; with args - pass multiple vectors if required.
+                     [:sql "INSERT INTO users (xt$id, name) VALUES (?, ?)"
+                      ["jms", "James"]
+                      ["jdt", "Jeremy"]]])
+
+;; => {:tx-id 0, :system-time #time/instant "...", :committed? true}
 ----
 
 [NOTE]

--- a/http-server/src/test/clojure/xtdb/json_serde_test.clj
+++ b/http-server/src/test/clojure/xtdb/json_serde_test.clj
@@ -1,17 +1,13 @@
 (ns xtdb.json-serde-test
   (:require [clojure.test :as t :refer [deftest]]
-            [xtdb.api :as xt]
             [xtdb.error :as err]
-            [xtdb.serde]
-            [xtdb.tx-ops :as tx-ops]
-            [xtdb.serde :as serde])
+            [xtdb.serde :as serde]
+            [xtdb.tx-ops :as tx-ops])
   (:import (java.time Instant)
            (java.util List UUID)
            (xtdb JsonSerde)
-           (xtdb.api TransactionKey)
-           (xtdb.api.query Basis Binding Expr Expr$Bool Expr$Call Expr$Null Expr$SetExpr Exprs
-                           Queries Query QueryOptions QueryRequest SqlQuery TemporalFilter TemporalFilter$AllTime TemporalFilters
-                           XtqlQuery$Aggregate XtqlQuery$Call XtqlQuery$From XtqlQuery$Join XtqlQuery$LeftJoin XtqlQuery$OrderBy XtqlQuery$OrderDirection XtqlQuery$OrderNulls XtqlQuery$ParamRelation XtqlQuery$Pipeline XtqlQuery$QueryTail XtqlQuery$Return XtqlQuery$Unify XtqlQuery$Unnest XtqlQuery$Where XtqlQuery$With XtqlQuery$Without)
+           xtdb.api.TransactionResult
+           (xtdb.api.query Basis Binding Expr Expr$Bool Expr$Call Expr$Null Expr$SetExpr Exprs Queries Query QueryOptions QueryRequest SqlQuery TemporalFilter TemporalFilter$AllTime TemporalFilters XtqlQuery$Aggregate XtqlQuery$Call XtqlQuery$From XtqlQuery$Join XtqlQuery$LeftJoin XtqlQuery$OrderBy XtqlQuery$OrderDirection XtqlQuery$OrderNulls XtqlQuery$ParamRelation XtqlQuery$Pipeline XtqlQuery$QueryTail XtqlQuery$Return XtqlQuery$Unify XtqlQuery$Unnest XtqlQuery$Where XtqlQuery$With XtqlQuery$Without)
            (xtdb.api.tx TxOp TxOptions TxRequest)))
 
 (defn- encode [v]
@@ -350,7 +346,6 @@
     (t/testing "sql-query"
       (let [v (SqlQuery. "SELECT * FROM docs")]
         (t/is (= v (roundtrip-query v)))))))
-
 
 (defn- roundtrip-query-tail [v]
   (-> v (JsonSerde/encode XtqlQuery$QueryTail) (JsonSerde/decode XtqlQuery$QueryTail)))

--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -92,6 +92,21 @@
                decode-transit))
         "testing tx")
 
+  (t/is (= #xt/tx-result {:tx-id 2,
+                          :system-time #time/instant "2020-01-03T00:00:00Z",
+                          :committed? true}
+           (-> (http/request {:accept :transit+json
+                              :as :string
+                              :request-method :post
+                              :content-type :transit+json
+                              :form-params {:tx-ops possible-tx-ops
+                                            :await-tx? true}
+                              :transit-opts xtc/transit-opts
+                              :url (http-url "tx")})
+               :body
+               decode-transit))
+        "testing await-tx")
+
   (t/is (= [{:xt/id 1}]
            (xt/q *node* '(from :docs [xt/id])
                  {:basis {:at-tx #xt/tx-key {:tx-id 1, :system-time #time/instant "2020-01-02T00:00:00Z"}}})))

--- a/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
+++ b/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
@@ -98,9 +98,7 @@
                                          (update fsql-tx :dml conj dml))))
                 (throw (UnsupportedOperationException. "unknown tx")))
 
-              (let [tx (xt/submit-tx node [dml])]
-                ;; HACK til we have the ability to await on the connection
-                (.awaitTx idxer tx nil))))
+              (xt/execute-tx node [dml])))
 
           (handle-get-stream [^BoundQuery bq, ^FlightProducer$ServerStreamListener listener]
             (with-open [res (.openCursor bq)
@@ -260,10 +258,8 @@
                  (.getAction req))
 
             (try
-              (let [tx-key (xt/submit-tx node dml)]
-                ;; HACK til we have the ability to await on the connection
-                (.awaitTx idxer tx-key nil)
-                (.onCompleted listener))
+              (xt/execute-tx node dml)
+              (.onCompleted listener)
 
               (catch Throwable t
                 (.onError listener t)))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1238,14 +1238,14 @@
 (deftest runtime-error-query-test
   (tu/with-log-level 'xtdb.pgwire :off
     (with-open [conn (jdbc-conn)]
-      (is (thrown? PSQLException #"Data error - trim error" (q conn ["SELECT TRIM(LEADING 'abc' FROM a.a) FROM (VALUES ('')) a (a)"]))))))
+      (is (thrown-with-msg? PSQLException #"Data Exception - trim error."
+                            (q conn ["SELECT TRIM(LEADING 'abc' FROM a.a) FROM (VALUES ('')) a (a)"]))))))
 
 (deftest runtime-error-commit-test
   (with-open [conn (jdbc-conn)]
     (q conn ["START TRANSACTION READ WRITE"])
     (q conn ["INSERT INTO foo (xt$id) VALUES (TRIM(LEADING 'abc' FROM ''))"])
-    #_ ; FIXME #401 - need to show this as an aborted transaction?
-    (is (thrown? PSQLException #"Data error - trim error" (q conn ["COMMIT"])))))
+    (t/is (thrown-with-msg? PSQLException #"Data Exception - trim error." (q conn ["COMMIT"])))))
 
 (deftest test-column-order
   (with-open [conn (jdbc-conn)]


### PR DESCRIPTION
This PR adds `xt/execute-tx`, which additionally awaits the transaction and returns details of whether it committed/rolled back and any errors, alongside the transaction key.

This saves the user a subsequent query to the `:xt/txs` table to figure out whether the transaction committed or not (something we've had requested many times in both XT1 and XT2 :relaxed:).

```clojure
;; currently
(xt/submit-tx node [[:put-docs ...]])
;; => #xt/tx-key {:tx-id 0, :system-time #time/instant "..."}

;; this PR adds
(xt/execute-tx node [[:put-docs ...]])
;; => #xt/tx-result {:tx-id 0, :system-time #time/instant "...", :committed? true}
;; or #xt/tx-result {:tx-id 0, :system-time #time/instant "...", :committed? false, :error ...}
```

* For more details of the rationale, see #3344 
* Behaviour of `submit-tx` is unchanged.
* Going forward, let's use (and recommend) `xt/submit-tx` either if you don't care whether the tx committed or not, or whether it's safe to assume it will; `xt/execute-tx` if you need to check.