### PR TITLE
Add data readers for arrow field and field-type

### DIFF
--- a/core/src/main/clojure/data_readers.clj
+++ b/core/src/main/clojure/data_readers.clj
@@ -1,1 +1,3 @@
-{xt.arrow/type xtdb.types/->arrow-type}
+{xt.arrow/type xtdb.types/->arrow-type
+ xt.arrow/field-type xtdb.types/->field-type
+ xt.arrow/field xtdb.types/->field*}


### PR DESCRIPTION
This allows now for `ArrowType` (as previously)
```clj
#xt.arrow/type :i64
```
`FieldType`
```clj
#xt.arrow/field-type [#xt.arrow/type :i64 false]
```
and `Field`
```clj
;; scalar
#xt.arrow/field ["hey" #xt.arrow/field-type [#xt.arrow/type :i64 false]]
;; composite
#xt.arrow/field ["my-struct" #xt.arrow/field-type [#xt.arrow/type :struct false]
                 #xt.arrow/field ["hey" #xt.arrow/field-type [#xt.arrow/type :i64 false]]]
```