### PR TITLE
add support for `SETTING DEFAULT VALID_TIME|SYSTEM_TIME ...` SQL query prefix

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -40,7 +40,7 @@ RECURSIVE: 'RECURSIVE' ;
 directSqlStatement : directlyExecutableStatement ';'? EOF ;
 
 directlyExecutableStatement
-    : queryExpression #QueryExpr
+    : settingDefaultTimePeriod? queryExpression #QueryExpr
     | insertStatement #InsertStmt
     | updateStatementSearched #UpdateStmt
     | deleteStatementSearched #DeleteStmt
@@ -55,6 +55,15 @@ directlyExecutableStatement
     | 'SET' identifier ( 'TO' | '=' ) literal #SetSessionVariableStatement
     | 'SET' 'VALID_TIME_DEFAULTS' ( 'TO' | '=' )? validTimeDefaults #SetValidTimeDefaults
     ;
+
+settingDefaultTimePeriod : 'SETTING'
+   ( (defaultValidTimePeriod (',' defaultSystemTimePeriod)?)
+   | (defaultSystemTimePeriod (',' defaultValidTimePeriod)?)
+   )
+   ;
+
+defaultValidTimePeriod : 'DEFAULT' 'VALID_TIME' 'TO'? tableTimePeriodSpecification ;
+defaultSystemTimePeriod : 'DEFAULT' 'SYSTEM_TIME' 'TO'? tableTimePeriodSpecification ;
 
 sessionCharacteristic : 'TRANSACTION' transactionMode (',' transactionMode)* ;
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1034,6 +1034,11 @@
       (is (= [{:version 2, :_valid_from "2020-01-02T00:00Z", :_valid_to nil}]
              (q conn ["SELECT version, _valid_from, _valid_to FROM foo"])))
 
+      (is (= [{:version 2, :_valid_from "2020-01-01T00:00Z", :_valid_to "2020-01-02T00:00Z"}
+              {:version 2, :_valid_from "2020-01-02T00:00Z", :_valid_to nil}]
+             (q conn ["SETTING DEFAULT VALID_TIME ALL
+                       SELECT version, _valid_from, _valid_to FROM foo"])))
+
       (sql "SET valid_time_defaults iso_standard")
       (is (= [{:version 2, :_valid_from "2020-01-01T00:00Z", :_valid_to "2020-01-02T00:00Z"}
               {:version 2, :_valid_from "2020-01-02T00:00Z", :_valid_to nil}]


### PR DESCRIPTION
Saves you writing `FOR ALL VALID_TIME` on every table:

```sql
SETTING DEFAULT VALID_TIME ALL 
     [, DEFAULT SYSTEM_TIME AS OF DATE '2024-06-01']
SELECT ...
FROM foo
  JOIN bar ...
  JOIN baz ...
```

* Anything that's valid after `FROM foo FOR VALID_TIME ...` is also valid here.
* Scoped to the current query only

(related to #3441, sort of)