### PR TITLE
Fixes for the nightly test failures #3362

### DIFF
--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -35,6 +35,7 @@
         servicebus-namespace (.getServiceBusNamespace factory)
         servicebus-topic-name (.getServiceBusTopicName factory)
         prefix (.getPrefix factory)
+        prefix-with-version (if prefix (.resolve prefix bp/storage-root) bp/storage-root)
         blob-service-client (cond-> (-> (BlobServiceClientBuilder.)
                                         (.endpoint (str "https://" storage-account ".blob.core.windows.net"))
                                         (.credential credential)
@@ -46,12 +47,12 @@
                                                                     :container container
                                                                     :servicebus-namespace servicebus-namespace
                                                                     :servicebus-topic-name servicebus-topic-name
-                                                                    :prefix prefix
+                                                                    :prefix prefix-with-version
                                                                     :blob-container-client blob-client
                                                                     :azure-credential credential}
                                                                    file-name-cache)]
     (os/->AzureBlobObjectStore blob-client
-                               prefix
+                               prefix-with-version
                                minimum-part-size
                                file-name-cache
                                file-list-watcher)))

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -29,12 +29,13 @@ dependencies {
     api(project(":xtdb-api"))
     api(project(":xtdb-core"))
 
-    api("com.google.cloud", "google-cloud-storage", "2.23.0") {
+    api("com.google.cloud", "google-cloud-storage", "2.38.0") {
         exclude("com.google.guava","listenablefuture")
     }
-    api("com.google.cloud", "google-cloud-pubsub", "1.124.0") {
+    api("com.google.cloud", "google-cloud-pubsub", "1.129.4") {
         exclude("com.google.guava","listenablefuture")
     }
+    
     api("com.google.guava","guava","32.1.1-jre")
 
     api(kotlin("stdlib-jdk8"))

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud.clj
@@ -16,6 +16,7 @@
         bucket (.getBucket factory)
         pubsub-topic (.getPubSubTopic factory)
         prefix (.getPrefix factory)
+        prefix-with-version (if prefix (.resolve prefix bp/storage-root) bp/storage-root)
         storage-service (-> (StorageOptions/newBuilder)
                             ^StorageOptions$Builder (.setProjectId project-id)
                             ^StorageOptions (.build)
@@ -25,7 +26,7 @@
         file-list-watcher (google-file-watch/open-file-list-watcher {:project-id project-id
                                                                      :bucket bucket
                                                                      :pubsub-topic pubsub-topic
-                                                                     :prefix prefix
+                                                                     :prefix prefix-with-version
                                                                      :storage-service storage-service}
                                                                     file-name-cache)]
-    (os/->GoogleCloudStorageObjectStore storage-service bucket prefix file-name-cache file-list-watcher)))
+    (os/->GoogleCloudStorageObjectStore storage-service bucket prefix-with-version file-name-cache file-list-watcher)))

--- a/modules/s3/build.gradle.kts
+++ b/modules/s3/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
     api(project(":xtdb-api"))
     api(project(":xtdb-core"))
 
-    api("software.amazon.awssdk", "s3", "2.16.76")
-    api("software.amazon.awssdk", "sqs", "2.16.76")
-    api("software.amazon.awssdk", "sns", "2.16.76")
+    api("software.amazon.awssdk", "s3", "2.25.50")
+    api("software.amazon.awssdk", "sqs", "2.25.50")
+    api("software.amazon.awssdk", "sns", "2.25.50")
     api(kotlin("stdlib-jdk8"))
 }

--- a/modules/s3/src/main/clojure/xtdb/s3.clj
+++ b/modules/s3/src/main/clojure/xtdb/s3.clj
@@ -208,18 +208,19 @@
         configurator (.getS3Configurator factory)
         s3-client (.makeClient configurator)
         prefix (.getPrefix factory)
+        prefix-with-version (if prefix (.resolve prefix bp/storage-root) bp/storage-root)
         file-name-cache (ConcurrentSkipListSet.)
         ;; Watch s3 bucket for changes
         file-list-watcher (s3-file-watch/open-file-list-watcher {:bucket bucket
                                                                  :sns-topic-arn sns-topic-arn
-                                                                 :prefix prefix
+                                                                 :prefix prefix-with-version
                                                                  :s3-client s3-client}
                                                                 file-name-cache)]
   
     (->S3ObjectStore configurator
                      s3-client
                      bucket
-                     prefix
+                     prefix-with-version
                      minimum-part-size
                      file-name-cache
                      file-list-watcher)))

--- a/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
+++ b/modules/s3/src/main/clojure/xtdb/s3/file_list.clj
@@ -4,6 +4,7 @@
             [clojure.tools.logging :as log] 
             [xtdb.util :as util])
   (:import [java.lang AutoCloseable]
+           [java.net URLDecoder]
            [java.nio.file Path]
            [java.util UUID NavigableSet]
            [software.amazon.awssdk.core.exception AbortedException]
@@ -121,7 +122,10 @@
                                                 event-type (cond
                                                              (string/starts-with? event-name "ObjectCreated") :create
                                                              (string/starts-with? event-name "ObjectRemoved") :delete)
-                                                filename (util/->path (get-in s3-event [:s3 :object :key]))
+                                                filename (-> s3-event
+                                                             (get-in [:s3 :object :key])
+                                                             (URLDecoder/decode "utf8")
+                                                             (util/->path))
                                                 ;; If prefix present - need to filter for objects that start with prefix
                                                 ;; And then relativize the path - otherwise, can leave it unaltered and unfiltered
                                                 file (if prefix

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -11,10 +11,11 @@
   (let [topic-name (str "xtdb.kafka-test." (UUID/randomUUID))]
     (with-open [node (xtn/start-node {:log [:kafka {:bootstrap-servers "localhost:9092"
                                                     :topic-name topic-name}]})]
-      (xt/submit-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+      (t/is (= true
+               (:committed? (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))
 
       (t/is (= [{:xt/id :foo}]
-               (tu/query-ra '[:scan {:table xt_docs} [xt/id]]
+               (tu/query-ra '[:scan {:table xt_docs} [xt$id]]
                             {:node node}))))))
 
 (t/deftest ^:requires-docker ^:kafka test-kafka-setup-with-provided-opts


### PR DESCRIPTION
Resolves #3362

**Successful 'Nightly on Demand' Run**: https://github.com/xtdb/xtdb/actions/runs/9066674997

Fixes numerous issues with the remote object stores to ensure they work properly and that we can pass the nightly tests:
- A lot of issues were fixed by version bumps for S3 and Google Cloud.
- Some test updates for kafka test and numerous test updates for the remote object stores.
- Most of the remaining remote object store failures were caused by behaviour in RemoteBufferPool that would cause errors on `finish-chunk!`:
  - Essentially - within RemoteBufferPool we were resolving numerous inputted paths against "storage-root"
    - Storage-root essentially being used to prefix files with a version number `v02` that we can update when storage format changes in a backwards-incompatible way.
  - Because we were handling this within RemoteBufferPool, internally object store filenames would include this prefix, and in places we were passing back the filenames with the `v02` prefix - this lead to failures/errors within compacting/chunk finishing as we would
    - Call to list files.
    - Get back filenames WITH their `v02` version prefix.
    - Pass said listed filenames back to caller, who would then attempt to call `GET` on the filenames.
    - RemoteBufferPool would then attempt to prefix them _again_, so would be attempting to get files like `v02/v02/tables/...`, which would not be present/found and would throw an error.
  - Elsewhere - ie, in the LocalBufferPool - we just treat the storage version prefix as part of the full directory name - none of the filenames will ever particularly see/care about it.
  - As such - made a change here to follow a similar pattern in RemoteBufferPool/Remote Object Stores:
    - RemoteBufferPool will just pass object keys/filenames that it gets - it doesn't do any resolving or the like on the Paths.
    - When creating the remote object store, we add the `v02` prefix to the existing object store `prefix` value set on configuration, so it becomes part of the folder structure without being passed around in filenames in the system.
    - This fixed the majority of the `finish-chunk` calls that were previously throwing errors.
- Also fixed an issue within the S3 file watcher where it would see slightly different filenames passed back from the SQS subscriptions:
  - Essentially, URL encoding certain values - ie, `table/xt$txs` became `table/xt%24txs`.
  - Now ensure that we decode the strings received from SQS properly.