### PR TITLE
Updates to error handling within google cloud storage `put-blob`

### DIFF
--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -103,6 +103,22 @@
       (t/is (= (mapv util/->path ["alan" "alice"])
                (.listAllObjects ^ObjectStore os-2))))))
 
+(t/deftest ^:google-cloud put-object-twice-shouldnt-throw
+  (let [prefix (random-uuid)
+        wait-time-ms 5000]
+    (with-open [os-1 (object-store prefix)
+                os-2 (object-store prefix)]
+      (t/is (os-test/put-edn os-1 (util/->path "alice") :alice))
+      (t/is (os-test/put-edn os-2 (util/->path "alice") :alice))
+
+      ;; Check alice is there
+      (Thread/sleep wait-time-ms)
+      (t/is (= (mapv util/->path ["alice"])
+               (.listAllObjects ^ObjectStore os-1)))
+
+      (t/is (= (mapv util/->path ["alice"])
+               (.listAllObjects ^ObjectStore os-2))))))
+
 (t/deftest ^:google-cloud node-level-test
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (xtn/start-node


### PR DESCRIPTION
Github action run: https://github.com/danmason/xtdb/actions?query=branch%3Ahandle-pre-existing-objects-better-google-cloud++

A few general things in here:

We saw some issues within auctionmark in that we were previously completely swallow `error code: 412` errors, the exact reasoning for this is as follows:
- Primarily, error code 412 is [PRECONDITION FAILED](https://cloud.google.com/resource-manager/docs/core_errors#PRECONDITION_FAILED)
- We were setting a pre-condition via the `Storage$BlobWriteOption` - namely, a `Storage$BlobWriteOption/doesNotExist` check to ensure we do not overwrite existing objects.
- However - google seems to throw other things as error code 412, in particular, when we having IAM permission errors from our kubernetes service account.
- We still want to ensure that attempting to put an existing object DOESNT throw an error, so updated the handling of this to check the message that comes out from the StorageException (unfortunately doesn't seem like we can search for specifically named preconditions that fail, but given that we've only specified a single pre-condition checking purely for the "precondition you supplied failed" error message does the job)
- Also added in a test specifically around this - it would fail if we **didn't** specifically handle these pre-condition failed messages.

Generally, better wrapping/handling of the errors within there - and also ensuring that InterruptedException gets raised out properly from Storage Exception.