### PR TITLE
Dealing with unresolved column references

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -499,7 +499,7 @@
   PlanError
   (error-string [_] (format "Missing grouping columns: %s" missing-grouping-cols)))
 
-(defrecord GroupInvariantColsTracker [env scope, ^Set !implied-gicrs]
+(defrecord GroupInvariantColsTracker [env scope, ^Set !implied-gicrs ^Set !unresolved-cr]
   SqlVisitor
   (visitSelectClause [this ctx] (.accept (.getParent ctx) this))
 
@@ -509,7 +509,9 @@
                                  (.accept grp-el
                                           (reify SqlVisitor
                                             (visitOrdinaryGroupingSet [_ ctx]
-                                              (.accept (.columnReference ctx) (->ExprPlanVisitor env scope)))))))]
+                                              (.accept (.columnReference ctx)
+                                                       (map->ExprPlanVisitor {:env env :scope scope
+                                                                              :!unresolved-cr !unresolved-cr})))))))]
 
         (if-let [missing-grouping-cols (not-empty (set/difference (set !implied-gicrs) (set grouping-cols)))]
           (add-err! env (->MissingGroupingColumns missing-grouping-cols))
@@ -1031,14 +1033,14 @@
       "true" true
       "false" false
       "unknown" nil))
-  
+
   (visitUUIDLiteral [this ctx] (parse-uuid-literal (.accept (.characterString ctx) this) env))
 
   (visitNullLiteral [_ _ctx] nil)
 
   (visitColumnExpr [this ctx] (-> (.columnReference ctx) (.accept this)))
 
-  (visitColumnReference [{:keys [^Set !ob-col-refs]} ctx]
+  (visitColumnReference [{{:keys [!id-count]} :env :keys [^Set !ob-col-refs ^Set !unresolved-cr]} ctx]
     (let [chain (rseq (mapv identifier-sym (.identifier (.identifierChain ctx))))]
       (case (first chain)
         _valid_time
@@ -1053,9 +1055,13 @@
 
         (let [matches (find-decls scope chain)]
           (when-let [sym (case (count matches)
-                           0 (add-warning! env (->ColumnNotFound chain))
+                           0 (do (add-warning! env (->ColumnNotFound chain))
+                                 (when !unresolved-cr
+                                   (let [sym (->col-sym (str "xt$missing_column" (swap! !id-count inc)))]
+                                     (.add !unresolved-cr sym)
+                                     sym)))
                            1 (first matches)
-                           (add-err! env (->AmbiguousColumnReference chain)))]
+                           (add-err! env (->AmbiguousColumnReference chain))) ]
             (some-> !ob-col-refs (.add sym))
             sym)))))
 
@@ -2159,7 +2165,8 @@
                          {:predicate (.accept (.expr where-clause) (map->ExprPlanVisitor {:env env, :scope qs-scope, :!subqs !subqs}))
                           :subqs (not-empty (into {} !subqs))}))
 
-          group-invar-col-tracker (->GroupInvariantColsTracker env qs-scope (HashSet.))
+          !unresolved-cr (HashSet.)
+          group-invar-col-tracker (->GroupInvariantColsTracker env qs-scope (HashSet.) !unresolved-cr)
 
           having-plan (when-let [having-clause (.havingClause ctx)]
                         (let [!subqs (HashMap.)
@@ -2184,12 +2191,18 @@
           _ (when (> (count windows) 1)
               (throw (UnsupportedOperationException. "TODO: only one window function supported at the moment!")))
           window-functions? (boolean windows)
+          unresolved-cr (not-empty (into #{} !unresolved-cr))
 
           ob-specs (some-> order-by-ctx
                            (plan-order-by env qs-scope (mapv :col-sym projected-cols)))
 
           ;; plan-table-ref reads the state written by all the find-decls
           plan (as-> (plan-table-ref qs-scope) plan
+                 (if unresolved-cr
+                   [:map (mapv #(hash-map % nil) unresolved-cr)
+                    plan]
+                   plan)
+
                  (if-let [{:keys [predicate subqs]} where-plan]
                    (-> plan
                        (apply-sqs subqs)

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-unresolved-column-reference.edn
@@ -1,0 +1,9 @@
+[:project
+ [{_column_1 _sum_out_2}]
+ [:group-by
+  [xt$missing_column4 {_sum_out_2 (sum _sum_in_3)}]
+  [:map
+   [{_sum_in_3 (+ docs.1/_id 1)}]
+   [:map
+    [{xt$missing_column4 nil}]
+    [:rename docs.1 [:scan {:table public/docs} [_id]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-having-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-having-with-unresolved-column-reference.edn
@@ -1,0 +1,9 @@
+[:project
+ [{s _sum_out_4}]
+ [:select
+  (> _sum_out_2 1)
+  [:group-by
+   [{_sum_out_4 (sum docs.1/_id)} {_sum_out_2 (sum _sum_in_3)}]
+   [:map
+    [{_sum_in_3 nil}]
+    [:rename docs.1 [:scan {:table public/docs} [_id]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-where-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-where-with-unresolved-column-reference.edn
@@ -1,0 +1,5 @@
+[:project
+ [{s docs.1/_id}]
+ [:rename
+  docs.1
+  [:select (> nil 1) [:scan {:table public/docs} [_id]]]]]


### PR DESCRIPTION
This mainly fixes https://github.com/xtdb/xtdb/issues/3640. As an example 

```sql
SELECT SUM(_id) FROM docs GROUP BY x
``` 
now works even when docs does not have an `x` column.

The more general question is where and how should we deal with unresolved column references. The options are:
- Don't allow unresolved column references. This does, to my understanding, go against the idea that the same queries work no matter the basis. 
- Deal with it (as in this PR) on case by case basis in the planner. If an operator doesn't support nil columns, assure that a nil column gets created somehow beneath (`[:map {xt$missing_column nil} ...]` ).
- Make all the operators more resilient to nil columns
- Another option? 