### PR TITLE
docs: fix gradle xtdb-core dependency

### DIFF
--- a/docs/src/content/docs/drivers/java/getting-started.adoc
+++ b/docs/src/content/docs/drivers/java/getting-started.adoc
@@ -72,7 +72,7 @@ dependencies {
     implementation("com.xtdb:xtdb-http-client-jvm:2.0.0-SNAPSHOT")
 
     // xtdb-core for running an in-process (test) node
-    implementation("com.xtdb:xtdb-http-core:2.0.0-SNAPSHOT")
+    implementation("com.xtdb:xtdb-core:2.0.0-SNAPSHOT")
 }
 ----
 ====


### PR DESCRIPTION
Fix `xtdb-core` dependency in Gradle `build.gradle.kts` example.

The correct artifactid is in the Maven `pom.xml` [example](https://github.com/xtdb/xtdb/blob/d1d6d457fcb17205707a03ac61934060f0bbafa5/docs/src/content/docs/drivers/java/getting-started.adoc?plain=1#L49)