### PR TITLE
Add support for pg ::regclass type and cast

### DIFF
--- a/api/src/main/kotlin/xtdb/types/RegClass.kt
+++ b/api/src/main/kotlin/xtdb/types/RegClass.kt
@@ -1,0 +1,3 @@
+package xtdb.types
+
+data class RegClass(@JvmField val oid: Int)

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -182,6 +182,7 @@ dataType
     | 'VARCHAR' # CharacterStringType
     | 'DURATION' ('(' precision ')')? # DurationType
     | 'ROW' '(' fieldDefinition (',' fieldDefinition)* ')' # RowType
+    | 'REGCLASS' #RegClassType
     | dataType 'ARRAY' ('[' maximumCardinality ']')? # ArrayType
     ;
 

--- a/core/src/main/clojure/xtdb/expression/pg.clj
+++ b/core/src/main/clojure/xtdb/expression/pg.clj
@@ -1,0 +1,66 @@
+(ns xtdb.expression.pg
+  (:require [clojure.string :as str]
+            [xtdb.error :as err]
+            [xtdb.expression :as expr]
+            [xtdb.information-schema :as info-schema])
+  (:import [clojure.lang MapEntry]))
+
+(def search-path
+  ["pg_catalog" "public"])
+
+(defn symbol-table-names
+  "returns possible symbol table names based on search path for unqualified names"
+  [table]
+  (let [parts (str/split table #"\.")]
+    (if (= 1 (count parts))
+      (mapv #(symbol % (first parts)) search-path)
+      [(symbol (str/join "." (butlast parts)) (last parts))])))
+
+(defn string-table-name [table]
+  (if (contains? (set search-path) (namespace table))
+    (name table)
+    (str (namespace table) "." (name table))))
+
+(defn find-matching-table-name [schema tn]
+  (let [namespaced-schema (merge info-schema/table-info
+                                 {'xt/txs #{"xt$id" "committed" "error" "tx_time"}}
+                                 (info-schema/namespace-public-tables schema))]
+    (some #(when (contains? namespaced-schema %) %) (symbol-table-names tn))))
+
+(defn table->oid [tn]
+  (Math/abs ^Integer (hash tn)))
+
+(defmethod expr/codegen-cast [:utf8 :regclass] [{:keys [target-type]}]
+  {:return-type target-type
+   :->call-code
+   (fn [[utf8-code]]
+     `(let [tn# (expr/buf->str ~utf8-code)]
+        (if-let [matching-tn# (find-matching-table-name ~expr/schema-sym tn#)]
+          (table->oid matching-tn#)
+          (throw (err/runtime-err ::unknown-relation
+                                  {::err/message (format "Relation %s does not exist" tn#)})))))})
+
+(defn ->oid->table [schema]
+  (->> (merge info-schema/table-info
+              {'xt/txs #{"xt$id" "committed" "error" "tx_time"}}
+              (info-schema/namespace-public-tables schema))
+       (keys)
+       (map #(MapEntry. (table->oid %) %))
+       (into {})))
+
+(defmethod expr/codegen-cast [:regclass :utf8] [{:keys [target-type]}]
+  {:return-type target-type
+   :->call-code
+   (fn [[regclass-code]]
+     `(let [oid# ~regclass-code]
+        (if-let [tn# (get (->oid->table ~expr/schema-sym) oid#)]
+          (expr/resolve-utf8-buf (string-table-name tn#))
+          (expr/resolve-utf8-buf (str oid#)))))})
+
+(defmethod expr/codegen-cast [:regclass :int] [{:keys [target-type]}]
+  {:return-type target-type
+   :->call-code first})
+
+(defmethod expr/codegen-cast [:int :regclass] [{:keys [target-type]}]
+  {:return-type target-type
+   :->call-code first})

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -240,7 +240,7 @@
                                    (tryAdvance [_ c]
                                      (.tryAdvance dep-cursor (reify Consumer
                                                                (accept [_ in-rel]
-                                                                 (with-open [match-vec (.project projection-spec allocator in-rel params)]
+                                                                 (with-open [match-vec (.project projection-spec allocator in-rel {} params)]
                                                                    (.accept c (vr/rel-reader [match-vec])))))))
 
                                    (close [_] (.close dep-cursor))))))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -287,7 +287,7 @@
             (finish [_]
               (with-open [sum (.finish sum-agg)
                           count (.finish count-agg)]
-                (.project projecter al (vr/rel-reader [sum count]) vw/empty-params)))
+                (.project projecter al (vr/rel-reader [sum count]) {} vw/empty-params)))
 
             Closeable
             (close [_]
@@ -334,7 +334,7 @@
             IAggregateSpec
             (aggregate [_ in-rel group-mapping]
               (let [in-vec (.readerForName in-rel (str from-name))]
-                (with-open [x2 (.project x2-projecter al (vr/rel-reader [in-vec]) vw/empty-params)]
+                (with-open [x2 (.project x2-projecter al (vr/rel-reader [in-vec]) {} vw/empty-params)]
                   (.aggregate sumx-agg in-rel group-mapping)
                   (.aggregate sumx2-agg (vr/rel-reader [x2]) group-mapping)
                   (.aggregate countx-agg in-rel group-mapping))))
@@ -345,6 +345,7 @@
                           countx (.finish countx-agg)]
                 (.project finish-projecter al
                           (vr/rel-reader [sumx sumx2 countx])
+                          {}
                           vw/empty-params)))
 
             Closeable
@@ -375,7 +376,7 @@
 
             (finish [_]
               (with-open [variance (.finish variance-agg)]
-                (.project finish-projecter al (vr/rel-reader [variance]) vw/empty-params)))
+                (.project finish-projecter al (vr/rel-reader [variance]) {} vw/empty-params)))
 
             Closeable
             (close [_]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -175,7 +175,7 @@
 
 (defn iid-selector [^ByteBuffer iid-bb]
   (reify SelectionSpec
-    (select [_ allocator rel-rdr _params]
+    (select [_ allocator rel-rdr _schema _params]
       (with-open [arrow-buf (util/->arrow-buf-view allocator iid-bb)]
         (let [iid-ptr (ArrowBufPointer. arrow-buf 0 (.capacity iid-bb))
               ptr (ArrowBufPointer.)
@@ -232,7 +232,7 @@
 (deftype TrieCursor [^BufferAllocator allocator, ^Iterator merge-tasks, ^IRelationWriter out-rel
                      col-names, ^Map col-preds,
                      ^TemporalBounds temporal-bounds
-                     params, vsr-cache, buffer-pool]
+                     schema, params, vsr-cache, buffer-pool]
   ICursor
   (tryAdvance [_ c]
     (let [!advanced? (boolean-array 1)]
@@ -249,7 +249,7 @@
                   leaf-rdrs (for [leaf leaves
                                   :let [^RelationReader data-rdr (trie/load-page leaf buffer-pool vsr-cache)]]
                               (cond-> data-rdr
-                                iid-pred (.select (.select iid-pred allocator data-rdr params))))
+                                iid-pred (.select (.select iid-pred allocator data-rdr {} params))))
                   [temporal-cols content-cols] ((juxt filter remove) temporal-column? col-names)
                   content-rel-factory (->content-rel-factory leaf-rdrs allocator content-cols)]
 
@@ -286,7 +286,7 @@
                                           (or (empty? (seq content-cols)) (seq temporal-cols))
                                           (vr/concat-rels (vw/rel-wtr->rdr out-rel)))
                     ^RelationReader rel (reduce (fn [^RelationReader rel ^SelectionSpec col-pred]
-                                                  (.select rel (.select col-pred allocator rel params)))
+                                                  (.select rel (.select col-pred allocator rel schema params)))
                                                 rel
                                                 (vals (dissoc col-preds "xt$iid")))]
                 (when (pos? (.rowCount rel))
@@ -434,9 +434,9 @@
 
         {:fields fields
          :stats {:row-count row-count}
-         :->cursor (fn [{:keys [allocator, ^Watermark watermark, basis, params]}]
+         :->cursor (fn [{:keys [allocator, ^Watermark watermark, basis, schema, params]}]
                      (if-let [derived-table-schema (info-schema/derived-tables table)]
-                       (info-schema/->cursor allocator derived-table-schema table col-names col-preds params metadata-mgr watermark)
+                       (info-schema/->cursor allocator derived-table-schema table col-names col-preds schema params metadata-mgr watermark)
                        (let [iid-bb (selects->iid-byte-buffer selects params)
                              col-preds (cond-> col-preds
                                          iid-bb (assoc "xt$iid" (iid-selector iid-bb)))
@@ -490,6 +490,7 @@
                                (->TrieCursor allocator (.iterator ^Iterable merge-tasks) out-rel
                                              col-names col-preds
                                              temporal-bounds
+                                             schema
                                              params
                                              (->vsr-cache buffer-pool allocator)
                                              buffer-pool)))))))}))))

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -18,7 +18,7 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype SelectCursor [^BufferAllocator allocator, ^ICursor in-cursor, ^SelectionSpec selector, params]
+(deftype SelectCursor [^BufferAllocator allocator, ^ICursor in-cursor, ^SelectionSpec selector, schema, params]
   ICursor
   (tryAdvance [_ c]
     (let [advanced? (boolean-array 1)]
@@ -26,7 +26,7 @@
                                (reify Consumer
                                  (accept [_ in-rel]
                                    (let [^RelationReader in-rel in-rel]
-                                     (when-let [idxs (.select selector allocator in-rel params)]
+                                     (when-let [idxs (.select selector allocator in-rel schema params)]
                                        (when-not (zero? (alength idxs))
                                          (.accept c (.select in-rel idxs))
                                          (aset advanced? 0 true)))))))
@@ -43,6 +43,6 @@
                          :param-types (update-vals param-fields types/field->col-type)}
             selector (expr/->expression-selection-spec (expr/form->expr predicate input-types) input-types)]
         {:fields inner-fields
-         :->cursor (fn [{:keys [allocator params]} in-cursor]
-                     (-> (SelectCursor. allocator in-cursor selector params)
+         :->cursor (fn [{:keys [allocator params schema]} in-cursor]
+                     (-> (SelectCursor. allocator in-cursor selector schema params)
                          (coalesce/->coalescing-cursor allocator)))}))))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -66,7 +66,7 @@
 
         (vr/rel-reader out-cols row-count)))))
 
-(defn- emit-rows-table [rows table-expr {:keys [param-fields] :as opts}]
+(defn- emit-rows-table [rows table-expr {:keys [param-fields schema] :as opts}]
   (let [param-types (update-vals param-fields types/field->col-type)
         field-sets (HashMap.)
         row-count (count rows)
@@ -106,7 +106,7 @@
                     projection-spec (expr/->expression-projection-spec "_scalar" expr input-types)]
                 (.add field-set (types/col-type->field (.getColumnType projection-spec)))
                 (.put out-row k (fn [{:keys [allocator params]}]
-                                  (util/with-open [out-vec (.project projection-spec allocator (vr/rel-reader [] 1) params)]
+                                  (util/with-open [out-vec (.project projection-spec allocator (vr/rel-reader [] 1) schema params)]
                                     (.getObject out-vec 0 key-fn))))))))
         (.add out-rows out-row)))
 
@@ -119,7 +119,7 @@
                                (fn [v opts]
                                  (if (fn? v) (v opts) v))))})))
 
-(defn- emit-col-table [col-spec table-expr {:keys [param-fields] :as opts}]
+(defn- emit-col-table [col-spec table-expr {:keys [param-fields schema] :as opts}]
   (let [[out-col v] (first col-spec)
         param-types (update-vals param-fields types/field->col-type)
 
@@ -134,7 +134,7 @@
                  (restrict-cols table-expr))
 
      :->out-rel (fn [{:keys [allocator ^RelationReader params]}]
-                  (util/with-open [list-rdr (.project projection-spec allocator (vr/rel-reader [] 1) params)]
+                  (util/with-open [list-rdr (.project projection-spec allocator (vr/rel-reader [] 1) schema params)]
                     (let [list-rdr (cond-> list-rdr
                                      (instance? ArrowType$Union (.getType (.getField list-rdr))) (.legReader "list"))]
 

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -6,6 +6,7 @@
             [xtdb.error :as err]
             [xtdb.expression :as expr]
             xtdb.expression.temporal
+            xtdb.expression.pg
             [xtdb.logical-plan :as lp]
             [xtdb.metadata :as meta]
             xtdb.operator.apply
@@ -220,7 +221,8 @@
                                        :basis (-> basis
                                                   (update :at-tx (fnil identity (some-> wm .txBasis)))
                                                   (assoc :current-time current-time))
-                                       :params params})
+                                       :params params
+                                       :schema (scan/tables-with-cols wm-src)})
                             (wrap-cursor wm allocator clock ref-ctr fields)))
 
                       (catch Throwable t

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -926,6 +926,10 @@
       {:cast-type :interval
        :cast-opts (when interval-qualifier (iq-context->iq-map interval-qualifier))}))
 
+  (visitRegClassType [_ ctx]
+    {:cast-type :regclass
+     :cast-opts {}})
+
   (visitCharacterStringType [_ _] {:cast-type :utf8}))
 
 (defn handle-cast-expr [ve {:keys [cast-type cast-opts ->cast-fn]}] 

--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -28,6 +28,7 @@ import xtdb.arrow.*;
 import xtdb.types.IntervalDayTime;
 import xtdb.types.IntervalMonthDayNano;
 import xtdb.types.IntervalYearMonth;
+import xtdb.types.RegClass;
 import xtdb.vector.extensions.*;
 import xtdb.vector.extensions.KeywordVector;
 import xtdb.vector.extensions.SetVector;
@@ -407,6 +408,22 @@ public class ValueVectorReader implements IVectorReader {
             @Override
             Object getObject0(int idx, IKeyFn<?> keyFn) {
                 return Keyword.intern((String) underlyingVec.getObject(idx));
+            }
+        };
+    }
+
+    public static IVectorReader regClassVector(RegClassVector v) {
+        var underlyingVec = intVector(v.getUnderlyingVector());
+
+        return new ValueVectorReader(v) {
+            @Override
+            public int getInt(int idx) {
+                return underlyingVec.getInt(idx);
+            }
+
+            @Override
+            Object getObject0(int idx, IKeyFn<?> keyFn) {
+                return new RegClass(getInt(idx));
             }
         };
     }

--- a/core/src/main/kotlin/xtdb/Types.kt
+++ b/core/src/main/kotlin/xtdb/Types.kt
@@ -84,6 +84,7 @@ fun ArrowType.toLeg() = accept(object : ArrowTypeVisitor<String> {
         is TransitType -> "transit"
         is UuidType -> "uuid"
         is UriType -> "uri"
+        is RegClassType -> "regclass"
         is SetType -> "set"
         is TsTzRangeType -> "tstz-range"
         else -> throw UnsupportedOperationException("not supported for $type")
@@ -123,6 +124,7 @@ fun valueToArrowType(obj: Any?) = when (obj) {
     is ByteBuffer -> MinorType.VARBINARY.type
     is UUID -> UuidType
     is URI -> UriType
+    is RegClass -> RegClassType
     is Keyword -> KeywordType
     is ClojureForm -> TransitType
     is IllegalArgumentException -> TransitType

--- a/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
@@ -12,5 +12,5 @@ interface ProjectionSpec {
     /**
      * @param params a single-row indirect relation containing the params for this invocation - maybe a view over a bigger param relation.
      */
-    fun project(allocator: BufferAllocator, readRelation: RelationReader, params: RelationReader): IVectorReader
+    fun project(allocator: BufferAllocator, readRelation: RelationReader, schema: Map<String, Any>, params: RelationReader): IVectorReader
 }

--- a/core/src/main/kotlin/xtdb/operator/SelectionSpec.kt
+++ b/core/src/main/kotlin/xtdb/operator/SelectionSpec.kt
@@ -7,5 +7,5 @@ interface SelectionSpec {
     /**
      * @param params a single-row indirect relation containing the params for this invocation - maybe a view over a bigger param relation.
      */
-    fun select(allocator: BufferAllocator, readRelation: RelationReader, params: RelationReader): IntArray
+    fun select(allocator: BufferAllocator, readRelation: RelationReader, schema: Map<String, Any>, params: RelationReader): IntArray
 }

--- a/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
+++ b/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
@@ -408,6 +408,13 @@ internal class KeywordVectorWriter(vector: KeywordVector) : ExtensionVectorWrite
     override fun writeValue0(v: ValueReader) = writeBytes(v.readBytes())
 }
 
+internal class RegClassVectorWriter(vector: RegClassVector) : ExtensionVectorWriter(vector, null) {
+    override fun writeObject0(obj: Any) =
+        if (obj !is RegClass) throw InvalidWriteObjectException(field, obj)
+        else super.writeObject0(obj.oid)
+
+    override fun writeValue0(v: ValueReader) = writeBytes(v.readBytes())
+}
 internal class UuidVectorWriter(vector: UuidVector) : ExtensionVectorWriter(vector, null) {
     override fun writeObject0(obj: Any) =
         if (obj !is UUID) throw InvalidWriteObjectException(field, obj)
@@ -550,6 +557,7 @@ private object WriterForVectorVisitor : VectorVisitor<IVectorWriter, FieldChange
 
     override fun visit(vec: ExtensionTypeVector<*>, notify: FieldChangeListener?): IVectorWriter = when (vec) {
         is KeywordVector -> KeywordVectorWriter(vec)
+        is RegClassVector -> RegClassVectorWriter(vec)
         is UuidVector -> UuidVectorWriter(vec)
         is UriVector -> UriVectorWriter(vec)
         is TransitVector -> TransitVectorWriter(vec)

--- a/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
+++ b/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
@@ -67,6 +67,7 @@ object VecToReader : VectorVisitor<IVectorReader, Any?> {
 
     override fun visit(v: ExtensionTypeVector<*>, value: Any?): IVectorReader = when (v) {
         is KeywordVector -> keywordVector(v)
+        is RegClassVector -> regClassVector(v)
         is UuidVector -> uuidVector(v)
         is UriVector -> uriVector(v)
         is TransitVector -> transitVector(v)

--- a/core/src/main/kotlin/xtdb/vector/extensions/RegClassType.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/RegClassType.kt
@@ -1,0 +1,19 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ExtensionTypeRegistry
+import org.apache.arrow.vector.types.pojo.FieldType
+
+object RegClassType : XtExtensionType("xt/regclass", Types.MinorType.INT.getType()) {
+    init {
+        ExtensionTypeRegistry.register(this)
+    }
+
+    override fun deserialize(serializedData: String): ArrowType = this
+
+    override fun getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator): FieldVector =
+        RegClassVector(name, allocator, fieldType)
+}

--- a/core/src/main/kotlin/xtdb/vector/extensions/RegClassVector.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/RegClassVector.kt
@@ -1,0 +1,12 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.types.RegClass
+
+class RegClassVector(name: String, allocator: BufferAllocator, fieldType: FieldType) :
+    XtExtensionVector<IntVector>(name, allocator, fieldType, IntVector(name, allocator)) {
+
+    override fun getObject0(index: Int): RegClass = RegClass(underlyingVector.get(index));
+}

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -42,6 +42,7 @@
                     expr (expr/form->expr form input-types)]
                 (with-open [project-col (.project (expr/->expression-projection-spec "c" expr input-types)
                                                   tu/*allocator* in-rel
+                                                  {}
                                                   vw/empty-params)]
                   (tu/<-reader project-col))))]
 
@@ -80,7 +81,7 @@
               (with-open [param-rel (tu/open-params params-map)]
                 (let [input-types {:col-types col-types, :param-types (expr/->param-types (RelationReader/from param-rel))}]
                   (alength (.select (expr/->expression-selection-spec (expr/form->expr form input-types) input-types)
-                                    tu/*allocator* in-rel param-rel)))))]
+                                    tu/*allocator* in-rel {} param-rel)))))]
 
       (t/testing "selector"
         (t/is (= 500 (select-relation '(>= a 500) {'a :f64} {})))
@@ -93,7 +94,7 @@
 (t/deftest nil-selection-doesnt-yield-the-row
   (t/is (= 0
            (-> (.select (expr/->expression-selection-spec (expr/form->expr '(and true nil) {}) {})
-                        tu/*allocator* (vr/rel-reader [] 1) vw/empty-params)
+                        tu/*allocator* (vr/rel-reader [] 1) {} vw/empty-params)
                (alength)))))
 
 (defn project
@@ -330,7 +331,7 @@
         input-types {:col-types col-types, :param-types {}}
         expr (expr/form->expr form input-types)]
     (with-open [out-ivec (.project (expr/->expression-projection-spec "out" expr input-types)
-                                   tu/*allocator* rel vw/empty-params)]
+                                   tu/*allocator* rel {} vw/empty-params)]
       {:res (tu/<-reader out-ivec)
        :res-type (types/field->col-type (.getField out-ivec))})))
 

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -134,7 +134,7 @@
               :attname "col1",
               :attisdropped false}
              {:atttypmod -1,
-              :attrelid -598393539,
+              :attrelid 598393539,
               :attidentity "",
               :attgenerated "",
               :attnotnull false,
@@ -144,7 +144,7 @@
               :attname "error",
               :attisdropped false}
              {:atttypmod -1,
-              :attrelid -598393539,
+              :attrelid 598393539,
               :attidentity "",
               :attgenerated "",
               :attnotnull false,
@@ -154,7 +154,7 @@
               :attname "_id",
               :attisdropped false}
              {:atttypmod -1,
-              :attrelid -598393539,
+              :attrelid 598393539,
               :attidentity "",
               :attgenerated "",
               :attnotnull false,
@@ -164,7 +164,7 @@
               :attname "tx_time",
               :attisdropped false}
              {:atttypmod -1,
-              :attrelid -598393539,
+              :attrelid 598393539,
               :attidentity "",
               :attgenerated "",
               :attnotnull false,
@@ -320,6 +320,14 @@
               :typowner 1376455703,
               :typnotnull false,
               :typname "timestamptz",
+              :typnamespace -2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 2205,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "regclass",
               :typnamespace -2125819141,
               :typbasetype 0}}
            (set (tu/query-ra '[:scan

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -575,7 +575,7 @@
                 (let [iid-wtr (.colWriter rel-wrt "xt$iid")]
                   (doseq [uuid uuids]
                     (.writeBytes iid-wtr (util/uuid->byte-buffer uuid))))
-                (.select iid-selector tu/*allocator* (vw/rel-wtr->rdr rel-wrt) nil)))]
+                (.select iid-selector tu/*allocator* (vw/rel-wtr->rdr rel-wrt) {} nil)))]
 
       (t/is (= nil
                (seq (test-uuids [])))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -6,8 +6,10 @@
             [xtdb.serde :as serde]
             [xtdb.sql :as sql]
             [xtdb.sql.plan :as plan]
-            [xtdb.test-util :as tu])
-  (:import xtdb.api.tx.TxOps))
+            [xtdb.test-util :as tu]
+            [xtdb.types])
+  (:import xtdb.api.tx.TxOps
+           xtdb.types.RegClass))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
@@ -1926,3 +1928,80 @@ JOIN docs2 FOR VALID_TIME ALL AS d2
   (t/is (= [{:timezone "America/New_York"}]
            (xt/q tu/*node* "SHOW TIME ZONE"
                  {:default-tz #xt.time/zone "America/New_York"}))))
+
+(t/deftest test-regclass
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+
+  (t/testing "regclass uses search path to resolve unqualified names"
+    (t/is (= [{:v (RegClass. 357712798)}]
+             (xt/q tu/*node* "SELECT 'public.foo'::regclass v")
+             (xt/q tu/*node* "SELECT 'foo'::regclass v"))
+          "text -> regclass"))
+
+  (t/testing "regclass name is returned qualified only if the schema does not appear in search path"
+    (t/is (= [{:v "foo"}]
+             (xt/q tu/*node* "SELECT 'public.foo'::regclass::varchar v"))
+          "text -> regclass -> text")
+
+    (t/is (= [{:v "information_schema.columns"}]
+             (xt/q tu/*node* "SELECT 'information_schema.columns'::regclass::varchar v"))
+          "text -> regclass -> text"))
+
+  (t/is (= [{:v 357712798}]
+           (xt/q tu/*node* "SELECT 'public.foo'::regclass::int v"))
+        "text -> regclass -> int")
+
+  (t/is (= [{:v (RegClass. 1151209360)}]
+           (xt/q tu/*node* "SELECT 1151209360::regclass v"))
+        "int -> regclass")
+
+  (t/is (thrown-with-msg?
+         RuntimeException
+         #"Relation public.baz does not exist"
+         (xt/q tu/*node* "SELECT 'public.baz'::regclass")))
+
+  (t/testing "regclass that doesn't match a known table"
+    (t/is (= [{:v "999999"}]
+             (xt/q tu/*node* "SELECT 999999::regclass::varchar v"))
+          "returns a stringified oid/int"))
+
+  (t/is (= [{:atttypmod -1,
+             :attrelid 357712798,
+             :attidentity "",
+             :attgenerated "",
+             :attnotnull false,
+             :attlen 8,
+             :atttypid 20,
+             :attnum 0,
+             :attname "_id",
+             :attisdropped false}]
+           (xt/q tu/*node* "SELECT * FROM pg_attribute WHERE attrelid = 'public.foo'::regclass")))
+
+  (t/is (= [{:v true}]
+           (xt/q tu/*node* "SELECT 357712798::regclass = 'foo'::regclass v"))
+        "regclass with identical oid are equal")
+
+  (t/testing "testing non-literal cast"
+    (xt/submit-tx tu/*node* [[:sql "INSERT INTO bar (_id, tn) VALUES (1, 'foo')"]])
+
+    (t/is (= [{:v (RegClass. 357712798)}]
+             (xt/q tu/*node* "SELECT tn::regclass v FROM bar"))
+          "text -> regclass")))
+
+(t/deftest test-regclass-where-expr
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO bar (_id) VALUES (1)"]
+                           [:sql "INSERT INTO bar (_id) VALUES (2)"]])
+
+  (t/is (= [{:xt/id 2} {:xt/id 1}]
+           (xt/q tu/*node* "SELECT _id FROM bar WHERE 'bar'::regclass = 904292726"))))
+
+(t/deftest test-regclass-search-path-precedence
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO pg_class (_id) VALUES (1)"]])
+
+  (t/is (= [{:v (RegClass. 529124840)}]
+           (xt/q tu/*node* "SELECT 'pg_class'::regclass v")
+           (xt/q tu/*node* "SELECT 'pg_catalog.pg_class'::regclass v"))
+        "matches pg_catalog.pg_class over public.pg_class as the former comes first in the search path"))

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -586,7 +586,7 @@
                 (let [^ICursor trie-cursor (scan/->TrieCursor al (.iterator ^Iterable merge-tasks) out-rel
                                                               ["xt$id" "foo"] {}
                                                               (TemporalBounds.)
-                                                              nil
+                                                              {} nil
                                                               (scan/->vsr-cache buffer-pool al)
                                                               buffer-pool)]
 

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -13,9 +13,9 @@
            (org.apache.arrow.vector BigIntVector BitVector DateDayVector DecimalVector Float4Vector Float8Vector IntVector IntervalMonthDayNanoVector NullVector SmallIntVector TimeNanoVector TimeStampMicroTZVector TinyIntVector VarBinaryVector VarCharVector)
            (org.apache.arrow.vector.complex DenseUnionVector ListVector StructVector)
            (org.apache.arrow.vector.types.pojo ArrowType)
-           (xtdb.types IntervalDayTime IntervalYearMonth)
+           (xtdb.types IntervalDayTime IntervalYearMonth RegClass)
            (xtdb.vector IVectorWriter)
-           (xtdb.vector.extensions KeywordVector TransitVector UriVector UuidVector)))
+           (xtdb.vector.extensions KeywordVector TransitVector UriVector UuidVector RegClassVector)))
 
 (t/use-fixtures :each tu/with-allocator)
 
@@ -354,3 +354,9 @@
                   l-rdr (.legReader rdr (.getLeg rdr 0))]
 
         (t/is (= val (read-binary {} (write-binary {} l-rdr 0))))))))
+
+(t/deftest test-regclass-rountrip
+  (let [vs [(RegClass. 101)]]
+    (t/is (= {:vs vs
+              :vec-types [RegClassVector]}
+             (test-round-trip vs)))))


### PR DESCRIPTION
Commit uses the newly available schema value available on watermark to enable casting to and from an approximation of the postgres regclass type. This type represents the OID of a pg class (which is currently synonymous with a table in XTDB), and uniquely identifies that relation via a hash of its namespaced table name (schema-name + table-name). This makes it possible to refer to tables by their name within SQL queries.

Commit does this by exposing the schema as an implicitly available variable to the expression engine.