### PR TITLE
Move schema to watermark

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -200,7 +200,7 @@
                      (let [table-info-at-execution-time (with-open [wm (.openWatermark wm-src)]
                                                           (.scanFields scan-emitter wm
                                                                        (mapcat #(map (partial vector (key %)) (val %))
-                                                                               (scan/tables-with-cols wm-src scan-emitter))))]
+                                                                               (scan/tables-with-cols wm-src))))]
 
                        ;;TODO nullability of col is considered a schema change, not relevant for pgwire, maybe worth ignoring
                        ;;especially given our "per path schema" principal.
@@ -253,9 +253,9 @@
     (reify
       IQuerySource
       (prepareRaQuery [_ query wm-src query-opts]
-        (prepare-ra query (assoc deps :wm-src wm-src) (assoc query-opts :table-info (scan/tables-with-cols wm-src (:scan-emitter deps)))))
+        (prepare-ra query (assoc deps :wm-src wm-src) (assoc query-opts :table-info (scan/tables-with-cols wm-src))))
       (planQuery [_ query wm-src query-opts]
-        (let [table-info (scan/tables-with-cols wm-src (:scan-emitter deps))
+        (let [table-info (scan/tables-with-cols wm-src)
               plan-query-opts
               (-> query-opts
                   (select-keys

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -136,104 +136,101 @@
                         (.getField col)))))))
 
 (defn prepare-ra ^xtdb.query.PreparedQuery
-  ;; this one used from zero-dep tests
-  (^xtdb.query.PreparedQuery [query] (prepare-ra query {:ref-ctr (RefCounter.)} {}))
+  [query
+   {:keys [^IScanEmitter scan-emitter, ^BufferAllocator allocator,
+           ^RefCounter ref-ctr ^IWatermarkSource wm-src] :as deps}
+   {:keys [param-types default-tz table-info]}]
 
-  (^xtdb.query.PreparedQuery [query, {:keys [^IScanEmitter scan-emitter, ^BufferAllocator allocator,
-                                             ^RefCounter ref-ctr ^IWatermarkSource wm-src] :as deps}
-                              {:keys [param-types default-tz table-info]}]
+  (let [conformed-query (s/conform ::lp/logical-plan query)]
+    (when (s/invalid? conformed-query)
+      (throw (err/illegal-arg :malformed-query
+                              {:plan query
+                               :explain (s/explain-data ::lp/logical-plan query)})))
 
-   (let [conformed-query (s/conform ::lp/logical-plan query)]
-     (when (s/invalid? conformed-query)
-       (throw (err/illegal-arg :malformed-query
-                               {:plan query
-                                :explain (s/explain-data ::lp/logical-plan query)})))
+    (let [param-count (or (:param-count (meta query)) 0)
+          param-types-with-defaults (->> (concat
+                                          (mapv #(if (= :default %) :utf8 %) param-types)
+                                          (repeat :utf8))
+                                         (take param-count))
+          tables (filter (comp #{:scan} :op) (lp/child-exprs conformed-query))
+          scan-cols (->> tables
+                         (into #{} (mapcat scan/->scan-cols)))
 
-     (let [param-count (or (:param-count (meta query)) 0)
-           param-types-with-defaults (->> (concat
-                                           (mapv #(if (= :default %) :utf8 %) param-types)
-                                           (repeat :utf8))
-                                          (take param-count))
-           tables (filter (comp #{:scan} :op) (lp/child-exprs conformed-query))
-           scan-cols (->> tables
-                          (into #{} (mapcat scan/->scan-cols)))
+          _ (assert (or scan-emitter (empty? scan-cols)))
 
-           _ (assert (or scan-emitter (empty? scan-cols)))
+          relevant-schema-at-prepare-time
+          (when (and table-info scan-emitter)
+            (with-open [wm (.openWatermark wm-src)]
+              (->> tables
+                   (map #(str (get-in % [:scan-opts :table])))
+                   (mapcat #(map (partial vector %) (get table-info %)))
+                   (.scanFields scan-emitter wm))))
 
-           relevant-schema-at-prepare-time
-           (when (and table-info scan-emitter)
-             (with-open [wm (.openWatermark wm-src)]
-               (->> tables
-                    (map #(str (get-in % [:scan-opts :table])))
-                    (mapcat #(map (partial vector %) (get table-info %)))
-                    (.scanFields scan-emitter wm))))
+          cache (ConcurrentHashMap.)
+          ordered-outer-projection (:named-projection (meta query))
+          param-fields (mapify-params (mapv (comp types/col-type->field types/col-type->nullable-col-type) param-types-with-defaults))
+          default-tz (or default-tz (.getZone expr/*clock*))]
 
-           cache (ConcurrentHashMap.)
-           ordered-outer-projection (:named-projection (meta query))
-           param-fields (mapify-params (mapv (comp types/col-type->field types/col-type->nullable-col-type) param-types-with-defaults))
-           default-tz (or default-tz (.getZone expr/*clock*))]
+      (reify PreparedQuery
+        (paramFields [_] param-fields)
+        (columnFields [_]
+          (let [{:keys [fields]} (emit-expr cache deps conformed-query scan-cols default-tz (into {} param-fields))]
+            ;; could store column-fields in the cache/map too
+            (->column-fields ordered-outer-projection fields)))
+        (bind [_ {:keys [args params basis default-tz]
+                  :or {default-tz default-tz}}]
 
-       (reify PreparedQuery
-         (paramFields [_] param-fields)
-         (columnFields [_]
-           (let [{:keys [fields]} (emit-expr cache deps conformed-query scan-cols default-tz (into {} param-fields))]
-             ;; could store column-fields in the cache/map too
-             (->column-fields ordered-outer-projection fields)))
-         (bind [_ {:keys [args params basis default-tz]
-                   :or {default-tz default-tz}}]
+          ;; TODO throw if basis is in the future?
+          (util/with-close-on-catch [args (open-args allocator args)]
+            ;;TODO consider making the either/or relationship between params/args explicit, e.g throw error if both are provided
+            (let [params (or params args)
+                  {:keys [fields ->cursor]} (emit-expr cache deps conformed-query scan-cols default-tz (->param-fields params))
+                  {:keys [current-time]} basis
+                  current-time (or current-time (.instant expr/*clock*))
+                  clock (Clock/fixed current-time default-tz)]
 
-           ;; TODO throw if basis is in the future?
-           (util/with-close-on-catch [args (open-args allocator args)]
-             ;;TODO consider making the either/or relationship between params/args explicit, e.g throw error if both are provided
-             (let [params (or params args)
-                   {:keys [fields ->cursor]} (emit-expr cache deps conformed-query scan-cols default-tz (->param-fields params))
-                   {:keys [current-time]} basis
-                   current-time (or current-time (.instant expr/*clock*))
-                   clock (Clock/fixed current-time default-tz)]
+              (reify
+                BoundQuery
+                (columnFields [_]
+                  (->column-fields ordered-outer-projection fields))
+                (openCursor [_]
+                  (when relevant-schema-at-prepare-time
+                    (let [table-info-at-execution-time (with-open [wm (.openWatermark wm-src)]
+                                                         (.scanFields scan-emitter wm
+                                                                      (mapcat #(map (partial vector (key %)) (val %))
+                                                                              (scan/tables-with-cols wm-src))))]
 
-               (reify
-                 BoundQuery
-                 (columnFields [_]
-                   (->column-fields ordered-outer-projection fields))
-                 (openCursor [_]
-                   (when relevant-schema-at-prepare-time
-                     (let [table-info-at-execution-time (with-open [wm (.openWatermark wm-src)]
-                                                          (.scanFields scan-emitter wm
-                                                                       (mapcat #(map (partial vector (key %)) (val %))
-                                                                               (scan/tables-with-cols wm-src))))]
+                      ;;TODO nullability of col is considered a schema change, not relevant for pgwire, maybe worth ignoring
+                      ;;especially given our "per path schema" principal.
+                      (when-not (= relevant-schema-at-prepare-time
+                                   (select-keys table-info-at-execution-time (keys relevant-schema-at-prepare-time)))
+                        (throw (err/runtime-err :prepared-query-out-of-date
+                                                ;;TODO consider adding the schema diff to the error, potentially quite large.
+                                                {::err/message "Relevant table schema has changed since preparing query, please prepare again"})))))
+                  (.acquire ref-ctr)
+                  (let [^BufferAllocator allocator
+                        (if allocator
+                          (util/->child-allocator allocator "BoundQuery/openCursor")
+                          (RootAllocator.))
+                        wm (.openWatermark wm-src)]
+                    (try
+                      (binding [expr/*clock* clock]
+                        (-> (->cursor {:allocator allocator, :watermark wm
+                                       :clock clock,
+                                       :basis (-> basis
+                                                  (update :at-tx (fnil identity (some-> wm .txBasis)))
+                                                  (assoc :current-time current-time))
+                                       :params params})
+                            (wrap-cursor wm allocator clock ref-ctr fields)))
 
-                       ;;TODO nullability of col is considered a schema change, not relevant for pgwire, maybe worth ignoring
-                       ;;especially given our "per path schema" principal.
-                       (when-not (= relevant-schema-at-prepare-time
-                                    (select-keys table-info-at-execution-time (keys relevant-schema-at-prepare-time)))
-                         (throw (err/runtime-err :prepared-query-out-of-date
-                                                 ;;TODO consider adding the schema diff to the error, potentially quite large.
-                                                 {::err/message "Relevant table schema has changed since preparing query, please prepare again"})))))
-                   (.acquire ref-ctr)
-                   (let [^BufferAllocator allocator
-                         (if allocator
-                           (util/->child-allocator allocator "BoundQuery/openCursor")
-                           (RootAllocator.))
-                         wm (some-> wm-src (.openWatermark))
-]
-                     (try
-                       (binding [expr/*clock* clock]
-                         (-> (->cursor {:allocator allocator, :watermark wm
-                                        :clock clock,
-                                        :basis (-> basis
-                                                   (update :at-tx (fnil identity (some-> wm .txBasis)))
-                                                   (assoc :current-time current-time))
-                                        :params params})
-                             (wrap-cursor wm allocator clock ref-ctr fields)))
+                      (catch Throwable t
+                        (.release ref-ctr)
+                        (util/try-close wm)
+                        (util/try-close allocator)
+                        (throw t)))))
 
-                       (catch Throwable t
-                         (.release ref-ctr)
-                         (util/try-close wm)
-                         (util/try-close allocator)
-                         (throw t)))))
-
-                 AutoCloseable
-                 (close [_] (util/try-close params)))))))))))
+                AutoCloseable
+                (close [_] (util/try-close params))))))))))
 
 (defmethod ig/prep-key ::query-source [_ opts]
   (merge opts

--- a/core/src/main/kotlin/xtdb/watermark/IWatermark.kt
+++ b/core/src/main/kotlin/xtdb/watermark/IWatermark.kt
@@ -21,6 +21,7 @@ interface ILiveIndexWatermark : AutoCloseable {
 class Watermark(
     @JvmField val txBasis: TransactionKey?,
     @JvmField val liveIndex: ILiveIndexWatermark?,
+    @JvmField val schema: Map<String, Any>
 ) : AutoCloseable {
     private val refCount = AtomicInteger(1)
 

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -619,3 +619,15 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
                    :valid-from #xt.time/zoned-date-time "2023-03-26T01:00Z[UTC]",
                    :valid-to #xt.time/zoned-date-time "2023-03-26T01:05Z[UTC]"}]
              (xt/q node "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _valid_from")))))
+
+(t/deftest test-wm-schema-is-updated-within-a-tx
+  (with-open [node (xtn/start-node)]
+    (xt/submit-tx node [[:sql "INSERT INTO t1(_id, foo) VALUES(1, 100)"]
+                        [:sql "INSERT INTO t1(_id, foo, bar) (SELECT 2, 200, 2000)"]
+                        [:sql "INSERT INTO t1(_id, foo, bar) (SELECT 3, x.foo, x.bar FROM (SELECT * FROM t1 WHERE bar = 2000) AS x)"]])
+
+    (t/is (=
+           [{:xt/id 2, :bar 2000, :foo 200}
+            {:xt/id 1, :foo 100}
+            {:xt/id 3, :bar 2000, :foo 200}]
+           (xt/q node "SELECT * FROM t1")))))

--- a/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/xtdb_engine.clj
@@ -38,8 +38,7 @@
   node)
 
 (defn- node->table-info [node]
-  (scan/tables-with-cols (util/component node :xtdb/indexer)
-                         (util/component node ::scan/scan-emitter)))
+  (scan/tables-with-cols (util/component node :xtdb/indexer)))
 
 (defn- execute-sql-query [node sql-statement variables {:keys [direct-sql] :as opts}]
   (let [!cache (atom {})


### PR DESCRIPTION
Begins the process of moving the schema object onto the watermark, by first moving the result of  `allTableColNames` from scanEmitter onto the watermark.

PR also removes the need for a zero dependency prepare-ra, by supplying minimal deps in the query-ra test util.