### PR TITLE
Fix O(n²) performance issue in number of visible versions of an entity

### DIFF
--- a/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
@@ -1,24 +1,47 @@
 package xtdb.bitemporal
 
 import com.carrotsearch.hppc.LongArrayList
-import java.util.*
 
-@JvmRecord
+/**
+ * searches a descending-sorted list for the last element greater than or equal to the needle
+ *
+ * @return the index of the element if found, otherwise `- (insertion point) - 1` of the element that would be inserted
+ */
+/*
+ * we opt for a linear search here rather than binary because of the probability that the needle is close to the end -
+ * we're scanning the events in reverse system-time order, so with vt≈tt our valid-from/valid-to are likely to be
+ * older than any we've seen so far.
+ */
+internal fun LongArrayList.reverseLinearSearch(needle: Long): Int {
+    var idx = elementsCount
+    while (--idx >= 0) {
+        val x = buffer[idx]
+        when {
+            x == needle -> return idx
+            x > needle -> return -idx - 2
+        }
+    }
+
+    return -1
+}
+
 data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArrayList) {
     constructor() : this(LongArrayList(), LongArrayList()) {
         reset()
     }
 
-    fun getValidFrom(rangeIdx: Int) = validTimes[rangeIdx]
+    private fun reverseIdx(idx: Int) = validTimes.elementsCount - 1 - idx
 
-    fun getValidTo(rangeIdx: Int) = validTimes[rangeIdx + 1]
+    fun getValidFrom(rangeIdx: Int) = validTimes[reverseIdx(rangeIdx)]
 
-    fun getSystemTime(rangeIdx: Int) = sysTimeCeilings[rangeIdx]
+    fun getValidTo(rangeIdx: Int) = validTimes[reverseIdx(rangeIdx + 1)]
+
+    fun getSystemTime(rangeIdx: Int) = sysTimeCeilings[reverseIdx(rangeIdx) - 1]
 
     @Suppress("MemberVisibilityCanBePrivate")
     fun reset() {
         validTimes.clear()
-        validTimes.add(Long.MIN_VALUE, Long.MAX_VALUE)
+        validTimes.add(Long.MAX_VALUE, Long.MIN_VALUE)
 
         sysTimeCeilings.clear()
         sysTimeCeilings.add(Long.MAX_VALUE)
@@ -27,34 +50,46 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
     fun applyLog(systemFrom: Long, validFrom: Long, validTo: Long) {
         if (validFrom >= validTo) return
 
-        var end = Arrays.binarySearch(validTimes.buffer, 0, validTimes.elementsCount, validTo)
+        var end = validTimes.reverseLinearSearch(validTo)
+        val insertedEnd = end < 0
+        if (insertedEnd) end = -(end + 1)
 
-        if (end < 0) {
-            end = -(end + 1)
-            validTimes.insert(end, validTo)
-            sysTimeCeilings.insert(end, sysTimeCeilings[end - 1])
-        }
-
-        var start = Arrays.binarySearch(validTimes.buffer, 0, validTimes.elementsCount, validFrom)
+        var start = validTimes.reverseLinearSearch(validFrom)
         val insertedStart = start < 0
-        start = if (insertedStart) -(start + 1) else start
+        if (insertedStart) start = -(start + 1)
 
-        if (insertedStart && start == end) {
-            // can't overwrite the value this time as this is already our validTo, so we insert
-            validTimes.insert(start, validFrom)
-            sysTimeCeilings.insert(start, systemFrom)
+        when {
+            !insertedEnd && !insertedStart -> {
+                sysTimeCeilings[end] = systemFrom
+            }
 
-            // we've shifted everything one to the right, so increment end
-            end++
-        } else {
-            validTimes[start] = validFrom
-            sysTimeCeilings[start] = systemFrom
+            !insertedEnd -> {
+                validTimes.insert(start, validFrom)
+                sysTimeCeilings.insert(end, systemFrom)
+            }
+
+            !insertedStart -> {
+                validTimes.insert(end, validTo)
+                sysTimeCeilings.insert(end, systemFrom)
+                start++
+            }
+
+            end == start -> {
+                validTimes.insert(end, validTo)
+                sysTimeCeilings.insert(end, systemFrom)
+                start++
+                validTimes.insert(start, validFrom)
+                sysTimeCeilings.insert(start, sysTimeCeilings[end - 1])
+            }
+
+            else -> {
+                validTimes.insert(end, validTo)
+                sysTimeCeilings.insert(end, systemFrom)
+                validTimes[start] = validFrom
+            }
         }
 
-        // delete all the ranges strictly between our start and our end
-        if (start + 1 < end) {
-            validTimes.removeRange(start + 1, end)
-            sysTimeCeilings.removeRange(start + 1, end)
-        }
+        validTimes.removeRange(end + 1, start)
+        sysTimeCeilings.removeRange(end + 1, start)
     }
 }

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -3,6 +3,7 @@ package xtdb.bitemporal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.Long.Companion.MAX_VALUE
 import com.carrotsearch.hppc.LongArrayList as longs
 import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
 import kotlin.Long.Companion.MIN_VALUE as MIN_LONG
@@ -16,32 +17,51 @@ internal class CeilingTest {
     }
 
     @Test
+    fun testReverseLinearSearch() {
+        val list = longs.from(10, 8, 6, 4, 2)
+        assertEquals(0, list.reverseLinearSearch(10))
+        assertEquals(2, list.reverseLinearSearch(6))
+        assertEquals(4, list.reverseLinearSearch(2))
+        assertEquals(-2, list.reverseLinearSearch(9))
+        assertEquals(-1, list.reverseLinearSearch(11))
+        assertEquals(-5, list.reverseLinearSearch(3))
+        assertEquals(-6, list.reverseLinearSearch(1))
+    }
+
+    @Test
     fun testAppliesLogs() {
-        assertEquals(longs.from(MIN_LONG, MAX_LONG), ceiling.validTimes)
+        assertEquals(longs.from(MAX_LONG, MIN_LONG), ceiling.validTimes)
         assertEquals(longs.from(MAX_LONG), ceiling.sysTimeCeilings)
 
         ceiling.applyLog(4, 4, MAX_LONG)
-        assertEquals(longs.from(MIN_LONG, 4, MAX_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 4), ceiling.sysTimeCeilings)
+        assertEquals(longs.from(MAX_LONG, 4, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(4, MAX_LONG), ceiling.sysTimeCeilings)
 
         // lower the whole ceiling
         ceiling.applyLog(3, 2, MAX_LONG)
-        assertEquals(longs.from(MIN_LONG, 2, MAX_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 3), ceiling.sysTimeCeilings)
+        assertEquals(longs.from(MAX_LONG, 2, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(3, MAX_LONG), ceiling.sysTimeCeilings)
 
         // lower part of the ceiling
         ceiling.applyLog(2, 1, 4)
-        assertEquals(longs.from(MIN_LONG, 1, 4, MAX_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 2, 3), ceiling.sysTimeCeilings)
+        assertEquals(longs.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(3, 2, MAX_LONG), ceiling.sysTimeCeilings)
 
         // replace a range exactly
         ceiling.applyLog(1, 1, 4)
-        assertEquals(longs.from(MIN_LONG, 1, 4, MAX_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 1, 3), ceiling.sysTimeCeilings)
+        assertEquals(longs.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(3, 1, MAX_LONG), ceiling.sysTimeCeilings)
 
         // replace the whole middle section
         ceiling.applyLog(0, 0, 6)
-        assertEquals(longs.from(MIN_LONG, 0, 6, MAX_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 0, 3), ceiling.sysTimeCeilings)
+        assertEquals(longs.from(MAX_LONG, 6, 0, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(3, 0, MAX_LONG), ceiling.sysTimeCeilings)
+    }
+
+    @Test
+    fun `test replace within a range`() {
+        ceiling.applyLog(4, 4, 6)
+        assertEquals(longs.from(MAX_LONG, 6, 4, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs.from(MAX_LONG, 4, MAX_LONG), ceiling.sysTimeCeilings)
     }
 }

--- a/core/src/test/kotlin/xtdb/bitemporal/PolygonTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/PolygonTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import com.carrotsearch.hppc.LongArrayList.from as longs
 import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
+import kotlin.Long.Companion.MIN_VALUE as MIN_LONG
 
 internal class PolygonTest {
     private lateinit var polygon: Polygon
@@ -126,6 +127,20 @@ internal class PolygonTest {
         applyEvent(0, 2005, 2009)
 
         assertEquals(longs(2005, 2009), polygon.validTimes)
+        assertEquals(longs(MAX_LONG), polygon.sysTimeCeilings)
+    }
+
+    @Test
+    fun testTimeSeries() {
+        ceiling.applyLog(10, 10, 12)
+        ceiling.applyLog(8, 8, 10)
+        ceiling.applyLog(6, 6, 8)
+
+        assertEquals(longs(MAX_LONG, 12, 10, 8, 6, MIN_LONG), ceiling.validTimes)
+        assertEquals(longs(MAX_LONG, 10, 8, 6, MAX_LONG), ceiling.sysTimeCeilings)
+
+        applyEvent(4, 4, 6)
+        assertEquals(longs(4, 6), polygon.validTimes)
         assertEquals(longs(MAX_LONG), polygon.sysTimeCeilings)
     }
 }


### PR DESCRIPTION
Issue we were seeing was that:

* 10 entities, 25k 'visible' versions (not overlapping in valid-time, e.g. 12:00-12:05, 12:05-12:10), `SELECT COUNT(*) FROM readings FOR ALL VALID_TIME` took ~1-2s on my machine
* for 40 entities, 25k 'visible' versions ~4-5s - so O(n) in entity count (as you'd expect)
* 10 entities, 100k visible versions: ~16s. - so proportional to visible-versions squared.

In bitemporal resolution, when playing through events in descending system-time order, we keep a 'ceiling' data structure - for each interval on the valid-timeline, what is the earliest system-time we've seen so far that covers this period. This is for calculating system-to, because the system-to of earlier events depend on when they were superseded by events later in system-time.

Trouble is, when maintaining this structure, due to the common nature of bitemporal data to have valid-time ≈ system-time, it turned out we were most often inserting at the start of this array list. Not a problem when there's only a handful of visible versions (most likely, just one), as there often is when you're updating the state of a normal entity - but when your entities have hundreds of thousands of visible versions, this was performing an array copy of roughly the size of the visible versions for every visible version.

This fix reverses the order of the ceiling data structure, which means that we're most often inserting at the _end_ of that list - this means that regardless of how many visible versions there are, we're most often copying a small constant number of entries for every visible version, which brings us back into O(n) territory.

Afterwards:
* 10 entities, 25k visible versions: ~350ms
* 40 entities, 25k visible versions: ~1.6s
* 10 entities, 100k visible versions: ~3.2s

So not quite equivalent, but significantly better :slightly_smiling_face: 
