### PR TITLE
Return query columnFields in the order defined by the logical plan

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -125,9 +125,7 @@
                           (lp/emit-expr conformed-query (assoc emit-opts :scan-emitter scan-emitter)))))))
 
 (defn ->column-fields [ordered-outer-projection fields]
-  (if ordered-outer-projection
-    (mapv #(hash-map (str %) (get fields %)) ordered-outer-projection)
-    (mapv #(hash-map (key %) (val %)) fields)))
+  (mapv #(hash-map (str %) (get fields %)) ordered-outer-projection))
 
 (defn ->param-fields [params]
   (->> params
@@ -168,7 +166,7 @@
                    (.scanFields scan-emitter wm))))
 
           cache (ConcurrentHashMap.)
-          ordered-outer-projection (:named-projection (meta query))
+          ordered-outer-projection (lp/relation-columns query)
           param-fields (mapify-params (mapv (comp types/col-type->field types/col-type->nullable-col-type) param-types-with-defaults))
           default-tz (or default-tz (.getZone expr/*clock*))]
 

--- a/core/src/main/clojure/xtdb/query_ra.clj
+++ b/core/src/main/clojure/xtdb/query_ra.clj
@@ -58,5 +58,7 @@
            (let [rows (-> (<-cursor res (serde/read-key-fn key-fn))
                           (cond->> (not preserve-blocks?) (into [] cat)))]
              (if with-col-types?
-               {:res rows, :col-types (update-vals (into {} (.columnFields bq)) types/field->col-type)}
+               {:res rows, :col-types (-> (into {} (.columnFields bq))
+                                          (update-vals types/field->col-type)
+                                          (update-keys symbol))}
                rows))))))))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1249,7 +1249,10 @@
              (sql "SELECT col0, col1, _id FROM foo")))
 
       (is (= [[2 20 "b"] [1 10 "a"] [3 30 "c"]]
-             (sql "SELECT * FROM foo"))))))
+             (sql "SELECT * FROM foo")))
+
+      (t/is (= [[1 2 3 4 5 6 7 8 9]]
+               (sql "SELECT 1, 2, 3, 4, 5, 6, 7, 8, 9"))))))
 
 ;; https://github.com/pgjdbc/pgjdbc/blob/8afde800bce64e9b22a7da10ca6c515017cf7db1/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java#L403
 ;; List of types/oids that support binary format


### PR DESCRIPTION
Commit uses lp/relation-columns as the source of truth for column ordering. While most ra operators don't explicitly define an order, project can be relied upon to correctly encode the outer order of any given SQL query due to the required nature of the SELECT clause.

Commit assumes the cost of calling `lp/logical-plan` is negligible enough that its not necessary to calculate and cache the outer projection order during query planning.