### PR TITLE
First-class periods

### DIFF
--- a/api/src/main/kotlin/xtdb/types/ZonedDateTimeRange.kt
+++ b/api/src/main/kotlin/xtdb/types/ZonedDateTimeRange.kt
@@ -1,0 +1,5 @@
+package xtdb.types
+
+import java.time.ZonedDateTime
+
+data class ZonedDateTimeRange(val from: ZonedDateTime, val to: ZonedDateTime?)

--- a/api/src/main/resources/data_readers.clj
+++ b/api/src/main/resources/data_readers.clj
@@ -15,6 +15,7 @@
  xt/interval-ym xtdb.serde/interval-ym-reader
  xt/interval-dt xtdb.serde/interval-dt-reader
  xt/interval-mdn xtdb.serde/interval-mdn-reader
+ xt/tstz-range xtdb.serde/tstz-range-reader
 
  xt.tx/sql xtdb.serde/sql-op-reader
  xt.tx/xtql xtdb.serde/xtql-reader

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -703,7 +703,7 @@ periodPredicand
     | 'PERIOD' '(' periodStartValue ',' periodEndValue ')' # PeriodValueConstructor
     ;
 
-periodColumnName : 'VALID_TIME' | 'SYSTEM_TIME' ;
+periodColumnName : '_VALID_TIME' | '_SYSTEM_TIME' ;
 periodStartValue : numericExpr ;
 periodEndValue : numericExpr ;
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -230,7 +230,7 @@
 
 (def ^:private col-type->rw-fn
   '{:bool Boolean, :i8 Byte, :i16 Short, :i32 Int, :i64 Long, :f32 Float, :f64 Double,
-    :time-local Long, :timestamp-tz Long, :timestamp-local Long, :duration Long
+    :time-local Long, :timestamp-tz Long, :timestamp-local Long, :duration Long, :tstz-range Object
     :utf8 Bytes, :varbinary Bytes, :keyword Bytes, :uuid Bytes, :uri Bytes
 
     :list Object, :set Object, :struct Object :transit Object})
@@ -239,7 +239,7 @@
 (defmethod write-value-code :null [_ w & _args] `(.writeNull ~w))
 
 (doseq [k [:bool :i8 :i16 :i32 :i64 :f32 :f64
-           :timestamp-tz :timestamp-local :time-local :duration
+           :timestamp-tz :timestamp-local :time-local :duration :tstz-range
            :utf8 :varbinary :uuid :uri :keyword :transit]
         :let [rw-fn (col-type->rw-fn k)]]
   (defmethod read-value-code k [_ & args] `(~(symbol (str ".read" rw-fn)) ~@args))

--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -1665,10 +1665,10 @@
 
 (doseq [[pred-name pred-sym] [[:contains `temporal-contains?]
                               [:strictly_contains `temporal-strictly-contains?]
-                              [:overlaps? `overlaps?]
+                              [:overlaps `overlaps?]
                               [:strictly_overlaps `strictly-overlaps?]
-                              [:equals? `equals?]
-                              [:precedes? `precedes?]
+                              [:equals `equals?]
+                              [:precedes `precedes?]
                               [:strictly_precedes `strictly-precedes?]
                               [:immediately_precedes `immediately-precedes?]
                               [:succeeds `succeeds?]

--- a/core/src/main/clojure/xtdb/log/watcher.clj
+++ b/core/src/main/clojure/xtdb/log/watcher.clj
@@ -43,7 +43,11 @@
                         (with-open [tx-ops-ch (util/->seekable-byte-channel (.getRecord record))
                                     sr (ArrowStreamReader. tx-ops-ch allocator)
                                     tx-root (.getVectorSchemaRoot sr)]
-                          (.loadNextBatch sr)
+                          (try
+                            (.loadNextBatch sr)
+                            (catch Throwable t
+                              (prn (.getSchema tx-root))
+                              (throw t)))
 
                           (let [^TimeStampMicroTZVector system-time-vec (.getVector tx-root "system-time")
                                 record-tx (.getTxKey record)

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -89,8 +89,7 @@
                 ^Set field-set (.computeIfAbsent field-sets k-sym (reify Function (apply [_ _] (HashSet.))))]
             (case (:op expr)
               :literal (do
-                         (.add field-set (let [arrow-type (vw/value->arrow-type v)]
-                                           (types/->field-default-name arrow-type (nil? v) nil)))
+                         (.add field-set (types/col-type->field (vw/value->col-type v)))
                          (.put out-row k v))
 
               :param (let [{:keys [param]} expr]

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -10,7 +10,7 @@
             [xtdb.types :as types]
             [xtdb.util :as util])
   (:import clojure.lang.MapEntry
-           (java.time Duration LocalDate LocalDateTime LocalTime OffsetTime Period ZoneId ZoneOffset ZonedDateTime)
+           (java.time Duration LocalDate LocalDateTime LocalTime OffsetTime Period ZoneOffset ZonedDateTime)
            (java.util Collection HashMap HashSet LinkedHashSet List Map SequencedSet Set UUID)
            java.util.function.Function
            (org.antlr.v4.runtime BaseErrorListener CharStreams CommonTokenStream ParserRuleContext Recognizer)
@@ -817,6 +817,12 @@
     (catch Exception e
       (add-err! env (->CannotParseDuration d-str (.getMessage e))))))
 
+(defn- <-period-literal [expr]
+  (when (and (seq? expr)
+             (= 'period (first expr))
+             (= 3 (count expr)))
+    (rest expr)))
+
 (defrecord CannotParseUUID [u-str msg]
   PlanError
   (error-string [_] (format "Cannot parse UUID: %s - failed with message %s" u-str msg)))
@@ -1269,78 +1275,102 @@
   (visitPeriodOverlapsPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (and (< ~(:from p1) (coalesce ~(:to p2) xtdb/end-of-time))
-            (> (coalesce ~(:to p1) xtdb/end-of-time) ~(:from p2))))))
+      (or (when-let [[f1 t1] (<-period-literal p1)]
+            (when-let [[f2 t2] (<-period-literal p2)]
+              (xt/template
+               (and (< ~f1 (coalesce ~t2 xtdb/end-of-time))
+                    (> (coalesce ~t1 xtdb/end-of-time) ~f2)))))
+          (xt/template (overlaps? ~p1 ~p2)))))
 
   (visitOverlapsFunction [this ctx]
-    (let [exprs (mapv #(.accept ^ParserRuleContext % this) (.periodPredicand ctx))]
+    ;; HACK assumes all are period literals for now, won't be able to do this with first-class periods
+    (let [exprs (mapv (comp <-period-literal #(.accept ^ParserRuleContext % this)) (.periodPredicand ctx))]
       (xt/template
-       (< (greatest ~@(map :from exprs))
-          (least ~@(for [{:keys [to]} exprs]
-                     (xt/template (coalesce ~to xtdb/end-of-time))))))))
+       (< (greatest ~@(map first exprs))
+          (least ~@(map (fn [[_ to]]
+                          (xt/template (coalesce ~to xtdb/end-of-time)))
+                        exprs))))))
 
   (visitPeriodEqualsPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (and (= ~(:from p1) ~(:from p2))
-            (null-eq ~(:to p1) ~(:to p2))))))
+      (or (when-let [[f1 t1] (<-period-literal p1)]
+            (when-let [[f2 t2] (<-period-literal p2)]
+              (xt/template
+               (and (= ~f1 ~f2)
+                    (null-eq ~t1 ~t2)))))
+          (xt/template (equals? ~p1 ~p2)))))
 
   (visitPeriodContainsPeriodPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (and (<= ~(:from p1) ~(:from p2))
-            (>= (coalesce ~(:to p1) xtdb/end-of-time)
-                (coalesce ~(:to p2) xtdb/end-of-time))))))
+      (or (when-let [[f1 t1] (<-period-literal p1)]
+            (when-let [[f2 t2] (<-period-literal p2)]
+              (xt/template
+               (and (<= ~f1 ~f2)
+                    (>= (coalesce ~t1 xtdb/end-of-time)
+                        (coalesce ~t2 xtdb/end-of-time))))))
+          (xt/template (contains? ~p1 ~p2)))))
 
   (visitPeriodContainsPointPredicate [this ctx]
     (let [period (-> (.periodPredicand ctx) (.accept this))
           pit (-> (.pointInTimePredicand ctx) (.accept this))]
-      ;; TODO this currently duplicates the expr, but emitting a `let`
-      ;; probably won't get optimised into scan preds
-      (xt/template
-       (and (<= ~(:from period) ~pit)
-            (> (coalesce ~(:to period) xtdb/end-of-time) ~pit)))))
+      (when-let [[from to] (<-period-literal period)]
+        ;; TODO this currently duplicates the expr, but emitting a `let`
+        ;; probably won't get optimised into scan preds
+        (xt/template
+         (and (<= ~from ~pit)
+              (> (coalesce ~to xtdb/end-of-time) ~pit))))))
 
   (visitPeriodPrecedesPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (<= (coalesce ~(:to p1) xtdb/end-of-time) ~(:from p2)))))
+      (or (when-let [[_ t1] (<-period-literal p1)]
+            (when-let [[f2 _] (<-period-literal p2)]
+              (xt/template
+               (<= (coalesce ~t1 xtdb/end-of-time) ~f2))))
+          (xt/template (precedes? ~p1 ~p2)))))
 
   (visitPeriodSucceedsPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (>= ~(:from p1) (coalesce ~(:to p2) xtdb/end-of-time)))))
+      (or (when-let [[f1 _t1] (<-period-literal p1)]
+            (when-let [[_f2 t2] (<-period-literal p2)]
+              (xt/template
+               (>= ~f1 (coalesce ~t2 xtdb/end-of-time)))))
+          (xt/template (succeeds? ~p1 ~p2)))))
 
   (visitPeriodImmediatelyPrecedesPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (= (coalesce ~(:to p1) xtdb/end-of-time) ~(:from p2)))))
+      (or (when-let [[_f1 t1] (<-period-literal p1)]
+            (when-let [[f2 _t2] (<-period-literal p2)]
+              (xt/template
+               (= (coalesce ~t1 xtdb/end-of-time) ~f2))))
+          (xt/template (immediately-precedes? ~p1 ~p2)))))
 
   (visitPeriodImmediatelySucceedsPredicate [this ctx]
     (let [p1 (-> (.periodPredicand ctx 0) (.accept this))
           p2 (-> (.periodPredicand ctx 1) (.accept this))]
-      (xt/template
-       (= ~(:from p1) (coalesce ~(:to p2) xtdb/end-of-time)))))
+      (or (when-let [[f1 _t1] (<-period-literal p1)]
+            (when-let [[_f2 t2] (<-period-literal p2)]
+              (xt/template
+               (= ~f1 (coalesce ~t2 xtdb/end-of-time)))))
+          (xt/template (immediately-succeeds? ~p1 ~p2)))))
 
   (visitPeriodColumnReference [_ ctx]
     (let [tn (identifier-sym (.tableName ctx))
           pcn (-> (.periodColumnName ctx) (.getText) (str/upper-case))]
       (case pcn
-        "VALID_TIME" {:from (find-decl scope ['xt$valid_from tn])
-                      :to (find-decl scope ['xt$valid_to tn])}
-        "SYSTEM_TIME" {:from (find-decl scope ['xt$system_from tn])
-                       :to (find-decl scope ['xt$system_to tn])})))
+        "_VALID_TIME" (xt/template (period ~(find-decl scope ['xt$valid_from tn])
+                                           ~(find-decl scope ['xt$valid_to tn])))
+        "_SYSTEM_TIME" (xt/template (period ~(find-decl scope ['xt$system_from tn])
+                                            ~(find-decl scope ['xt$system_to tn]))))))
 
   (visitPeriodValueConstructor [this ctx]
-    (let [sv (some-> (.periodStartValue ctx) (.numericExpr) (.accept this))
-          ev (some-> (.periodEndValue ctx) (.numericExpr) (.accept this))]
-      {:from sv :to ev}))
+    (xt/template
+     (period ~(some-> (.periodStartValue ctx) (.numericExpr) (.accept this))
+             ~(some-> (.periodEndValue ctx) (.numericExpr) (.accept this)))))
 
   (visitPointInTimePredicand [this ctx] (.accept (.numericExpr ctx) this))
 
@@ -1375,15 +1405,18 @@
                          vector))))
 
   (visitRangeBinsFunction [this ctx]
-    (let [{:keys [from to]} (-> (.rangeBinsSource ctx) .periodPredicand (.accept this))]
-      (xt/template
-       (range-bins ~(-> (.intervalLiteral ctx) (.accept this))
-                   ~from
-                   ~to
-                   ~@(some-> (.dateBinOrigin ctx)
-                             .expr
-                             (.accept this)
-                             vector)))))
+    (let [p (-> (.rangeBinsSource ctx) .periodPredicand (.accept this))]
+      (if-let [[from to] (<-period-literal p)]
+        (xt/template
+         (range-bins ~(-> (.intervalLiteral ctx) (.accept this))
+                     ~from
+                     ~to
+                     ~@(some-> (.dateBinOrigin ctx)
+                               .expr
+                               (.accept this)
+                               vector)))
+
+        (throw (UnsupportedOperationException. "TODO")))))
 
   (visitAgeFunction [this ctx]
     (let [ve1 (-> (.expr ctx 0) (.accept this))

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -12,7 +12,7 @@
            (org.apache.arrow.vector PeriodDuration ValueVector VectorSchemaRoot)
            (org.apache.arrow.vector.types.pojo Field FieldType)
            xtdb.Types
-           (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
+           (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalYearMonth ZonedDateTimeRange)
            (xtdb.vector FieldVectorWriters IRelationWriter IVectorReader IVectorWriter RelationReader RelationWriter RootWriter)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -86,6 +86,9 @@
 
   IntervalMonthDayNano
   (value->col-type [_] [:interval :month-day-nano])
+
+  ZonedDateTimeRange
+  (value->col-type [_] :tstz-range)
 
   PeriodDuration
   (value->col-type [_] [:interval :month-day-nano]))

--- a/core/src/main/kotlin/xtdb/Types.kt
+++ b/core/src/main/kotlin/xtdb/Types.kt
@@ -17,10 +17,7 @@ import org.apache.arrow.vector.types.Types.MinorType
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeVisitor
 import org.apache.arrow.vector.types.pojo.FieldType
-import xtdb.types.ClojureForm
-import xtdb.types.IntervalDayTime
-import xtdb.types.IntervalMonthDayNano
-import xtdb.types.IntervalYearMonth
+import xtdb.types.*
 import xtdb.vector.extensions.*
 import java.math.BigDecimal
 import java.net.URI
@@ -88,6 +85,7 @@ fun ArrowType.toLeg() = accept(object : ArrowTypeVisitor<String> {
         is UuidType -> "uuid"
         is UriType -> "uri"
         is SetType -> "set"
+        is TsTzRangeType -> "tstz-range"
         else -> throw UnsupportedOperationException("not supported for $type")
     }
 })
@@ -139,6 +137,8 @@ fun valueToArrowType(obj: Any?) = when (obj) {
     is IntervalYearMonth -> MinorType.INTERVALYEAR.type
     is IntervalDayTime -> MinorType.INTERVALDAY.type
     is IntervalMonthDayNano, is PeriodDuration -> MinorType.INTERVALMONTHDAYNANO.type
+
+    is ZonedDateTimeRange -> TsTzRangeType
 
     else -> throw UnsupportedOperationException("unknown object type: ${obj.javaClass}")
 }

--- a/core/src/main/kotlin/xtdb/vector/FixedSizeListVectorWriter.kt
+++ b/core/src/main/kotlin/xtdb/vector/FixedSizeListVectorWriter.kt
@@ -1,0 +1,134 @@
+package xtdb.vector
+
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.NullVector
+import org.apache.arrow.vector.ValueVector
+import org.apache.arrow.vector.complex.DenseUnionVector
+import org.apache.arrow.vector.complex.FixedSizeListVector
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeList
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.arrow.ListValueReader
+import xtdb.arrow.RowCopier
+import xtdb.arrow.ValueReader
+import xtdb.arrow.VectorPosition
+
+internal class FixedSizeListVectorWriter(
+    override val vector: FixedSizeListVector,
+    private val notify: FieldChangeListener?
+) : IVectorWriter {
+    private val listSize = (vector.field.type as FixedSizeList).listSize
+    private val wp = VectorPosition.build(vector.valueCount)
+    override var field: Field = vector.field
+
+    private fun upsertElField(elField: Field) {
+        field = Field(field.name, field.fieldType, listOf(elField))
+        notify(field)
+    }
+
+    private var elWriter = writerFor(vector.dataVector, ::upsertElField)
+
+    override fun writerPosition() = wp
+
+    override fun clear() {
+        super.clear()
+        elWriter.clear()
+    }
+
+    override fun writeNull() {
+        super.writeNull()
+        repeat(listSize) { elWriter.writeNull() }
+    }
+
+    override fun listElementWriter(): IVectorWriter =
+        if (vector.dataVector is NullVector) listElementWriter(UNION_FIELD_TYPE) else elWriter
+
+    override fun listElementWriter(fieldType: FieldType): IVectorWriter {
+        val res = vector.addOrGetVector<FieldVector>(fieldType)
+        if (!res.isCreated) return elWriter
+
+        val newDataVec = res.vector
+        upsertElField(newDataVec.field)
+        elWriter = writerFor(newDataVec, ::upsertElField).also { it.writerPosition().position = wp.position * listSize }
+        return elWriter
+    }
+
+    override fun startList() {
+        vector.startNewValue(wp.position)
+    }
+
+    override fun endList() {
+        wp.getPositionAndIncrement()
+    }
+
+    private inline fun writeList(f: () -> Unit) {
+        startList(); f(); endList()
+    }
+
+    override fun writeObject0(obj: Any) {
+        writeList {
+            when (obj) {
+                is ListValueReader ->
+                    repeat(obj.size()) { i ->
+                        try {
+                            elWriter.writeValue(obj.nth(i))
+                        } catch (e: InvalidWriteObjectException) {
+                            TODO("FSLV promotion")
+                        }
+                    }
+
+                is List<*> -> obj.forEach {
+                    try {
+                        elWriter.writeObject(it)
+                    } catch (e: InvalidWriteObjectException) {
+                        TODO("FSLV promotion")
+                    }
+                }
+
+                else -> throw InvalidWriteObjectException(field, obj)
+            }
+        }
+    }
+
+    override fun writeValue0(v: ValueReader) = writeObject(v.readObject())
+
+    override fun promoteChildren(field: Field) {
+        if (field.type != this.field.type || (field.isNullable && !this.field.isNullable))
+            throw FieldMismatch(this.field.fieldType, field.fieldType)
+        val child = field.children.single()
+        if (
+            (child.type != elWriter.field.type
+                    || (child.isNullable && !elWriter.field.isNullable))
+            && elWriter.field.type !is ArrowType.Union
+        ) {
+            TODO("FSLV promotion")
+        }
+        if (child.children.isNotEmpty()) elWriter.promoteChildren(child)
+    }
+
+    override fun rowCopier(src: ValueVector) = when (src) {
+        is NullVector -> nullToVecCopier(this)
+        is DenseUnionVector -> duvToVecCopier(this, src)
+        is FixedSizeListVector -> {
+            if (src.field.isNullable && !field.isNullable
+                || src.field.fieldType != field.fieldType)
+                throw InvalidCopySourceException(src.field, field)
+
+            val innerCopier = listElementWriter().rowCopier(src.dataVector)
+
+            RowCopier { srcIdx ->
+                wp.position.also {
+                    if (src.isNull(srcIdx)) writeNull()
+                    else writeList {
+                        for (i in src.getElementStartIndex(srcIdx)..<src.getElementEndIndex(srcIdx)) {
+                            innerCopier.copyRow(i)
+                        }
+                    }
+                }
+            }
+        }
+
+        else -> throw InvalidCopySourceException(src.field, field)
+    }
+}

--- a/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
+++ b/core/src/main/kotlin/xtdb/vector/IndirectMultiVectorReader.kt
@@ -250,7 +250,5 @@ class IndirectMultiVectorReader(
         readers.map { it?.close() }
     }
 
-    override fun toString(): String {
-        return "(IndirectMultiVectorReader ".plus(readers.map { it.toString() }.toString()).plus(")")
-    }
+    override fun toString() = "(IndirectMultiVectorReader ${readers.map { it.toString() }})"
 }

--- a/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
+++ b/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
@@ -58,7 +58,7 @@ object VecToReader : VectorVisitor<IVectorReader, Any?> {
         else -> listVector(v)
     }
 
-    override fun visit(v: FixedSizeListVector, value: Any?): IVectorReader = throw UnsupportedOperationException()
+    override fun visit(v: FixedSizeListVector, value: Any?): IVectorReader = fixedSizeListVector(v)
     override fun visit(v: LargeListVector, value: Any?): IVectorReader = throw UnsupportedOperationException()
     override fun visit(v: NonNullableStructVector, value: Any?): IVectorReader = structVector(v)
     override fun visit(v: UnionVector, value: Any?): IVectorReader = throw UnsupportedOperationException()
@@ -70,6 +70,7 @@ object VecToReader : VectorVisitor<IVectorReader, Any?> {
         is UuidVector -> uuidVector(v)
         is UriVector -> uriVector(v)
         is TransitVector -> transitVector(v)
+        is TsTzRangeVector -> tstzRangeVector(v)
         is SetVector -> setVector(v)
         else -> ValueVectorReader(v)
     }

--- a/core/src/main/kotlin/xtdb/vector/extensions/TsTzRangeType.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/TsTzRangeType.kt
@@ -1,0 +1,18 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ExtensionTypeRegistry
+import org.apache.arrow.vector.types.pojo.FieldType
+
+object TsTzRangeType : XtExtensionType("xt/tstz-range", FixedSizeList(2)) {
+    init {
+        ExtensionTypeRegistry.register(this)
+    }
+
+    override fun deserialize(serializedData: String): ArrowType = this
+
+    override fun getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator): FieldVector =
+        TsTzRangeVector(name, allocator, fieldType)
+}

--- a/core/src/main/kotlin/xtdb/vector/extensions/TsTzRangeVector.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/TsTzRangeVector.kt
@@ -1,0 +1,41 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.complex.FixedSizeListVector
+import org.apache.arrow.vector.types.TimeUnit.MICROSECOND
+import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeList
+import org.apache.arrow.vector.types.pojo.ArrowType.Timestamp
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.types.ZonedDateTimeRange
+import xtdb.vector.from
+import java.time.Instant.EPOCH
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.MICROS
+
+class TsTzRangeVector(name: String, allocator: BufferAllocator, fieldType: FieldType) :
+    XtExtensionVector<FixedSizeListVector>(
+        Field(name, fieldType, listOf(elField)),
+        allocator,
+        FixedSizeListVector(
+            Field(name, FieldType.notNullable(FixedSizeList(2)), listOf(elField)),
+            allocator, null
+        )
+    ) {
+
+    companion object {
+        private val elField =
+            Field("\$data\$", FieldType.notNullable(Timestamp(MICROSECOND, "UTC")), null)
+    }
+
+    private fun Long.toZdt(): ZonedDateTime = EPOCH.plus(this, MICROS).atZone(UTC)
+
+    override fun getObject0(index: Int): ZonedDateTimeRange =
+        from(underlyingVector.dataVector).let { elVec ->
+            ZonedDateTimeRange(
+                elVec.getLong(index * 2).toZdt(),
+                elVec.getLong(index * 2 + 1).takeUnless { it == Long.MAX_VALUE }?.toZdt()
+            )
+        }
+}

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -15,8 +15,7 @@
             [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector.reader :as vr]
-            [xtdb.vector.writer :as vw]
-            [xtdb.error :as err])
+            [xtdb.vector.writer :as vw])
   (:import [ch.qos.logback.classic Level Logger]
            clojure.lang.ExceptionInfo
            (java.io FileOutputStream)
@@ -24,7 +23,7 @@
            (java.nio.channels Channels)
            (java.nio.file Files Path)
            java.nio.file.attribute.FileAttribute
-           (java.time Instant InstantSource LocalTime Period YearMonth ZoneOffset ZoneId)
+           (java.time Instant InstantSource LocalTime Period YearMonth ZoneId ZoneOffset)
            (java.time.temporal ChronoUnit)
            (java.util LinkedList TreeMap)
            (java.util.function Consumer IntConsumer)
@@ -39,8 +38,9 @@
            xtdb.api.query.IKeyFn
            xtdb.arrow.Relation
            xtdb.indexer.live_index.ILiveTable
-           xtdb.util.RowCounter
+           xtdb.types.ZonedDateTimeRange
            (xtdb.util TemporalBounds TemporalDimension)
+           xtdb.util.RowCounter
            (xtdb.vector IVectorReader)))
 
 #_{:clj-kondo/ignore [:uninitialized-var]}
@@ -165,6 +165,9 @@
 
 (defn with-mock-clock [f]
   (with-opts {:log [:in-memory {:instant-src (->mock-clock)}]} f))
+
+(defn ->tstz-range ^xtdb.types.ZonedDateTimeRange [from to]
+  (ZonedDateTimeRange. (time/->zdt from) (some-> to time/->zdt)))
 
 (defn finish-chunk! [node]
   (then-await-tx node)

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -10,7 +10,7 @@
   (:import (java.time Duration Instant LocalDate LocalDateTime LocalTime Period ZoneId ZoneOffset ZonedDateTime)
            java.time.temporal.ChronoUnit
            (org.apache.arrow.vector PeriodDuration)
-           (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)))
+           (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth ZonedDateTimeRange)))
 
 (t/use-fixtures :each tu/with-allocator)
 
@@ -1357,14 +1357,14 @@
           (instance? IntervalMonthDayNano res)))))
 
 (deftest test-period-constructor
-  (let [from #xt.time/zoned-date-time "2020-01-01T00:00Z[UTC]"
-        to #xt.time/zoned-date-time "2022-01-01T00:00Z[UTC]"]
-    (t/is (= {:xt/from from :xt/to to}
+  (let [from #xt.time/zoned-date-time "2020-01-01T00:00Z"
+        to #xt.time/zoned-date-time "2022-01-01T00:00Z"]
+    (t/is (= (tu/->tstz-range from to)
              (et/project1 '(period x y)
                           {:x from, :y to}))))
 
-  (let [from #xt.time/zoned-date-time "2030-01-01T00:00Z[UTC]"
-        to #xt.time/zoned-date-time "2020-01-01T00:00Z[UTC]"]
+  (let [from #xt.time/zoned-date-time "2030-01-01T00:00Z"
+        to #xt.time/zoned-date-time "2020-01-01T00:00Z"]
     (t/is
       (thrown-with-msg?
         RuntimeException
@@ -1377,15 +1377,15 @@
     (= true
        (et/project1
          '(overlaps? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2023"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2021", #inst "2023")})))
 
   (t/is
     (= false
        (et/project1
          '(overlaps? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2021"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2023"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2021")
+          :y (tu/->tstz-range #inst "2021", #inst "2023")}))))
 
 (deftest test-contains?-predicate
   (t/testing "period to period"
@@ -1393,30 +1393,30 @@
       (= true
          (et/project1
            '(contains? x y)
-           {:x {:xt$from #inst "2020", :xt$to #inst "2025"}
-            :y {:xt$from #inst "2021", :xt$to #inst "2023"}})))
+           {:x (tu/->tstz-range #inst "2020", #inst "2025")
+            :y (tu/->tstz-range #inst "2021", #inst "2023")})))
 
     (t/is
       (= false
          (et/project1
            '(contains? x y)
-           {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-            :y {:xt$from #inst "2021", :xt$to #inst "2023"}}))))
+           {:x (tu/->tstz-range #inst "2020", #inst "2022")
+            :y (tu/->tstz-range #inst "2021", #inst "2023")}))))
 
   (t/testing "period to timestamp"
     (t/is (true? (et/project1
                   '(contains? x y)
-                  {:x {:xt$from #inst "2020", :xt$to #inst "2025"}
+                  {:x (tu/->tstz-range #inst "2020", #inst "2025")
                    :y #inst "2021"})))
 
     (t/is (false? (et/project1
                    '(contains? x y)
-                   {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
+                   {:x (tu/->tstz-range #inst "2020", #inst "2022")
                     :y #inst "2023"})))
 
     (t/is (false? (et/project1
                    '(contains? x y)
-                   {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
+                   {:x (tu/->tstz-range #inst "2020", #inst "2022")
                     :y #inst "2022"})))))
 
 (deftest test-equals?-predicate
@@ -1424,225 +1424,225 @@
     (= true
        (et/project1
          '(equals? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2022"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2020", #inst "2022")})))
 
   (t/is
     (= false
        (et/project1
          '(equals? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2021"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2023"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2021")
+          :y (tu/->tstz-range #inst "2020", #inst "2023")}))))
 
 (deftest test-precedes?-predicate
   (t/is
     (= true
        (et/project1
          '(precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2023", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2023", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2021"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2023"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2021")
+          :y (tu/->tstz-range #inst "2020", #inst "2023")}))))
 
 (deftest test-succeeds?-predicate
   (t/is
     (= true
        (et/project1
          '(succeeds? x y)
-         {:x {:xt$from #inst "2023", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2022"}})))
+         {:x (tu/->tstz-range #inst "2023", #inst "2025")
+          :y (tu/->tstz-range #inst "2020", #inst "2022")})))
 
   (t/is
     (= false
        (et/project1
          '(succeeds? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2021"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2023"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2021")
+          :y (tu/->tstz-range #inst "2020", #inst "2023")}))))
 
 (deftest test-immediately-precedes?-predicate
   (t/is
     (= true
        (et/project1
          '(immediately-precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2023"}
-          :y {:xt$from #inst "2023", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2023")
+          :y (tu/->tstz-range #inst "2023", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(immediately-precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2023", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2023", #inst "2025")}))))
 
 (deftest test-immediately-succeeds?-predicate
   (t/is
     (= true
        (et/project1
          '(immediately-succeeds? x y)
-         {:x {:xt$from #inst "2022", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2022"}})))
+         {:x (tu/->tstz-range #inst "2022", #inst "2025")
+          :y (tu/->tstz-range #inst "2020", #inst "2022")})))
 
   (t/is
     (= false
        (et/project1
          '(immediately-succeeds? x y)
-         {:x {:xt$from #inst "2023", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2022"}}))))
+         {:x (tu/->tstz-range #inst "2023", #inst "2025")
+          :y (tu/->tstz-range #inst "2020", #inst "2022")}))))
 
 (deftest test-leads?-predicate
   (t/is
     (= true
        (et/project1
          '(leads? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(leads? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")}))))
 
 (deftest test-strictly-leads?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-leads? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-leads? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")}))))
 
 (deftest test-lags?-predicate
   (t/is
     (= true
        (et/project1
          '(lags? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2020", :xt$to #inst "2024"}})))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2020", #inst "2024")})))
 
   (t/is
     (= false
        (et/project1
          '(lags? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2024")
+          :y (tu/->tstz-range #inst "2022", #inst "2025")}))))
 
 (deftest test-strictly-lags?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-lags? x y)
-         {:x {:xt$from #inst "2022", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2024"}})))
+         {:x (tu/->tstz-range #inst "2022", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2024")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-lags? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2024"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2024")}))))
 
 (deftest test-strictly-overlaps?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-overlaps? x y)
-         {:x {:xt$from #inst "2022", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2022", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-overlaps? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")}))))
 
 (deftest test-strictly-contains?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-contains? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2024"}})))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2022", #inst "2024")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-contains? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2022", #inst "2025")}))))
 
 (deftest test-strictly-precedes?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2023", :xt$to #inst "2025"}})))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2023", #inst "2025")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-precedes? x y)
-         {:x {:xt$from #inst "2020", :xt$to #inst "2022"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2023"}}))))
+         {:x (tu/->tstz-range #inst "2020", #inst "2022")
+          :y (tu/->tstz-range #inst "2022", #inst "2023")}))))
 
 (deftest test-strictly-succeeds?-predicate
   (t/is
     (= true
        (et/project1
          '(strictly-succeeds? x y)
-         {:x {:xt$from #inst "2023", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2022"}})))
+         {:x (tu/->tstz-range #inst "2023", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2022")})))
 
   (t/is
     (= false
        (et/project1
          '(strictly-succeeds? x y)
-         {:x {:xt$from #inst "2022", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2022"}}))))
+         {:x (tu/->tstz-range #inst "2022", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2022")}))))
 
 (deftest test-immediately-leads?-predicate
   (t/is
     (= true
        (et/project1
          '(immediately-leads? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2024"}})))
+         {:x (tu/->tstz-range #inst "2021", #inst "2024")
+          :y (tu/->tstz-range #inst "2022", #inst "2024")})))
 
   (t/is
     (= false
        (et/project1
          '(immediately-leads? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2022", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2024")
+          :y (tu/->tstz-range #inst "2022", #inst "2025")}))))
 
 (deftest test-immediately-lags?-predicate
   (t/is
     (= true
        (et/project1
          '(immediately-lags? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2025"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2024"}})))
+         {:x (tu/->tstz-range #inst "2021", #inst "2025")
+          :y (tu/->tstz-range #inst "2021", #inst "2024")})))
 
   (t/is
     (= false
        (et/project1
          '(immediately-lags? x y)
-         {:x {:xt$from #inst "2021", :xt$to #inst "2024"}
-          :y {:xt$from #inst "2021", :xt$to #inst "2025"}}))))
+         {:x (tu/->tstz-range #inst "2021", #inst "2024")
+          :y (tu/->tstz-range #inst "2021", #inst "2025")}))))
 
 (deftest test-date-bin
   (t/is (= (time/->zdt #inst "2020")

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -926,20 +926,20 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     '(and (<= f/xt$valid_from #xt.time/zoned-date-time "2000-01-01T00:00Z")
           (>= (coalesce f/xt$valid_to xtdb/end-of-time)
               (coalesce #xt.time/zoned-date-time "2001-01-01T00:00Z" xtdb/end-of-time)))
-    "foo.VALID_TIME CONTAINS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._VALID_TIME CONTAINS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(and (<= f/xt$valid_from #xt.time/zoned-date-time "2000-01-01T00:00Z")
           (> (coalesce f/xt$valid_to xtdb/end-of-time) #xt.time/zoned-date-time "2000-01-01T00:00Z"))
-    "foo.VALID_TIME CONTAINS TIMESTAMP '2000-01-01 00:00:00+00:00'"
+    "foo._VALID_TIME CONTAINS TIMESTAMP '2000-01-01 00:00:00+00:00'"
 
     ;; also testing all period-predicate permutations
     '(and (< f/xt$valid_from (coalesce #xt.time/zoned-date-time "2001-01-01T00:00Z" xtdb/end-of-time))
           (> (coalesce f/xt$valid_to xtdb/end-of-time) #xt.time/zoned-date-time "2000-01-01T00:00Z"))
-    "foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(and (< f/xt$valid_from (coalesce f/xt$valid_to xtdb/end-of-time))
           (> (coalesce f/xt$valid_to xtdb/end-of-time) f/xt$valid_from))
-    "foo.VALID_TIME OVERLAPS foo.VALID_TIME"
+    "foo._VALID_TIME OVERLAPS foo._VALID_TIME"
 
     '(and (< #xt.time/zoned-date-time "2000-01-01T00:00Z" (coalesce #xt.time/zoned-date-time "2003-01-01T00:00Z" xtdb/end-of-time))
           (> (coalesce #xt.time/zoned-date-time "2001-01-01T00:00Z" xtdb/end-of-time) #xt.time/zoned-date-time "2002-01-01T00:00Z"))
@@ -948,38 +948,38 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
 
     '(and (= f/xt$system_from #xt.time/zoned-date-time "2000-01-01T00:00Z")
           (null-eq f/xt$system_to #xt.time/zoned-date-time "2001-01-01T00:00Z"))
-    "foo.SYSTEM_TIME EQUALS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._SYSTEM_TIME EQUALS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(<= (coalesce f/xt$valid_to xtdb/end-of-time) #xt.time/zoned-date-time "2000-01-01T00:00Z")
-    "foo.VALID_TIME PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._VALID_TIME PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(>= f/xt$system_from (coalesce #xt.time/zoned-date-time "2001-01-01T00:00Z" xtdb/end-of-time))
-    "foo.SYSTEM_TIME SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._SYSTEM_TIME SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(= (coalesce f/xt$valid_to xtdb/end-of-time) #xt.time/zoned-date-time "2000-01-01T00:00Z")
-    "foo.VALID_TIME IMMEDIATELY PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
+    "foo._VALID_TIME IMMEDIATELY PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
     '(= f/xt$valid_from (coalesce #xt.time/zoned-date-time "2001-01-01T00:00Z" xtdb/end-of-time))
-    "foo.VALID_TIME IMMEDIATELY SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"))
+    "foo._VALID_TIME IMMEDIATELY SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"))
 
 (t/deftest test-period-predicates-point-in-time
   (t/are [expected sql] (= expected (plan-expr-with-foo sql))
 
     '(and (<= f/xt$valid_from f/a)
           (> (coalesce f/xt$valid_to xtdb/end-of-time) f/a))
-    "foo.valid_time CONTAINS foo.a"
+    "foo._valid_time CONTAINS foo.a"
 
     '(and (<= f/xt$valid_from #xt.time/zoned-date-time "2010-01-01T11:10:11Z")
           (> (coalesce f/xt$valid_to xtdb/end-of-time) #xt.time/zoned-date-time "2010-01-01T11:10:11Z"))
-    "foo.valid_time CONTAINS TIMESTAMP '2010-01-01T11:10:11Z'"
+    "foo._valid_time CONTAINS TIMESTAMP '2010-01-01T11:10:11Z'"
 
     '(and (<= f/xt$valid_from f/a)
           (>= (coalesce f/xt$valid_to xtdb/end-of-time) (coalesce f/a xtdb/end-of-time)))
-    "foo.valid_time CONTAINS PERIOD(foo.a, foo.a)"
+    "foo._valid_time CONTAINS PERIOD(foo.a, foo.a)"
 
     '(and (<= f/xt$valid_from f/xt$system_from)
           (> (coalesce f/xt$valid_to xtdb/end-of-time) f/xt$system_from))
-    "foo.valid_time CONTAINS foo.xt$system_from"))
+    "foo._valid_time CONTAINS foo.xt$system_from"))
 
 (t/deftest test-coalesce
   (t/testing "planning"
@@ -1023,15 +1023,15 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
 (t/deftest test-period-predicates-point-in-time-errors
   (t/is (thrown-with-msg?
          IllegalArgumentException
-         #"line 1:66 no viable alternative at input"
-         (sql-test/plan-sql "SELECT f.foo FROM foo f WHERE f.valid_time OVERLAPS f.other_column"
+         #"line 1:67 no viable alternative at input"
+         (sql-test/plan-sql "SELECT f.foo FROM foo f WHERE f._valid_time OVERLAPS f.other_column"
                             {:table-info {"foo" #{"foo" "other_column"}}})))
 
   (t/is (thrown-with-msg?
          IllegalArgumentException
-         #"line 1:52 no viable alternative at input"
+         #"line 1:53 no viable alternative at input"
          (sql-test/plan-sql
-          "SELECT f.foo FROM foo f WHERE f.valid_time OVERLAPS TIMESTAMP '2010-01-01T11:10:11Z'"
+          "SELECT f.foo FROM foo f WHERE f._valid_time OVERLAPS TIMESTAMP '2010-01-01T11:10:11Z'"
           {:table-info {"foo" #{"foo"}}}))))
 
 (t/deftest test-min-long-value-275
@@ -1171,19 +1171,19 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
            (xt/q tu/*node* "SETTING DEFAULT VALID_TIME ALL
                             SELECT foo._id foo, bar._id bar
                             FROM foo, bar
-                            WHERE OVERLAPS(foo.valid_time, bar.valid_time)")))
+                            WHERE OVERLAPS(foo._valid_time, bar._valid_time)")))
 
   (t/is (= [{:foo 2, :baz 5} {:foo 1, :baz 6}]
            (xt/q tu/*node* "SETTING DEFAULT VALID_TIME ALL
                             SELECT foo._id foo, baz._id baz
                             FROM foo, baz
-                            WHERE OVERLAPS(foo.valid_time, baz.valid_time)")))
+                            WHERE OVERLAPS(foo._valid_time, baz._valid_time)")))
 
   (t/is (= [{:bar 4, :baz 5} {:bar 3, :baz 5} {:bar 3, :baz 6}]
            (xt/q tu/*node* "SETTING DEFAULT VALID_TIME ALL
                             SELECT bar._id bar, baz._id baz
                             FROM bar, baz
-                            WHERE OVERLAPS(bar.valid_time, baz.valid_time)")))
+                            WHERE OVERLAPS(bar._valid_time, baz._valid_time)")))
 
   (t/is (= [{:foo 2, :bar 4, :baz 5}
             {:foo 2, :bar 3, :baz 5}
@@ -1191,4 +1191,4 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
            (xt/q tu/*node* "SETTING DEFAULT VALID_TIME ALL
                             SELECT foo._id foo, bar._id bar, baz._id baz
                             FROM foo, bar, baz
-                            WHERE OVERLAPS(foo.valid_time, bar.valid_time, baz.valid_time)"))))
+                            WHERE OVERLAPS(foo._valid_time, bar._valid_time, baz._valid_time)"))))

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -126,22 +126,22 @@
 
       (is (= [{:last-updated "2000"}]
              (query-at-tx
-              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
+              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
               tx)))
 
       (is (= [{:last-updated "3000"}]
              (query-at-tx
-              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '3000-01-01 00:00:00', TIMESTAMP '3001-01-01 00:00:00')"
+              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '3000-01-01 00:00:00', TIMESTAMP '3001-01-01 00:00:00')"
               tx)))
 
       (is (= [{:last-updated "3000"} {:last-updated "4000"}]
              (query-at-tx
-              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '4000-01-01 00:00:00', TIMESTAMP '4001-01-01 00:00:00')"
+              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '4000-01-01 00:00:00', TIMESTAMP '4001-01-01 00:00:00')"
               tx)))
 
       (is (= [{:last-updated "3000"}]
              (query-at-tx
-              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '4002-01-01 00:00:00', TIMESTAMP '9999-01-01 00:00:00')"
+              "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '4002-01-01 00:00:00', TIMESTAMP '9999-01-01 00:00:00')"
               tx))))))
 
 (deftest app-time-multiple-tables
@@ -154,35 +154,35 @@
     (is (= [{:last-updated "2001"}]
            (query-at-tx
             "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME
-             WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2002-01-01 00:00:00')"
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2002-01-01 00:00:00')"
             tx)))
 
     (is (= [{:l-updated "2003"}]
            (query-at-tx
             "SELECT bar.l_updated FROM bar FOR ALL VALID_TIME
-             WHERE bar.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
+             WHERE bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
             tx)))
 
     (is (= []
            (query-at-tx
             "SELECT foo.last_updated, bar.l_updated FROM foo, bar
-             WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
              AND
-             bar.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
+             bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
             tx)))
 
     (is (= [{:last-updated "2001", :l-updated "2003"}]
            (query-at-tx
             "SETTING DEFAULT VALID_TIME ALL
              SELECT foo.last_updated, bar.l_updated FROM foo, bar
-             WHERE foo.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
-               AND bar.VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
+               AND bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
             tx)))
 
     (is (= []
            (query-at-tx
             "SELECT foo.last_updated, bar.name FROM foo, bar
-             WHERE foo.VALID_TIME OVERLAPS bar.VALID_TIME" tx)))))
+             WHERE foo._VALID_TIME OVERLAPS bar._VALID_TIME" tx)))))
 
 (deftest app-time-joins
   (let [tx (xt/submit-tx tu/*node* [[:put-docs {:into :foo, :valid-from #inst "2016", :valid-to #inst "2019"}
@@ -194,7 +194,7 @@
            (query-at-tx
             "SELECT foo.name, bar.also_name
              FROM foo, bar
-             WHERE foo.VALID_TIME SUCCEEDS bar.VALID_TIME"
+             WHERE foo._VALID_TIME SUCCEEDS bar._VALID_TIME"
             tx)))
 
     (is (= [{:name "Bill" :also-name "Jeff"}]
@@ -202,7 +202,7 @@
             "SETTING DEFAULT VALID_TIME ALL
              SELECT foo.name, bar.also_name
              FROM foo, bar
-             WHERE foo.VALID_TIME OVERLAPS bar.VALID_TIME"
+             WHERE foo._VALID_TIME OVERLAPS bar._VALID_TIME"
             tx)))))
 
 (deftest test-inconsistent-valid-time-range-2494

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -154,29 +154,29 @@
     (is (= [{:last-updated "2001"}]
            (query-at-tx
             "SELECT foo.last_updated FROM foo FOR ALL VALID_TIME
-             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2002-01-01 00:00:00')"
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00Z', TIMESTAMP '2002-01-01 00:00:00Z')"
             tx)))
 
     (is (= [{:l-updated "2003"}]
            (query-at-tx
             "SELECT bar.l_updated FROM bar FOR ALL VALID_TIME
-             WHERE bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
+             WHERE bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00Z', TIMESTAMP '2003-01-01 00:00:00Z')"
             tx)))
 
     (is (= []
            (query-at-tx
             "SELECT foo.last_updated, bar.l_updated FROM foo, bar
-             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00Z', TIMESTAMP '2001-01-01 00:00:00Z')
              AND
-             bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
+             bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00Z', TIMESTAMP '2001-01-01 00:00:00Z')"
             tx)))
 
     (is (= [{:last-updated "2001", :l-updated "2003"}]
            (query-at-tx
             "SETTING DEFAULT VALID_TIME ALL
              SELECT foo.last_updated, bar.l_updated FROM foo, bar
-             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
-               AND bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
+             WHERE foo._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00Z', TIMESTAMP '2001-01-01 00:00:00Z')
+               AND bar._VALID_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00Z', TIMESTAMP '2003-01-01 00:00:00Z')"
             tx)))
 
     (is (= []

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1849,9 +1849,6 @@ VALUES
                {:value 580, :xt/valid-from (zdt 27), :xt/valid-to (zdt 30)}}
              (q)))))
 
-(t/deftest test-contains-period-datetime
-  (t/is (= [{:contains false}] (xt/q tu/*node* "SELECT PERIOD(TIMESTAMP '2024-01-01T00:00:00', TIMESTAMP '2024-01-02T00:00:00') CONTAINS TIMESTAMP '2024-01-02T00:00:00' AS `contains`"))))
-
 (t/deftest contains-precedence-bug-3473
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO docs1 (_id) VALUES (1)"]
                            [:sql "INSERT INTO docs2 (_id) VALUES (1)"]])

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/period_predicates.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/period_predicates.test
@@ -23,26 +23,26 @@ SELECT t1.xt$id, t1.start, t1.end FROM t1
 2020-01-01
 
 query ITT nosort
-SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE t1.VALID_TIME CONTAINS PERIOD (t1.start, t1.end)
+SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE t1._VALID_TIME CONTAINS PERIOD (t1.start, t1.end)
 ----
 2
 2100-01-01
 3000-01-01
 
 query ITT nosort
-SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE PERIOD (t1.start, t1.end) PRECEDES t1.VALID_TIME
+SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE PERIOD (t1.start, t1.end) PRECEDES t1._VALID_TIME
 ----
 3
 2000-01-01
 2020-01-01
 
 query ITT nosort
-SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE PERIOD (t1.start, t1.end) PRECEDES t1.SYSTEM_TIME
+SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE PERIOD (t1.start, t1.end) PRECEDES t1._SYSTEM_TIME
 ----
 3
 2000-01-01
 2020-01-01
 
 query ITT nosort
-SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE t1.SYSTEM_TIME OVERLAPS PERIOD (DATE '2000-01-01', DATE '2020-01-01')
+SELECT t1.xt$id, t1.start, t1.end FROM t1 WHERE t1._SYSTEM_TIME OVERLAPS PERIOD (DATE '2000-01-01', DATE '2020-01-01')
 ----

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-demo.test
@@ -664,7 +664,7 @@ FOR ALL VALID_TIME AS P2
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.VALID_TIME OVERLAPS P2.VALID_TIME
+  AND P1._VALID_TIME OVERLAPS P2._VALID_TIME
 ----
 3621
 1998-01-15T00:00Z[UTC]
@@ -688,7 +688,7 @@ FROM Prop_Owner FOR ALL SYSTEM_TIME AS P1,
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.SYSTEM_TIME OVERLAPS P2.SYSTEM_TIME
+  AND P1._SYSTEM_TIME OVERLAPS P2._SYSTEM_TIME
 ----
 
 
@@ -703,8 +703,8 @@ FROM Prop_Owner FOR ALL SYSTEM_TIME FOR ALL VALID_TIME AS P1,
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.VALID_TIME OVERLAPS P2.VALID_TIME
-  AND P1.SYSTEM_TIME OVERLAPS P2.SYSTEM_TIME
+  AND P1._VALID_TIME OVERLAPS P2._VALID_TIME
+  AND P1._SYSTEM_TIME OVERLAPS P2._SYSTEM_TIME
 ----
 3621
 1998-01-15T00:00Z[UTC]
@@ -725,7 +725,7 @@ FOR ALL VALID_TIME AS P2
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.SYSTEM_TIME OVERLAPS P2.SYSTEM_TIME
+  AND P1._SYSTEM_TIME OVERLAPS P2._SYSTEM_TIME
 ----
 3621
 2020-01-08T00:00Z[UTC]
@@ -741,7 +741,7 @@ FOR ALL SYSTEM_TIME AS P2
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
+  AND P1._SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
 ----
 
 
@@ -755,8 +755,8 @@ FROM Prop_Owner FOR ALL SYSTEM_TIME FOR ALL VALID_TIME AS P1,
 WHERE P1.property_number = 7797
   AND P2.property_number <> P1.property_number
   AND P1.customer_number = P2.customer_number
-  AND P1.VALID_TIME OVERLAPS P2.VALID_TIME
-  AND P1.SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
+  AND P1._VALID_TIME OVERLAPS P2._VALID_TIME
+  AND P1._SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
 ----
 3621
 1998-01-15T00:00Z[UTC]
@@ -770,7 +770,7 @@ SELECT P2.property_number, P2.xt$system_from AS Recorded_Start
  WHERE P1.property_number = 7797
    AND P2.property_number <> P1.property_number
    AND P1.customer_number = P2.customer_number
-   AND P1.SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
+   AND P1._SYSTEM_TIME CONTAINS PERIOD(P2.xt$system_from, P2.xt$system_to)
 ----
 3621
 2020-01-08T00:00Z[UTC]


### PR DESCRIPTION
(pre-req for #3493)

This PR adds first-class support for periods (Postgres: `tstzrange`s), so that they can be returned from a query, and stored in a table.

e.g.

```sql
SELECT _id, _valid_time FROM foo
-- => [{:xt/id 1, :xt/valid-time #xt/tstz-range [#xt/zdt "...", #xt/zdt "..."]}]

INSERT INTO bar (_id, for_range) VALUES (2, PERIOD(?, ?))
```

* Added tstz-range as an Arrow extension vector, backed by a FixedSizeList (which also needed reader and writer support).
  * The legacy reader/writer support for FSL is pretty rudimentary, on account of us migrating to XT Arrow
  * Turns out the previous issues with us doing this in Arrow Java were related to an extension vector backed by a StructVector (we previously used `{:xt/from ..., :xt/to ...}`)
* I had to change how the SQL planner plans period operations: we can no longer rely on these being literals (as they have to be in the SQL spec), so rather than a from/to map, I emit a `(->period from to)` expression, then have an inline optimisation that tries to unpack this into raw `>`/`<`s, otherwise delegates to the dynamic EE impls of the period predicates.
* (breaking change) I've also renamed `VALID_TIME` and `SYSTEM_TIME` to be `_valid_time` and `_system_time`, to make them consistent with the other built-in cols