### PR TITLE
Scan recency filter for older recency pages

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -20,6 +20,7 @@
            xtdb.bitemporal.IPolygonReader
            (xtdb.metadata IMetadataManager)
            (xtdb.trie EventRowPointer HashTrieKt IDataRel MergePlanTask)
+           (xtdb.util TemporalBounds)
            xtdb.vector.IRelationWriter
            xtdb.vector.IRowCopier
            xtdb.vector.IVectorWriter
@@ -70,7 +71,8 @@
                                                                            (let [^bytes page-path page-path
                                                                                  len (min path-len (alength page-path))]
                                                                              (Arrays/equals path-filter 0 len
-                                                                                            page-path 0 len)))))))
+                                                                                            page-path 0 len))))))
+                                                                   (TemporalBounds.))
             :let [_ (when (Thread/interrupted)
                       (throw (InterruptedException.)))
 

--- a/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
@@ -52,7 +52,6 @@ class ArrowHashTrie(private val nodesVec: DenseUnionVector) :
 
         override val recencies: RecencyArray
             get() {
-                val startIdx = startIdx
                 return RecencyArray(count) { idx ->
                     recencyVec.getLong(idx + startIdx)
                 }


### PR DESCRIPTION
This adds the recency filter to scan for older pages than the query range of scan. 

The formula is essentially `while recency of page < min(validTo.lower, systemTo.lower)` we are ignoring those pages. 

Todo:
- [x] Walk through scan recency test.