### PR TITLE
Multi node configuration on Azure Benchmark using AKS

### DIFF
--- a/cloud-benchmark/azure/Dockerfile
+++ b/cloud-benchmark/azure/Dockerfile
@@ -10,7 +10,7 @@ ENTRYPOINT ["java", \
     "-Dclojure.main.report=stderr", \
     "-Dlogback.configurationFile=logback.xml", \
     "-Xmx2000m", "-Xms2000m", \
-    "-XX:MaxDirectMemorySize=1500m", \
+    "-XX:MaxDirectMemorySize=2000m", \
     "-XX:MaxMetaspaceSize=500m", \
     "--add-opens=java.base/java.nio=ALL-UNNAMED", \
     "-Dio.netty.tryReflectionSetAccessible=true", \

--- a/cloud-benchmark/azure/README.adoc
+++ b/cloud-benchmark/azure/README.adoc
@@ -116,6 +116,12 @@ terraform outputs
 
 Ensure that the contents of the files under `kubernetes` match the values of the terraform outputs.
 
+We must also ensure that we have both a namespace and a service account for the benchmark to run under. To create these, you can run the following:
+```
+kubectl create namespace cloud-benchmark
+kubectl create serviceaccount xtdb-service-account --namespace cloud-benchmark 
+```
+
 The config for the deployments/jobs live under `kubernetes` - within these, you can set/configure any of the necessary parameters for running the image on the cluster. When ready to run a single node auctionmark job, run the following command from the base of this directory:
 ```
 kubectl apply -f kubernetes/single-node-auctionmark.yaml
@@ -131,25 +137,69 @@ Trail the logs of the single node run by running:
 kubectl logs job.batch/xtdb-single-node-auctionmark --namespace cloud-benchmark -f
 ```
 
+=== Multinode Benchmarking
+
+Running a multi-node benchmark is similar, though requires a few more steps.
+
+Firstly, update the terraform config to have the correct amount of memory/cpu for the nodes you wish to run. 
+
+* This can be altered with the `kubernetes_vm_size` variable in the `terraform.tfvars` file.
+* You will need to set a `temporary_name_for_rotation` when resizing the node pool.
+
+We will also need to update the node config and push a new image, as we are now using Kafka as the txLog and running multiple nodes - update the contents of the `azure-config.yaml` file:
+
+* Switch the txLog implementation to `kafka`, adding the relevant config/env vars.
+* Set a reasonable maxDiskCachePercentage size depending on number of nodes running.
+
+After this, push a new image to the Azure Container Registry. 
+
+To set up all the necessary kafka pods that will be used/shared by the nodes txLog, run the following:
+
+```
+kubectl apply -f kubernetes/kafka.yaml
+```
+
+This will setup a kafka service the pods can connect to, alongside the persistent volume claim for kafka.
+
+When the kafka pods are ready, you can then deploy the multi-node benchmark by running the following:
+```
+kubectl apply -f kubernetes/multi-node-auctionmark.yaml
+```
+
+
 == Clear up between runs
 
 If you want to totally clear up data between runs, you'll want to do the following:
 
 * Clear up the job/pods
+** Clear up the Kafka deployment (if running a multi-node benchmark)
 * Empty the Azure Storage Blobs Container
 * Delete the Persistent Storage volume used by the TxLog
+** Delete the Persistent Storage volume used by Kafka (if running a multi-node benchmark)
 * Delete the Persistent Storage volume containing the Local Disk Caches
 
-.Clear up the Workload
+.Clear up the XTDB job
 
-To clear up the workload, you can do the following
+To clear up the single node workload, you can run:
 ```bash
 kubectl delete jobs xtdb-single-node-auctionmark --namespace cloud-benchmark
 ```
 
+For the multi-node workload, you can run:
+```bash
+kubectl delete jobs xtdb-multi-node-auctionmark --namespace cloud-benchmark
+```
+
+.Clear up the Kafka deployment
+
+To clear up the Kafka deployment, you can run:
+```bash
+kubectl delete deployment kafka-app --namespace cloud-benchmark
+```
+
 .Command to empty the Azure Storage Blob Container:
 ```bash
-./clear-azure-storage.sh
+./scripts/clear-azure-storage.sh
 ```
 
 .Deleting Persistent Storage Volumes:
@@ -157,6 +207,11 @@ You can remove the Persistent Storage volumes within the google cloud UI, but wi
 ```bash
 kubectl delete pvc xtdb-pvc-log --namespace cloud-benchmark
 kubectl delete pvc xtdb-pvc-local-caches --namespace cloud-benchmark
+# If running a multi-node benchmark with Kafka
+kubectl delete pvc kafka-pvc --namespace cloud-benchmark
 ``` 
 
-NOTE: You do not necessarily _need_ to delete all of the above between runs - you can also change the kubernetes config map to use slightly different directory names (ie, changing bucket prefix, new local-disk-cache directory, etc) to avoid conflicts between runs. 
+There is a helper script to do _all_ of the above, which can be run by:
+```bash
+./scripts/clear-azure-bench.sh
+```

--- a/cloud-benchmark/azure/azure-config.yaml
+++ b/cloud-benchmark/azure/azure-config.yaml
@@ -1,10 +1,10 @@
 # CONFIG FOR RUNNING WITH AZURE INFRA
-# txLog: !Kafka
-#   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
-#   topicName: !Env XTDB_TOPIC_NAME
+txLog: !Kafka
+  bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+  topicName: !Env XTDB_TOPIC_NAME
 
-txLog: !Local
-  path: !Env XTDB_LOCAL_LOG_PATH
+# txLog: !Local
+#   path: !Env XTDB_LOCAL_LOG_PATH
 
 storage: !Remote
   objectStore: !Azure
@@ -15,5 +15,6 @@ storage: !Remote
     prefix: "xtdb-object-store"
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
   localDiskCache: !Env XTDB_LOCAL_DISK_CACHE
+  maxDiskCachePercentage: 25
 
 metrics: !AzureMonitor

--- a/cloud-benchmark/azure/kubernetes/kafka.yaml
+++ b/cloud-benchmark/azure/kubernetes/kafka.yaml
@@ -1,0 +1,95 @@
+
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "kafka-pvc"
+  namespace: "cloud-benchmark"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "100Gi"
+  storageClassName: "managed-csi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "kafka-app"
+  namespace: "cloud-benchmark"
+  labels:
+    app: "kafka-app"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kafka-app"
+  template:
+    metadata:
+      labels:
+        app: "kafka-app"
+    spec:
+      nodeSelector:
+        nodepool: "benchmark"
+
+      containers:
+      - name: "kafka-app"
+        image: "confluentinc/cp-kafka:latest"
+        ports:
+        - containerPort: 9092
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        resources:
+          requests:
+            memory: "2Gi"
+          limits:
+            memory: "2Gi"
+        env:
+          - name: KAFKA_NODE_ID
+            value: "1"
+          - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+            value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+          - name: KAFKA_LISTENERS
+            value: "PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9092"
+          - name: KAFKA_ADVERTISED_LISTENERS
+            value: "PLAINTEXT://kafka-service.cloud-benchmark.svc.cluster.local:29092,PLAINTEXT_HOST://kafka-service.cloud-benchmark.svc.cluster.local:9092"
+          - name: KAFKA_JMX_PORT
+            value: "9101"
+          - name: KAFKA_JMX_HOSTNAME
+            value: "localhost"
+          - name: KAFKA_PROCESS_ROLES
+            value: "broker,controller"
+          - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+            value: "1"
+          - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+            value: "1@localhost:29093"
+          - name: KAFKA_INTER_BROKER_LISTENER_NAME
+            value: "PLAINTEXT"
+          - name: KAFKA_CONTROLLER_LISTENER_NAMES
+            value: "CONTROLLER"
+          - name: CLUSTER_ID
+            value: "q1Sh-9_ISia_zwGINzRvyQ"
+        volumeMounts:
+          - name: "kafka-persistent-storage"
+            mountPath: "/var/lib/kafka"
+      volumes:
+        - name: "kafka-persistent-storage"
+          persistentVolumeClaim:
+            claimName: "kafka-pvc"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "kafka-service"
+  namespace: "cloud-benchmark"
+spec:
+  ports:
+    - port: 9092
+      targetPort: 9092
+      protocol: TCP
+      name: plaintext
+  selector:
+    app: "kafka-app"
+  type: ClusterIP
+---

--- a/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
@@ -1,0 +1,137 @@
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "xtdb-pvc-local-caches"
+  namespace: "cloud-benchmark"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "50Gi"
+  storageClassName: "managed-csi"
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "xtdb-env-config"
+  namespace: "cloud-benchmark"
+data:
+  CLOUD_PLATFORM_NAME: "Azure"
+  XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID: "c76c6e6a-59e2-4172-8097-6c48d36cdb92"
+  XTDB_AZURE_STORAGE_ACCOUNT: "xtdbazurebenchmark"
+  XTDB_AZURE_STORAGE_CONTAINER: "xtdbazurebenchmarkcontainer"
+  XTDB_AZURE_SERVICE_BUS_NAMESPACE: "cloud-benchmark-eventbus"
+  XTDB_AZURE_SERVICE_BUS_TOPIC_NAME: "cloud-benchmark-servicebus-topic"
+  KAFKA_BOOTSTRAP_SERVERS: "kafka-service.cloud-benchmark.svc.cluster.local:9092"
+  XTDB_TOPIC_NAME: "xtdb-topic"
+  AUCTIONMARK_DURATION: "PT1H"
+  AUCTIONMARK_SCALE_FACTOR: "0.1"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "xtdb-multi-node-auctionmark"
+  namespace: "cloud-benchmark"
+  labels:
+    app: "xtdb-multi-node-auctionmark"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: "xtdb-multi-node-auctionmark"
+        azure.workload.identity/use: "true" 
+    spec:
+      nodeSelector:
+        nodepool: "benchmark"
+      serviceAccountName: "xtdb-service-account"
+      restartPolicy: "Never"
+      volumes:
+        - name: "xtdb-pvc-local-caches-vol"
+          persistentVolumeClaim:
+            claimName: "xtdb-pvc-local-caches"
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox
+        command: ['sh', '-c', 'until nc -z kafka-service.cloud-benchmark.svc.cluster.local 9092; do echo waiting for kafka; sleep 5; done;']
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+      - name: load-phase
+        image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
+        volumeMounts:
+        - mountPath: /var/lib/xtdb/buffers
+          name: xtdb-pvc-local-caches-vol
+        resources:
+          requests:
+            memory: "5120Mi"
+          limits:
+            memory: "5120Mi"
+        envFrom:
+        - configMapRef:
+            name: xtdb-env-config
+        env:
+        - name: XTDB_LOCAL_DISK_CACHE
+          value: "/var/lib/xtdb/buffers/disk-cache-lp"
+        - name: AUCTIONMARK_LOAD_PHASE_ONLY
+          value: "True"
+      containers:
+      - name: xtdb-azure-bench-1
+        image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
+        volumeMounts:
+        - mountPath: /var/lib/xtdb/buffers
+          name: xtdb-pvc-local-caches-vol
+        resources:
+          requests:
+            memory: "5120Mi"
+          limits:
+            memory: "5120Mi"
+        envFrom:
+        - configMapRef:
+            name: xtdb-env-config
+        env:
+        - name: XTDB_LOCAL_DISK_CACHE
+          value: "/var/lib/xtdb/buffers/disk-cache-1"
+        - name: AUCTIONMARK_LOAD_PHASE
+          value: "False"
+      - name: xtdb-azure-bench-2
+        image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
+        volumeMounts:
+        - mountPath: /var/lib/xtdb/buffers
+          name: xtdb-pvc-local-caches-vol
+        resources:
+          requests:
+            memory: "5120Mi"
+          limits:
+            memory: "5120Mi"
+        envFrom:
+        - configMapRef:
+            name: xtdb-env-config
+        env:
+        - name: XTDB_LOCAL_DISK_CACHE
+          value: "/var/lib/xtdb/buffers/disk-cache-2"
+        - name: AUCTIONMARK_LOAD_PHASE
+          value: "False"
+      - name: xtdb-azure-bench-3
+        image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
+        volumeMounts:
+        - mountPath: /var/lib/xtdb/buffers
+          name: xtdb-pvc-local-caches-vol
+        resources:
+          requests:
+            memory: "5120Mi"
+          limits:
+            memory: "5120Mi"
+        envFrom:
+        - configMapRef:
+            name: xtdb-env-config
+        env:
+        - name: XTDB_LOCAL_DISK_CACHE
+          value: "/var/lib/xtdb/buffers/disk-cache-2"
+        - name: AUCTIONMARK_LOAD_PHASE
+          value: "False"

--- a/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
@@ -73,6 +73,8 @@ spec:
         app: "xtdb-single-node-auctionmark"
         azure.workload.identity/use: "true" 
     spec:
+      nodeSelector:
+        nodepool: "benchmark"
       serviceAccountName: "xtdb-service-account"
       restartPolicy: "Never"
       volumes:

--- a/cloud-benchmark/azure/scripts/clear-azure-bench.sh
+++ b/cloud-benchmark/azure/scripts/clear-azure-bench.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+(
+  kubectl delete jobs xtdb-single-node-auctionmark --namespace cloud-benchmark || true
+  kubectl delete jobs xtdb-multi-node-auctionmark --namespace cloud-benchmark || true
+  kubectl delete deployment kafka-app --namespace cloud-benchmark || true 
+
+  echo Clearing Blob Store Container - xtdbazurebenchmarkcontainer ...
+  az storage blob delete-batch --account-name xtdbazurebenchmark --source xtdbazurebenchmarkcontainer
+  echo Done
+  
+  kubectl delete pvc xtdb-pvc-log --namespace cloud-benchmark || true
+  kubectl delete pvc xtdb-pvc-local-caches --namespace cloud-benchmark || true
+  kubectl delete pvc kafka-pvc --namespace cloud-benchmark || true
+)
+

--- a/cloud-benchmark/azure/terraform/main.tf
+++ b/cloud-benchmark/azure/terraform/main.tf
@@ -121,7 +121,7 @@ resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
   dns_prefix          = "cloud-benchmark-cluster"
 
   default_node_pool {
-    name       = "default"
+    name       = "system"
     node_count = 1
     vm_size    = "Standard_D2_v2"
     upgrade_settings {
@@ -140,6 +140,16 @@ resource "azurerm_kubernetes_cluster" "cloud_benchmark" {
 
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "cloud_benchmark_nodes" {
+  name                  = "benchmark"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.cloud_benchmark.id
+  vm_size               = var.kubernetes_vm_size
+  node_count            = 1
+  node_labels           = {
+    "nodepool" = "benchmark"
+  }
 }
 
 resource "azurerm_role_assignment" "cloud_benchmark_cluster_role" {

--- a/cloud-benchmark/azure/terraform/terraform.tfvars
+++ b/cloud-benchmark/azure/terraform/terraform.tfvars
@@ -1,3 +1,8 @@
 kubernetes_namespace            = "cloud-benchmark"
 kubernetes_service_account_name = "xtdb-service-account"
-kubernetes_vm_size              = "Standard_D2_v2"
+
+# Appropriate for single node clusters
+# kubernetes_vm_size              = "Standard_D2_v2"
+
+# Appropriate for multi-node clusters
+kubernetes_vm_size              = "Standard_D8_v3"

--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -261,6 +261,7 @@
 
       (catch Throwable upload-loop-t
         (try
+          (log/infof "Error caught in upload-multipart-buffers - aborting multipart upload of %s" k)
           @(.abort upload)
           (catch Throwable abort-t
             (.addSuppressed upload-loop-t abort-t)))


### PR DESCRIPTION
Resolves #3530 

Updates the azure benchmark setup to use multiple nodes:
- Bumps kubernetes resources in the template accrdingly.
- Split K8s cluster into two separate node pools - one for system components ran by Azure and one for application components ran by us.
- Added a template to run kafka on kubernetes as a service.
- Added a multi node template that:
  - Runs an initcontainer to ensure it can connect to kafka.
  - Runs an initcontainer with one XTDB node doing the load phase only
  - Runs three container XTDB nodes running the main auctionmark loop (no load phase).
- Did a few runs against this to ensure all was setup correctly across node pools.

Runs into some issues with OoMs and also noticed and documented some IOOBE exceptions - added a bit of extra logging to catch for some of those.
