### PR TITLE
Fix escape sequence `SyntaxWarning`

### DIFF
--- a/docs/public/xtsql.py
+++ b/docs/public/xtsql.py
@@ -460,13 +460,13 @@ class XtdbConsole(cmd.Cmd):
     def do_accept(self, arg):
         'Sets or shows the accepted mime type.'
         if arg:
-            self.accept = re.sub('=\s*', '', arg)
+            self.accept = re.sub('=\\s*', '', arg)
         print2(self.accept)
 
     def do_url(self, arg):
         'Sets or shows the database URL.'
         if arg:
-            self.url = re.sub('=\s*', '', arg)
+            self.url = re.sub('=\\s*', '', arg)
         print2(self.url)
 
     def do_quit(self, arg):


### PR DESCRIPTION
Replace invalid escape sequences in regular expression string literals which was [upgraded](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes) from `DeprecationWarning `to a `SyntaxWarning` in  Python 3.12

When starting the script using Python +3.12 the following output is displayed:
```shell
/Users/LtTempletonPeck/xtsql.py:463: SyntaxWarning: invalid escape sequence '\s'
  self.accept = re.sub('=\s*', '', arg)
/Users/LtTempletonPeck/xtsql.py:469: SyntaxWarning: invalid escape sequence '\s'
  self.url = re.sub('=\s*', '', arg)
```

Alternatively raw string literals could be used:
```python
            self.accept = re.sub(r'=\s*', '', arg)
```