### PR TITLE
Simplify pgwire lifecycle - remove code complexity caused solely by 'testability'

### DIFF
--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -315,7 +315,7 @@
   [^CompletableFuture fut f]
   (.thenCompose fut (->jfn f)))
 
-(def uncaught-exception-handler
+(def ^Thread$UncaughtExceptionHandler uncaught-exception-handler
   (reify Thread$UncaughtExceptionHandler
     (uncaughtException [_ _thread throwable]
       (log/error throwable "Uncaught exception:"))))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -365,7 +365,6 @@
   (.interrupt (:accept-thread *server*))
   (.join (:accept-thread *server*) 1000)
 
-  (is (:accept-interrupted @(:server-state *server*)))
   (is (= Thread$State/TERMINATED (.getState (:accept-thread *server*)))))
 
 (deftest accept-thread-interrupt-allows-server-shutdown-test


### PR DESCRIPTION
* Removing the lifecycle statuses of both connection and server - replacing with a much simpler boolean `closing?` flag
* Removing code-paths that were only required for tests - these generally moved us away from 'obviously no bugs' towards 'no obvious bugs'
* Clarifying ownership of the resources - ensuring they're cleaned up per RAII rather than kept around 'just in case' (see 'obviously no bugs' above)
* Make defrecords responsible for closing their resources rather than having decoupled close functions that were sometimes being called from elsewhere and sometimes from the defrecord.