### PR TITLE
Add `StringMapWithEnvVarsSerde`, use within Kafka. Resolves #3557

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/Kafka.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/Kafka.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(DurationSerde::class)
+@file:UseSerializers(StringMapWithEnvVarsSerde::class, DurationSerde::class, StringWithEnvVarSerde::class, PathWithEnvVarSerde::class)
 package xtdb.api.log
 
 import kotlinx.serialization.SerialName
@@ -7,6 +7,7 @@ import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
 import xtdb.api.PathWithEnvVarSerde
 import xtdb.api.StringWithEnvVarSerde
+import xtdb.api.StringMapWithEnvVarsSerde
 import xtdb.api.Xtdb
 import xtdb.api.module.XtdbModule
 import xtdb.util.requiringResolve
@@ -49,14 +50,14 @@ object Kafka {
     @Serializable
     @SerialName("!Kafka")
     data class Factory(
-        @Serializable(StringWithEnvVarSerde::class) val bootstrapServers: String,
-        @Serializable(StringWithEnvVarSerde::class) val topicName: String,
+        val bootstrapServers: String,
+        val topicName: String,
         var autoCreateTopic: Boolean = true,
         var replicationFactor: Int = 1,
         var pollDuration: Duration = Duration.ofSeconds(1),
         var topicConfig: Map<String, String> = emptyMap(),
         var propertiesMap: Map<String, String> = emptyMap(),
-        @Serializable(PathWithEnvVarSerde::class) var propertiesFile: Path? = null
+        var propertiesFile: Path? = null
     ) : Log.Factory {
 
         fun autoCreateTopic(autoCreateTopic: Boolean) = apply { this.autoCreateTopic = autoCreateTopic }


### PR DESCRIPTION
Adding a new deserializer class such that we can handle environment variables inside of nested maps - and then use within kafka. This would allow you to set things within the `propertiesMap` in Kafka and pass them in via environment variables (ie, can pass in things like `sasl.jaas.config` from a secret)