### PR TITLE
Supporting window functions with `PARTITION BY` and `ORDER BY`

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -265,6 +265,11 @@
     [:arrow _path]
     []
 
+    [:window specs relation]
+    (concat
+     (->> specs :projections (map ->projected-column))
+     (relation-columns relation))
+
     (throw (err/illegal-arg ::cannot-calculate-relation-cols
                             {::err/message (str "cannot calculate columns for: " (pr-str relation-in))
                              :relation relation-in}))))
@@ -1263,4 +1268,3 @@
                             {::err/message (s/explain-str ::logical-plan plan)
                              :plan plan
                              :explain-data (s/explain-data ::logical-plan plan)}))))
-

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -85,7 +85,7 @@
     (.close group-mapping)
     (util/try-close rel-map)))
 
-(defn- ->group-mapper [^BufferAllocator allocator, group-fields]
+(defn ->group-mapper [^BufferAllocator allocator, group-fields]
   (let [gm-vec (IntVector. "group-mapping" allocator)]
     (if-let [group-col-names (not-empty (set (keys group-fields)))]
       (GroupMapper. group-col-names

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -1,0 +1,193 @@
+(ns xtdb.operator.window
+  (:require [clojure.spec.alpha :as s]
+            [xtdb.expression :as expr]
+            [xtdb.logical-plan :as lp]
+            [xtdb.operator.group-by :as group-by]
+            [xtdb.operator.order-by :as order-by]
+            [xtdb.rewrite :refer [zmatch]]
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr]
+            [xtdb.vector.writer :as vw])
+  (:import (clojure.lang IPersistentMap)
+           (com.carrotsearch.hppc LongLongMap LongLongHashMap)
+           (java.io Closeable)
+           (java.util LinkedList List Spliterator)
+           (org.apache.arrow.memory BufferAllocator)
+           (org.apache.arrow.vector BigIntVector)
+           (xtdb ICursor)
+           (org.apache.arrow.vector.types.pojo Field)
+           (xtdb.operator.group_by IGroupMapper)
+           (xtdb.vector RelationWriter IVectorWriter)))
+
+(s/def ::window-name symbol?)
+
+;; TODO
+(s/def ::frame any?)
+;; TODO assert at least one is present
+(s/def ::partition-cols (s/coll-of ::lp/column :min-count 1))
+(s/def ::window-spec (s/keys :opt-un [::partition-cols ::order-by/order-specs ::frame]))
+(s/def ::windows (s/map-of ::window-name ::window-spec))
+
+
+(s/def ::window-agg-expr
+  (s/or :nullary (s/cat :f simple-symbol?)
+        :unary (s/cat :f simple-symbol?
+                      :from-column ::lp/column)
+        :binary (s/cat :f simple-symbol?
+                       :left-column ::lp/column
+                       :right-column ::lp/column)))
+
+(s/def ::window-agg ::window-agg-expr)
+(s/def ::window-projection (s/map-of ::lp/column (s/keys :req-un [::window-name ::window-agg])))
+(s/def ::projections (s/coll-of ::window-projection :min-count 1))
+
+(defmethod lp/ra-expr :window [_]
+  (s/cat :op #{:window}
+         :specs (s/keys :req-un [::windows ::projections])
+         :relation ::lp/ra-expression))
+
+(comment
+  (s/valid? ::lp/logical-plan
+            '[:window {:windows {window1 {:partition-cols [a]
+                                          :order-specs [[b]]
+                                          :frame {}}}
+                       :projections [{col-name {:window-name window1
+                                                :window-agg (row-number)}}]}
+              [:table [{}]]]))
+
+
+#_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
+(definterface IWindowFnSpec
+  (^xtdb.vector.IVectorReader aggregate [^org.apache.arrow.vector.IntVector groupMapping
+                                         ^ints sortMapping
+                                         ^xtdb.vector.RelationReader in-rel]))
+
+#_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
+(definterface IWindowFnSpecFactory
+  (^clojure.lang.Symbol getToColumnName [])
+  (getToColumnField [])
+  (^xtdb.operator.window.IWindowFnSpec build [^org.apache.arrow.memory.BufferAllocator allocator]))
+
+#_{:clj-kondo/ignore [:unused-binding]}
+(defmulti ^xtdb.operator.window.IWindowFnSpecFactory ->window-fn-factory
+  (fn [{:keys [f from-name from-type to-name zero-row?]}]
+    (expr/normalise-fn-name f)))
+
+(defmethod ->window-fn-factory :row_number [{:keys [to-name]}]
+  (reify IWindowFnSpecFactory
+    (getToColumnName [_] to-name)
+    (getToColumnField [_] (types/col-type->field :i64))
+
+    (build [_ al]
+      (let [^BigIntVector out-vec (-> (types/col-type->field to-name :i64)
+                                      (.createVector al))
+            ^LongLongMap group-to-cnt (LongLongHashMap.)]
+        (reify
+          IWindowFnSpec
+          (aggregate [_ group-mapping sortMapping]
+            (let [offset (.getValueCount out-vec)
+                  row-count (.getValueCount group-mapping)]
+              (.setValueCount out-vec (+ offset row-count))
+              (dotimes [idx row-count]
+                (.set out-vec (+ offset idx) (.putOrAdd group-to-cnt (.get group-mapping (aget sortMapping idx)) 0 1)))
+              (vr/vec->reader out-vec)))
+
+          Closeable
+          (close [_] (.close out-vec)))))))
+
+
+(deftype WindowFnCursor [^BufferAllocator allocator
+                         ^ICursor in-cursor
+                         ^IPersistentMap static-fields
+                         ^IGroupMapper group-mapper
+                         order-specs
+                         ^List window-specs
+                         ^:unsynchronized-mutable ^boolean done?]
+  ICursor
+  (tryAdvance [this c]
+    (boolean
+     (when-not done?
+       (set! (.done? this) true)
+
+       (try
+         (let [grouping-vec-name "grouping-vec"]
+           ;; TODO we likely want to do some retaining here instead of copying
+           (util/with-open [rel-wtr (RelationWriter. allocator (for [^Field field static-fields]
+                                                                 (vw/->writer (.createVector field allocator))))
+                            ;; TODO check why grouping can be null
+                            ^IVectorWriter grouping-wtr (-> #xt.arrow/field ["grouping-vec" #xt.arrow/field-type [#xt.arrow/type :i32 true]]
+                                                            (.createVector allocator)
+                                                            vw/->writer)]
+
+             (.forEachRemaining in-cursor (fn [in-rel]
+                                            (vw/append-rel rel-wtr in-rel)
+                                            (with-open [group-mapping (.groupMapping group-mapper in-rel)]
+                                              (vw/append-vec grouping-wtr (vr/vec->reader group-mapping)))))
+
+             (let [rel-rdr (vw/rel-wtr->rdr rel-wtr)
+                   sort-mapping (order-by/sorted-idxs (vr/rel-reader (conj (seq rel-rdr) (vw/vec-wtr->rdr grouping-wtr)))
+                                                      (into [[(symbol grouping-vec-name)]] order-specs))]
+               (doseq [^IWindowFnSpec window-spec window-specs]
+                 (.aggregate window-spec (.getVector grouping-wtr) sort-mapping))
+
+               (util/with-open [window-cols (->> window-specs
+                                                 (mapv #(.aggregate ^IWindowFnSpec % (.getVector grouping-wtr) sort-mapping rel-rdr)))]
+                 (let [out-rel (vr/rel-reader (concat (seq (.select rel-rdr sort-mapping)) window-cols))]
+                   (if (pos? (.rowCount out-rel))
+                     (do
+                       (.accept c out-rel)
+                       true)
+                     false))))))
+         (finally
+           (util/try-close group-mapper)
+           (run! util/try-close window-specs))))))
+
+  (characteristics [_] Spliterator/IMMUTABLE)
+
+  (close [_]
+    (run! util/try-close window-specs)
+    (util/try-close in-cursor)
+    (util/try-close group-mapper)))
+
+
+(defmethod lp/emit-expr :window [{:keys [specs relation]} args]
+  (let [window-spec (-> specs :windows first)
+        _window-name (key window-spec)
+        {:keys [partition-cols order-specs]} (val window-spec)
+        projections (-> specs :projections)]
+    (lp/unary-expr (lp/emit-expr relation args)
+      (fn [fields]
+        (let [window-fn-factories
+              (for [p projections]
+                ;; ignoring window-name for now
+                (let [[to-column {:keys [_window-name window-agg]}] (first p)]
+                  (->window-fn-factory (into {:to-name to-column
+                                              :zero-row? (empty? partition-cols)}
+                                             (zmatch window-agg
+                                               [:nullary agg-opts]
+                                               (select-keys agg-opts [:f])
+
+                                               [:unary _agg-opts]
+                                               (throw (UnsupportedOperationException.)))))))
+              fields (-> (into fields
+                               (->> window-fn-factories
+                                    (into {} (map (juxt #(.getToColumnName ^IWindowFnSpecFactory  %)
+                                                        #(.getToColumnField ^IWindowFnSpecFactory %)))))))]
+          {:fields fields
+
+           :->cursor (fn [{:keys [allocator]} in-cursor]
+                       (let [window-fn-specs (LinkedList.)]
+                         (try
+                           (doseq [^IWindowFnSpecFactory factory window-fn-factories]
+                             (.add window-fn-specs (.build factory allocator)))
+
+                           (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
+                                            (group-by/->group-mapper allocator (select-keys fields partition-cols))
+                                            order-specs
+                                            (vec window-fn-specs)
+                                            false)
+
+                           (catch Throwable e
+                             (run! util/try-close window-fn-specs)
+                             (throw e)))))})))))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -16,6 +16,7 @@
             xtdb.operator.order-by
             xtdb.operator.project
             xtdb.operator.rename
+            xtdb.operator.window
             [xtdb.operator.scan :as scan]
             xtdb.operator.select
             xtdb.operator.set

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -14,7 +14,13 @@
            (java.util Collection HashMap HashSet LinkedHashSet List Map SequencedSet Set UUID)
            java.util.function.Function
            (org.antlr.v4.runtime BaseErrorListener CharStreams CommonTokenStream ParserRuleContext Recognizer)
-           (xtdb.antlr SqlLexer SqlParser SqlParser$BaseTableContext SqlParser$DirectSqlStatementContext SqlParser$IntervalQualifierContext SqlParser$JoinSpecificationContext SqlParser$JoinTypeContext SqlParser$ObjectNameAndValueContext SqlParser$OrderByClauseContext SqlParser$PostgresVersionFunctionContext SqlParser$QualifiedRenameColumnContext SqlParser$QueryBodyTermContext SqlParser$QuerySpecificationContext SqlParser$RenameColumnContext SqlParser$SearchedWhenClauseContext SqlParser$SetClauseContext SqlParser$SimpleWhenClauseContext SqlParser$SortSpecificationContext SqlParser$WhenOperandContext SqlParser$WithTimeZoneContext SqlVisitor)
+           (xtdb.antlr SqlLexer SqlParser SqlParser$BaseTableContext SqlParser$DirectSqlStatementContext
+                       SqlParser$IntervalQualifierContext SqlParser$JoinSpecificationContext SqlParser$JoinTypeContext
+                       SqlParser$ObjectNameAndValueContext SqlParser$OrderByClauseContext SqlParser$PostgresVersionFunctionContext
+                       SqlParser$QualifiedRenameColumnContext SqlParser$QueryBodyTermContext SqlParser$QuerySpecificationContext
+                       SqlParser$RenameColumnContext SqlParser$SearchedWhenClauseContext SqlParser$SetClauseContext
+                       SqlParser$SimpleWhenClauseContext SqlParser$SortSpecificationContext SqlParser$SortSpecificationListContext
+                       SqlParser$WhenOperandContext SqlParser$WithTimeZoneContext SqlVisitor)
            xtdb.api.tx.TxOps
            (xtdb.types IntervalMonthDayNano)
            xtdb.util.StringUtil))
@@ -663,8 +669,8 @@
       [:table [{}]])))
 
 (defn- ->projected-col-expr [col-idx expr]
-  (let [{:keys [column? sq-out-sym? agg-out-sym? unnamed-unnest-col? identifier]} (meta expr)]
-    (if (and column? (not sq-out-sym?) (not agg-out-sym?) (not unnamed-unnest-col?))
+  (let [{:keys [column? sq-out-sym? agg-out-sym? window-out-sym? unnamed-unnest-col? identifier]} (meta expr)]
+    (if (and column? (not sq-out-sym?) (not agg-out-sym?) (not window-out-sym?) (not unnamed-unnest-col?))
       (->ProjectedCol expr expr)
       (let [col-name (or identifier (->col-sym (str "xt$column_" (inc col-idx))))]
         (->ProjectedCol {col-name expr} col-name)))))
@@ -674,7 +680,8 @@
   (visitSelectClause [_ ctx]
     (let [sl-ctx (.selectList ctx)
           !subqs (HashMap.)
-          !aggs (HashMap.)]
+          !aggs (HashMap.)
+          !windows (HashMap.)]
 
       {:projected-cols (vec (concat (when-let [star-ctx (.selectListAsterisk sl-ctx)]
                                       (let [renames (->> (for [^SqlParser$RenameColumnContext rename-pair (some-> (.renameClause star-ctx)
@@ -707,7 +714,7 @@
                                                                       (visitDerivedColumn [_ ctx]
                                                                         (let [expr-ctx (.expr ctx)]
                                                                           [(let [expr (.accept expr-ctx
-                                                                                               (map->ExprPlanVisitor {:env env, :scope scope, :!subqs !subqs, :!aggs !aggs}))]
+                                                                                               (map->ExprPlanVisitor {:env env, :scope scope, :!subqs !subqs, :!aggs !aggs :!windows !windows}))]
                                                                              (if-let [as-clause (.asClause ctx)]
                                                                                (let [col-name (->col-sym (identifier-sym as-clause))]
                                                                                  (->ProjectedCol {col-name expr} col-name))
@@ -741,7 +748,8 @@
                                                                             (throw (UnsupportedOperationException. (str "Table not found: " table-name))))))))))
                                                         cat)))))
        :subqs (not-empty (into {} !subqs))
-       :aggs (not-empty (into {} !aggs))})))
+       :aggs (not-empty (into {} !aggs))
+       :windows (not-empty (into {} !windows))})))
 
 (defn- project-all-cols [scope]
   ;; duplicated from the ASTERISK case above
@@ -938,6 +946,10 @@
   PlanError
   (error-string [_] "Aggregates are not allowed in this context"))
 
+(defrecord WindowFunctionsDisallowed []
+  PlanError
+  (error-string [_] "Window functions are not allowed in this context"))
+
 (def ^xtdb.antlr.SqlVisitor string-literal-visitor
   (reify SqlVisitor
     (visitCharacterStringLiteral [this ctx] (-> (.characterString ctx) (.accept this)))
@@ -951,6 +963,8 @@
     (visitCEscapesString [_ ctx]
       (let [str (.getText ctx)]
         (StringUtil/parseCString (subs str 2 (dec (count str))))))))
+
+(declare plan-sort-specification-list)
 
 (defrecord ExprPlanVisitor [env scope]
   SqlVisitor
@@ -1569,6 +1583,54 @@
 
       agg-sym))
 
+  (visitWindowFunctionExpr [{:keys [^Map !windows] :as this} ctx]
+    (if-not !windows
+      (add-err! env (->WindowFunctionsDisallowed))
+      (let [[window-sym window-projection] (-> (.windowFunctionType ctx) (.accept this))
+            [window-name window-spec] (-> (.windowNameOrSpecification ctx) (.accept this))]
+        (.put !windows window-sym {:windows {window-name window-spec}
+                                   :projections [{window-sym (-> window-projection
+                                                                 (assoc :window-name window-name))}]})
+
+        window-sym)))
+
+  (visitWindowNameOrSpecification [this ctx]
+    (if-let [_window-name-ctx (.windowName ctx)]
+      (throw (UnsupportedOperationException. "TODO: Window names currently not supported!"))
+      (-> (.windowSpecification ctx) (.accept this))))
+
+  (visitRowNumberWindowFunction [{{:keys [!id-count]} :env} _]
+    (let [window-sym (-> (->col-sym (str "xt$row_number_" (swap! !id-count inc)))
+                         (vary-meta assoc :window-out-sym? true))]
+      [window-sym {:window-agg '(row-number)}]))
+
+  (visitWindowSpecification [this ctx]
+    (-> (.windowSpecificationDetails ctx) (.accept this)))
+
+  (visitWindowSpecificationDetails [{{:keys [!id-count]} :env :as this} ctx]
+    (let [window-name (symbol (str "window-name" (swap! !id-count inc)))
+          partition-cols (some-> (.windowPartitionClause ctx) (.accept this))
+          order-specs (some-> (.windowOrderClause ctx) (.accept this))
+          _frame (some-> (.windowFrameClause ctx) (.accept this))]
+      [window-name (cond-> {}
+                     partition-cols (assoc :partition-cols partition-cols)
+                     order-specs (assoc :order-specs order-specs))]))
+
+  (visitWindowPartitionClause [this ctx]
+    (-> (.windowPartitionColumnReferenceList ctx) (.accept this)))
+
+  (visitWindowPartitionColumnReferenceList [this ctx]
+    (mapv #(.accept ^ParserRuleContext % this) (.windowPartitionColumnReference ctx)))
+
+  (visitWindowPartitionColumnReference [this ctx]
+    (-> (.columnReference ctx) (.accept this)))
+
+  (visitWindowOrderClause [_this ctx]
+    (plan-sort-specification-list (.sortSpecificationList ctx) env scope nil))
+
+  (visitWindowFrameClause [_this _ctx]
+    (throw (UnsupportedOperationException. "TODO: Window frames currently not supported!")))
+
   (visitScalarSubqueryExpr [{:keys [!subqs]} ctx]
     (plan-sq (.subquery ctx) env scope !subqs
              {:sq-type :scalar}))
@@ -1670,8 +1732,8 @@
 (defrecord QueryExpr [plan col-syms]
   OptimiseStatement (optimise-stmt [this] (update this :plan lp/rewrite-plan)))
 
-(defn- plan-order-by [^SqlParser$OrderByClauseContext ctx
-                      {:keys [!id-count] :as env} inner-scope outer-col-syms]
+(defn- plan-sort-specification-list [^SqlParser$SortSpecificationListContext ctx
+                                     {:keys [!id-count] :as env} inner-scope outer-col-syms]
   (let [available-cols (set outer-col-syms)
         ob-expr-visitor (->ExprPlanVisitor env
                                            (reify Scope
@@ -1685,8 +1747,7 @@
                                                        [sym]))
                                                    (find-decls inner-scope chain)))))]
 
-    (-> (.sortSpecificationList ctx)
-        (.sortSpecification)
+    (-> (.sortSpecification ctx)
         (->> (mapv (fn [^SqlParser$SortSpecificationContext sort-spec-ctx]
                      (let [expr (-> (.expr sort-spec-ctx) (.accept ob-expr-visitor))
                            dir (or (some-> (.orderingSpecification sort-spec-ctx)
@@ -1719,6 +1780,9 @@
                                  {:order-by-spec [in-sym ob-opts]
                                   :in-projection {in-sym expr}})))))))))
 
+(defn- plan-order-by [^SqlParser$OrderByClauseContext ctx env inner-scope outer-col-syms]
+  (plan-sort-specification-list (.sortSpecificationList ctx) env inner-scope outer-col-syms))
+
 (defn- wrap-isolated-ob [plan outer-col-syms ob-specs]
   (let [in-projs (not-empty (into [] (keep :in-projection) ob-specs))]
     (as-> plan plan
@@ -1746,6 +1810,25 @@
       (if in-projs
         [:project (mapv :col-sym projected-cols) plan]
         plan))))
+
+(defn- wrap-windows [plan windows]
+  (let [{:keys [windows] :as window-opts} (apply merge-with into (vals windows))
+        in-projs (not-empty (->> (mapcat :order-specs (vals windows))
+                                 (into [] (keep :in-projection))))
+        window-opts (->> (update-vals windows (fn [window-name->window-spec]
+                                                (update window-name->window-spec :order-specs #(mapv :order-by-spec %))))
+                         (assoc window-opts :windows))]
+
+    (as-> plan plan
+      (if in-projs
+        [:map in-projs plan]
+        plan)
+
+      [:window window-opts
+       plan]
+
+      ;; hygienics happen in the order by planning
+      )))
 
 (defrecord DuplicateColumnProjection [col-sym]
   PlanError
@@ -1968,9 +2051,9 @@
 
           select-clause (.selectClause ctx)
 
-          {:keys [projected-cols] :as select-plan} (if select-clause
-                                                     (.accept select-clause (->SelectClauseProjectedCols env group-invar-col-tracker))
-                                                     (project-all-cols group-invar-col-tracker))
+          {:keys [projected-cols windows] :as select-plan} (if select-clause
+                                                             (.accept select-clause (->SelectClauseProjectedCols env group-invar-col-tracker))
+                                                             (project-all-cols group-invar-col-tracker))
 
           aggs (not-empty (merge (:aggs select-plan) (:aggs having-plan)))
           grouped-table? (boolean (or aggs (.groupByClause ctx)))
@@ -1979,9 +2062,14 @@
 
           distinct? (some-> select-clause .setQuantifier (.getText) (str/upper-case) (= "DISTINCT"))
 
+          _ (when (> (count windows) 1)
+              (throw (UnsupportedOperationException. "TODO: only one window function supported at the moment!")))
+          window-functions? (boolean windows)
+
           ob-specs (some-> order-by-ctx
                            (plan-order-by env qs-scope (mapv :col-sym projected-cols)))
 
+          ;; plan-table-ref reads the state written by all the find-decls
           plan (as-> (plan-table-ref qs-scope) plan
                  (if-let [{:keys [predicate subqs]} where-plan]
                    (-> plan
@@ -1999,6 +2087,9 @@
                    plan)
 
                  (-> plan (apply-sqs (:subqs select-plan)))
+
+                 (cond-> plan
+                   window-functions? (wrap-windows windows))
 
                  (if order-by-ctx
                    (-> plan

--- a/src/test/clojure/xtdb/operator/window_test.clj
+++ b/src/test/clojure/xtdb/operator/window_test.clj
@@ -1,0 +1,87 @@
+(ns xtdb.operator.window-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(deftest test-window-operator
+  (letfn [(run-test
+            [window-spec projection-specs blocks]
+            (let [window-name (gensym "window")]
+              (-> (tu/query-ra [:window {:windows {window-name window-spec}
+                                         :projections (mapv (fn [[col-name projection]]
+                                                              {col-name {:window-name window-name
+                                                                         :window-agg projection}}) projection-specs) }
+                                [::tu/blocks '{a :i64, b :i64} blocks]])
+                  set)))]
+
+    (t/is (= #{} (run-test '{:partition-cols [a]
+                             :order-specs [[b]]}
+                           '{rn (row-number)}
+                           [[] []])))
+
+    (t/is (= #{{:a 1, :b 20, :rn 0}
+               {:a 1, :b 10, :rn 1}
+               {:a 1, :b 50, :rn 2}
+               {:a 1, :b 60, :rn 3}
+               {:a 2, :b 30, :rn 0}
+               {:a 2, :b 40, :rn 1}
+               {:a 2, :b 70, :rn 2}
+               {:a 3, :b 80, :rn 0}
+               {:a 3, :b 90, :rn 1}}
+             (run-test '{:partition-cols [a]}
+                       '{rn (row-number)}
+                       [[{:a 1 :b 20}
+                         {:a 1 :b 10}
+                         {:a 2 :b 30}
+                         {:a 2 :b 40}]
+                        [{:a 1 :b 50}
+                         {:a 1 :b 60}
+                         {:a 2 :b 70}
+                         {:a 3 :b 80}
+                         {:a 3 :b 90}]]))
+          "only partition by")
+    (t/is (= #{{:a 1, :b 10, :rn 0}
+               {:a 1, :b 20, :rn 1}
+               {:a 2, :b 30, :rn 2}
+               {:a 2, :b 40, :rn 3}
+               {:a 1, :b 50, :rn 4}
+               {:a 1, :b 60, :rn 5}
+               {:a 2, :b 70, :rn 6}
+               {:a 3, :b 80, :rn 7}
+               {:a 3, :b 90, :rn 8}}
+             (run-test '{:order-specs [[b]]}
+                       '{rn (row-number)}
+                       [[{:a 1 :b 20}
+                         {:a 1 :b 10}
+                         {:a 2 :b 30}
+                         {:a 2 :b 40}]
+                        [{:a 1 :b 50}
+                         {:a 1 :b 60}
+                         {:a 2 :b 70}
+                         {:a 3 :b 80}
+                         {:a 3 :b 90}]]))
+          "only order-by")
+
+    (t/is (= #{{:a 1, :b 10, :rn 0}
+               {:a 1, :b 20, :rn 1}
+               {:a 1, :b 50, :rn 2}
+               {:a 1, :b 60, :rn 3}
+               {:a 2, :b 30, :rn 0}
+               {:a 2, :b 40, :rn 1}
+               {:a 2, :b 70, :rn 2}
+               {:a 3, :b 80, :rn 0}
+               {:a 3, :b 90, :rn 1}}
+             (run-test '{:partition-cols [a]
+                         :order-specs [[b]]}
+                       '{rn (row-number)}
+                       [[{:a 1 :b 20}
+                         {:a 1 :b 10}
+                         {:a 2 :b 30}
+                         {:a 2 :b 40}]
+                        [{:a 1 :b 50}
+                         {:a 1 :b 60}
+                         {:a 2 :b 70}
+                         {:a 3 :b 80}
+                         {:a 3 :b 90}]]))
+          "partition by + order-by")))

--- a/src/test/clojure/xtdb/operator/window_test.clj
+++ b/src/test/clojure/xtdb/operator/window_test.clj
@@ -84,4 +84,27 @@
                          {:a 2 :b 70}
                          {:a 3 :b 80}
                          {:a 3 :b 90}]]))
-          "partition by + order-by")))
+          "partition by + order-by")
+
+    ;; see min/max comment in window.clj
+    #_(t/is (= #{{:a 1, :b 20, :min-b 20}
+                 {:a 1, :b 10, :min-b 10}
+                 {:a 1, :b 50, :min-b 10}
+                 {:a 1, :b 60, :min-b 10}
+                 {:a 2, :b 30, :min-b 30}
+                 {:a 2, :b 40, :min-b 30}
+                 {:a 2, :b 70, :min-b 30}
+                 {:a 3, :b 80, :min-b 80}
+                 {:a 3, :b 90, :min-b 80}}
+               (run-test '{:partition-cols [a]}
+                         '{min-b (min b)}
+                         [[{:a 1 :b 20}
+                           {:a 1 :b 10}
+                           {:a 2 :b 30}
+                           {:a 2 :b 40}]
+                          [{:a 1 :b 50}
+                           {:a 1 :b 60}
+                           {:a 2 :b 70}
+                           {:a 3 :b 80}
+                           {:a 3 :b 90}]]))
+            "only partition by")))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -806,6 +806,107 @@
             FROM foo "
             {:table-info {"foo" #{"a"}}}))))
 
+(deftest test-window-functions
+  (t/is (=plan-file
+         "test-window-with-partition-and-order-by"
+         (plan-sql "SELECT y, ROW_NUMBER() OVER (PARTITION BY y ORDER BY z) FROM docs"
+                   {:table-info {"docs" #{"y" "z"}}})))
+
+  (t/is (thrown-with-msg? UnsupportedOperationException #"TODO"
+                          (plan-sql "SELECT ROW_NUMBER() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM docs"
+                                    {:table-info {"docs" #{"y" "z"}}}))
+        "window frames not yet supported")
+
+  (t/is (thrown-with-msg? UnsupportedOperationException #"TODO"
+                          (plan-sql "SELECT
+                                       ROW_NUMBER() OVER (PARTITION BY y) AS rn,
+                                       ROW_NUMBER() OVER (PARTITION BY z) AS rn2
+                                     FROM docs"
+                                    {:table-info {"docs" #{"y" "z"}}}))
+        "multiple windows not supported")
+
+  ;; TODO similar to #3640
+  #_
+  (t/is (= nil
+           (plan-sql "SELECT ROW_NUMBER() OVER (PARTITION BY y ORDER BY z) FROM docs"
+                     {:table-info {"docs" #{"xt$id"}}})))
+
+  (let [docs [{:a 1 :b 20}
+              {:a 1 :b 10}
+              {:a 2 :b 30}
+              {:a 2 :b 40}
+              {:a 1 :b 50}
+              {:a 1 :b 60}
+              {:a 2 :b 70}
+              {:a 3 :b 80}
+              {:a 3 :b 90}]]
+
+    (xt/submit-tx tu/*node* [(into [:put-docs :docs ]
+                                   (for [[id doc] (zipmap (range) docs)] (assoc doc :xt/id id)))])
+
+    (t/is (= #{{:a 1, :b 10, :rn 0}
+               {:a 1, :b 20, :rn 1}
+               {:a 1, :b 50, :rn 2}
+               {:a 1, :b 60, :rn 3}
+               {:a 2, :b 30, :rn 0}
+               {:a 2, :b 40, :rn 1}
+               {:a 2, :b 70, :rn 2}
+               {:a 3, :b 80, :rn 0}
+               {:a 3, :b 90, :rn 1}}
+             (->> (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rn FROM docs")
+                  set)))
+
+    (t/is (= #{{:a 1, :b 60, :rn 0}
+               {:a 1, :b 10, :rn 1}
+               {:a 1, :b 50, :rn 2}
+               {:a 1, :b 20, :rn 3}
+               {:a 2, :b 70, :rn 0}
+               {:a 2, :b 30, :rn 1}
+               {:a 2, :b 40, :rn 2}
+               {:a 3, :b 90, :rn 0}
+               {:a 3, :b 80, :rn 1}}
+             (->> (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a) AS rn FROM docs")
+                  set))
+          "only partition by")
+
+    (t/is (= #{{:a 1, :b 10, :rn 0}
+               {:a 1, :b 20, :rn 1}
+               {:a 2, :b 30, :rn 2}
+               {:a 2, :b 40, :rn 3}
+               {:a 1, :b 50, :rn 4}
+               {:a 1, :b 60, :rn 5}
+               {:a 2, :b 70, :rn 6}
+               {:a 3, :b 80, :rn 7}
+               {:a 3, :b 90, :rn 8}}
+             (->> (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER (ORDER BY b) AS rn FROM docs")
+                  set))
+          "only order by")
+
+    (t/is (= #{{:a 1, :b 60, :rn 0}
+               {:a 2, :b 70, :rn 1}
+               {:a 2, :b 30, :rn 2}
+               {:a 3, :b 90, :rn 3}
+               {:a 1, :b 10, :rn 4}
+               {:a 3, :b 80, :rn 5}
+               {:a 1, :b 50, :rn 6}
+               {:a 2, :b 40, :rn 7}
+               {:a 1, :b 20, :rn 8}}
+             (-> (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER () AS rn FROM docs")
+                 set))
+          "nothing")
+    #_
+    (t/is (= [{:a 1, :b 60, :rn 0}
+              {:a 2, :b 70, :rn 1}
+              {:a 2, :b 30, :rn 2}
+              {:a 3, :b 90, :rn 3}
+              {:a 1, :b 10, :rn 4}
+              {:a 3, :b 80, :rn 5}
+              {:a 1, :b 50, :rn 6}
+              {:a 2, :b 40, :rn 7}
+              {:a 1, :b 20, :rn 8}]
+             (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER (PARTITION BY y ORDER BY z) AS rn FROM docs"))
+          "no existing columns")))
+
 (deftest test-array-subqueries
   (t/are [file q]
     (=plan-file file (plan-sql q {:table-info {"a" #{"a" "b"}, "b" #{"b1" "b2"}}}))

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-window-with-partition-and-order-by.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-window-with-partition-and-order-by.edn
@@ -1,0 +1,14 @@
+[:project
+ [{y docs.1/y} {xt$column_2 xt$row_number_2}]
+ [:window
+  {:windows
+   {window-name3
+    {:partition-cols [docs.1/y],
+     :order-specs
+     [[xt$ob4 {:direction :asc, :null-ordering :nulls-last}]]}},
+   :projections
+   [{xt$row_number_2
+     {:window-agg (row-number), :window-name window-name3}}]}
+  [:map
+   [{xt$ob4 docs.1/z}]
+   [:rename docs.1 [:scan {:table docs} [y z]]]]]]


### PR DESCRIPTION
This adds window function support for `ROW_NUMBER() OVER (PARTITION BY x ORDER BY z) AS rn`. 

The operator currently looks like
```clj
[:window {:windows {window1 {:partition-cols [a]
                             :order-specs [[b]]
                             :frame {}}}
          :projections [{col-name {:window-name window1
                                   :window-agg (row-number)}}]}
 plan]
```

The algorithm currently works on the whole input relation. This could be parallelized later or the grouping step goes to disk (as `GROUP BY` also works completely in memory this is something for another ticket). We use the same grouping logic from `GROUP BY` to partition the relation. We then sort the whole relation by prepending the grouping vector and then pass `grouping vector`, `sorted indirection vector` and the input relation to the WindowFunctionAggregate to generate some specific aggregate. I have not touched frames in this PR, although I make the assumption of the default behaviour of `BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`


Things that need further work / thought:
- [x] I currently copy the whole relation (sort does a similar thing), we could try to use some retaining logic.
- [x] The current version supports one window function (although multiple aggregates). My current approach would be to treat window functions separately and only merge them later (in some optimization step). Window functions with different partitions need to run anyway after one another (except if we plan to parallelize). 
  - Let's throw with multiple window functions
- [x] I added a `min`/`max` aggregate (without going through the EE) to test if one can add some more complicated window aggregates easily.
  - Comment it out or put it on a branch.
- [x] Some `order-by` planning logic in the SQL planner is reused. As the planner contains some state, we need to make sure that is correctly used. 
  - Should be ok from @jarohen and @FiV0 understanding.