### PR TITLE
Size limiting local-disk-cache using Caffeine based evictor

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -519,8 +519,8 @@
 (defn open-remote-storage ^xtdb.IBufferPool [^BufferAllocator allocator, ^Storage$RemoteStorageFactory factory]
   (util/with-close-on-catch [object-store (.openObjectStore (.getObjectStore factory))]
     (let [^Path local-disk-cache (.getLocalDiskCache factory)
-          local-disk-size-limit (or (.getMaxLocalDiskCacheBytes factory)
-                                    (calculate-limit-from-percentage-of-disk local-disk-cache (.getMaxLocalDiskCachePercentageOfTotalDisk factory)))
+          local-disk-size-limit (or (.getMaxDiskCacheBytes factory)
+                                    (calculate-limit-from-percentage-of-disk local-disk-cache (.getMaxDiskCachePercentage factory)))
           ^AsyncCache local-disk-cache-evictor (->local-disk-cache-evictor local-disk-size-limit local-disk-cache)
           !evictor-max-weight (atom local-disk-size-limit)]
 
@@ -557,14 +557,14 @@
 (defmethod ->object-store-factory :google-cloud [_ opts] (->object-store-factory :xtdb.google-cloud/object-store opts))
 (defmethod ->object-store-factory :azure [_ opts] (->object-store-factory :xtdb.azure/object-store opts))
 
-(defmethod xtn/apply-config! ::remote [^Xtdb$Config config _ {:keys [object-store local-disk-cache max-cache-bytes max-cache-entries max-local-disk-cache-bytes max-local-disk-cache-percentage-of-total-disk]}]
+(defmethod xtn/apply-config! ::remote [^Xtdb$Config config _ {:keys [object-store local-disk-cache max-cache-bytes max-cache-entries max-disk-cache-bytes max-disk-cache-percentage]}]
   (.storage config (cond-> (Storage/remoteStorage (let [[tag opts] object-store]
                                                     (->object-store-factory tag opts))
                                                   (util/->path local-disk-cache))
                      max-cache-bytes (.maxCacheBytes max-cache-bytes)
                      max-cache-entries (.maxCacheEntries max-cache-entries)
-                     max-local-disk-cache-bytes (.maxLocalDiskCacheBytes max-local-disk-cache-bytes)
-                     max-local-disk-cache-percentage-of-total-disk (.maxLocalDiskCachePercentageOfTotalDisk max-local-disk-cache-percentage-of-total-disk))))
+                     max-disk-cache-bytes (.maxDiskCacheBytes max-disk-cache-bytes)
+                     max-disk-cache-percentage (.maxDiskCachePercentage max-disk-cache-percentage))))
 
 (defn get-footer ^ArrowFooter [^IBufferPool bp ^Path path]
   (util/with-open [^ArrowBuf arrow-buf @(.getBuffer bp path)]

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -268,6 +268,9 @@
 (defn delete-file [^Path file]
   (Files/deleteIfExists file))
 
+(defn size-on-disk [^Path file]
+  (Files/size file))
+
 (defn mkdirs [^Path path]
   (Files/createDirectories path (make-array FileAttribute 0)))
 
@@ -448,26 +451,30 @@
   (doto (.getDeclaredMethod AllocationManager "associate" (into-array Class [BufferAllocator]))
     (.setAccessible true)))
 
-(defn ->arrow-buf-view ^org.apache.arrow.memory.ArrowBuf [^BufferAllocator allocator ^ByteBuffer nio-buffer]
-  (let [nio-buffer (if (and (.isDirect nio-buffer) (zero? (.position nio-buffer)))
-                     nio-buffer
-                     (-> (ByteBuffer/allocateDirect (.remaining nio-buffer))
-                         (.put (.duplicate nio-buffer))
-                         (.clear)))
-        address (MemoryUtil/getByteBufferAddress nio-buffer)
-        size (.remaining nio-buffer)
-        allocation-manager (proxy [AllocationManager] [allocator]
-                             (getSize [] size)
-                             (memoryAddress [] address)
-                             (release0 []
-                               (try-free-direct-buffer nio-buffer)))
-        listener (.getListener allocator)
-        _ (with-open [reservation (.newReservation allocator)]
-            (.onPreAllocation listener size)
-            (.reserve reservation size)
-            (.onAllocation listener size))
-        buffer-ledger (.invoke allocation-manager-associate-method allocation-manager (object-array [allocator]))]
-    (ArrowBuf. buffer-ledger nil size address)))
+(defn ->arrow-buf-view ^org.apache.arrow.memory.ArrowBuf 
+  ([^BufferAllocator allocator ^ByteBuffer nio-buffer]
+   (->arrow-buf-view allocator nio-buffer nil))
+  ([^BufferAllocator allocator ^ByteBuffer nio-buffer release-fn]
+   (let [nio-buffer (if (and (.isDirect nio-buffer) (zero? (.position nio-buffer)))
+                      nio-buffer
+                      (-> (ByteBuffer/allocateDirect (.remaining nio-buffer))
+                          (.put (.duplicate nio-buffer))
+                          (.clear)))
+         address (MemoryUtil/getByteBufferAddress nio-buffer)
+         size (.remaining nio-buffer)
+         allocation-manager (proxy [AllocationManager] [allocator]
+                              (getSize [] size)
+                              (memoryAddress [] address)
+                              (release0 []
+                                (try-free-direct-buffer nio-buffer)
+                                (when release-fn (release-fn))))
+         listener (.getListener allocator)
+         _ (with-open [reservation (.newReservation allocator)]
+             (.onPreAllocation listener size)
+             (.reserve reservation size)
+             (.onAllocation listener size))
+         buffer-ledger (.invoke allocation-manager-associate-method allocation-manager (object-array [allocator]))]
+     (ArrowBuf. buffer-ledger nil size address))))
 
 (defn ->arrow-record-batch-view ^org.apache.arrow.vector.ipc.message.ArrowRecordBatch [^ArrowBlock block ^ArrowBuf buffer]
   (let [prefix-size (if (= (.getInt buffer (.getOffset block)) MessageSerializer/IPC_CONTINUATION_TOKEN)

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -109,10 +109,13 @@ object Storage {
         val localDiskCache: Path,
         var maxCacheEntries: Long = 1024,
         var maxCacheBytes: Long = 536870912,
+        // 10GB default
+        var maxLocalDiskCacheBytes: Long = 10737418240, 
     ) : Factory {
 
         fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
         fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
+        fun maxLocalDiskCacheBytes(maxLocalDiskCacheBytes: Long) = apply { this.maxLocalDiskCacheBytes = maxLocalDiskCacheBytes }
 
         override fun openStorage(allocator: BufferAllocator) =
             requiringResolve("xtdb.buffer-pool/open-remote-storage").invoke(allocator, this) as IBufferPool

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -93,8 +93,9 @@ object Storage {
      *       localDiskCache = Paths.get("test-path")
      *    ) {
      *       maxCacheEntries = 1024,
-     *       maxCacheBytes = 536870912
-     *       maxLocalDiskCacheBytes = 10737418240
+     *       maxCacheBytes = 536870912,
+     *       maxDiskCachePercentage = 75,
+     *       maxDiskCacheBytes = 10737418240
      *    },
      *    ...
      * }
@@ -110,15 +111,14 @@ object Storage {
         val localDiskCache: Path,
         var maxCacheEntries: Long = 1024,
         var maxCacheBytes: Long = 536870912,
-        // 10GB default
-        var maxLocalDiskCacheBytes: Long? = null, 
-        var maxLocalDiskCachePercentageOfTotalDisk: Long = 75,
+        var maxDiskCachePercentage: Long = 75,
+        var maxDiskCacheBytes: Long? = null
     ) : Factory {
 
         fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
         fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
-        fun maxLocalDiskCacheBytes(maxLocalDiskCacheBytes: Long) = apply { this.maxLocalDiskCacheBytes = maxLocalDiskCacheBytes }
-        fun maxLocalDiskCachePercentageOfTotalDisk(maxLocalDiskCachePercentageOfTotalDisk: Long) = apply { this.maxLocalDiskCachePercentageOfTotalDisk = maxLocalDiskCachePercentageOfTotalDisk }
+        fun maxDiskCachePercentage(maxDiskCachePercentage: Long) = apply { this.maxDiskCachePercentage = maxDiskCachePercentage }
+        fun maxDiskCacheBytes(maxDiskCacheBytes: Long) = apply { this.maxDiskCacheBytes = maxDiskCacheBytes }
 
         override fun openStorage(allocator: BufferAllocator) =
             requiringResolve("xtdb.buffer-pool/open-remote-storage").invoke(allocator, this) as IBufferPool

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -111,12 +111,14 @@ object Storage {
         var maxCacheEntries: Long = 1024,
         var maxCacheBytes: Long = 536870912,
         // 10GB default
-        var maxLocalDiskCacheBytes: Long = 10737418240, 
+        var maxLocalDiskCacheBytes: Long? = null, 
+        var maxLocalDiskCachePercentageOfTotalDisk: Long = 75,
     ) : Factory {
 
         fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
         fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
         fun maxLocalDiskCacheBytes(maxLocalDiskCacheBytes: Long) = apply { this.maxLocalDiskCacheBytes = maxLocalDiskCacheBytes }
+        fun maxLocalDiskCachePercentageOfTotalDisk(maxLocalDiskCachePercentageOfTotalDisk: Long) = apply { this.maxLocalDiskCachePercentageOfTotalDisk = maxLocalDiskCachePercentageOfTotalDisk }
 
         override fun openStorage(allocator: BufferAllocator) =
             requiringResolve("xtdb.buffer-pool/open-remote-storage").invoke(allocator, this) as IBufferPool

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -94,6 +94,7 @@ object Storage {
      *    ) {
      *       maxCacheEntries = 1024,
      *       maxCacheBytes = 536870912
+     *       maxLocalDiskCacheBytes = 10737418240
      *    },
      *    ...
      * }

--- a/docs/src/content/docs/config/storage.adoc
+++ b/docs/src/content/docs/config/storage.adoc
@@ -82,10 +82,12 @@ storage: !Remote
   # The maximum number of bytes to store in the in-memory cache.
   # maxCacheBytes: 536870912
 
-  # The upper limit of bytes to store within the localDiskCache directory
-  # maxLocalDiskCacheBytes: 10737418240
-----
+  # The max percentage of space to use on the filesystem for the localDiskCache directory (overriden by maxDiskCacheBytes, if set).
+  # maxDiskCachePercentage: 75
 
+  # The upper limit of bytes that can be stored within the localDiskCache directory (unset by default).
+  # maxDiskCacheBytes: 107374182400
+----
 Each Object Store implementation is configured separately - see the individual documentation for more information:
 
 * link:storage/s3[S3]

--- a/docs/src/content/docs/config/storage.adoc
+++ b/docs/src/content/docs/config/storage.adoc
@@ -81,6 +81,9 @@ storage: !Remote
 
   # The maximum number of bytes to store in the in-memory cache.
   # maxCacheBytes: 536870912
+
+  # The upper limit of bytes to store within the localDiskCache directory
+  # maxLocalDiskCacheBytes: 10737418240
 ----
 
 Each Object Store implementation is configured separately - see the individual documentation for more information:

--- a/docs/src/content/docs/drivers/clojure/configuration.adoc
+++ b/docs/src/content/docs/drivers/clojure/configuration.adoc
@@ -97,7 +97,6 @@ Main article: link:/config/storage#local-disk[local-disk storage]
 
             ;; :max-cache-bytes 1024
             ;; :max-cache-entries 536870912
-            ;; :max-local-disk-cache-bytes 10737418240
            }]}
 ----
 
@@ -120,6 +119,8 @@ Main article: link:/config/storage#remote[remote storage]
                     ;; -- optional
                     ;; :max-cache-entries 1024
                     ;; :max-cache-bytes 536870912
+                    ;; :max-disk-cache-percentage 75
+                    ;; :max-disk-cache-bytes 107374182400
                     }]}
 ----
 

--- a/docs/src/content/docs/drivers/clojure/configuration.adoc
+++ b/docs/src/content/docs/drivers/clojure/configuration.adoc
@@ -97,6 +97,7 @@ Main article: link:/config/storage#local-disk[local-disk storage]
 
             ;; :max-cache-bytes 1024
             ;; :max-cache-entries 536870912
+            ;; :max-local-disk-cache-bytes 10737418240
            }]}
 ----
 

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -9,7 +9,9 @@
             [xtdb.test-util :as tu]
             [xtdb.types :as types]
             [xtdb.util :as util])
-  (:import (java.nio ByteBuffer)
+  (:import (com.github.benmanes.caffeine.cache AsyncCache)
+           (java.io File)
+           (java.nio ByteBuffer)
            (java.nio.file Files Path)
            (java.nio.file.attribute FileAttribute)
            (java.util.concurrent CompletableFuture)
@@ -19,7 +21,8 @@
            (xtdb.api.storage ObjectStore ObjectStoreFactory Storage)
            xtdb.buffer_pool.RemoteBufferPool
            xtdb.IBufferPool
-           (xtdb.multipart IMultipartUpload SupportsMultipart)))
+           (xtdb.multipart IMultipartUpload SupportsMultipart)
+           (org.apache.arrow.memory BufferAllocator RootAllocator)))
 
 (defonce tmp-dirs (atom []))
 
@@ -50,7 +53,6 @@
 
       (let [{:keys [^ObjectStore object-store] :as buffer-pool} (val (first (ig/find-derived (:system node) :xtdb/buffer-pool)))]
         (t/is (instance? RemoteBufferPool buffer-pool))
-
         (t/is (seq (.listAllObjects object-store)))))))
 
 (defn copy-byte-buffer ^ByteBuffer [^ByteBuffer buf]
@@ -78,7 +80,7 @@
   (ByteBuffer/wrap (arrow-buf-bytes arrow-buf)))
 
 (defn test-get-object [^IBufferPool bp, ^Path k, ^ByteBuffer expected]
-  (let [{:keys [^Path disk-store, object-store]} bp]
+  (let [{:keys [^Path disk-store, object-store, ^Path local-disk-cache, ^AsyncCache local-disk-cache-evictor]} bp]
 
     (t/testing "immediate get from buffers map produces correct buffer"
       (util/with-open [buf @(.getBuffer bp k)]
@@ -97,8 +99,10 @@
     (when object-store
       (t/testing "if the buffer is evicted and deleted from disk, it is delivered from object storage"
         (bp/evict-cached-buffer! bp k)
-        (when disk-store
-          (util/delete-file (.resolve disk-store k)))
+        ;; Evicted from map and deleted from disk (ie, replicating effects of 'eviction' here)
+        (.remove (.asMap local-disk-cache-evictor) (.resolve local-disk-cache k))
+        (util/delete-file (.resolve local-disk-cache k)) 
+        ;; Will fetch from object store again
         (util/with-open [buf @(.getBuffer bp k)]
           (t/is (= 0 (util/compare-nio-buffers-unsigned expected (arrow-buf->nio buf)))))))))
 
@@ -198,3 +202,38 @@
         (util/with-open [buf @(.getBuffer bp (util/->path "aw"))]
           (let [{:keys [root]} (util/read-arrow-buf buf)]
             (util/close root)))))))
+
+(defn file-info [^Path dir]
+  (let [files (filter #(.isFile ^File %) (file-seq (.toFile dir)))]
+    {:file-count (count files) :file-names (set (map #(.getName ^File %) files))}))
+
+(defn insert-utf8-to-local-cache [^IBufferPool bp k len]
+  ;; PutObject on ObjectStore
+  @(.putObject bp k (utf8-buf (apply str (repeat len "a"))))
+  ;; Add to local disk cache
+  (with-open [^ArrowBuf _buf @(.getBuffer bp k)]))
+
+(t/deftest local-disk-cache-max-size
+  (util/with-tmp-dirs #{local-disk-cache}
+    (with-open [bp (bp/open-remote-storage
+                    tu/*allocator*
+                    (-> (Storage/remoteStorage simulated-obj-store-factory local-disk-cache)
+                        (.maxLocalDiskCacheBytes 10)
+                        (.maxCacheBytes 12)))]
+      (t/testing "staying below max size - all elements available"
+        (insert-utf8-to-local-cache bp (util/->path "a") 4)
+        (insert-utf8-to-local-cache bp (util/->path "b") 4)
+        (t/is (= {:file-count 2 :file-names #{"a" "b"}} (file-info local-disk-cache)))) 
+      
+      (t/testing "going above max size - all entries pinned (ie, in memory cache) - should return all elements"
+        (insert-utf8-to-local-cache bp (util/->path "c") 4)
+        (t/is (= {:file-count 3 :file-names #{"a" "b" "c"}} (file-info local-disk-cache)))) 
+      
+      (t/testing "entries unpinned (cleared from memory cache by new entries) - should evict entries since above size limit"
+        (insert-utf8-to-local-cache bp (util/->path "d") 4) 
+        (Thread/sleep 100) 
+        (t/is (= 3 (:file-count (file-info local-disk-cache)))) 
+
+        (insert-utf8-to-local-cache bp (util/->path "e") 4)
+        (Thread/sleep 100)
+        (t/is (= 3 (:file-count (file-info local-disk-cache))))))))

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -218,7 +218,7 @@
     (with-open [bp (bp/open-remote-storage
                     tu/*allocator*
                     (-> (Storage/remoteStorage simulated-obj-store-factory local-disk-cache)
-                        (.maxLocalDiskCacheBytes 10)
+                        (.maxDiskCacheBytes 10)
                         (.maxCacheBytes 12)))]
       (t/testing "staying below max size - all elements available"
         (insert-utf8-to-local-cache bp (util/->path "a") 4)


### PR DESCRIPTION
Associated issue: #3424
Github Action Runs: [Here](https://github.com/danmason/xtdb/tree/limit-disk-cache-size)

## Description

Allows the setting of a "max size in bytes" for the local disk cache.
- You can configure a "max size" in bytes for the local disk cache to have.
  - Defaulting to 10GB - really just a random number - I have been testing with 1GB, 5GB, etc for example.
  - It's not entirely a hard limit but we aim to keep under it generally.
- Utilizes a caffeine cache to save buffer paths and model their relative weightings/sizes - also where we set our limit:
  - The concept essentially being that we can use Caffeine and it's semantics to evict files once it's beyond a certain max size.
  - Uses custom weightings to achieve this - essentially weighing function run whenever a file is inserted/updated - and is based on it's file size on disk.
  - We prevent files that are currently being used from being deleted by using caffeine's [pinning mechanism](https://github.com/ben-manes/caffeine/wiki/Faq#pinning-entries) - in the case of a 'maxweight' based eviction policy:
    - If we want a file to be preserved we can return a `weight` of `0`.
    - I've accomplished this via the value stored in Caffeine, which has a `pinned?` key.
  - Load up any files previously on the disk under the `local-disk-cache` path when starting the cache.
 - Pinning behaviour:
   - Files are pinned when they are first fetched to be returned (ie, from `getBuffer`), pinning just prior to them being memory mapped.
   - Files are unpinned when the ArrowBuf that memory maps them is released from memory - passing a custom `release-fn` into the allocation-manager they are using.     
   - At the point of files being pinned, we adjust/lower the max weight of the cache to account for them towards the overall cache weight.
   - When they are unpinned, we re-add their size on disk back to the max weight.  
- Added configuration of the above into the relevant docs.
- Using AsyncCache in Caffeine to achieve all of this.

## Thoughts
- The `release-fn` inside of `release0` feels a bit hacky - perhaps not in the right place, but seems to work - our intention here is very much to remove files as and when we consider them "unused" by anything.

## Observations
- When ran with a very low disk cache size limit (ie, 1GB), we can very well go over that depending on how much is currently being held in memory. Running at _slightly_ higher limits though, (ie, 5GB on Auctionmark), we seem to keep under the max fairly well, and actively remove files. Expecting at more proper size limits (ie, 100GB), should keep at that limit fairly well. 
- Most of our previous observed issues here (ie, with heap size OoMs, with file not found), seem to be fixed (OoM's still caused with lower amounts of memory), seemed to run okay on a 1hour long run (even with a pretty small disk cache limit of 5GB)

## Update

In summary:
- I have fixed the issues that seem to cause race conditions.
- It seems to no longer hang on google cloud after moving over to use the async caffeine cache.
- I've fixed a bug causing it to not respect the size limit.

Ran it against google cloud auctionmark for an hour, with a limited size disk cache of 5GB, and it seemed to respect that number just fine. At this point, opening it up as ready for review.