### PR TITLE
Switch to use AKS for single node benchmark

### DIFF
--- a/cloud-benchmark/azure/terraform/.terraform.lock.hcl
+++ b/cloud-benchmark/azure/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.111.0"
   constraints = "3.111.0"
   hashes = [
+    "h1:ipFQShK0j3mtJeSgSBQDR985KzwC19913+0GkiF8Sfo=",
     "h1:vgrdy5JWGAK5N44/V75etoHIAMvXKNlMrIHTaWApehA=",
     "zh:0db8afb9278993df7e74796bdd125153b07a7045e5ca1756783a8b8cfec564f4",
     "zh:22c424fcfda13dc720caa289248c1b71b2ad20e329fd4a52cc6be7e45f795a4a",
@@ -18,5 +19,43 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:e7b3d96f0c9ea47261dbd015f1f64fdb43c8ccb196afda862c0865e30d88245c",
     "zh:f1ec7da6ab5526845274bff77e023b9faec71c2cf38bd18587274932b2aa2e89",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.32.0"
+  hashes = [
+    "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
+    "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
+    "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
+    "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
+    "zh:5344405fde7b1febf0734052052268ee24e7220818155702907d9ece1c0697c7",
+    "zh:92ee11e8c23bbac3536df7b124456407f35c6c2468bc0dbab15c3fc9f414bd0e",
+    "zh:a45488fe8d5bb59c49380f398da5d109a4ac02ebc10824567dabb87f6102fda8",
+    "zh:a4a0b57cf719a4c91f642436882b7bea24d659c08a5b6f4214ce4fe6a0204caa",
+    "zh:b7a27a6d11ba956a2d7b0f7389a46ec857ebe46ae3aeee537250e66cac15bf03",
+    "zh:bf94ce389028b686bfa70a90f536e81bb776c5c20ab70138bbe5c3d0a04c4253",
+    "zh:d965b2608da0212e26a65a0b3f33c5baae46cbe839196be15d93f70061516908",
+    "zh:f441fc793d03057a17af8bdca8b26d54916645bc5c148f54e22a54ed39089e83",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.1"
+  hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
+    "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
+    "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
+    "zh:37c92ec084d059d37d6cffdb683ccf68e3a5f8d2eb69dd73c8e43ad003ef8d24",
+    "zh:4269f01a98513651ad66763c16b268f4c2da76cc892ccfd54b401fff6cc11667",
+    "zh:51904350b9c728f963eef0c28f1d43e73d010333133eb7f30999a8fb6a0cc3d8",
+    "zh:73a66611359b83d0c3fcba2984610273f7954002febb8a57242bbb86d967b635",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ae387993a92bcc379063229b3cce8af7eaf082dd9306598fcd42352994d2de0",
+    "zh:9e0f365f807b088646db6e4a8d4b188129d9ebdbcf2568c8ab33bddd1b82c867",
+    "zh:b5263acbd8ae51c9cbffa79743fbcadcb7908057c87eb22fd9048268056efbc4",
+    "zh:dfcd88ac5f13c0d04e24be00b686d069b4879cc4add1b7b1a8ae545783d97520",
   ]
 }

--- a/cloud-benchmark/azure/terraform/main.tf
+++ b/cloud-benchmark/azure/terraform/main.tf
@@ -143,7 +143,6 @@ resource "azurerm_role_assignment" "cloud_benchmark_eventhub_receive" {
   scope                = azurerm_eventhub.cloud_benchmark.id
 }
 
-# Container App Config
 resource "azurerm_container_registry" "acr" {
   name                = "cloudbenchmarkregistry"
   resource_group_name = azurerm_resource_group.cloud_benchmark.name
@@ -152,29 +151,29 @@ resource "azurerm_container_registry" "acr" {
   admin_enabled       = true
 }
 
-resource "azurerm_container_app_environment" "cloud_benchmark" {
-  name                       = "cloud-benchmark-container-app-environment"
-  location                   = azurerm_resource_group.cloud_benchmark.location
-  resource_group_name        = azurerm_resource_group.cloud_benchmark.name
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.cloud_benchmark.id
+locals {
+  namespace            = "cloud-benchmark"
+  service_account_name = "cloud-benchmark-account"
 }
 
-## Fileshare Storage
-resource "azurerm_container_app_environment_storage" "cloud_benchmark" {
-  name                         = "app-persistent-storage"
-  container_app_environment_id = azurerm_container_app_environment.cloud_benchmark.id
-  account_name                 = azurerm_storage_account.cloud_benchmark.name
-  share_name                   = azurerm_storage_share.cloud_benchmark.name
-  access_key                   = azurerm_storage_account.cloud_benchmark.primary_access_key
-  access_mode                  = "ReadWrite"
-}
+## Kubernetes Cluster
+resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
+  count               = var.run_single_node ? 1 : 0
+  name                = "cloud-benchmark-cluster"
+  location            = "East US"
+  resource_group_name = azurerm_resource_group.cloud_benchmark.name
+  dns_prefix          = "cloud-benchmark-cluster"
 
-resource "azurerm_container_app" "cloud_benchmark_single_node" {
-  count                        = var.run_single_node ? 1 : 0
-  name                         = "cloud-benchmark-single-node"
-  resource_group_name          = azurerm_resource_group.cloud_benchmark.name
-  container_app_environment_id = azurerm_container_app_environment.cloud_benchmark.id
-  revision_mode                = "Single"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
 
   identity {
     type = "UserAssigned"
@@ -183,108 +182,186 @@ resource "azurerm_container_app" "cloud_benchmark_single_node" {
     ]
   }
 
-  registry {
-    server   = "cloudbenchmarkregistry.azurecr.io"
-    identity = azurerm_user_assigned_identity.cloud_benchmark.id
-  }
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+}
 
+resource "azurerm_role_assignment" "cloud_benchmark_cluster_role" {
+  count                            = var.run_single_node ? 1 : 0
+  principal_id                     = azurerm_kubernetes_cluster.cloud_benchmark[0].kubelet_identity[0].object_id
+  role_definition_name             = "AcrPull"
+  scope                            = azurerm_container_registry.acr.id
+  skip_service_principal_aad_check = true
+}
 
-  template {
-    max_replicas = 1
-    min_replicas = 1
+resource "azurerm_federated_identity_credential" "cloud_benchmark" {
+  count               = var.run_single_node ? 1 : 0
+  name                = "cloud-benchmark-worker"
+  resource_group_name = azurerm_resource_group.cloud_benchmark.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.cloud_benchmark[0].oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.cloud_benchmark.id
+  subject             = "system:serviceaccount:${local.namespace}:${local.service_account_name}"
+}
 
-    container {
-      image = "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
-      name  = "cloud-benchmark"
+resource "local_file" "kubeconfig" {
+  count      = var.run_single_node ? 1 : 0
+  depends_on = [azurerm_kubernetes_cluster.cloud_benchmark]
+  filename   = "kubeconfig"
+  content    = azurerm_kubernetes_cluster.cloud_benchmark[0].kube_config_raw
+}
 
-      cpu    = 2
-      memory = "4Gi"
+provider "kubernetes" {
+  config_path = local_file.kubeconfig[0].filename
+}
 
-      env {
-        name  = "AUCTIONMARK_DURATION"
-        value = var.auctionmark_duration
-      }
-
-      env {
-        name  = "AUCTIONMARK_SCALE_FACTOR"
-        value = var.auctionmark_scale_factor
-      }
-
-      env {
-        name  = "AUCTIONMARK_LOAD_PHASE"
-        value = true
-      }
-
-      env {
-        name  = "AUCTIONMARK_LOAD_PHASE_ONLY"
-        value = false
-      }
-
-      env {
-        name  = "XTDB_LOCAL_DISK_CACHE"
-        value = "/var/lib/xtdb/disk-cache/cache-1"
-      }
-
-      env {
-        name  = "XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID"
-        value = azurerm_user_assigned_identity.cloud_benchmark.client_id
-      }
-
-      env {
-        name  = "XTDB_AZURE_STORAGE_ACCOUNT"
-        value = azurerm_storage_account.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_STORAGE_CONTAINER"
-        value = azurerm_storage_container.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_SERVICE_BUS_NAMESPACE"
-        value = azurerm_servicebus_namespace.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_SERVICE_BUS_TOPIC_NAME"
-        value = azurerm_servicebus_topic.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_EVENTHUB_NAMESPACE"
-        value = azurerm_eventhub_namespace.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_EVENTHUB_NAME"
-        value = azurerm_eventhub.cloud_benchmark.name
-      }
-
-      env {
-        name  = "CLOUD_PLATFORM_NAME"
-        value = "Azure"
-      }
-
-      # env {
-      #   name = "SLACK_WEBHOOK_URL"
-      #   value = var.slack_webhook_url
-      # }
-
-      volume_mounts {
-        name = "app-persistent-storage"
-        path = "/var/lib/xtdb"
-      }
-    }
-
-    volume {
-      name         = "app-persistent-storage"
-      storage_name = azurerm_container_app_environment_storage.cloud_benchmark.name
-      storage_type = "AzureFile"
-    }
+resource "kubernetes_namespace" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name = local.namespace
   }
 }
 
-# TODO: Multi node config could probably be added here - taking inspiration 
-# from the above. Generally speaking, similar to how I'd handle in kubernetes:
-# - InitContainer that runs first which ONLY runs load phase (ie, AUCTIONMARK_LOAD_PHASE_ONLY = true)
-# - Can run a number of parallel containers that point to different local disk cache paths
+resource "kubernetes_service_account" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = local.service_account_name
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = "cloud-benchmark-pvc"
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    storage_class_name = "managed-csi"
+    resources {
+      requests = {
+        storage = "50Gi"
+      }
+    }
+  }
+
+  wait_until_bound = false
+}
+
+
+resource "kubernetes_deployment" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = "cloud-benchmark"
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "cloud-benchmark"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app                           = "cloud-benchmark"
+          "azure.workload.identity/use" = "true"
+        }
+      }
+      spec {
+        service_account_name = kubernetes_service_account.cloud_benchmark[0].metadata[0].name
+
+        container {
+          image = "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
+          name  = "cloud-benchmark"
+
+          volume_mount {
+            name = "volume"
+            mount_path = "/var/lib/xtdb"
+          }
+
+          env {
+            name  = "AUCTIONMARK_DURATION"
+            value = var.auctionmark_duration
+          }
+
+          env {
+            name  = "AUCTIONMARK_SCALE_FACTOR"
+            value = var.auctionmark_scale_factor
+          }
+
+          env {
+            name  = "AUCTIONMARK_LOAD_PHASE"
+            value = true
+          }
+
+          env {
+            name  = "AUCTIONMARK_LOAD_PHASE_ONLY"
+            value = false
+          }
+
+          env {
+            name  = "XTDB_LOCAL_DISK_CACHE"
+            value = "/var/lib/xtdb/disk-cache/cache-1"
+          }
+
+          env {
+            name  = "XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID"
+            value = azurerm_user_assigned_identity.cloud_benchmark.client_id
+          }
+
+          env {
+            name  = "XTDB_AZURE_STORAGE_ACCOUNT"
+            value = azurerm_storage_account.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_STORAGE_CONTAINER"
+            value = azurerm_storage_container.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_SERVICE_BUS_NAMESPACE"
+            value = azurerm_servicebus_namespace.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_SERVICE_BUS_TOPIC_NAME"
+            value = azurerm_servicebus_topic.cloud_benchmark.name
+          }
+
+          env {
+            name  = "KAFKA_BOOTSTRAP_SERVERS"
+            value = "${azurerm_eventhub_namespace.cloud_benchmark.name}.servicebus.windows.net:9093"
+          }
+
+          env {
+            name  = "XTDB_TOPIC_NAME"
+            value = azurerm_eventhub.cloud_benchmark.name
+          }
+
+          env {
+            name  = "CLOUD_PLATFORM_NAME"
+            value = "Azure"
+          }
+
+          env {
+            name  = "SLACK_WEBHOOK_URL"
+            value = var.slack_webhook_url
+          }
+        }
+
+        volume {
+          name = "volume"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim.cloud_benchmark[0].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use AKS instead of container apps for the single node benchmark run. One caveat is that you may need to comment out the kubernetes resources when destroying the cluster.

Closes #3592