### PR TITLE
promoteChildren + fix #3338

### DIFF
--- a/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
+++ b/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
@@ -349,7 +349,7 @@ abstract class ExtensionVectorWriter(
     ScalarVectorWriter(vector) {
     override var field: Field = vector.field
 
-    private val inner = writerFor(vector.underlyingVector, {
+    internal val inner = writerFor(vector.underlyingVector, {
         field = Field(field.name, field.fieldType, it.children)
         notify(field)
     })
@@ -439,6 +439,11 @@ internal class SetVectorWriter(vector: SetVector, notify: FieldChangeListener?) 
         }
 
     override fun writeValue0(v: IValueReader) = writeObject(v.readObject())
+
+    override fun promoteChildren(field: Field) {
+        if (field.type != this.field.type || (field.isNullable && !this.field.isNullable)) throw FieldMismatch(this.field.fieldType, field.fieldType)
+        inner.promoteChildren(Field(field.name, inner.field.fieldType, field.children))
+    }
 }
 
 private object WriterForVectorVisitor : VectorVisitor<IVectorWriter, FieldChangeListener?> {

--- a/core/src/main/kotlin/xtdb/vector/IVectorWriter.kt
+++ b/core/src/main/kotlin/xtdb/vector/IVectorWriter.kt
@@ -33,6 +33,10 @@ interface IVectorWriter : IValueWriter, AutoCloseable {
         vector.valueCount = writerPosition().position
     }
 
+    fun promoteChildren(field: Field) {
+        if (field.type != this.field.type || (field.isNullable && !this.field.isNullable)) throw FieldMismatch(this.field.fieldType, field.fieldType)
+    };
+
     fun rowCopier(src: ValueVector): IRowCopier
 
     fun rowCopier(src: RelationReader): IRowCopier {

--- a/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
+++ b/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
@@ -182,6 +182,7 @@ class IndirectMultiVectorReader(
     }
 
     override fun rowCopier(writer: IVectorWriter): IRowCopier {
+        readers.map { it?.also { writer.promoteChildren(it.field) }}
         val rowCopiers = readers.map { it?.rowCopier(writer) ?: ValueVectorReader(NullVector()).rowCopier(writer) }
         return IRowCopier { sourceIdx -> rowCopiers[readerIndirection[sourceIdx]].copyRow(vectorIndirections[sourceIdx]) }
     }


### PR DESCRIPTION
This adds a method `promoteChildren(field : Field)` to the `IVectorWriter` interface. The composite writers take care of dealing with internal promotion themselves when writing values which they can't yet hold.

 The new `promoteChildren` method should be used when creating multiple row copiers on the same writer. In this case the writer needs to know upfront the potential child changes for every reader it will receive data from.
```clj
(let [struct-int-field (types/->field "foo" #xt.arrow/type :struct false (types/col-type->field "bar" :i64))
      struct-str-field (types/->field "foo" #xt.arrow/type :struct false (types/col-type->field "bar" :utf8))]
  (with-open [struct-int-vec (.createVector struct-int-field tu/*allocator*)
              struct-str-vec (.createVector struct-str-field tu/*allocator*)]

    ;; write something to the two vectors

    (with-open [wtr (vw/->vec-writer tu/*allocator* "my-new-struct" (FieldType/notNullable #xt.arrow/type :struct))]
      (.promoteChildren wtr struct-int-field)
      (.promoteChildren wtr struct-str-field)
      (let [int-copier (.rowCopier wtr struct-int-vec)
            ;; creating this copier previously invalidated the `int-copier` just above
            str-copier (.rowCopier wtr struct-str-vec)]
        (.copyRow int-copier 0)
        (t/is (= [{:bar 42}]
                 (tu/vec->vals (vw/vec-wtr->rdr wtr))))
        (.copyRow str-copier 0)
        (t/is (= [{:bar 42} {:bar "forty-two"}]
                 (tu/vec->vals (vw/vec-wtr->rdr wtr))))))))
```