### PR TITLE
Add config for setting up/running Auctionmark on Google Cloud.

### DIFF
--- a/cloud-benchmark/google-cloud/Dockerfile
+++ b/cloud-benchmark/google-cloud/Dockerfile
@@ -1,0 +1,35 @@
+FROM eclipse-temurin:21
+
+LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
+LABEL org.opencontainers.image.description="XTDB Google Cloud Benchmark 2.x"
+LABEL org.opencontainers.image.licenses="MPL-2.0"
+
+WORKDIR /usr/local/lib/xtdb
+
+ENTRYPOINT ["java", \
+    "-Dclojure.main.report=stderr", \
+    "-Dlogback.configurationFile=logback.xml", \
+    "-Xmx1500m", "-Xms1500m", \
+    "-XX:MaxDirectMemorySize=2000m", \
+    "-XX:MaxMetaspaceSize=500m", \
+    "--add-opens=java.base/java.nio=ALL-UNNAMED", \
+    "-Dio.netty.tryReflectionSetAccessible=true", \
+    "-cp","xtdb-google-cloud-bench.jar", \
+    "clojure.main", "-m", "xtdb.run-auctionmark.main"]
+
+HEALTHCHECK --start-period=15s --timeout=3s \
+    CMD curl -f http://localhost:3000/status || exit 1
+
+RUN mkdir -p /var/lib/xtdb
+VOLUME /var/lib/xtdb
+
+ARG GIT_SHA
+ARG XTDB_VERSION
+ENV GIT_SHA=${GIT_SHA}
+ENV XTDB_VERSION=${XTDB_VERSION}
+
+LABEL org.opencontainers.image.version=${XTDB_VERSION}
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+
+ADD google-cloud-config.yaml node-config.yaml
+ADD build/libs/xtdb-google-cloud-bench.jar xtdb-google-cloud-bench.jar

--- a/cloud-benchmark/google-cloud/README.adoc
+++ b/cloud-benchmark/google-cloud/README.adoc
@@ -1,0 +1,194 @@
+= Google Cloud Auctionmark Benchmark
+
+Contained within this folder are a number of things for setting up & running a cluster of containerized auctionmark running worker tasks on Google Cloud Platform.
+
+Within this README is the following:
+
+* Instructions for setting up the docker image.
+* How to setup the infra necessary on Google Cloud
+* How to push the docker image to Google Cloud.
+
+== Requirements
+
+For local development, you will need the following:
+* To run the various scripts and commands within this folder, you will need the `gcloud` command line tool:
+** See https://cloud.google.com/sdk[**here**] for more details. 
+* Ensure that you are https://cloud.google.com/sdk/gcloud/reference/auth/login[authenticated with the CLI] and have sufficient permissions to do all of the below.
+* `docker` available on your machine.
+* `kubectl` available on your machine.
+
+In order to deploy the necessary infrastructure on Google Cloud, you will need the following:
+
+* An existing Google Cloud project with the following activated APIs:
+** Cloud Deployment Manager API
+** Cloud Storage API
+** Pub/Sub API
+** IAM API
+** Compute Engine API
+** Kubernetes Engine API
+* Within the configuration, we create a custom IAM role for all of the necessary infrastructure and assign it to a service account. In order for Cloud Deployment Manager to create this, it will require IAM permissions to do so:
+** See link:https://cloud.google.com/iam/docs/maintain-custom-roles-deployment-manager#grant_permissions["Grant permissions to the Google APIs service account"] on how to do this.
+** We need to grant the following roles to the Google APIs service account:
+*** `roles/iam.roleAdmin`
+*** `roles/iam.serviceAccountAdmin`
+
+== Creating the ShadowJAR
+
+Included within this folder is a script, `scripts/build-google-cloud-bench.sh`, which does the following:
+
+* Creates a Shadow JAR of the `cloud-benchmark:google-cloud` project.
+** This contains the compiled `cloud-benchmark` project, which has a main file that runs auctionmark & configures it with provided node config, and also any of the dependencies we require to run the Google Cloud module
+* Creates a docker image, copying in the Shadow JAR and the `google-cloud-config.yaml` file with the node config.
+** If you want to set any JVM opts - do it by editing the Dockerfile's `ENTRYPOINT`.
+
+
+It will build the local image as `xtdb-google-cloud-bench:latest`.
+
+== Pushing the Docker Image to Google Cloud
+
+Firstly, we wil need to set up a google cloud artifact repository to store the docker image. This can be done by running the following command:
+
+```bash
+gcloud artifacts repositories create xtdb-google-cloud-bench-repo --repository-format=docker --location=europe-west1 --description="Repository for storing the xtdb-google-cloud-bench docker image"
+```
+
+You can view that the repository was created used the following command:
+```bash
+gcloud artifacts repositories list
+```
+
+We can configure our docker client  repository by running the following command:
+```bash
+gcloud auth configure-docker europe-west1-docker.pkg.dev
+```
+
+We now tag the image we created in the previous step to match our created repository:
+```bash
+docker tag xtdb-google-cloud-bench:latest europe-west1-docker.pkg.dev/xtdb-scratch/xtdb-google-cloud-bench-repo/xtdb-google-cloud-bench:latest
+```
+
+Finally, we can push the image to the Google Cloud Artifact Repository:
+```bash
+docker push europe-west1-docker.pkg.dev/xtdb-scratch/xtdb-google-cloud-bench-repo/xtdb-google-cloud-bench:latest
+```
+
+== Setting up the infra on Google Cloud
+
+Within this directory is a subdirectory, `deployment-manager`, that contains the Google Cloud Deployment Manager configuration for setting up all the necessary infra on Google Cloud. We also provide a script to create the deployment, `create-google-cloud-deployment.sh`.
+
+You can edit the configuration for the deployment under the `xtdb-google-cloud-bench.yaml` file.
+
+To create the initial deployment, run the following command:
+```
+./scripts/create-google-cloud-deployment.sh
+```
+
+This will set up the following:
+
+* A Cloud Storage bucket
+* A Pub/Sub topic, subscribed to notifications from the Cloud Storage bucket.
+* A custom role for all of the necessary permissions for XTDB to use the above:
+** Using the bucket (get, create, delete, list, and update storage objects)
+** Creating, consuming, and deleting subscriptions on PubSub topics.
+* A service account with the custom role attached.
+* A Kubernetes cluster with a single node pool.
+
+If you make any changes to the deployment configuration, you can update the deployment by running the following command:
+```
+./scripts/update-google-cloud-deployment.sh
+```
+
+With the infrastructure set up and created, we should ensure that the created service account has the permissions needed to pull the docker image from the Google Cloud Artifact Repository, and to interract with the other resources. Run the two following commands (ensuring members/roles match what is expected/created):
+```
+gcloud artifacts repositories add-iam-policy-binding xtdb-google-cloud-bench-repo \
+   --location=europe-west1 \
+   --member=serviceAccount:xtdb-bench-sa-task@xtdb-scratch.iam.gserviceaccount.com \
+   --role=roles/artifactregistry.reader
+
+gcloud projects add-iam-policy-binding projects/xtdb-scratch \
+  --member serviceAccount:xtdb-bench-sa-task@xtdb-scratch.iam.gserviceaccount.com \
+  --role=projects/xtdb-scratch/roles/xtdb_auctionmark_bench_role
+```
+
+With the cluster up and running, you can now deploy the benchmark containers to it.
+
+== Deploying the Benchmark Containers
+
+Before trying to deploy the benchmark containers, you will need to ensure that you have the necessary permissions to deploy to the Kubernetes cluster. You can do this by running the following command:
+```
+gcloud container clusters get-credentials google-cloud-auctionmark-benchmark --zone europe-west1-b
+```
+
+NOTE: You may need to update the auth plugin within google cloud - see here https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke and also ensure your various gcloud components are up to date.
+
+This will configure your `kubectl` to use the credentials for the Kubernetes cluster. 
+
+Prior to setting up the kubernetes deployment, we will need to set up one final thing for it to use - a Kubernetes Service Account. This service account will be used by the pods to authenticate with Google Cloud applications, using the custom role we created earlier. To create the service account, run the following command:
+```
+kubectl create serviceaccount xtdb-k8s-service-account --namespace default 
+```
+
+We need to link our kubernetes service account to our created IAM Service Account with the relevant permissions, so that the pods can authenticate with Google Cloud. Following the instructions from https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iamidentity, we run the following two commands:
+```bash
+gcloud iam service-accounts add-iam-policy-binding xtdb-bench-sa-task@xtdb-scratch.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:xtdb-scratch.svc.id.goog[default/xtdb-k8s-service-account]"
+
+kubectl annotate serviceaccount xtdb-k8s-service-account \
+    --namespace default \
+    iam.gke.io/gcp-service-account=xtdb-bench-sa-task@xtdb-scratch.iam.gserviceaccount.com
+```
+
+The config for the deployments/jobs live under `kubernetes` - within these, you can set/configure any of the necessary parameters for running the image on the cluster. When ready to run a single node auctionmark job, run the following command:
+```
+kubectl apply -f kubernetes/single-node-auctionmark.yaml
+```
+
+You can see the status of pod creation using the following:
+```
+kubectl get pods
+```
+
+With the pod name of the job in hand & when it is created, you can locally trail the logs by doing the following:
+```
+kubectl logs xtdb-single-node-auctionmark-<pod suffix> -f
+```
+
+NOTE: If you follow the below and clear up/delete the persistent storage volumes, you will drop the TxLog and Local Disk Cache data between runs. This may or may not be desired - to note, recreating persistent storage volumes can take some time.
+
+== Clear up between runs
+
+If you want to totally clear up data between runs, you'll want to do the following:
+
+* Clear up the job/pods
+* Empty the Cloud Storage bucket
+* Delete the Persistent Storage volume containing the TxLog
+* Delete the Persistent Storage volume containing the Local Disk Caches
+
+.Clear up the Workload
+
+To clear up the workload, you can do so in Google Cloud or using kubectl. To do so using kubectl, you can do the following:
+```bash
+kubectl delete jobs xtdb-single-node-auctionmark
+```
+
+.Command to empty the Cloud Storage bucket:
+```bash
+gcloud storage rm gs://xtdb-am-bench-object-store/**
+```
+
+.Deleting Persistent Storage Volumes:
+You can remove the Persistent Storage volumes within the google cloud UI, but will need to be careful to ensure they are both removed from GKE and deleted within Compute Engine's storage as well. You will need to ensure any pods are closed/deleted first, and then to delete them, you can do the following:
+```bash
+kubectl delete pvc xtdb-pvc-log
+kubectl delete pvc xtdb-pvc-local-caches
+``` 
+
+NOTE: You do not necessarily _need_ to delete all of the above between runs - you can also change the kubernetes config map to use slightly different directory names (ie, changing bucket prefix, new local-disk-cache directory, etc) to avoid conflicts between runs. 
+
+.Helper Script
+
+For convenience, there is a script, `clear-google-cloud-bench.sh`, that will clear up any existing/lingering jobs, empty the Cloud Storage bucket, and delete the Persistent Storage volumes.
+```bash
+./scripts/clear-google-cloud-bench.sh
+```

--- a/cloud-benchmark/google-cloud/build.gradle.kts
+++ b/cloud-benchmark/google-cloud/build.gradle.kts
@@ -1,0 +1,28 @@
+import xtdb.DataReaderTransformer
+
+plugins {
+    java
+    application
+    id("com.github.johnrengelman.shadow")
+}
+
+dependencies {
+    implementation(project(":cloud-benchmark"))
+    implementation(project(":modules:xtdb-google-cloud"))
+    implementation("ch.qos.logback", "logback-classic", "1.4.5")
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+application {
+    mainClass.set("clojure.main")
+}
+
+tasks.shadowJar {
+    archiveBaseName.set("xtdb")
+    archiveVersion.set("")
+    archiveClassifier.set("google-cloud-bench")
+    mergeServiceFiles()
+    transform(DataReaderTransformer())
+    isZip64 = true
+}

--- a/cloud-benchmark/google-cloud/deployment-manager/xtdb-bench-k8s-cluster.jinja
+++ b/cloud-benchmark/google-cloud/deployment-manager/xtdb-bench-k8s-cluster.jinja
@@ -1,0 +1,44 @@
+{% set ROLE = properties["custom_role_name"] %}
+{% set SERVICE_ACCOUNT_PREFIX = properties["service_account_prefix"] %}
+{% set TASK_SERVICE_ACCOUNT = SERVICE_ACCOUNT_PREFIX + "-task" %}
+{% set CLUSTER_NAME = properties["cluster_name"] %}
+{% set CLUSTER_LOCATION = properties["cluster_location"] %}
+{% set CLUSTER_MACHINE_TYPE = properties["cluster_machine_type"] %}
+{% set ENV_VARS = properties["env_vars"] %}
+
+resources:
+{# Service account for task #}
+- type: gcp-types/iam-v1:projects.serviceAccounts
+  name: xtdb-bench-service-account
+  metadata:
+    dependsOn: 
+      - {{ ROLE }}
+  properties:
+    displayName: XTDB Bench Task Service Account
+    accountId: {{ TASK_SERVICE_ACCOUNT }}
+
+- name: {{ env["deployment"] }}
+  type: gcp-types/container-v1beta1:projects.locations.clusters
+  metadata:
+    dependsOn:
+      - xtdb-bench-service-account
+  properties:
+    parent: projects/{{ env["project"] }}/locations/{{ CLUSTER_LOCATION }}
+    cluster:
+      name: {{ CLUSTER_NAME }}
+      description: XTDB Bench Cluster
+      locations:
+        - {{ CLUSTER_LOCATION }}
+      nodePools:
+      - name: {{ CLUSTER_NAME }}-node-pools
+        config:
+          machineType: {{ CLUSTER_MACHINE_TYPE }}
+          diskSizeGb: 50
+          oauthScopes:
+          - https://www.googleapis.com/auth/devstorage.read_only
+          serviceAccount: {{ TASK_SERVICE_ACCOUNT }}@{{ env["project"] }}.iam.gserviceaccount.com
+          imageType: cos_containerd
+        initialNodeCount: 1
+      workloadIdentityConfig:
+        workloadPool: {{ env["project"] }}.svc.id.goog
+

--- a/cloud-benchmark/google-cloud/deployment-manager/xtdb-bench-stack.jinja
+++ b/cloud-benchmark/google-cloud/deployment-manager/xtdb-bench-stack.jinja
@@ -1,0 +1,52 @@
+{% set TOPIC = properties["notifications_pubsub_topic_name"] %}
+{% set BUCKET = properties["object_store_bucketname"] %}
+{% set ROLE = properties["custom_role_name"] %}
+
+resources:
+- type: gcp-types/pubsub-v1:projects.topics
+  name: {{ TOPIC }} 
+  properties:
+    topic: {{ TOPIC }}
+
+- type: gcp-types/storage-v1:buckets
+  name: {{ BUCKET }}
+  properties:
+    location: {{ properties["bucket_location"] }}
+    locationType: {{ properties["bucket_location_type"] }}
+    storageClass: STANDARD
+
+- type: gcp-types/storage-v1:notifications
+  name: {{ BUCKET }}-notifications
+  properties:
+    bucket: $(ref.{{ BUCKET }}.name)
+    topic: $(ref.{{ TOPIC }}.name)
+    payload_format: JSON_API_V1
+    event_types:
+    - OBJECT_FINALIZE
+    - OBJECT_DELETE
+
+- type: gcp-types/iam-v1:projects.roles
+  name: {{ ROLE }}
+  properties:
+    parent: projects/{{ env["project"] }}
+    roleId: {{ ROLE }}
+    role:
+      title: XTDB Bench Custom role
+      stage: GA
+      description: Custom role for XTDB bench - allows usage of containers and pubsub for reading container notifications.
+      includedPermissions:
+      - storage.objects.create
+      - storage.objects.delete
+      - storage.objects.get
+      - storage.objects.list
+      - storage.objects.update
+      - storage.buckets.get 
+      - pubsub.subscriptions.create
+      - pubsub.subscriptions.delete
+      - pubsub.subscriptions.get
+      - pubsub.subscriptions.consume
+      - pubsub.snapshots.seek
+      - pubsub.topics.attachSubscription
+      {% for permission in properties["additionalPermission"] %}
+      - {{ permission }}
+      {% endfor %}

--- a/cloud-benchmark/google-cloud/deployment-manager/xtdb-google-cloud-bench.yaml
+++ b/cloud-benchmark/google-cloud/deployment-manager/xtdb-google-cloud-bench.yaml
@@ -1,0 +1,31 @@
+imports:
+- path: xtdb-bench-stack.jinja
+- path: xtdb-bench-k8s-cluster.jinja
+
+resources:
+- name: xtdb-bench-stack
+  type: xtdb-bench-stack.jinja
+  properties:
+    # Object Store Config
+    bucket_location: EUROPE-WEST2
+    bucket_location_type: region
+    object_store_bucketname: xtdb-am-bench-object-store
+    notifications_pubsub_topic_name: xtdb-am-bench-object-store-notif-topic
+
+    # Custom Role Config - role name should have unique suffix each time
+    custom_role_name: xtdb_auctionmark_bench_role
+    custom_role_additional_permissions: []
+
+- name: xtdb-bench-k8s-cluster
+  type: xtdb-bench-k8s-cluster.jinja
+  properties:
+    # Custom role from the above 
+    custom_role_name: xtdb_auctionmark_bench_role
+    
+    # Unique prefix used by created service accounts
+    service_account_prefix: xtdb-bench-sa
+
+    # K8S Cluster Info
+    cluster_name: xtdb-cluster
+    cluster_location: europe-west1-b
+    cluster_machine_type: n2-standard-2

--- a/cloud-benchmark/google-cloud/google-cloud-config.yaml
+++ b/cloud-benchmark/google-cloud/google-cloud-config.yaml
@@ -1,0 +1,11 @@
+# CONFIG FOR RUNNING WITH GOOGLE CLOUD INFRA
+txLog: !Local
+  path: !Env XTDB_GCP_LOCAL_LOG_PATH
+
+storage: !Remote
+  objectStore: !GoogleCloud
+    projectId: !Env XTDB_GCP_PROJECT_ID
+    bucket: !Env XTDB_GCP_BUCKET
+    pubSubTopic: !Env XTDB_GCP_PUBSUB_TOPIC
+    prefix: !Env XTDB_GCP_BUCKET_PREFIX
+  localDiskCache: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH

--- a/cloud-benchmark/google-cloud/kubernetes/single-node-auctionmark.yaml
+++ b/cloud-benchmark/google-cloud/kubernetes/single-node-auctionmark.yaml
@@ -1,0 +1,88 @@
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "xtdb-pvc-log"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "100Gi"
+  storageClassName: "standard-rwo"
+---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "xtdb-pvc-local-caches"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "50Gi"
+  storageClassName: "standard-rwo"
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "xtdb-env-config"
+  namespace: "default"
+data:
+  CLOUD_PLATFORM_NAME: "Google Cloud"
+  XTDB_GCP_PROJECT_ID: "xtdb-scratch"
+  XTDB_GCP_BUCKET: "xtdb-am-bench-object-store"
+  XTDB_GCP_PUBSUB_TOPIC: "xtdb-am-bench-object-store-notif-topic"
+  XTDB_GCP_BUCKET_PREFIX: "run-1"
+  XTDB_GCP_LOCAL_LOG_PATH: "/var/lib/xtdb/log/local-log-1"
+  AUCTIONMARK_DURATION: "PT1H"
+  AUCTIONMARK_SCALE_FACTOR: "0.1"
+  AUCTIONMARK_LOAD_PHASE: "True"
+  AUCTIONMARK_LOAD_PHASE_ONLY: "False"
+---
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  name: "xtdb-single-node-auctionmark"
+  namespace: "default"
+  labels:
+    app: "xtdb-single-node-auctionmark"
+spec:
+  completions: 1
+  parallelism: 1
+  # No retries
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: "xtdb-single-node-auctionmark"
+    spec:
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
+      serviceAccountName: "xtdb-k8s-service-account"
+      restartPolicy: "Never"
+      volumes:
+        - name: "xtdb-pvc-log-vol"
+          persistentVolumeClaim:
+            claimName: "xtdb-pvc-log"
+        - name: "xtdb-pvc-local-caches-vol"
+          persistentVolumeClaim:
+            claimName: "xtdb-pvc-local-caches"
+      containers:
+      - name: "xtdb-google-cloud-bench-1"
+        image: "europe-west1-docker.pkg.dev/xtdb-scratch/xtdb-google-cloud-bench-repo/xtdb-google-cloud-bench:latest"
+        volumeMounts:
+        - mountPath: "/var/lib/xtdb/log"
+          name: "xtdb-pvc-local-caches-vol"
+        - mountPath: "/var/lib/xtdb/buffers"
+          name: "xtdb-pvc-local-caches-vol"
+        resources:
+          requests:
+            memory: "4056Mi"
+          limits:
+            memory: "4056Mi"
+        envFrom:
+        - configMapRef:
+            name: "xtdb-env-config"
+        env:
+        - name: "XTDB_GCP_LOCAL_DISK_CACHE_PATH"
+          value: "/var/lib/xtdb/buffers/disk-cache-1"

--- a/cloud-benchmark/google-cloud/scripts/build-google-cloud-bench.sh
+++ b/cloud-benchmark/google-cloud/scripts/build-google-cloud-bench.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+(
+    echo Building Google Cloud ShadowJar ...
+
+    ../../gradlew :cloud-benchmark:google-cloud:shadowJar
+
+    sha=$(git rev-parse --short HEAD)
+
+    echo Building Docker image ...
+    docker build -t xtdb-google-cloud-bench:latest --build-arg GIT_SHA="$sha" --build-arg XTDB_VERSION="${XTDB_VERSION:-dev-SNAPSHOT}" --output type=docker .
+    echo Done
+)

--- a/cloud-benchmark/google-cloud/scripts/clear-google-cloud-bench.sh
+++ b/cloud-benchmark/google-cloud/scripts/clear-google-cloud-bench.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+(
+  kubectl delete jobs xtdb-single-node-auctionmark || true
+  kubectl delete jobs xtdb-multi-node-auctionmark || true
+  gcloud storage rm gs://xtdb-am-bench-object-store/** || true
+  kubectl delete pvc xtdb-pvc-log || true
+  kubectl delete pvc xtdb-pvc-local-caches || true
+)
+

--- a/cloud-benchmark/google-cloud/scripts/create-google-cloud-deployment.sh
+++ b/cloud-benchmark/google-cloud/scripts/create-google-cloud-deployment.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+(
+  gcloud deployment-manager deployments create google-cloud-auctionmark-benchmark --config deployment-manager/xtdb-google-cloud-bench.yaml
+)

--- a/cloud-benchmark/google-cloud/scripts/update-google-cloud-deployment.sh
+++ b/cloud-benchmark/google-cloud/scripts/update-google-cloud-deployment.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+(
+  gcloud deployment-manager deployments update google-cloud-auctionmark-benchmark --config deployment-manager/xtdb-google-cloud-bench.yaml
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ include("lang:test-harness")
 project(":lang:test-harness").name = "test-harness"
 
 include("docker:standalone","docker:aws")
-include("cloud-benchmark", "cloud-benchmark:aws", "cloud-benchmark:local")
+include("cloud-benchmark", "cloud-benchmark:aws", "cloud-benchmark:google-cloud", "cloud-benchmark:local")
 
 include("modules:kafka", "modules:s3", "modules:azure", "modules:google-cloud")
 project(":modules:kafka").name = "xtdb-kafka"


### PR DESCRIPTION
Resolves #3398 

Adds all of the necessary setup to run auctionmark benchmark on a single node for google cloud:
- All of the necessary GCP infra in deployment manager to setup roles, service accounts, GKE clusters.
- README detailed with numerous other steps for image/artifact setup, IAM and kubernetes.
- Numerous scripts to make certain tasks easier.
- Node run setup as a single runnable job in Kubernetes - easy to set off a run and observe.