### PR TITLE
Enable custom logging settings when running Docker image

### DIFF
--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -2,6 +2,7 @@
 
 == Building a local image for testing
 
+* Make sure to install docker buildx (`docker-buildx` package in Arch Linux)
 * Make sure your Docker daemon is running
 * `./bin/build-standalone-image.sh [--clean]` will build and tag as `xtdb-standalone-ea:latest`, and load it into your images list. The `--clean` flag can be used to ensure the xtdb uberjar is rebuilt.
 * To run: `docker run -ti --rm -p -p 3000:3000 xtdb-standalone-ea:latest` (this will run the server, exposing port 3000)

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /usr/local/lib/xtdb
 
 ENTRYPOINT ["java", \
     "-Dclojure.main.report=stderr", \
-    "-Dlogback.configurationFile=logback.xml", \
     "--add-opens=java.base/java.nio=ALL-UNNAMED", \
     "-Dio.netty.tryReflectionSetAccessible=true", \
     "-cp","xtdb-standalone.jar", \

--- a/docker/standalone/src/main/resources/logback.xml
+++ b/docker/standalone/src/main/resources/logback.xml
@@ -14,4 +14,6 @@
     <logger name="kafka" level="ERROR" />
     <logger name="org.apache.arrow" level="WARN" />
     <logger name="org.eclipse.jetty" level="WARN" />
+
+    <include optional="true" file="/config/logback_include.xml" />
 </configuration>


### PR DESCRIPTION
For example: create file in current directory `xtdb-logback-include.xml`, with contents:

```
<included>
    <root level="DEBUG">
        <appender-ref ref="STDOUT" />
    </root>
</included>
```

Run:
```
docker run --tty --interactive --publish 6543:3000 --publish 5434:5432 --volume .:/usr/local/lib/xtdb/config  ghcr.io/xtdb/xtdb-standalone-ea
```