### PR TITLE
Switch Azure auctionmark benchmark to use a single node hosted on AKS 

### DIFF
--- a/cloud-benchmark/azure/Dockerfile
+++ b/cloud-benchmark/azure/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /usr/local/lib/xtdb
 ENTRYPOINT ["java", \
     "-Dclojure.main.report=stderr", \
     "-Dlogback.configurationFile=logback.xml", \
-    "-Xmx1500m", "-Xms1500m", \
-    "-XX:MaxDirectMemorySize=2000m", \
+    "-Xmx2000m", "-Xms2000m", \
+    "-XX:MaxDirectMemorySize=1500m", \
     "-XX:MaxMetaspaceSize=500m", \
     "--add-opens=java.base/java.nio=ALL-UNNAMED", \
     "-Dio.netty.tryReflectionSetAccessible=true", \

--- a/cloud-benchmark/azure/README.adoc
+++ b/cloud-benchmark/azure/README.adoc
@@ -16,6 +16,7 @@ For local development, you will need the following:
 * To run the various scripts and commands within this folder, you will need the `az` command line tool, and to be authenticated with it.
 * `docker` available on your machine.
 * `terraform` available on your machine.
+* `kubectl` available on your machine.
 
 === Authenticating with Azure
 
@@ -50,7 +51,7 @@ It will build the local image as `xtdb-azure-bench:latest`.
 All of the config for setting up the infrastructure on Azure is handled by Terraform - and the files are within the `terraform` directory. 
 
 * The `main.tf` file contains the main configuration for the Azure resources.
-* Most of the general config that you will need to change when running auctionmark (ie, environment variables for auctionmark, node count, etc), can be edited within the `terraform.tfvars` file. 
+* Can update the names of a few things within `terraform.tfvars` - though this is not expected to change so much from the default values. The only thing that may be expected to change is the `kubernetes_vm_size` if you wish to run more than one pod/multiple nodes.
 
 Prior to deploying any of the infra using terraform, you will need to initialize the terraform directory. From the `terraform` directory:
 ```bash
@@ -77,7 +78,7 @@ To actually deploy the infra, you can run:
 terraform apply
 ```
 
-NOTE: By default - we will create all of the required Azure infrastructure, but will not create container app. See below to scale up/run the application itself.
+This will setup all of the azure resources we use and a base 
 
 == Pushing the Docker Image to Azure
 
@@ -98,60 +99,64 @@ Finally, to push the image to the Azure Container Registry, you can run:
 docker push cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench
 ```
 
-== Deploying the Container App
+== Deploying the Benchmark Containers
 
-Deploying/running the container app is as simple as updating the `terraform.tfvars` file and applying the terraform config. Within the file, you can update a number of Auctionmark/XTDB options/parameters prior to running the container app.
 
-You can either update the file and run `terraform apply` again, or you can set the parameters using the terraform CLI.
+Before trying to deploy the benchmark containers, you will need to ensure that you have the necessary permissions to deploy to the Kubernetes cluster. You can do this by running the following command:
+```
+az aks get-credentials --resource-group cloud-benchmark-resources --name cloud-benchmark-cluster
+```
 
-Ie, to run with a single node:
+This will configure your `kubectl` to use the credentials for the Kubernetes cluster. 
+
+Before deploying anything, must ensure all of the necessary pieces of config are set within the ConfigMap/match the values/names of the terraform architecture, run the following in the terraform directory:
+```
+terraform outputs
+```
+
+Ensure that the contents of the files under `kubernetes` match the values of the terraform outputs.
+
+The config for the deployments/jobs live under `kubernetes` - within these, you can set/configure any of the necessary parameters for running the image on the cluster. When ready to run a single node auctionmark job, run the following command from the base of this directory:
+```
+kubectl apply -f kubernetes/single-node-auctionmark.yaml
+```
+
+You can see the status of job creation using the following:
+```
+kubectl get jobs --namespace cloud-benchmark
+```
+
+Trail the logs of the single node run by running:
+```
+kubectl logs job.batch/xtdb-single-node-auctionmark --namespace cloud-benchmark -f
+```
+
+== Clear up between runs
+
+If you want to totally clear up data between runs, you'll want to do the following:
+
+* Clear up the job/pods
+* Empty the Azure Storage Blobs Container
+* Delete the Persistent Storage volume used by the TxLog
+* Delete the Persistent Storage volume containing the Local Disk Caches
+
+.Clear up the Workload
+
+To clear up the workload, you can do the following
 ```bash
-terraform apply -var run_single_node=true
+kubectl delete jobs xtdb-single-node-auctionmark --namespace cloud-benchmark
 ```
 
-NOTE: The `run_single_node` variable is a boolean, and will default to `false`. If you wish to destroy a running container app, ensure this is false and simply re-run `terraform apply`.
-
-=== Monitoring Logs
-
-To watch the container logs on a single node run, you can run:
-
+.Command to empty the Azure Storage Blob Container:
 ```bash
-az containerapp logs show --resource-group cloud-benchmark-resources --name cloud-benchmark-single-node  --tail 100 --format text --follow
+./clear-azure-storage.sh
 ```
 
-This will print the last 100 lines of the logs, and then follow the logs as they are printed.
+.Deleting Persistent Storage Volumes:
+You can remove the Persistent Storage volumes within the google cloud UI, but will need to be careful to ensure they are both removed from GKE and deleted within Compute Engine's storage as well. You will need to ensure any pods are closed/deleted first, and then to delete them, you can do the following:
+```bash
+kubectl delete pvc xtdb-pvc-log --namespace cloud-benchmark
+kubectl delete pvc xtdb-pvc-local-caches --namespace cloud-benchmark
+``` 
 
-
-== Clearing up resources
-
-Between runs it can be useful to entirely clear all of the persisted data from the Container App. This can be done in a few steps:
-
-=== Clearing up the Object Store
-
-To clear up _most_ of the storage used by the XTDB node, you can run the following script:
-
-```
-./scripts/clear-azure-storage.sh
-```
-
-This will delete:
-
-* The Contents of the Azure Blob Storage container.
-
-=== Clearing eventhub
-
-We cannot clear the actual contents of Azure Event Hub very easily, but if we want to reset from a relatively clean state we should be able to "bump" the topic version within `main.tf` and reapply the terraform config. This will create a new Event Hub with a new name, and the old one will be deleted.
-
-To assist with this, I've added a variable to the `terraform.tfvars` file called `eventhub_topic_suffix`. This defaults to "v1", but you can update this whenever you need to reset the Event Hub.
-
-=== Clearing up the File Share
-
-To clear up the file share contents (ie, which we mount to the app container and persist our local disk cache) is somewhat more complex within the CLI. I would recommend using the Azure Portal to do this:
-
-* Go to the Azure "Storage Browser" page.
-* Navigate to the storage account we use for azure auctionmark, `xtdbazurebenchmark`
-* Navigate to the "File Shares" section.
-* Go to `cloudbenchmarkshare`.
-* Delete the contents of the share.
-
-
+NOTE: You do not necessarily _need_ to delete all of the above between runs - you can also change the kubernetes config map to use slightly different directory names (ie, changing bucket prefix, new local-disk-cache directory, etc) to avoid conflicts between runs. 

--- a/cloud-benchmark/azure/azure-config.yaml
+++ b/cloud-benchmark/azure/azure-config.yaml
@@ -3,12 +3,8 @@
 #   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 #   topicName: !Env XTDB_TOPIC_NAME
 
-txLog: !Azure
-  namespace: !Env XTDB_AZURE_EVENTHUB_NAMESPACE
-  eventHubName: !Env XTDB_AZURE_EVENTHUB_NAME
-  maxWaitTime: PT5S
-  pollSleepDuration: PT1S
-  userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
+txLog: !Local
+  path: !Env XTDB_LOCAL_LOG_PATH
 
 storage: !Remote
   objectStore: !Azure

--- a/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cloud-benchmark"
+  labels:
+    name: "cloud-benchmark"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "xtdb-service-account"
+  namespace: "cloud-benchmark"
+---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "xtdb-pvc-log"
+  namespace: "cloud-benchmark"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "50Gi"
+  storageClassName: "managed-csi"
+---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "xtdb-pvc-local-caches"
+  namespace: "cloud-benchmark"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "50Gi"
+  storageClassName: "managed-csi"
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "xtdb-env-config"
+  namespace: "cloud-benchmark"
+data:
+  CLOUD_PLATFORM_NAME: "Azure"
+  XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID: "c76c6e6a-59e2-4172-8097-6c48d36cdb92"
+  XTDB_AZURE_STORAGE_ACCOUNT: "xtdbazurebenchmark"
+  XTDB_AZURE_STORAGE_CONTAINER: "xtdbazurebenchmarkcontainer"
+  XTDB_AZURE_SERVICE_BUS_NAMESPACE: "cloud-benchmark-eventbus"
+  XTDB_AZURE_SERVICE_BUS_TOPIC_NAME: "cloud-benchmark-servicebus-topic"
+  XTDB_LOCAL_LOG_PATH: "/var/lib/xtdb/log/local-log-1"
+  AUCTIONMARK_DURATION: "PT1H"
+  AUCTIONMARK_SCALE_FACTOR: "0.1"
+  AUCTIONMARK_LOAD_PHASE: "True"
+  AUCTIONMARK_LOAD_PHASE_ONLY: "False"
+---
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  name: "xtdb-single-node-auctionmark"
+  namespace: "cloud-benchmark"
+  labels:
+    app: "xtdb-single-node-auctionmark"
+spec:
+  completions: 1
+  parallelism: 1
+  # No retries
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: "xtdb-single-node-auctionmark"
+        azure.workload.identity/use: "true" 
+    spec:
+      serviceAccountName: "xtdb-service-account"
+      restartPolicy: "Never"
+      volumes:
+        - name: "xtdb-pvc-log-vol"
+          persistentVolumeClaim:
+            claimName: "xtdb-pvc-log"
+        - name: "xtdb-pvc-local-caches-vol"
+          persistentVolumeClaim:
+            claimName: "xtdb-pvc-local-caches"
+      containers:
+      - name: "xtdb-azure-bench-1"
+        image: "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
+        volumeMounts:
+        - mountPath: "/var/lib/xtdb/log"
+          name: "xtdb-pvc-log-vol"
+        - mountPath: "/var/lib/xtdb/buffers"
+          name: "xtdb-pvc-local-caches-vol"
+        resources:
+          requests:
+            memory: "4056Mi"
+          limits:
+            memory: "4056Mi"
+        envFrom:
+        - configMapRef:
+            name: "xtdb-env-config"
+        env:
+        - name: "XTDB_LOCAL_DISK_CACHE"
+          value: "/var/lib/xtdb/buffers/disk-cache-1"

--- a/cloud-benchmark/azure/terraform/.terraform.lock.hcl
+++ b/cloud-benchmark/azure/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.111.0"
   constraints = "3.111.0"
   hashes = [
+    "h1:ipFQShK0j3mtJeSgSBQDR985KzwC19913+0GkiF8Sfo=",
     "h1:vgrdy5JWGAK5N44/V75etoHIAMvXKNlMrIHTaWApehA=",
     "zh:0db8afb9278993df7e74796bdd125153b07a7045e5ca1756783a8b8cfec564f4",
     "zh:22c424fcfda13dc720caa289248c1b71b2ad20e329fd4a52cc6be7e45f795a4a",
@@ -18,5 +19,43 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:e7b3d96f0c9ea47261dbd015f1f64fdb43c8ccb196afda862c0865e30d88245c",
     "zh:f1ec7da6ab5526845274bff77e023b9faec71c2cf38bd18587274932b2aa2e89",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.32.0"
+  hashes = [
+    "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
+    "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
+    "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
+    "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
+    "zh:5344405fde7b1febf0734052052268ee24e7220818155702907d9ece1c0697c7",
+    "zh:92ee11e8c23bbac3536df7b124456407f35c6c2468bc0dbab15c3fc9f414bd0e",
+    "zh:a45488fe8d5bb59c49380f398da5d109a4ac02ebc10824567dabb87f6102fda8",
+    "zh:a4a0b57cf719a4c91f642436882b7bea24d659c08a5b6f4214ce4fe6a0204caa",
+    "zh:b7a27a6d11ba956a2d7b0f7389a46ec857ebe46ae3aeee537250e66cac15bf03",
+    "zh:bf94ce389028b686bfa70a90f536e81bb776c5c20ab70138bbe5c3d0a04c4253",
+    "zh:d965b2608da0212e26a65a0b3f33c5baae46cbe839196be15d93f70061516908",
+    "zh:f441fc793d03057a17af8bdca8b26d54916645bc5c148f54e22a54ed39089e83",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.1"
+  hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
+    "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
+    "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
+    "zh:37c92ec084d059d37d6cffdb683ccf68e3a5f8d2eb69dd73c8e43ad003ef8d24",
+    "zh:4269f01a98513651ad66763c16b268f4c2da76cc892ccfd54b401fff6cc11667",
+    "zh:51904350b9c728f963eef0c28f1d43e73d010333133eb7f30999a8fb6a0cc3d8",
+    "zh:73a66611359b83d0c3fcba2984610273f7954002febb8a57242bbb86d967b635",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ae387993a92bcc379063229b3cce8af7eaf082dd9306598fcd42352994d2de0",
+    "zh:9e0f365f807b088646db6e4a8d4b188129d9ebdbcf2568c8ab33bddd1b82c867",
+    "zh:b5263acbd8ae51c9cbffa79743fbcadcb7908057c87eb22fd9048268056efbc4",
+    "zh:dfcd88ac5f13c0d04e24be00b686d069b4879cc4add1b7b1a8ae545783d97520",
   ]
 }

--- a/cloud-benchmark/azure/terraform/.terraform.lock.hcl
+++ b/cloud-benchmark/azure/terraform/.terraform.lock.hcl
@@ -26,6 +26,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.32.0"
   hashes = [
     "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
+    "h1:HqeU0sZBh+2loFYqPMFx7jJamNUPEykyqJ9+CkMCYE0=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
     "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
@@ -45,6 +46,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.1"
   hashes = [
     "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
     "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",

--- a/cloud-benchmark/azure/terraform/main.tf
+++ b/cloud-benchmark/azure/terraform/main.tf
@@ -143,7 +143,6 @@ resource "azurerm_role_assignment" "cloud_benchmark_eventhub_receive" {
   scope                = azurerm_eventhub.cloud_benchmark.id
 }
 
-# Container App Config
 resource "azurerm_container_registry" "acr" {
   name                = "cloudbenchmarkregistry"
   resource_group_name = azurerm_resource_group.cloud_benchmark.name
@@ -152,29 +151,29 @@ resource "azurerm_container_registry" "acr" {
   admin_enabled       = true
 }
 
-resource "azurerm_container_app_environment" "cloud_benchmark" {
-  name                       = "cloud-benchmark-container-app-environment"
-  location                   = azurerm_resource_group.cloud_benchmark.location
-  resource_group_name        = azurerm_resource_group.cloud_benchmark.name
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.cloud_benchmark.id
+locals {
+  namespace            = "cloud-benchmark"
+  service_account_name = "cloud-benchmark-account"
 }
 
-## Fileshare Storage
-resource "azurerm_container_app_environment_storage" "cloud_benchmark" {
-  name                         = "app-persistent-storage"
-  container_app_environment_id = azurerm_container_app_environment.cloud_benchmark.id
-  account_name                 = azurerm_storage_account.cloud_benchmark.name
-  share_name                   = azurerm_storage_share.cloud_benchmark.name
-  access_key                   = azurerm_storage_account.cloud_benchmark.primary_access_key
-  access_mode                  = "ReadWrite"
-}
+## Kubernetes Cluster
+resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
+  count               = var.run_single_node ? 1 : 0
+  name                = "cloud-benchmark-cluster"
+  location            = "East US"
+  resource_group_name = azurerm_resource_group.cloud_benchmark.name
+  dns_prefix          = "cloud-benchmark-cluster"
 
-resource "azurerm_container_app" "cloud_benchmark_single_node" {
-  count                        = var.run_single_node ? 1 : 0
-  name                         = "cloud-benchmark-single-node"
-  resource_group_name          = azurerm_resource_group.cloud_benchmark.name
-  container_app_environment_id = azurerm_container_app_environment.cloud_benchmark.id
-  revision_mode                = "Single"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
 
   identity {
     type = "UserAssigned"
@@ -183,108 +182,186 @@ resource "azurerm_container_app" "cloud_benchmark_single_node" {
     ]
   }
 
-  registry {
-    server   = "cloudbenchmarkregistry.azurecr.io"
-    identity = azurerm_user_assigned_identity.cloud_benchmark.id
-  }
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+}
 
+resource "azurerm_role_assignment" "cloud_benchmark_cluster_role" {
+  count                            = var.run_single_node ? 1 : 0
+  principal_id                     = azurerm_kubernetes_cluster.cloud_benchmark[0].kubelet_identity[0].object_id
+  role_definition_name             = "AcrPull"
+  scope                            = azurerm_container_registry.acr.id
+  skip_service_principal_aad_check = true
+}
 
-  template {
-    max_replicas = 1
-    min_replicas = 1
+resource "azurerm_federated_identity_credential" "cloud_benchmark" {
+  count               = var.run_single_node ? 1 : 0
+  name                = "cloud-benchmark-worker"
+  resource_group_name = azurerm_resource_group.cloud_benchmark.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.cloud_benchmark[0].oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.cloud_benchmark.id
+  subject             = "system:serviceaccount:${local.namespace}:${local.service_account_name}"
+}
 
-    container {
-      image = "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
-      name  = "cloud-benchmark"
+resource "local_file" "kubeconfig" {
+  count      = var.run_single_node ? 1 : 0
+  depends_on = [azurerm_kubernetes_cluster.cloud_benchmark]
+  filename   = "kubeconfig"
+  content    = azurerm_kubernetes_cluster.cloud_benchmark[0].kube_config_raw
+}
 
-      cpu    = 2
-      memory = "4Gi"
+provider "kubernetes" {
+  config_path = local_file.kubeconfig[0].filename
+}
 
-      env {
-        name  = "AUCTIONMARK_DURATION"
-        value = var.auctionmark_duration
-      }
-
-      env {
-        name  = "AUCTIONMARK_SCALE_FACTOR"
-        value = var.auctionmark_scale_factor
-      }
-
-      env {
-        name  = "AUCTIONMARK_LOAD_PHASE"
-        value = true
-      }
-
-      env {
-        name  = "AUCTIONMARK_LOAD_PHASE_ONLY"
-        value = false
-      }
-
-      env {
-        name  = "XTDB_LOCAL_DISK_CACHE"
-        value = "/var/lib/xtdb/disk-cache/cache-1"
-      }
-
-      env {
-        name  = "XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID"
-        value = azurerm_user_assigned_identity.cloud_benchmark.client_id
-      }
-
-      env {
-        name  = "XTDB_AZURE_STORAGE_ACCOUNT"
-        value = azurerm_storage_account.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_STORAGE_CONTAINER"
-        value = azurerm_storage_container.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_SERVICE_BUS_NAMESPACE"
-        value = azurerm_servicebus_namespace.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_SERVICE_BUS_TOPIC_NAME"
-        value = azurerm_servicebus_topic.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_EVENTHUB_NAMESPACE"
-        value = azurerm_eventhub_namespace.cloud_benchmark.name
-      }
-
-      env {
-        name  = "XTDB_AZURE_EVENTHUB_NAME"
-        value = azurerm_eventhub.cloud_benchmark.name
-      }
-
-      env {
-        name  = "CLOUD_PLATFORM_NAME"
-        value = "Azure"
-      }
-
-      # env {
-      #   name = "SLACK_WEBHOOK_URL"
-      #   value = var.slack_webhook_url
-      # }
-
-      volume_mounts {
-        name = "app-persistent-storage"
-        path = "/var/lib/xtdb"
-      }
-    }
-
-    volume {
-      name         = "app-persistent-storage"
-      storage_name = azurerm_container_app_environment_storage.cloud_benchmark.name
-      storage_type = "AzureFile"
-    }
+resource "kubernetes_namespace" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name = local.namespace
   }
 }
 
-# TODO: Multi node config could probably be added here - taking inspiration 
-# from the above. Generally speaking, similar to how I'd handle in kubernetes:
-# - InitContainer that runs first which ONLY runs load phase (ie, AUCTIONMARK_LOAD_PHASE_ONLY = true)
-# - Can run a number of parallel containers that point to different local disk cache paths
+resource "kubernetes_service_account" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = local.service_account_name
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = "cloud-benchmark-pvc"
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    storage_class_name = "managed-csi"
+    resources {
+      requests = {
+        storage = "50Gi"
+      }
+    }
+  }
+
+  wait_until_bound = false
+}
+
+
+resource "kubernetes_deployment" "cloud_benchmark" {
+  count = var.run_single_node ? 1 : 0
+  metadata {
+    name      = "cloud-benchmark"
+    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "cloud-benchmark"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app                           = "cloud-benchmark"
+          "azure.workload.identity/use" = "true"
+        }
+      }
+      spec {
+        service_account_name = kubernetes_service_account.cloud_benchmark[0].metadata[0].name
+
+        container {
+          image = "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
+          name  = "cloud-benchmark"
+
+          volume_mount {
+            name = "volume"
+            mount_path = "/var/lib/xtdb"
+          }
+
+          env {
+            name  = "AUCTIONMARK_DURATION"
+            value = var.auctionmark_duration
+          }
+
+          env {
+            name  = "AUCTIONMARK_SCALE_FACTOR"
+            value = var.auctionmark_scale_factor
+          }
+
+          env {
+            name  = "AUCTIONMARK_LOAD_PHASE"
+            value = true
+          }
+
+          env {
+            name  = "AUCTIONMARK_LOAD_PHASE_ONLY"
+            value = false
+          }
+
+          env {
+            name  = "XTDB_LOCAL_DISK_CACHE"
+            value = "/var/lib/xtdb/disk-cache/cache-1"
+          }
+
+          env {
+            name  = "XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID"
+            value = azurerm_user_assigned_identity.cloud_benchmark.client_id
+          }
+
+          env {
+            name  = "XTDB_AZURE_STORAGE_ACCOUNT"
+            value = azurerm_storage_account.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_STORAGE_CONTAINER"
+            value = azurerm_storage_container.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_SERVICE_BUS_NAMESPACE"
+            value = azurerm_servicebus_namespace.cloud_benchmark.name
+          }
+
+          env {
+            name  = "XTDB_AZURE_SERVICE_BUS_TOPIC_NAME"
+            value = azurerm_servicebus_topic.cloud_benchmark.name
+          }
+
+          env {
+            name  = "KAFKA_BOOTSTRAP_SERVERS"
+            value = "${azurerm_eventhub_namespace.cloud_benchmark.name}.servicebus.windows.net:9093"
+          }
+
+          env {
+            name  = "XTDB_TOPIC_NAME"
+            value = azurerm_eventhub.cloud_benchmark.name
+          }
+
+          env {
+            name  = "CLOUD_PLATFORM_NAME"
+            value = "Azure"
+          }
+
+          env {
+            name  = "SLACK_WEBHOOK_URL"
+            value = var.slack_webhook_url
+          }
+        }
+
+        volume {
+          name = "volume"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim.cloud_benchmark[0].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/cloud-benchmark/azure/terraform/main.tf
+++ b/cloud-benchmark/azure/terraform/main.tf
@@ -28,14 +28,6 @@ resource "azurerm_storage_container" "cloud_benchmark" {
   container_access_type = "private"
 }
 
-# Fileshare Configuration
-
-resource "azurerm_storage_share" "cloud_benchmark" {
-  name                 = "cloudbenchmarkshare"
-  storage_account_name = azurerm_storage_account.cloud_benchmark.name
-  quota                = 50
-}
-
 # Service Bus Setup
 resource "azurerm_eventgrid_system_topic" "cloud_benchmark" {
   name                = "cloud-benchmark-system-topic"
@@ -65,24 +57,6 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "cloud_benchmark" {
   resource_group_name           = azurerm_resource_group.cloud_benchmark.name
   event_delivery_schema         = "EventGridSchema"
   service_bus_topic_endpoint_id = azurerm_servicebus_topic.cloud_benchmark.id
-}
-
-# Event Hub Configuration
-
-resource "azurerm_eventhub_namespace" "cloud_benchmark" {
-  name                = "cloud-benchmark-eventhub-namespace"
-  location            = azurerm_resource_group.cloud_benchmark.location
-  resource_group_name = azurerm_resource_group.cloud_benchmark.name
-  sku                 = "Standard"
-  capacity            = 1
-}
-
-resource "azurerm_eventhub" "cloud_benchmark" {
-  name                = "cloud-benchmark-eventhub-topic-${var.eventhub_topic_suffix}"
-  namespace_name      = azurerm_eventhub_namespace.cloud_benchmark.name
-  resource_group_name = azurerm_resource_group.cloud_benchmark.name
-  partition_count     = 1
-  message_retention   = 7
 }
 
 # Metrics Config
@@ -131,18 +105,6 @@ resource "azurerm_role_assignment" "cloud_benchmark_servicebus_contributor" {
   scope                = azurerm_servicebus_namespace.cloud_benchmark.id
 }
 
-resource "azurerm_role_assignment" "cloud_benchmark_eventhub_send" {
-  principal_id         = azurerm_user_assigned_identity.cloud_benchmark.principal_id
-  role_definition_name = "Azure Event Hubs Data Sender"
-  scope                = azurerm_eventhub.cloud_benchmark.id
-}
-
-resource "azurerm_role_assignment" "cloud_benchmark_eventhub_receive" {
-  principal_id         = azurerm_user_assigned_identity.cloud_benchmark.principal_id
-  role_definition_name = "Azure Event Hubs Data Receiver"
-  scope                = azurerm_eventhub.cloud_benchmark.id
-}
-
 resource "azurerm_container_registry" "acr" {
   name                = "cloudbenchmarkregistry"
   resource_group_name = azurerm_resource_group.cloud_benchmark.name
@@ -151,14 +113,8 @@ resource "azurerm_container_registry" "acr" {
   admin_enabled       = true
 }
 
-locals {
-  namespace            = "cloud-benchmark"
-  service_account_name = "cloud-benchmark-account"
-}
-
 ## Kubernetes Cluster
 resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
-  count               = var.run_single_node ? 1 : 0
   name                = "cloud-benchmark-cluster"
   location            = "East US"
   resource_group_name = azurerm_resource_group.cloud_benchmark.name
@@ -187,181 +143,37 @@ resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
 }
 
 resource "azurerm_role_assignment" "cloud_benchmark_cluster_role" {
-  count                            = var.run_single_node ? 1 : 0
-  principal_id                     = azurerm_kubernetes_cluster.cloud_benchmark[0].kubelet_identity[0].object_id
+  principal_id                     = azurerm_kubernetes_cluster.cloud_benchmark.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"
   scope                            = azurerm_container_registry.acr.id
   skip_service_principal_aad_check = true
 }
 
 resource "azurerm_federated_identity_credential" "cloud_benchmark" {
-  count               = var.run_single_node ? 1 : 0
   name                = "cloud-benchmark-worker"
   resource_group_name = azurerm_resource_group.cloud_benchmark.name
   audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.cloud_benchmark[0].oidc_issuer_url
+  issuer              = azurerm_kubernetes_cluster.cloud_benchmark.oidc_issuer_url
   parent_id           = azurerm_user_assigned_identity.cloud_benchmark.id
-  subject             = "system:serviceaccount:${local.namespace}:${local.service_account_name}"
+  subject             = "system:serviceaccount:${var.kubernetes_namespace}:${var.kubernetes_service_account_name}"
 }
 
-resource "local_file" "kubeconfig" {
-  count      = var.run_single_node ? 1 : 0
-  depends_on = [azurerm_kubernetes_cluster.cloud_benchmark]
-  filename   = "kubeconfig"
-  content    = azurerm_kubernetes_cluster.cloud_benchmark[0].kube_config_raw
+output "user_managed_identity_client_id" {
+  value = azurerm_user_assigned_identity.cloud_benchmark.client_id
 }
 
-provider "kubernetes" {
-  config_path = local_file.kubeconfig[0].filename
+output "storage_account_name" {
+  value = azurerm_storage_account.cloud_benchmark.name
 }
 
-resource "kubernetes_namespace" "cloud_benchmark" {
-  count = var.run_single_node ? 1 : 0
-  metadata {
-    name = local.namespace
-  }
+output "storage_account_container" {
+  value = azurerm_storage_container.cloud_benchmark.name
 }
 
-resource "kubernetes_service_account" "cloud_benchmark" {
-  count = var.run_single_node ? 1 : 0
-  metadata {
-    name      = local.service_account_name
-    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
-  }
+output "service_bus_namespace" {
+  value = azurerm_servicebus_namespace.cloud_benchmark.name
 }
 
-resource "kubernetes_persistent_volume_claim" "cloud_benchmark" {
-  count = var.run_single_node ? 1 : 0
-  metadata {
-    name      = "cloud-benchmark-pvc"
-    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
-  }
-
-  spec {
-    access_modes = ["ReadWriteOnce"]
-    storage_class_name = "managed-csi"
-    resources {
-      requests = {
-        storage = "50Gi"
-      }
-    }
-  }
-
-  wait_until_bound = false
-}
-
-
-resource "kubernetes_deployment" "cloud_benchmark" {
-  count = var.run_single_node ? 1 : 0
-  metadata {
-    name      = "cloud-benchmark"
-    namespace = kubernetes_namespace.cloud_benchmark[0].metadata[0].name
-  }
-
-  spec {
-    replicas = 1
-    selector {
-      match_labels = {
-        app = "cloud-benchmark"
-      }
-    }
-    template {
-      metadata {
-        labels = {
-          app                           = "cloud-benchmark"
-          "azure.workload.identity/use" = "true"
-        }
-      }
-      spec {
-        service_account_name = kubernetes_service_account.cloud_benchmark[0].metadata[0].name
-
-        container {
-          image = "cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest"
-          name  = "cloud-benchmark"
-
-          volume_mount {
-            name = "volume"
-            mount_path = "/var/lib/xtdb"
-          }
-
-          env {
-            name  = "AUCTIONMARK_DURATION"
-            value = var.auctionmark_duration
-          }
-
-          env {
-            name  = "AUCTIONMARK_SCALE_FACTOR"
-            value = var.auctionmark_scale_factor
-          }
-
-          env {
-            name  = "AUCTIONMARK_LOAD_PHASE"
-            value = true
-          }
-
-          env {
-            name  = "AUCTIONMARK_LOAD_PHASE_ONLY"
-            value = false
-          }
-
-          env {
-            name  = "XTDB_LOCAL_DISK_CACHE"
-            value = "/var/lib/xtdb/disk-cache/cache-1"
-          }
-
-          env {
-            name  = "XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID"
-            value = azurerm_user_assigned_identity.cloud_benchmark.client_id
-          }
-
-          env {
-            name  = "XTDB_AZURE_STORAGE_ACCOUNT"
-            value = azurerm_storage_account.cloud_benchmark.name
-          }
-
-          env {
-            name  = "XTDB_AZURE_STORAGE_CONTAINER"
-            value = azurerm_storage_container.cloud_benchmark.name
-          }
-
-          env {
-            name  = "XTDB_AZURE_SERVICE_BUS_NAMESPACE"
-            value = azurerm_servicebus_namespace.cloud_benchmark.name
-          }
-
-          env {
-            name  = "XTDB_AZURE_SERVICE_BUS_TOPIC_NAME"
-            value = azurerm_servicebus_topic.cloud_benchmark.name
-          }
-
-          env {
-            name  = "KAFKA_BOOTSTRAP_SERVERS"
-            value = "${azurerm_eventhub_namespace.cloud_benchmark.name}.servicebus.windows.net:9093"
-          }
-
-          env {
-            name  = "XTDB_TOPIC_NAME"
-            value = azurerm_eventhub.cloud_benchmark.name
-          }
-
-          env {
-            name  = "CLOUD_PLATFORM_NAME"
-            value = "Azure"
-          }
-
-          env {
-            name  = "SLACK_WEBHOOK_URL"
-            value = var.slack_webhook_url
-          }
-        }
-
-        volume {
-          name = "volume"
-          persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim.cloud_benchmark[0].metadata[0].name
-          }
-        }
-      }
-    }
-  }
+output "service_bus_topic" {
+  value = azurerm_servicebus_topic.cloud_benchmark.name
 }

--- a/cloud-benchmark/azure/terraform/terraform.tfvars
+++ b/cloud-benchmark/azure/terraform/terraform.tfvars
@@ -1,8 +1,3 @@
-# Auctionmark Params
-auctionmark_duration     = "PT10M"
-auctionmark_scale_factor = 0.1
-
-# Deployment Options
-eventhub_topic_suffix = "v1"
-run_single_node   = false # no deployment by default
-slack_webhook_url = ""
+kubernetes_namespace            = "cloud-benchmark"
+kubernetes_service_account_name = "xtdb-service-account"
+kubernetes_vm_size              = "Standard_D2_v2"

--- a/cloud-benchmark/azure/terraform/variables.tf
+++ b/cloud-benchmark/azure/terraform/variables.tf
@@ -1,25 +1,17 @@
-variable "slack_webhook_url" {
-  description = "The URL of the Slack webhook to send notifications to"
+variable "kubernetes_namespace" {
+  description = "The namespace to deploy the Kubernetes cluster into"
   type        = string
-  sensitive   = true
+  default     = "cloud-benchmark"
 }
 
-variable "auctionmark_duration" {
-  description = "The duration of the auctionmark test"
+variable "kubernetes_service_account_name" {
+  description = "The name of the service account to create for the Kubernetes cluster"
   type        = string
+  default     = "xtdb-service-account"
 }
 
-variable "auctionmark_scale_factor" {
-  description = "The scale factor of the auctionmark test"
-  type        = number
-}
-
-variable "eventhub_topic_suffix" {
-  description = "String to suffix the eventhub topic with - update whenever you want to create a new topic"
+variable "kubernetes_vm_size" {
+  description = "The size of the Kubernetes VMs - update as necessary to scale"
   type        = string
-}
-
-variable "run_single_node" {
-  description = "Whether to run a single node deployment"
-  type        = bool
+  default     = "Standard_D2_v2"
 }


### PR DESCRIPTION
Resolves #3592

Switches our Azure auctionmark setup to be somewhat more similar to the google cloud one - primarily to make use of AKS and the (hopefully) more resilient Azure Disk volumes:
- Similar to google cloud - we use terraform to provision relevant service account config & the kubernetes cluster + node pools.
- Actual deployment config pulled out to it's own folder under `kubernetes`.
- Using persistent volume claims to create storage using Azure Disk.
- Switched node back to `local` txLog - at least for now.
  - Remove eventhub config within here.
  - Planning to run sample kafka on kubernetes as well.
- Node is set up as a kubernetes `job` - so will run once and then stop rather than constantly restarting.
- Updated all the relevant setup instructions.  

