### PR TITLE
Use NotifyingSubscriberHandler for local-directory-log

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -5,7 +5,6 @@
             [xtdb.error :as err]
             [xtdb.node :as xtn]
             xtdb.protocols
-            [xtdb.sql :as sql]
             [xtdb.trie :as trie]
             [xtdb.types :as types]
             [xtdb.util :as util]
@@ -39,6 +38,7 @@
 
     (.getTxId (.getTxKey record))))
 
+#_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (defn handle-polling-subscription [^Log log, after-tx-id, {:keys [^Duration poll-sleep-duration]}, ^Log$Subscriber subscriber]
   (doto (.newThread subscription-thread-factory
                     (fn []

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -245,21 +245,6 @@
                      :indexer (->> {:log-limit log-limit, :page-limit page-limit, :rows-per-chunk rows-per-chunk}
                                    (into {} (filter val)))})))
 
-(defn ->local-submit-client ^xtdb.api.IXtdb [{:keys [^Path node-dir]}]
-  (let [sys (-> {:xtdb/allocator {}
-                 :xtdb/log (Logs/localLog (.resolve node-dir "log"))
-                 :xtdb/default-tz #time/zone "UTC"}
-                (ig/prep)
-                (ig/init))]
-    (reify IXtdb
-      (submitTx [_ tx-opts tx-ops]
-        @(xtdb.log/submit-tx& {:allocator (:xtdb/allocator sys)
-                               :log (:xtdb/log sys)
-                               :default-tz (:xtdb/default-tz sys)}
-                              (vec tx-ops) tx-opts))
-      (close [_]
-        (ig/halt! sys)))))
-
 (defn with-tmp-dir* [prefix f]
   (let [dir (Files/createTempDirectory prefix (make-array FileAttribute 0))]
     (try


### PR DESCRIPTION
This uses the notifying subscriber handler for the local directory log. 

As the local log might need to reread previously written transactions (called records in the log), we get the `latest-submitted-tx` from the log file (this is just an offset). We also do some simple checks (record-seperator in place, offset + record size line up with total log size) to assure we are not reading from a corrupted log. 

Closes #3382.

This doesn't deal with the azure log for which the issue of #3382 also exists.