### PR TITLE
Simplify TemporalBounds from hypercubes to rectangles

### DIFF
--- a/core/src/main/clojure/xtdb/bitemporal.clj
+++ b/core/src/main/clojure/xtdb/bitemporal.clj
@@ -37,7 +37,7 @@
                    valid-from (.getValidFrom ev-ptr)
                    valid-to (.getValidTo ev-ptr)]
                (when (or (nil? temporal-bounds)
-                         (.inRange (.getSystemFrom temporal-bounds) system-from))
+                         (< system-from (.getUpper (.getSystemTime temporal-bounds))))
                  (.calculateFor polygon ceiling valid-from valid-to)
                  (.applyLog ceiling system-from valid-from valid-to)
                  polygon)))))))))

--- a/core/src/main/kotlin/xtdb/trie/HashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/HashTrie.kt
@@ -90,7 +90,7 @@ class MergePlanTask(val mpNodes: List<MergePlanNode>, val path: ByteArray)
 fun toMergePlan(segments: List<ISegment>, pathPred: Predicate<ByteArray>?, temporalBounds: TemporalBounds = TemporalBounds()): List<MergePlanTask> {
     val result = mutableListOf<MergePlanTask>()
     val stack = ObjectStack<MergePlanTask>()
-    val minRecency = min(temporalBounds.validTo.lower, temporalBounds.systemTo.lower)
+    val minRecency = min(temporalBounds.validTime.lower, temporalBounds.systemTime.lower)
 
     val initialMpNodes = segments.mapNotNull { seg -> seg.trie.rootNode?.let { MergePlanNode(seg, it) } }
     if (initialMpNodes.isNotEmpty()) stack.push(MergePlanTask(initialMpNodes, ByteArray(0)))
@@ -107,7 +107,8 @@ fun toMergePlan(segments: List<ISegment>, pathPred: Predicate<ByteArray>?, tempo
                     if (recencies != null) {
                         val tempMpNodes = mutableListOf<MergePlanNode>()
                         for(i in recencies.indices.reversed()) {
-                            if (recencies[i] < minRecency) break
+                            // the recency of a bucket is non inclusive, i.e. no event in the bucket has the recency of the bucket
+                            if (recencies[i] <= minRecency) break
                             tempMpNodes += MergePlanNode(mpNode.segment, mpNode.node.recencyNode(i))
                         }
                         newMpNodes += tempMpNodes.reversed()


### PR DESCRIPTION
As per https://github.com/xtdb/xtdb/issues/3581 move from:

TemporalBounds (vf,vt,sf,st) -> TemporalColumn(lower, upper)

to

TemporalBounds(valid-time, system-time) -> TemporalDimension(lower, upper)

~For completeness, I also restate the semantics at the boundaries for the temporal dimensions and events. An event is made up of vf, vt, sf and st. vt and st are non inclusive, meaning the event ceases to exists at vt and st respectively. In particular if vf = vt or sf = st then event is non existent. The lower and upper bound of a temporal dimension are inclusive. This means an event with vf = upper and vf < vt gets included and an event with vt = lower does NOT get included. Similarly for sf and st.~

We decided to make the `upper` of `TemporalDimension(lower, upper)` non inclusive. This also means that an event intersection becomes easier as we don't have to take special care of events ending at `lower`. Both events and temporal bounds describe a rectangle where the upper bound of the two time dimensions is non inclusive. 

Todo:
- [x] ~move from `lower/upper` to `min-from, max-to`~ moved back to `lower`/`upper`
