### PR TITLE
Add `range_bins` function

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -312,6 +312,7 @@ exprPrimary
     | 'LOCALTIME' ('(' precision ')')? # LocalTimeFunction
     | 'DATE_TRUNC' '(' dateTruncPrecision ',' dateTruncSource (',' dateTruncTimeZone)? ')' # DateTruncFunction
     | 'DATE_BIN' '(' intervalLiteral ',' dateBinSource (',' dateBinOrigin)? ')' # DateBinFunction
+    | 'RANGE_BINS' '(' intervalLiteral ',' rangeBinsSource (',' dateBinOrigin)? ')' #RangeBinsFunction
 
     // interval value functions
     | 'AGE' '(' expr ',' expr ')' # AgeFunction
@@ -444,6 +445,7 @@ dateTruncSource : expr ;
 dateTruncTimeZone : characterString ;
 
 dateBinSource : expr ;
+rangeBinsSource : periodPredicand ;
 dateBinOrigin : expr ;
 
 /// §6.34 <interval value function>

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -1370,8 +1370,20 @@
      (date-bin ~(-> (.intervalLiteral ctx) (.accept this))
                ~(-> (.expr (.dateBinSource ctx)) (.accept this))
                ~@(some-> (.dateBinOrigin ctx)
+                         .expr
                          (.accept this)
                          vector))))
+
+  (visitRangeBinsFunction [this ctx]
+    (let [{:keys [from to]} (-> (.rangeBinsSource ctx) .periodPredicand (.accept this))]
+      (xt/template
+       (range-bins ~(-> (.intervalLiteral ctx) (.accept this))
+                   ~from
+                   ~to
+                   ~@(some-> (.dateBinOrigin ctx)
+                             .expr
+                             (.accept this)
+                             vector)))))
 
   (visitAgeFunction [this ctx]
     (let [ve1 (-> (.expr ctx 0) (.accept this))

--- a/docs/src/content/docs/reference/main/stdlib/temporal.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/temporal.adoc
@@ -243,6 +243,25 @@ Bins the given timestamp within the given 'stride' interval, optionally relative
 
 e.g. `TIMESTAMP '2024-01-01T12:34:00Z'` with an `INTERVAL 'PT20M'` stride would yield `2024-01-01T12:20Z`.
 
+| | `RANGE_BINS(stride, period [, origin])`
+a|
+Aligns the given period within bins of the given 'stride' interval, optionally relative to the given origin (or '1970-01-01' if not supplied).
+
+Returns an array of structs, each containing the `_from` and `_to` of the bin, and a `_weight` representing the proportion of the original range contained within the given bin.
+
+e.g.
+
+* A period of 00:05-00:10 within 15 minute bins yields one bin, 00:00-00:15 with weight 1.0:
++
+`RANGE_BINS(INTERVAL 'PT15M', PERIOD(TIMESTAMP '2020-01-01T00:05Z', TIMESTAMP '2020-01-01T00:10Z'))`
++
+-> `[{_from: '2020-01-01T00:00Z', _to: '2020-01-01T00:15Z', _weight: 1.0}]`
+* A period of 12:57-13:02 within hourly bins yields two bins, 12:00-13:00 with weight 0.6, and 13:00-14:00 with weight 0.4:
++
+`RANGE_BINS(INTERVAL 'PT1H', PERIOD(TIMESTAMP '2020-01-01T12:57Z', TIMESTAMP '2020-01-01T13:02Z'))`
++
+-> `[{_from: '2020-01-01T12:00Z', _to: '2020-01-01T13:00Z', _weight: 0.6}, {_from: '2020-01-01T13:00Z', _to: '2020-01-01T14:00Z', _weight: 0.4}]`
+
 | `(extract "field" date-time)` | `EXTRACT(field FROM date_time)`
 | Extracts the given field from the date-time. Field must be one of `YEAR`, `MONTH`, `DAY`, `MINUTE` or `SECOND`. Datetimes with timezones additionally support field values of `TIMEZONE_HOUR` and `TIMEZONE_MINUTE`.
 


### PR DESCRIPTION
This PR adds a `range_bins` function - similar to `date_bin`, but works on a range instead.

e.g. `RANGE_BINS(INTERVAL 'PT15M', VALID_TIME)`, `RANGE_BINS(INTERVAL 'P3D', PERIOD(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-07')`

The function then returns a list of bins, each containing `_from`, `_to` and `_weight`. Weight is useful here because it tells the user what proportion of the origin range is contained within each bin. For example, if I had a range from 12:57 to 13:02 and I wanted hourly bins, it would tell me that 0.6 of the range was in the 12:00-13:00 range, and 0.4 in the 13:00-14:00 range.