### PR TITLE
Default unspecified param types to utf8/text

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,6 +255,7 @@ dependencies {
     testImplementation("org.clojure", "test.check", "1.1.1")
     testImplementation("clj-kondo", "clj-kondo", "2023.12.15")
     testImplementation("com.github.seancorfield", "next.jdbc", "1.3.939")
+    testImplementation("com.github.igrishaev", "pg2-core", "0.1.17")
 
     // For generating clojure docs
     testImplementation("codox", "codox", "0.10.8")


### PR DESCRIPTION
Changes prepareQuery to assume the type of any param without an explicit type to be utf8. It does this by comparing the param count of the query to the number param-types its provided, defaulting the difference.

Commit also exposes the calculated paramFields as part of PreparedQuery. This allows the pgwire server to correctly describe the expected type of any such defaulted params.

This is not yet true for DML statements as they do not use the preparedQuery lifecycle, and so require explicit types.

Commit also brings in pg2 as a test dep to allow easier testing of default param types and postgres native params ($1, $2 ..)