### PR TITLE
Filter newer pages that don't overlap in system-time and valid-time

### DIFF
--- a/core/src/main/kotlin/xtdb/metadata/Metadata.kt
+++ b/core/src/main/kotlin/xtdb/metadata/Metadata.kt
@@ -1,6 +1,7 @@
 package xtdb.metadata
 
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap
+import xtdb.util.TemporalBounds
 import xtdb.vector.IVectorReader
 
 interface ITableMetadata {
@@ -8,6 +9,7 @@ interface ITableMetadata {
    fun columnNames() : Set<String>
    fun rowIndex(columnName: String, pageIdx: Int) : Long
    fun iidBloomBitmap(pageIdx: Int) : ImmutableRoaringBitmap
+   fun temporalBounds(pageIdx: Int) : TemporalBounds
 }
 
 data class PageIndexKey(val columnName: String, val pageIdx: Int)

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -381,7 +381,7 @@
                                      (filter zero?)))))))))))))
 
 (t/deftest test-l2-compaction-badly-distributed
-  (let [node-dir (util/->path "target/compactor/test-l1-compaction-badly-distributed")]
+  (let [node-dir (util/->path "target/compactor/test-l2-compaction-badly-distributed")]
     (util/delete-dir node-dir)
 
     (binding [c/*page-size* 8


### PR DESCRIPTION
This uses the temporal metadata information to filter pages in scan.

The two main advantages are:
- historical system time queries filter out newer pages completely
- valid time queries only include pages that can effect the requested valid time range

Todo:
- [x] rebase
- [x] index bump
- [x] refactor of `->merge-tasks` with data structures that are easier to setup
- [x] move comments in tests into `t/is / t/testing` strings
- [x] What cases (in terms of valid-time pruning) does this NOT cover?