### PR TITLE
Add a "demo mode" to the docs pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -267,7 +267,8 @@ export default defineConfig({
             components: {
                 TableOfContents: './src/components/table-of-contents.astro',
                 MobileTableOfContents: './src/components/mobile-table-of-contents.astro',
-		MobileMenuToggle: './src/components/mobile-menu-toggle.astro',
+                MobileMenuToggle: './src/components/mobile-menu-toggle.astro',
+                Head: './src/components/Head.astro',
             },
         }),
 

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,28 @@
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+---
+<Default {...Astro.props} />
+
+<script>
+    {/** NOTE: Included here not in https://starlight.astro.build/reference/configuration/#head
+       *       because the tailwind integration doesn't pick up on classes added in the head.
+       */}
+    if (window.location.search.includes('demo=true')) {
+        // Delete the header
+        document.querySelector('header').remove();
+        // Delete sidebar
+        document.querySelector('.sidebar').remove();
+        // Delete "on this page"
+        document.querySelector('aside').remove();
+        // Delete the footer
+        document.querySelector('footer').remove();
+
+        // Make all non-fiddle elements more transparent
+        document.querySelectorAll('.sl-markdown-content > *').forEach((el) => {
+            if (el.tagName != 'FIDDLE-EMBED') {
+                el.classList.add('opacity-30');
+            }
+        });
+            
+    }
+</script>


### PR DESCRIPTION
[Add `?demo=true` to the url and it will be activated](https://pr-3357.d2zcybuz6k9g4m.amplifyapp.com/tutorials/financial-usecase/backtesting.html?demo=true)
- Removes header, both sidebars & footer
- Makes anything other than the fiddle transparent


https://github.com/xtdb/xtdb/assets/8889986/7e6f7fb3-b0a5-49dc-a446-fe8d1f6c3d98



Works best on non-asciidoc pages