### PR TITLE
Add standalone docker image for Azure & Kafka.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,3 +84,42 @@ jobs:
           build-args: |
             GIT_SHA=${{ github.sha }}
             XTDB_VERSION="dev-SNAPSHOT"
+  
+  deploy-azure-docker:
+    name: Deploy XTDB Azure Docker Image
+    runs-on: ubuntu-latest
+    if: github.repository == 'xtdb/xtdb'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Build Uberjar
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: :docker:azure:shadowJar
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Azure Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/azure
+          platforms: linux/arm64/v8,linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/xtdb/xtdb-azure-ea:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            XTDB_VERSION="dev-SNAPSHOT"

--- a/docker/azure/Dockerfile
+++ b/docker/azure/Dockerfile
@@ -1,0 +1,32 @@
+FROM eclipse-temurin:21
+
+LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
+LABEL org.opencontainers.image.description="XTDB 2.x"
+LABEL org.opencontainers.image.licenses="MPL-2.0"
+
+WORKDIR /usr/local/lib/xtdb
+
+ENTRYPOINT ["java", \
+    "-Dclojure.main.report=stderr", \
+    "-Dlogback.configurationFile=logback.xml", \
+    "--add-opens=java.base/java.nio=ALL-UNNAMED", \
+    "-Dio.netty.tryReflectionSetAccessible=true", \
+    "-cp","xtdb-azure.jar", \
+    "clojure.main", "-m", "xtdb.main"]
+
+HEALTHCHECK --start-period=15s --timeout=3s \
+    CMD curl -f http://localhost:3000/status || exit 1
+
+RUN mkdir -p /var/lib/xtdb
+VOLUME /var/lib/xtdb
+
+ARG GIT_SHA
+ARG XTDB_VERSION
+ENV GIT_SHA=${GIT_SHA}
+ENV XTDB_VERSION=${XTDB_VERSION}
+
+LABEL org.opencontainers.image.version=${XTDB_VERSION}
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+
+ADD azure_config.edn xtdb.edn
+ADD build/libs/xtdb-azure.jar xtdb-azure.jar

--- a/docker/azure/azure_config.edn
+++ b/docker/azure/azure_config.edn
@@ -1,0 +1,18 @@
+{:log [:kafka {:topic-name #env XTDB_TOPIC_NAME
+               :bootstrap-servers #env KAFKA_BOOTSTRAP_SERVERS
+               :properties-map {"compression.type" #env KAFKA_COMPRESSION_TYPE
+                                "security.protocol" "SASL_SSL"
+                                "sasl.mechanism" "PLAIN"
+                                "sasl.jaas.config" #env KAFKA_SASL_JAAS_CONFIG}}]
+
+ :storage [:remote {:object-store [:azure {:storageAccount #env XTDB_AZURE_STORAGE_ACCOUNT
+                                           :container #env XTDB_AZURE_STORAGE_CONTAINER
+                                           :serviceBusNamespace #env XTDB_AZURE_SERVICE_BUS_NAMESPACE
+                                           :serviceBusTopicName #env XTDB_AZURE_SERVICE_BUS_TOPIC_NAME
+                                           :prefix "xtdb-object-store"
+                                           :userManagedIdentityClientId #env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID}]
+                    :local-disk-cache "/var/lib/xtdb/disk-cache"}]
+ 
+ :http-server {:port 3000}
+
+ :xtdb/metrics-server {}}

--- a/docker/azure/build.gradle.kts
+++ b/docker/azure/build.gradle.kts
@@ -1,0 +1,29 @@
+import xtdb.DataReaderTransformer
+
+plugins {
+    java
+    application
+    id("com.github.johnrengelman.shadow")
+}
+
+dependencies {
+    implementation(project(":xtdb-core"))
+    implementation(project(":xtdb-http-server"))
+    implementation(project(":modules:xtdb-kafka"))
+    implementation(project(":modules:xtdb-azure"))
+    implementation("ch.qos.logback", "logback-classic", "1.4.5")
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+application {
+    mainClass.set("clojure.main")
+}
+
+tasks.shadowJar {
+    archiveBaseName.set("xtdb")
+    archiveVersion.set("")
+    archiveClassifier.set("azure")
+    mergeServiceFiles()
+    transform(DataReaderTransformer())
+}

--- a/docker/azure/src/main/resources/logback.xml
+++ b/docker/azure/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} | %-5level %logger{36} | %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="xtdb" level="DEBUG" />
+    <logger name="org.apache.kafka" level="ERROR" />
+    <logger name="org.apache.zookeeper" level="ERROR" />
+    <logger name="kafka" level="ERROR" />
+    <logger name="org.apache.arrow" level="WARN" />
+    <logger name="org.eclipse.jetty" level="WARN" />
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ project(":http-client-jvm").name = "xtdb-http-client-jvm"
 include("lang:test-harness")
 project(":lang:test-harness").name = "test-harness"
 
-include("docker:standalone","docker:aws")
+include("docker:standalone","docker:aws", "docker:azure")
 include("cloud-benchmark", "cloud-benchmark:aws", "cloud-benchmark:azure", "cloud-benchmark:google-cloud", "cloud-benchmark:local")
 
 include("modules:kafka", "modules:aws", "modules:azure", "modules:google-cloud")


### PR DESCRIPTION
Resolves #3525 

Adds a standalone docker image, deployed using `docker-latest`, for use within Azure Deployments:
- Azure Blob Storage as the Remote Storage Module
- Kafka as the Transaction Log
- HTTP Server exposed on port 3000.
- Metrics Server running on default port.

There are some slight differences to the AWS standalone docker image, in that we allow the user to also configure SASL kafka auth using environment variables. Exact method for this might want to change, but complete list of exposed env vars:
- For the storage module:
  - `XTDB_AZURE_STORAGE_ACCOUNT`
  - `XTDB_AZURE_STORAGE_CONTAINER`
  - `XTDB_AZURE_SERVICE_BUS_NAMESPACE`
  - `XTDB_AZURE_SERVICE_BUS_TOPIC_NAME`
  - `XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID` - necessary to provide if using User Assigned Managed Identities.
- For Kafka:
  - `XTDB_TOPIC_NAME`
  - `KAFKA_BOOTSTRAP_SERVERS`
  - `KAFKA_COMPRESSION_TYPE` (when running kafka on event hubs, we've needed to change this - in general probably could use default)
  - `KAFKA_SASL_JAAS_CONFIG` - necessary to provide username/password when connecting over PLAIN sasl