### PR TITLE
Add support for "json" type within pgwire, #3648

### DIFF
--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -6,7 +6,7 @@
             [xtdb.time :as time]
             [xtdb.util :as util])
   (:import (clojure.lang MapEntry)
-           [java.io Writer]
+           [java.io ByteArrayInputStream Writer]
            [java.nio ByteBuffer]
            [java.nio.charset StandardCharsets]
            [java.time LocalDate LocalDateTime OffsetDateTime ZoneId ZoneOffset ZonedDateTime]
@@ -15,7 +15,7 @@
            (org.apache.arrow.vector.types DateUnit FloatingPointPrecision IntervalUnit TimeUnit Types$MinorType UnionMode)
            (org.apache.arrow.vector.types.pojo ArrowType ArrowType$Binary ArrowType$Bool ArrowType$Date ArrowType$Decimal ArrowType$Duration ArrowType$FixedSizeBinary ArrowType$FixedSizeList ArrowType$FloatingPoint ArrowType$Int ArrowType$Interval ArrowType$List ArrowType$Map ArrowType$Null ArrowType$Struct ArrowType$Time ArrowType$Time ArrowType$Timestamp ArrowType$Union ArrowType$Utf8 Field FieldType)
            xtdb.api.query.IKeyFn
-           xtdb.Types
+           (xtdb JsonSerde Types)
            [xtdb.vector IVectorReader]
            (xtdb.vector.extensions KeywordType SetType TransitType TsTzRangeType UriType UuidType RegClassType)))
 
@@ -989,7 +989,9 @@
                            (utf8 (if (.getBoolean rdr idx) "t" "f")))}
    ;; json-write-text is essentially the default in send-query-result so no need to specify here
    :json {:typname "json"
-          :oid 114}})
+          :oid 114
+          :read-text (fn [_env ba]
+                       (JsonSerde/decode (ByteArrayInputStream. ba)))}})
 
 (def pg-types-by-oid (into {} (map #(hash-map (:oid (val %)) (val %))) pg-types))
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1293,7 +1293,14 @@
 
     (t/is (= [{:_id 1, :a 2, :b nil, :c {"d" 3}, :d 3}
               {:_id 0, :a 1, :b 2, :c nil, :d nil}]
-             (jdbc/execute! conn ["SELECT _id, (json).a, (json).b, (json).c, (json).c.d FROM foo"])))))
+             (jdbc/execute! conn ["SELECT _id, (json).a, (json).b, (json).c, (json).c.d FROM foo"])))
+
+    ;; we don't currently support JSON as a _query_ param-type, because we have to prepare the statement
+    ;; without the dynamic arg values, and we can't know the type of the JSON arg until we see the value
+    (t/is (thrown-with-msg? PSQLException
+                            #"ERROR: Unsupported param-types in query: \[\"json\"\]"
+                            (jdbc/execute! conn ["SELECT * FROM foo WHERE json = ?"
+                                                 (as-json-param {:a 2, :c {:d 3}})])))))
 
 (deftest test-odbc-queries
   (with-open [conn (jdbc-conn)]


### PR DESCRIPTION
Added read-text for "json" in xtdb.types, with a JS test.

* Also added a couple of test utils to submit and parse JSON objects within next.jdbc - we could consider making these available as a library.
* Confirmed `sql.typed.json(obj)` works in JS
* We also explicitly reject JSON parameters in _queries_, because we need to know the types involved when we prepare the query (i.e. before we get dynamic argument values).