### PR TITLE
Return postgres types over pgwire for monomorphic types, update pg_catalog

### DIFF
--- a/pgwire-server/src/main/clojure/xtdb/pgwire.clj
+++ b/pgwire-server/src/main/clojure/xtdb/pgwire.clj
@@ -1,6 +1,5 @@
 (ns xtdb.pgwire
   (:require [clojure.data.json :as json]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
@@ -9,14 +8,14 @@
             [xtdb.query]
             [xtdb.sql.plan :as plan]
             [xtdb.time :as time]
+            [xtdb.types :as types]
             [xtdb.util :as util])
   (:import [clojure.lang PersistentQueue]
            [java.io ByteArrayInputStream ByteArrayOutputStream Closeable DataInputStream DataOutputStream EOFException IOException InputStream OutputStream PushbackInputStream]
            [java.lang Thread$State]
            [java.net ServerSocket Socket SocketException]
-           [java.nio ByteBuffer]
            [java.nio.charset StandardCharsets]
-           [java.time Clock Duration LocalDate LocalDateTime OffsetDateTime Period ZoneId ZonedDateTime]
+           [java.time Clock Duration LocalDate LocalDateTime OffsetDateTime Period ZoneId ZoneOffset ZonedDateTime]
            [java.util List Map]
            [java.util.concurrent ExecutorService Executors TimeUnit]
            [java.util.function Consumer]
@@ -231,123 +230,8 @@
   (.write out (.getBytes s StandardCharsets/UTF_8))
   (.write out 0))
 
-(defn- utf8
-  "Returns the utf8 byte-array for the given string"
-  ^bytes [s]
-  (.getBytes (str s) StandardCharsets/UTF_8))
-
-(def oids
-  "A map of postgres type (that we may support to some extent) to numeric oid.
-  Mapping to oid is useful for result descriptions, as well as to determine the semantics of received parameters."
-  {:undefined 0
-
-   :int2 21
-   :int2-array 1005
-
-   :int4 23
-   :int4-array 1007
-
-   :int8 20
-   :int8-array 1016
-
-   :text 25
-   :text-array 1009
-
-   :numeric 1700
-   :numeric-array 1231
-
-   :float4 700
-   :float4-array 1021
-
-   :float8 701
-   :float8-array 1022
-
-   :bool 16
-   :bool-array 1000
-
-   :date 1082
-   :date-array 1182
-
-   :time 1083
-   :time-array 1183
-
-   :timetz 1266
-   :timetz-array 1270
-
-   :timestamp 1114
-   :timestamp-array 1115
-
-   :timestamptz 1184
-   :timestamptz-array 1185
-
-   :bytea 17
-   :bytea-array 1001
-
-   :varchar 1043
-   :varchar-array 1015
-
-   :bit 1560
-   :bit-array 1561
-
-   :interval 1186
-   :interval-array 1187
-
-   :char 18
-   :char-array 1002
-
-   :jsonb 3802
-   :jsonb-array 3807
-   :json 114
-   :json-array 199})
-
-(def oid->kw (set/map-invert oids))
-
-(def ^:private oid-varchar (oids :varchar))
-(def ^:private oid-json (oids :json))
-
-(defn- read-utf8 [^bytes barr] (String. barr StandardCharsets/UTF_8))
-(defn- read-ascii [^bytes barr] (String. barr StandardCharsets/US_ASCII))
-
-(def type-mappings
-  "Defines how we map from one type to another (pg, java/arrow) where possible."
-  [{:pg :undefined
-    :pg-read-binary (fn [x] (some-> x read-utf8))
-    :pg-read-text (fn [x] (some-> x read-utf8))}
-
-   {:pg :bool
-    :pg-read-binary (fn [barr] (= 1 (nth barr 0 0)))
-    :pg-read-text (fn [barr] (Boolean/parseBoolean (read-utf8 barr)))}
-
-   ;; ints
-   ;; not sure if bit should be mapped to bool?
-   {:pg :bit
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .get))
-    :pg-read-text (fn [barr] (-> barr read-ascii Byte/parseByte))}
-   {:pg :int2
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .getShort))
-    :pg-read-text (fn [barr] (-> barr read-ascii Short/parseShort))}
-   {:pg :int4
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .getInt))
-    :pg-read-text (fn [barr] (-> barr read-ascii Integer/parseInt))}
-   {:pg :int8
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .getLong))
-    :pg-read-text (fn [barr] (-> barr read-ascii Long/parseLong))}
-
-   ;; floats
-   {:pg :float4
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .getFloat))
-    :pg-read-text (fn [barr] (-> barr read-ascii Float/parseFloat))}
-   {:pg :float8
-    :pg-read-binary (fn [barr] (-> barr ByteBuffer/wrap .getDouble))
-    :pg-read-text (fn [barr] (-> barr read-ascii Double/parseDouble))}
-
-   ;; strings
-   {:pg :varchar
-    :pg-read-binary read-utf8
-    :pg-read-text read-utf8}
-   {:pg :text
-    :pg-read-binary read-utf8
-    :pg-read-text read-utf8}])
+(def ^:private oid-varchar (get-in types/pg-types [:varchar :oid]))
+(def ^:private oid-json (get-in types/pg-types [:json :oid]))
 
 ;; all postgres client IO arrives as either an untyped (startup) or typed message
 (defn- read-untyped-msg [^DataInputStream in]
@@ -423,6 +307,7 @@
   [{:q ";"
     :cols []
     :rows []}
+
    {:q "select pg_catalog.version()"
     :cols [{:column-name "version" :column-oid oid-varchar}]
     :rows [["PostgreSQL 14.2"]]}
@@ -434,10 +319,9 @@
     :cols [{:column-name "transaction_isolation" :column-oid oid-varchar}]
     :rows [["read committed"]]}
 
-   ;; ODBC issues this query by default, you may be able to disable with an option
-   {:q "select oid, typbasetype from pg_type where typname = 'lo'"
-    :cols [{:column-name "oid", :column-oid oid-varchar} {:column-name "typebasetype", :column-oid oid-varchar}]
-    :rows []}
+   {:q "show timezone"
+    :cols [{:column-name "TimeZone" :column-oid oid-varchar}]
+    :rows [["GMT"]]}
 
    ;; jdbc meta getKeywords (hibernate)
    ;; I think this should work, but it causes some kind of low level issue, likely
@@ -1093,7 +977,7 @@
 
 (defn cmd-write-canned-response [conn {:keys [q rows] :as _canned-resp}]
   (doseq [row rows]
-    (cmd-write-msg conn msg-data-row {:vals (mapv (fn [v] (if (bytes? v) v (utf8 v))) row)}))
+    (cmd-write-msg conn msg-data-row {:vals (mapv (fn [v] (if (bytes? v) v (types/utf8 v))) row)}))
 
   (cmd-write-msg conn msg-command-complete {:command (str (statement-head q) " " (count rows))}))
 
@@ -1236,10 +1120,10 @@
   (swap! conn-state update :cmd-buf (fnil into PersistentQueue/EMPTY) cmds))
 
 (defn cmd-send-query-result [{:keys [conn-status, conn-state] :as conn}
-                             {:keys [query, ^IResultCursor result-cursor fields]}]
+                             {:keys [query, ^IResultCursor result-cursor fields result-format] :as x}]
 
-  (let [projection (mapv ffirst fields)
-        json-bytes (comp utf8 json/json-str json-clj)
+
+  (let [json-bytes (comp types/utf8 json/json-str json-clj)
 
         ;; this query has been cancelled!
         cancelled-by-client? #(:cancel @conn-state)
@@ -1251,6 +1135,7 @@
      result-cursor
      (reify Consumer
        (accept [_ rel]
+
          (cond
            (cancelled-by-client?)
            (do (log/trace "Query cancelled by client")
@@ -1267,16 +1152,16 @@
 
            :else
            (try
-             (let [^RelationReader rel rel
-                   rdrs (mapv (fn [col-name]
-                                (.readerForName rel (str col-name)))
-                              projection)]
-               (dotimes [idx (.rowCount ^RelationReader rel)]
-                 (let [row (mapv (fn [^IVectorReader rdr]
-                                   (.getObject rdr idx))
-                                 rdrs)]
-                   (cmd-write-msg conn msg-data-row {:vals (mapv json-bytes row)})
-                   (vswap! n-rows-out inc))))
+             (dotimes [idx (.rowCount ^RelationReader rel)]
+               (let [row (map-indexed
+                          (fn [field-idx {:keys [field-name write-binary write-text]}]
+                            (if (or (= result-format [:binary]) (= (nth result-format field-idx nil) :binary))
+                              (write-binary (.readerForName ^RelationReader rel field-name) idx)
+                              (if write-text
+                                (write-text (.readerForName ^RelationReader rel field-name) idx)
+                                (json-bytes (.getObject (.readerForName ^RelationReader rel field-name) idx))))) fields)]
+                 (cmd-write-msg conn msg-data-row {:vals row})
+                 (vswap! n-rows-out inc)))
 
              ;; allow interrupts - this can happen if we are blocking during the row reduce and our conn is forced to close.
              (catch InterruptedException e
@@ -1293,7 +1178,7 @@
 
              ;; (ideally) unexpected (e.g bug in operator)
              (catch Throwable e
-               (log/warn e "An exception was caught during query result set iteration")
+               (log/error e "An exception was caught during query result set iteration")
                (cmd-send-error conn (err-internal "unexpected server error during query execution"))))))))
 
       (cmd-write-msg conn msg-command-complete {:command (str (statement-head query) " " @n-rows-out)})))
@@ -1306,7 +1191,7 @@
       (.close ^Closeable conn))))
 
 (def supported-param-oids
-  (set (map (comp oids :pg) type-mappings)))
+  (set (map :oid (vals types/pg-types))))
 
 (defn- execute-tx [{:keys [node]} dml-buf {:keys [default-all-valid-time?]}]
   (let [tx-ops (mapv (fn [{:keys [transformed-query params]}]
@@ -1324,13 +1209,12 @@
     (let [param-oid (nth arg-types param-idx nil)
           param-format (nth param-format param-idx nil)
           param-format (or param-format (nth param-format param-idx :text))
-          pg-type (oid->kw param-oid)
-          mapping (some #(when (= pg-type (:pg %)) %) type-mappings)
+          mapping (get types/pg-types-by-oid param-oid)
           _ (when-not mapping (throw (Exception. "Unsupported param type provided for read")))
-          {:keys [pg-read-binary, pg-read-text]} mapping]
+          {:keys [read-binary, read-text]} mapping]
       (if (= :binary param-format)
-        (pg-read-binary param)
-        (pg-read-text param)))))
+        (read-binary param)
+        (read-text param)))))
 
 (defn- cmd-exec-dml [{:keys [conn-state] :as conn} {:keys [dml-type query transformed-query params] :as stmt}]
   (let [xtify-param (->xtify-param stmt)
@@ -1365,7 +1249,7 @@
 (defn cmd-exec-query
   "Given a statement of type :query will execute it against the servers :node and send the results."
   [conn
-   {:keys [query fields bound-query]}]
+   {:keys [query fields bound-query] :as portal}]
   (let [result-cursor
         (try
           (.openCursor ^BoundQuery bound-query)
@@ -1373,19 +1257,19 @@
             (log/trace e "Interrupt thrown opening result cursor")
             (throw e))
           (catch Throwable e
-            (log/warn e)
+            (log/error e)
             (cmd-send-error conn (err-pg-exception e "unexpected server error opening cursor for portal"))
             :failed-to-open-cursor))]
 
 
     (when-not (= result-cursor :failed-to-open-cursor)
       (try
-        (cmd-send-query-result conn {:query query, :result-cursor result-cursor :fields fields})
+        (cmd-send-query-result conn (assoc portal :result-cursor result-cursor))
         (catch InterruptedException e
           (log/trace e "Interrupt thrown sending query results")
           (throw e))
         (catch Throwable e
-          (log/warn e)
+          (log/error e)
           (cmd-send-error conn (err-pg-exception e "unexpected server error during query execution")))
         (finally
           ;; try and close the result-cursor (to warn on leak!)
@@ -1413,7 +1297,7 @@
     (cmd-send-row-description conn cols)))
 
 (defn cmd-describe-portal [conn {:keys [fields]}]
-  (cmd-send-row-description conn (map ffirst fields)))
+  (cmd-send-row-description conn fields))
 
 (defn cmd-begin [{:keys [node conn-state] :as conn} access-mode]
   (swap! conn-state
@@ -1462,19 +1346,14 @@
                  (Object.))
         {:keys [statement-type canned-response] :as describe-target} (get-in @conn-state [coll-k describe-name])]
 
-    (when (= :prepared-statements describe-type)
-      (throw (UnsupportedOperationException.
-              ;;TODO consider if we can send some kind of describe statement for prepared statments
-              ;;Not possible to return accurate param and return types but maybe we can return something
-              ;;generic enough to not upset clients
-              "XTDB does not support describing prepared statements,
-               please bind the statement and describe the portal")))
+   (if (= :prepared-stmt describe-type)
+     nil
 
-    (case statement-type
-      :empty-query (cmd-write-msg conn msg-no-data)
-      :canned-response (cmd-describe-canned-response conn canned-response)
-      :query (cmd-describe-portal conn describe-target)
-      (cmd-write-msg conn msg-no-data))))
+     (case statement-type
+       :empty-query (cmd-write-msg conn msg-no-data)
+       :canned-response (cmd-describe-canned-response conn canned-response)
+       :query (cmd-describe-portal conn describe-target)
+       (cmd-write-msg conn msg-no-data)))))
 
 (defn cmd-set-session-parameter [conn parameter value]
   (set-session-parameter conn parameter value)
@@ -1568,7 +1447,7 @@
         stmt (when-not err (assoc stmt :arg-types arg-types))
         err (or err
                 (when-some [oid (first unsupported-arg-types)]
-                  (err-protocol-violation (format "parameter type (%s) currently unsupported by xt" (name (oid->kw oid (str oid))))))
+                  (err-protocol-violation (format "parameter type oid(%s) currently unsupported by xt" oid)))
                 (permissibility-err conn stmt))]
     (if err
       (cmd-send-error conn err)
@@ -1614,7 +1493,7 @@
                         (log/trace e "Interrupt thrown compiling query")
                         (throw e))
                       (catch Throwable e
-                        (log/warn e)
+                        (log/error e)
                         (cmd-send-error
                          conn
                          (err-pg-exception e "unexpected server error compiling query"))))]
@@ -1622,13 +1501,14 @@
                 (when (= :success prep-outcome)
                   (try
                     (let [^BoundQuery bound-query (.bind ^PreparedQuery prepared-query query-opts)]
-                      {:portal (assoc stmt-with-bind-msg :bound-query bound-query :fields (.columnFields bound-query))
+
+                      {:portal (assoc stmt-with-bind-msg :bound-query bound-query :fields (map types/field->pg-type (.columnFields bound-query)))
                        :bind-outcome :success})
                     (catch InterruptedException e
                       (log/trace e "Interrupt thrown binding prepared statement")
                       (throw e))
                     (catch Throwable e
-                      (log/warn e)
+                      (log/error e)
                       (cmd-send-error conn (err-pg-exception (.getCause e) "unexpected server error binding prepared statement"))))))
 
               {:portal stmt-with-bind-msg
@@ -2005,4 +1885,3 @@
       (close [_]
         (util/try-close ^Closeable srv)
         (log/info "PGWire server stopped")))))
-

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -83,19 +83,100 @@
 (deftest test-pg-attribute
   (xt/submit-tx tu/*node* test-data)
 
-  (t/is (=
-         #{{:attrelid 732573471, :atttypid 114, :attname "col2", :attlen -1}
-           {:attrelid -598393539, :atttypid 114, :attname "_id", :attlen -1}
-           {:attrelid 127091884, :atttypid 114, :attname "_id", :attlen -1}
-           {:attrelid 732573471, :atttypid 114, :attname "_id", :attlen -1}
-           {:attrelid -598393539, :atttypid 114, :attname "tx_time", :attlen -1}
-           {:attrelid -598393539, :atttypid 114, :attname "committed", :attlen -1}
-           {:attrelid 732573471, :atttypid 114, :attname "col1", :attlen -1}
-           {:attrelid -598393539, :atttypid 114, :attname "error", :attlen -1}
-           {:attrelid 127091884, :atttypid 114, :attname "col1", :attlen -1}}
+  (t/is (= #{{:atttypmod -1,
+              :attrelid 127091884,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 114,
+              :attnum 0,
+              :attname "_id",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid 732573471,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 114,
+              :attnum 0,
+              :attname "_id",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid 127091884,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 114,
+              :attnum 1,
+              :attname "col1",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid 732573471,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen 8,
+              :atttypid 20,
+              :attnum 1,
+              :attname "col2",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid 732573471,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen 8,
+              :atttypid 20,
+              :attnum 2,
+              :attname "col1",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid -598393539,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 114,
+              :attnum 3,
+              :attname "error",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid -598393539,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen 8,
+              :atttypid 20,
+              :attnum 2,
+              :attname "_id",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid -598393539,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 114,
+              :attnum 0,
+              :attname "tx_time",
+              :attisdropped false}
+             {:atttypmod -1,
+              :attrelid -598393539,
+              :attidentity "",
+              :attgenerated "",
+              :attnotnull false,
+              :attlen -1,
+              :atttypid 16,
+              :attnum 1,
+              :attname "committed",
+              :attisdropped false}}
            (set (tu/query-ra '[:scan
                                {:table pg_catalog/pg_attribute}
-                               [attrelid attname atttypid attlen]]
+                               [attrelid attname atttypid attlen attnum attisdropped
+                                attnotnull atttypmod attidentity attgenerated]]
                              {:node tu/*node*})))))
 
 (deftest test-pg-tables
@@ -114,6 +195,134 @@
                                {:table pg_catalog/pg_tables}
                                [schemaname tablename tableowner tablespace]]
                              {:node tu/*node*})))))
+
+(deftest test-pg-class
+  (xt/submit-tx tu/*node* test-data)
+
+  (t/is (= #{{:relkind "r",
+              :relnamespace 1106696632,
+              :oid 732573471,
+              :relname "baseball"}
+             {:relkind "r",
+              :relnamespace 1106696632,
+              :oid -598393539,
+              :relname "txs"}
+             {:relkind "r",
+              :relnamespace 1106696632,
+              :oid 127091884,
+              :relname "beanie"}}
+           (set (tu/query-ra '[:scan
+                               {:table pg_catalog/pg_class}
+                               [oid relname relnamespace relkind]]
+                             {:node tu/*node*})))))
+
+(deftest test-pg-type
+  (xt/submit-tx tu/*node* test-data)
+  (t/is (= #{{:typtypmod -1,
+              :oid 700,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "float4",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 114,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "json",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 701,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "float8",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 21,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "int2",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 2950,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "uuid",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 1043,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "varchar",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 25,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "text",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 20,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "int8",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 0,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "undefined",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 23,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "int4",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 16,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "boolean",
+              :typnamespace -2125819141,
+              :typbasetype 0}}
+           (set (tu/query-ra '[:scan
+                               {:table pg_catalog/pg_type}
+                               [oid
+                                typname
+                                typnamespace
+                                typowner
+                                typtype
+                                typbasetype
+                                typnotnull
+                                typtypmod]]
+                             {:node tu/*node*})))))
+(deftest test-pg-description
+  (t/is (= []
+           (tu/query-ra '[:scan
+                          {:table pg_catalog/pg_desciption}
+                          [objoid classoid objsubid description]]
+                        {:node tu/*node*}))))
 
 (deftest test-pg-views
   (t/is (= []


### PR DESCRIPTION
PR creates an explicit type mapping between arrow/xtdb
types and postgres types, including how to read/write those
types to and from pgwire.

This enables us to accept (as params) and return (from queries)
postgres types via pgwire, both in binary and text format.

PR also updates pg_catalog to include more information, including postgres types.