### PR TITLE
Allow specification of full endpoints for storageaccount/service bus namespace

### DIFF
--- a/docs/src/content/docs/config/storage/azure.adoc
+++ b/docs/src/content/docs/config/storage/azure.adoc
@@ -84,17 +84,29 @@ storage: !Remote
   objectStore: !Azure
     # -- required
 
-    # The storage account which has the storage container
+    # --- At least one of storageAccount or storageAccountEndpoint is required
+
+    # The name of the storage account which has the storage container
     # (Can be set as an !Env value)
     storageAccount: storage-account
+
+    # The full endpoint of the storage account which has the storage container
+    # (Can be set as an !Env value)
+    # storageAccountEndpoint: https://storage-account.privatelink.blob.core.windows.net
     
     # The name of the blob storage container to be used as the object store
     # (Can be set as an !Env value)
     container: xtdb-container
 
-    # The service bus namespace which contains the serviceBusTopicName
+    # --- At least one of serviceBusNamespace or serviceBusNamespaceFQDN is required
+
+    # The name of the service bus namespace which contains the serviceBusTopicName
     # (Can be set as an !Env value)
     serviceBusNamespace: xtdb-service-bus
+
+    # The fully qualified domain name of the service bus namespace which contains the serviceBusTopicName
+    # (Can be set as an !Env value)
+    # serviceBusNamespaceFQDN: xtdb-service-bus.privatelink.servicebus.windows.net
 
     # The name of the service bus topic which is collecting notifications from the container
     # (Can be set as an !Env value)

--- a/docs/src/content/docs/drivers/clojure/configuration.adoc
+++ b/docs/src/content/docs/drivers/clojure/configuration.adoc
@@ -155,10 +155,14 @@ Main article: link:/config/storage/azure[Azure Blob Storage]
 {:storage [:remote
            {:object-store [:azure
                            {;; -- required
+                            ;; --- At least one of storage-account or storage-account-endpoint is required
                             :storage-account "storage-account"
+                            ;; :storage-account-endpoint "https://storage-account.privatelink.blob.core.windows.net"
                             :container "xtdb-container"
-                            :service-bus-namespace "xtdb-service-bus"
-                            :service-bus-topic-name "xtdb-service-bus-topic"
+                            ;; --- At least one of service-bus-namespace or service-bus-namespace-fqdn is required
+                            :servicebus-namespace "xtdb-service-bus"
+                            ;; :servicebus-namespace-fqdn "xtdb-service-bus.servicebus.windows.net"
+                            :servicebus-topic-name "xtdb-service-bus-topic"
 
                             ;; -- optional
 


### PR DESCRIPTION
Resolves #3586

Makes `storageAccount` and `serviceBusNamespace` optional (defaulted to `null`) and allows passing in of `storageAccountEndpoint` and `serviceBusNamespaceFQDN`. At least one of each type of parameter needs to be specified, otherwise we throw an IAE. 

Allows users to explicitly provide the relevant endpoints which will be used directly by the APIs instead of constructing endpoints/FQDNs from the passed in names.