### PR TITLE
Add MetricsConfigFactory, LocalMetricsConfig and CloudWatchMetricsConfig

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -394,15 +394,14 @@
 
       (util/root->arrow-ipc-byte-buffer root :stream))))
 
-(defmethod xtn/apply-config! :xtdb/log [config _ foo]
-  (let [[tag opts] foo]
-    (xtn/apply-config! config
-                       (case tag
-                         :in-memory :xtdb.log/memory-log
-                         :local :xtdb.log/local-directory-log
-                         :kafka :xtdb.kafka/log
-                         :azure-event-hub :xtdb.azure/event-hub-log)
-                       opts)))
+(defmethod xtn/apply-config! :xtdb/log [config _ [tag opts]]
+  (xtn/apply-config! config
+                     (case tag
+                       :in-memory :xtdb.log/memory-log
+                       :local :xtdb.log/local-directory-log
+                       :kafka :xtdb.kafka/log
+                       :azure-event-hub :xtdb.azure/event-hub-log)
+                     opts))
 
 (defmethod ig/init-key :xtdb/log [_ ^Log$Factory factory]
   (.openLog factory))

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -46,7 +46,8 @@
 (defmethod xtn/apply-config! :xtdb.metrics/registry [^Xtdb$Config config, _ [tag opts]]
   (xtn/apply-config! config
                      (case tag
-                       :prometheus :xtdb.metrics/prometheus)
+                       :prometheus :xtdb.metrics/prometheus
+                       :cloudwatch :xtdb.aws.cloudwatch/metrics)
                      opts))
 
 (defmethod ig/init-key :xtdb.metrics/registry [_ ^Metrics$Factory factory]

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -51,6 +51,9 @@
 (defmethod apply-config! :pgwire-server [config _ opts]
   (apply-config! config :xtdb.pgwire/server opts))
 
+(defmethod apply-config! :metrics [config _ opts]
+  (apply-config! config :xtdb.metrics/registry opts))
+
 (defmethod apply-config! ::default [_ _ _])
 
 (defn start-node
@@ -80,4 +83,3 @@
                                                               (apply-config! k v)))
                                                           config
                                                           opts)))))))
-

--- a/core/src/main/kotlin/xtdb/api/MetricsConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/MetricsConfig.kt
@@ -1,6 +1,0 @@
-package xtdb.api
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class MetricsConfig(var port: Int = 8080)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.UseSerializers
 import xtdb.ZoneIdSerde
 import xtdb.api.log.Log
 import xtdb.api.log.Logs.inMemoryLog
+import xtdb.api.metrics.Metrics
+import xtdb.api.metrics.PrometheusMetrics
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.inMemoryStorage
@@ -22,7 +24,7 @@ object Xtdb {
     data class Config(
         var txLog: Log.Factory = inMemoryLog(),
         var storage: Storage.Factory = inMemoryStorage(),
-        var metrics: MetricsConfig? = null,
+        var metrics: Metrics.Factory? = null,
         var defaultTz: ZoneId = ZoneOffset.UTC,
         @JvmField val indexer: IndexerConfig = IndexerConfig()
     ) {
@@ -43,7 +45,7 @@ object Xtdb {
         fun defaultTz(defaultTz: ZoneId) = apply { this.defaultTz = defaultTz }
 
         @JvmSynthetic
-        fun metrics(configure: MetricsConfig.() -> Unit = {}) = apply { this.metrics = MetricsConfig().also(configure) }
+        fun metrics(metrics: Metrics.Factory) = apply { this.metrics = metrics }
     }
 
     @JvmStatic

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.modules.subclass
 import xtdb.api.log.Log
 import xtdb.api.log.Logs.InMemoryLogFactory
 import xtdb.api.log.Logs.LocalLogFactory
+import xtdb.api.metrics.Metrics
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.ObjectStoreFactory
 import java.nio.file.Path
@@ -111,6 +112,13 @@ val YAML_SERDE = Yaml(
                         serializer: KSerializer<F>,
                     ) {
                         polymorphic(ObjectStoreFactory::class) { subclass(factory, serializer) }
+                    }
+
+                    override fun <F : Metrics.Factory> registerMetricsFactory(
+                        factory: KClass<F>,
+                        serializer: KSerializer<F>,
+                    ) {
+                        polymorphic(Metrics.Factory::class) { subclass(factory, serializer) }
                     }
                 })
             }

--- a/core/src/main/kotlin/xtdb/api/metrics/Metrics.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/Metrics.kt
@@ -1,0 +1,14 @@
+package xtdb.api.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+
+interface Metrics : AutoCloseable {
+
+    val registry: MeterRegistry
+
+    override fun close() {}
+
+    interface Factory {
+        fun openMetrics(): Metrics
+    }
+}

--- a/core/src/main/kotlin/xtdb/api/metrics/PrometheusMetrics.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/PrometheusMetrics.kt
@@ -1,0 +1,58 @@
+package xtdb.api.metrics
+
+import com.sun.net.httpserver.HttpServer
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import xtdb.api.module.XtdbModule
+import java.io.IOException
+import java.lang.System.Logger.Level.INFO
+import java.lang.System.LoggerFinder
+import java.net.InetSocketAddress
+
+private val LOGGER = LoggerFactory.getLogger(PrometheusMetrics::class.java)
+
+class PrometheusMetrics(override val registry: PrometheusMeterRegistry, private val server: HttpServer) : Metrics {
+
+    @Serializable
+    @SerialName("!Prometheus")
+    data class Factory(
+        @Serializable val port: Int = 8080
+    ): Metrics.Factory {
+        override fun openMetrics(): Metrics {
+            val reg = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            try {
+                val server = HttpServer.create(InetSocketAddress(port), 0).apply {
+                    createContext("/metrics") { exchange ->
+                        val resp = reg.scrape().encodeToByteArray()
+                        exchange.sendResponseHeaders(200, resp.size.toLong())
+                        exchange.responseBody.use { it.write(resp) }
+                    }
+
+                    start()
+                    LOGGER.info("Prometheus server started on port $port")
+                }
+
+                return PrometheusMetrics(reg, server)
+            } catch (e: IOException) {
+                throw RuntimeException("Failed to start Prometheus server on port $port", e)
+            }
+        }
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+
+    /**
+     * @suppress
+     */
+    class Registration : XtdbModule.Registration {
+        override fun register(registry: XtdbModule.Registry) {
+            registry.registerMetricsFactory(Factory::class)
+        }
+    }
+}

--- a/core/src/main/kotlin/xtdb/api/module/XtdbModule.kt
+++ b/core/src/main/kotlin/xtdb/api/module/XtdbModule.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import xtdb.api.IXtdb
 import xtdb.api.log.Log
+import xtdb.api.metrics.Metrics
 import xtdb.api.storage.ObjectStoreFactory
 import kotlin.reflect.KClass
 
@@ -25,6 +26,9 @@ interface XtdbModule : AutoCloseable {
 
         @OptIn(InternalSerializationApi::class)
         fun <F : ObjectStoreFactory> registerObjectStore(factory: KClass<F>, serializer: KSerializer<F> = factory.serializer())
+
+        @OptIn(InternalSerializationApi::class)
+        fun <F : Metrics.Factory> registerMetricsFactory(factory: KClass<F>, serializer: KSerializer<F> = factory.serializer())
     }
 
     interface Registration {

--- a/core/src/main/resources/META-INF/services/xtdb.api.module.XtdbModule$Registration
+++ b/core/src/main/resources/META-INF/services/xtdb.api.module.XtdbModule$Registration
@@ -1,1 +1,2 @@
 xtdb.api.PgwireServer$Registration
+xtdb.api.metrics.PrometheusMetrics$Registration

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -12,10 +12,11 @@ import xtdb.api.log.Logs.LocalLogFactory
 import xtdb.api.metrics.PrometheusMetrics
 import xtdb.api.storage.AzureBlobStorage.azureBlobStorage
 import xtdb.api.storage.GoogleCloudStorage
-import xtdb.aws.S3.s3
 import xtdb.api.storage.Storage.InMemoryStorageFactory
 import xtdb.api.storage.Storage.LocalStorageFactory
 import xtdb.api.storage.Storage.RemoteStorageFactory
+import xtdb.aws.CloudWatchMetrics
+import xtdb.aws.S3.s3
 import java.nio.file.Paths
 
 class YamlSerdeTest {
@@ -45,6 +46,13 @@ class YamlSerdeTest {
         """.trimIndent()
 
         assertEquals(PrometheusMetrics.Factory(port = 3000), nodeConfig(input).metrics)
+
+        val awsInput = """
+        metrics: !CloudWatch
+            namespace: "aws.namespace" 
+        """.trimIndent()
+
+        assertEquals(CloudWatchMetrics.Factory("aws.namespace").namespace, (nodeConfig(awsInput).metrics as CloudWatchMetrics.Factory).namespace)
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import xtdb.api.log.Kafka
 import xtdb.api.log.Logs.InMemoryLogFactory
 import xtdb.api.log.Logs.LocalLogFactory
+import xtdb.api.metrics.PrometheusMetrics
 import xtdb.api.storage.AzureBlobStorage.azureBlobStorage
 import xtdb.api.storage.GoogleCloudStorage
 import xtdb.aws.S3.s3
@@ -29,9 +30,21 @@ class YamlSerdeTest {
         storage: !Local
             path: local-storage
             maxCacheEntries: 1025
+        metrics: !Prometheus
+            port: 3000
         """.trimIndent()
 
         println(nodeConfig(input).toString())
+    }
+
+    @Test
+    fun testMetricsConfigDecoding() {
+        val input = """
+        metrics: !Prometheus
+            port: 3000
+        """.trimIndent()
+
+        assertEquals(PrometheusMetrics.Factory(port = 3000), nodeConfig(input).metrics)
     }
 
     @Test

--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -28,5 +28,10 @@ dependencies {
     api("software.amazon.awssdk", "s3", "2.25.50")
     api("software.amazon.awssdk", "sqs", "2.25.50")
     api("software.amazon.awssdk", "sns", "2.25.50")
+
+    // metrics
+    api("io.micrometer", "micrometer-registry-cloudwatch2", "1.12.2")
+    api("software.amazon.awssdk", "cloudwatch", "2.25.50")
+
     api(kotlin("stdlib-jdk8"))
 }

--- a/modules/aws/src/main/clojure/xtdb/aws/cloudwatch.clj
+++ b/modules/aws/src/main/clojure/xtdb/aws/cloudwatch.clj
@@ -1,0 +1,9 @@
+(ns xtdb.aws.cloudwatch
+  (:require [xtdb.node :as xtn])
+  (:import (software.amazon.awssdk.services.cloudwatch CloudWatchAsyncClient)
+           (xtdb.aws CloudWatchMetrics$Factory)))
+
+(defmethod xtn/apply-config! ::metrics [config _ {:keys [namespace client]
+                                                  :or {namespace "xtdb.metrics"
+                                                       client (CloudWatchAsyncClient/create)}}]
+  (.setMetrics config (CloudWatchMetrics$Factory. namespace client)))

--- a/modules/aws/src/main/kotlin/xtdb/aws/CloudWatchMetrics.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/CloudWatchMetrics.kt
@@ -1,0 +1,41 @@
+package xtdb.aws
+
+import io.micrometer.cloudwatch2.CloudWatchConfig
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry
+import io.micrometer.core.instrument.Clock
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import xtdb.api.metrics.Metrics
+import xtdb.api.module.XtdbModule
+import xtdb.util.requiringResolve
+
+class CloudWatchMetrics(override val registry: MeterRegistry) : Metrics {
+
+    @Serializable
+    @SerialName("!CloudWatch")
+    data class Factory (
+        @Serializable val namespace: String = "xtdb.metrics",
+        @Transient val client: CloudWatchAsyncClient = CloudWatchAsyncClient.create()
+    ): Metrics.Factory {
+        override fun openMetrics(): Metrics {
+            val config = object : CloudWatchConfig {
+                override fun get(key: String) = null
+                override fun namespace() = namespace
+            }
+
+            return CloudWatchMetrics(CloudWatchMeterRegistry(config, Clock.SYSTEM, client))
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    class Registration : XtdbModule.Registration {
+        override fun register(registry: XtdbModule.Registry) {
+            registry.registerMetricsFactory(Factory::class)
+        }
+    }
+}

--- a/modules/aws/src/main/resources/META-INF/services/xtdb.api.module.XtdbModule$Registration
+++ b/modules/aws/src/main/resources/META-INF/services/xtdb.api.module.XtdbModule$Registration
@@ -1,1 +1,2 @@
 xtdb.aws.S3$Registration
+xtdb.aws.CloudWatchMetrics$Registration

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -34,7 +34,7 @@
   {::xtdb {:node-opts {:log [:local {:path (io/file dev-node-dir "log")}]
                        :storage [:local {:path (io/file dev-node-dir "objects")}]
                        :http-server {}
-                       :xtdb/metrics-server {}
+                       :metrics [:prometheus {:port 8080}]
                        :pgwire-server {:port 5433}
                        :flight-sql-server {:port 52358}}}})
 

--- a/src/test/resources/test-config.yaml
+++ b/src/test/resources/test-config.yaml
@@ -3,3 +3,5 @@ indexer:
   logLimit: 64
   flushDuration: PT4H
 storage: !InMemory
+metrics: !Prometheus
+  port: 8282


### PR DESCRIPTION
This adds a `Metrics` interface from which all concrete metric implementations should inherit. 

We also then implemented `PrometheusMetrics` in terms of that. There is little functional change in this regard, except that one can also configure the Prometheus metrics server via the YAML config.

Secondly we add `CloudWatchMetrics` to the AWS module. This should allow to enable CloudWatch metrics via YAML, Kotlin and EDN. For example:

```yaml
metrics: !CloudWatch
    namespace: "aws.metrics.namespace"
```