### PR TITLE
Improve SQL 'pipelining' - ability for SELECT to optionally go after HAVING, before ORDER BY

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -584,7 +584,8 @@ queryExpressionBody
     ;
 
 queryTerm
-    : (selectClause fromClause? | fromClause) whereClause? groupByClause? havingClause? windowClause? # QuerySpecification
+    : selectClause fromClause? whereClause? groupByClause? havingClause? windowClause? # QuerySpecification
+    | fromClause whereClause? groupByClause? havingClause? selectClause? windowClause? # QuerySpecification
     | tableValueConstructor # ValuesQuery
     | '(' queryExpressionBody ')' # WrappedQuery
     | queryTerm 'INTERSECT' (ALL | DISTINCT)? queryTerm # IntersectQuery

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -53,8 +53,14 @@
                                   "movie_star" #{"name" "birthdate"}}})))
 
   (t/is (=plan-file
+          "basic-query-1"
+          (plan-sql "FROM StarsIn AS si, MovieStar AS ms WHERE si.starName = ms.name AND ms.birthdate = 1960 SELECT si.movieTitle"
+                    {:table-info {"stars_in" #{"movie_title" "star_name" "year"}
+                                  "movie_star" #{"name" "birthdate"}}})))
+
+  (t/is (=plan-file
           "basic-query-2"
-          (plan-sql "SELECT si.movieTitle FROM StarsIn AS si, MovieStar AS ms WHERE si.starName = ms.name AND ms.birthdate < 1960 AND ms.birthdate > 1950"
+          (plan-sql "FROM StarsIn AS si, MovieStar AS ms WHERE si.starName = ms.name AND ms.birthdate < 1960 AND ms.birthdate > 1950 SELECT si.movieTitle"
                     {:table-info {"stars_in" #{"movie_title" "star_name" "year"}
                                   "movie_star" #{"name" "birthdate"}}})))
 
@@ -205,13 +211,28 @@
                     {:table-info {"stars_in" #{"movie_title"}}})))
 
   (t/is (=plan-file
+          "basic-query-20"
+          (plan-sql "FROM StarsIn AS si SELECT si.movieTitle FETCH FIRST 10 ROWS ONLY"
+                    {:table-info {"stars_in" #{"movie_title"}}})))
+
+  (t/is (=plan-file
           "basic-query-21"
           (plan-sql "SELECT si.movieTitle FROM StarsIn AS si OFFSET 5 ROWS"
                     {:table-info {"stars_in" #{"movie_title"}}})))
 
   (t/is (=plan-file
+          "basic-query-21"
+          (plan-sql "FROM StarsIn AS si SELECT si.movieTitle OFFSET 5 ROWS"
+                    {:table-info {"stars_in" #{"movie_title"}}})))
+
+  (t/is (=plan-file
           "basic-query-22"
           (plan-sql "SELECT si.movieTitle FROM StarsIn AS si OFFSET 5 LIMIT 10"
+                    {:table-info {"stars_in" #{"movie_title"}}})))
+
+  (t/is (=plan-file
+          "basic-query-22"
+          (plan-sql "FROM StarsIn AS si SELECT si.movieTitle OFFSET 5 LIMIT 10"
                     {:table-info {"stars_in" #{"movie_title"}}})))
 
   (t/is (=plan-file
@@ -739,6 +760,11 @@
     (t/is (= #{{:heads 1, :count-heads 3}}
              (set (xt/q tu/*node*
                         "SELECT heads, COUNT(heads) AS count_heads FROM docs HAVING COUNT(heads) > 1")))
+          "having frequency > 1")
+
+    (t/is (= #{{:heads 1, :count-heads 3}}
+             (set (xt/q tu/*node*
+                        "FROM docs HAVING COUNT(heads) > 1 SELECT heads, COUNT(heads) AS count_heads")))
           "having frequency > 1")
 
     #_ ; this is a Postgres extension to the SQL syntax that we may want to support at a later date.

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
@@ -21,13 +21,13 @@
      c.1/c_phone
      c.1/c_comment]
     [:group-by
-     [c.1/c_custkey
-      c.1/c_name
+     [n.4/n_name
+      c.1/c_custkey
+      c.1/c_comment
       c.1/c_acctbal
       c.1/c_phone
-      n.4/n_name
+      c.1/c_name
       c.1/c_address
-      c.1/c_comment
       {xt$sum_out_5 (sum xt$sum_in_6)}]
      [:map
       [{xt$sum_in_6 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]

--- a/src/test/resources/xtdb/sql/tpch/q01.sql
+++ b/src/test/resources/xtdb/sql/tpch/q01.sql
@@ -1,3 +1,10 @@
+FROM
+  lineitem AS l
+WHERE
+  l.l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+l.l_returnflag,
+l.l_linestatus
 SELECT
   l.l_returnflag,
   l.l_linestatus,
@@ -9,13 +16,6 @@ SELECT
   AVG(l.l_extendedprice)                                      AS avg_price,
   AVG(l.l_discount)                                           AS avg_disc,
   COUNT(*)                                                    AS count_order
-FROM
-  lineitem AS l
-WHERE
-  l.l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
-GROUP BY
-l.l_returnflag,
-l.l_linestatus
 ORDER BY
 l.l_returnflag,
 l.l_linestatus

--- a/src/test/resources/xtdb/sql/tpch/q05.sql
+++ b/src/test/resources/xtdb/sql/tpch/q05.sql
@@ -1,6 +1,3 @@
-SELECT
-  n.n_name,
-  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue
 FROM
   customer AS c,
   orders AS o,
@@ -18,7 +15,7 @@ WHERE
   AND r.r_name = 'ASIA'
   AND o.o_orderdate >= DATE '1994-01-01'
   AND o.o_orderdate < DATE '1994-01-01' + INTERVAL '1' YEAR
-GROUP BY
-n.n_name
-ORDER BY
-revenue DESC
+SELECT
+  n.n_name,
+  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue
+ORDER BY revenue DESC

--- a/src/test/resources/xtdb/sql/tpch/q10.sql
+++ b/src/test/resources/xtdb/sql/tpch/q10.sql
@@ -1,12 +1,3 @@
-SELECT
-  c.c_custkey,
-  c.c_name,
-  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue,
-  c.c_acctbal,
-  n.n_name,
-  c.c_address,
-  c.c_phone,
-  c.c_comment
 FROM
   customer AS c,
   orders AS o,
@@ -19,13 +10,14 @@ WHERE
   AND o.o_orderdate < DATE '1993-10-01' + INTERVAL '3' MONTH
   AND l.l_returnflag = 'R'
   AND c.c_nationkey = n.n_nationkey
-GROUP BY
+SELECT
   c.c_custkey,
   c.c_name,
+  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue,
   c.c_acctbal,
-  c.c_phone,
   n.n_name,
   c.c_address,
+  c.c_phone,
   c.c_comment
 ORDER BY
   revenue DESC

--- a/src/test/resources/xtdb/sql/tpch/q21.sql
+++ b/src/test/resources/xtdb/sql/tpch/q21.sql
@@ -1,6 +1,3 @@
-SELECT
-  s.s_name,
-  COUNT(*) AS numwait
 FROM
   supplier AS  s,
   lineitem AS l1,
@@ -12,17 +9,13 @@ WHERE
   AND o.o_orderstatus = 'F'
   AND l1.l_receiptdate > l1.l_commitdate
   AND EXISTS(
-    SELECT *
-    FROM
-      lineitem l2
+    FROM lineitem l2
     WHERE
       l2.l_orderkey = l1.l_orderkey
       AND l2.l_suppkey <> l1.l_suppkey
   )
   AND NOT EXISTS(
-    SELECT *
-    FROM
-      lineitem l3
+    FROM lineitem l3
     WHERE
       l3.l_orderkey = l1.l_orderkey
       AND l3.l_suppkey <> l1.l_suppkey
@@ -30,9 +23,6 @@ WHERE
   )
   AND s.s_nationkey = n.n_nationkey
   AND n.n_name = 'SAUDI ARABIA'
-GROUP BY
-  s.s_name
-ORDER BY
-  numwait DESC,
-  s.s_name
+SELECT s.s_name, COUNT(*) AS numwait
+ORDER BY numwait DESC, s.s_name
 FETCH FIRST 100 ROWS ONLY

--- a/src/test/resources/xtdb/sql/tpch/q22.sql
+++ b/src/test/resources/xtdb/sql/tpch/q22.sql
@@ -1,34 +1,27 @@
-SELECT
-  custsale.cntrycode,
-  COUNT(*)                AS numcust,
-  SUM(custsale.c_acctbal) AS totacctbal
 FROM (
-       SELECT
-         SUBSTRING(c.c_phone FROM 1 FOR 2) AS cntrycode,
-         c.c_acctbal
        FROM
          customer AS c
        WHERE
          SUBSTRING(c.c_phone FROM 1 FOR 2) IN
          ('13', '31', '23', '29', '30', '18', '17')
          AND c.c_acctbal > (
-           SELECT AVG(c.c_acctbal)
-           FROM
-             customer AS c
+           FROM customer AS c
            WHERE
              c.c_acctbal > 0.00
              AND SUBSTRING(c.c_phone FROM 1 FOR 2) IN
                  ('13', '31', '23', '29', '30', '18', '17')
+           SELECT AVG(c.c_acctbal)
          )
          AND NOT EXISTS(
-           SELECT *
-           FROM
-             orders AS o
-           WHERE
-             o.o_custkey = c.c_custkey
+           FROM orders AS o
+           WHERE o.o_custkey = c.c_custkey
          )
+       SELECT
+         SUBSTRING(c.c_phone FROM 1 FOR 2) AS cntrycode,
+         c.c_acctbal
      ) AS custsale
-GROUP BY
-  custsale.cntrycode
-ORDER BY
-  custsale.cntrycode
+SELECT
+  custsale.cntrycode,
+  COUNT(*)                AS numcust,
+  SUM(custsale.c_acctbal) AS totacctbal
+ORDER BY custsale.cntrycode


### PR DESCRIPTION
In terms of execution order, SQL's SELECT happens after the GROUP BY, before ORDER BY [1] - this PR allows users to optionally put the SELECT in that position in their queries.

In the long run, this kind of thing would also help IDE completion/AI figure out what's in scope before it needs to make predictions of what you want in your SELECT clause.

RFC?

[1] sort of. In simple (no unions/intersects etc) queries, ORDER BY can use references both before and after the projection.