### PR TITLE
Bringing workflows over from `1.x`, general workflow updates #3269

### DIFF
--- a/.github/workflows/nightly-test-on-demand.yml
+++ b/.github/workflows/nightly-test-on-demand.yml
@@ -1,0 +1,71 @@
+name: XTDB Nightly on demand
+run-name: XTDB Nightly on demand
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+on: workflow_dispatch
+
+jobs:
+  nightly-test:
+    if: github.repository == 'xtdb/xtdb'
+    name: Nightly Test (on demand)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    services:
+      kafka:
+        image: 'confluentinc/cp-kafka:7.5.1'
+        ports:
+          - '9092:9092'
+        env:
+          KAFKA_NODE_ID: 1
+          KAFKA_ENABLE_KRAFT: yes
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+          KAFKA_BROKER_ID: 1
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          ALLOW_PLAINTEXT_LISTENER: yes
+          CLUSTER_ID: q1Sh-9_ISia_zwGINzRvyQ
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CLOUD_CREDENTIALS }}'
+      - name: Run Nightly Test Task
+        uses: gradle/gradle-build-action@v2.6.1
+        with:
+          arguments: nightly-test
+          cache-read-only: ${{ github.ref != 'refs/heads/2.x' }}
+      - name: Publish Nightly Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          check_name: JUnit Nightly Test Report
+          report_paths: '**/build/test-results/nightly-test/TEST-*.xml'
+      - name: Post Slack Notification
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*Nightly test*"
+          message_format: "{emoji} *Nightly test* has {status_message}!"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -1,0 +1,74 @@
+name: XTDB Nightly
+run-name: XTDB Nightly
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+on:
+  schedule:
+    - cron:  '0 19 * * 1-5'
+
+
+jobs:
+  nightly-test:
+    if: github.repository == 'xtdb/xtdb'
+    name: Nightly test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    services:
+      kafka:
+        image: 'confluentinc/cp-kafka:7.5.1'
+        ports:
+          - '9092:9092'
+        env:
+          KAFKA_NODE_ID: 1
+          KAFKA_ENABLE_KRAFT: yes
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+          KAFKA_BROKER_ID: 1
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          ALLOW_PLAINTEXT_LISTENER: yes
+          CLUSTER_ID: q1Sh-9_ISia_zwGINzRvyQ
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CLOUD_CREDENTIALS }}'
+      - name: Run Nightly Test Task
+        uses: gradle/gradle-build-action@v2.6.1
+        with:
+          arguments: nightly-test
+          cache-read-only: ${{ github.ref != 'refs/heads/2.x' }}
+      - name: Publish Nightly Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          check_name: JUnit Nightly Test Report
+          report_paths: '**/build/test-results/nightly-test/TEST-*.xml'
+      - name: Post Slack Notification
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*Nightly test*"
+          message_format: "{emoji} *Nightly test* has {status_message}!"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slt.yml
+++ b/.github/workflows/slt.yml
@@ -1,0 +1,47 @@
+name: XTDB SLT
+run-name: XTDB SLT
+
+on:
+  schedule:
+    - cron:  '0 19 * * 1-5'
+
+jobs:
+  slt-test-dir:
+    if: github.repository == 'xtdb/xtdb'
+    name: SLT Test Dir
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        slt-dir: [{dir: "random/expr/", error: 62},
+                  {dir: "random/aggregates/", error: 19},
+                  {dir: "random/groupby/", error: 8},
+                  {dir: "random/select/"},
+                  {dir: "index/between/", error: 10},
+                  {dir: "index/commute/", error: 10},
+                  {dir: "index/orderby/", error: 60},
+                  {dir: "index/orderby_nosort/"},
+                  {dir: "index/in/"},
+                  {dir: "index/random/"}]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: SLT Test Dir
+        uses: gradle/gradle-build-action@v2.6.1
+        with:
+          arguments: slt-test-dir -PtestDir=${{ matrix.slt-dir.dir }} -PtestMaxErrors=${{ matrix.slt-dir.error }} -PtestMaxFailures=${{ matrix.slt-dir.failure }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+      - name: Post Slack Notification
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*SLT Test*"
+          message_format: "{emoji} Scheduled *SLT Test* has {status_message}!"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slt_on_demand.yml
+++ b/.github/workflows/slt_on_demand.yml
@@ -22,10 +22,10 @@ jobs:
                   {dir: "index/random/"}]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: SLT Test Dir
         uses: gradle/gradle-build-action@v2.6.1


### PR DESCRIPTION
Resolves #3269 

- Moves the various nightly scheduled workflows over from `1.x` to `main` such that they will run once more. 
- Updates the various workflows to use JDK 21.
- Adds a "nightly test on demand" workflow so we can trigger it manually in Github Actions (may be useful on debugging certain problems/verifying certain changes haven't broken the nightly tests)
- Updates the nightly test workflows to use the JUnit test reporter as we do on the `build` workflow.

I am aware that the nightly test is currently failing - going to spend rest of today debugging/fixing problems there and ensure it's back to green.