### PR TITLE
Azure `getBlob` downloading to temporary file and using `atomic-move`.

### DIFF
--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -11,7 +11,6 @@
            [java.nio.file FileAlreadyExistsException Path]
            [java.util ArrayList Base64 Base64$Encoder List]
            [java.util.concurrent CompletableFuture]
-           [java.util.function Supplier]
            [reactor.core Exceptions]
            xtdb.api.storage.ObjectStore
            [xtdb.multipart IMultipartUpload SupportsMultipart]))
@@ -29,7 +28,7 @@
   ([^BlobContainerClient blob-container-client blob-name ^Path out-file]
    (try
      (-> (.getBlobClient blob-container-client blob-name)
-         (.downloadToFile (str out-file) false))
+         (.downloadToFile (str out-file) true))
      (catch BlobStorageException e
        (if (= 404 (.getStatusCode e))
          (throw (os/obj-missing-exception blob-name))
@@ -137,10 +136,9 @@
   (getObject [_ k out-path]
     (let [prefixed-key (util/prefix-key prefix k)]
       (CompletableFuture/supplyAsync
-       (reify Supplier
-         (get [_]
-           (get-blob blob-container-client (str prefixed-key) out-path)
-           out-path)))))
+       (fn []
+         (get-blob blob-container-client (str prefixed-key) out-path)
+         out-path))))
 
   (getObjectRange [_ k start len]
     (let [prefixed-key (util/prefix-key prefix k)]


### PR DESCRIPTION
Was encountering some issues with multiple files downloading to the same file (even with `overwrite` set to false). Ie, we seemed to bump our heads against some different IOOBE on certain arrow files, namely any which we've attempted to fetch more than once (ie, have returned a "File Already Exists" for).

```
17:33:34.556 [ForkJoinPool.commonPool-worker-7] ERROR c.a.s.b.s.BlobAsyncClientBase - java.nio.file.FileAlreadyExistsException: /var/lib/xtdb/buffers/disk-cache-1/tables/public$gag/data/log-l01-fr512ca2a-nr5145a2c-rs64.arrow
17:33:34.567 [core2-benchmark-pool-7-thread-7] ERROR xtdb.bench - Error while executing xtdb.bench.auctionmark$proc_new_item@31aa41cc
clojure.lang.ExceptionInfo: Failed opening record batch 'tables/public$gag/data/log-l01-fr512ca2a-nr5145a2c-rs64.arrow'
```

Decided instead to take the following approach (instead of catching FIleAlreadyExists and relying on that):
- When `getBlob` is called, create a temp file.
- We download to the temporary file.
- Call `util/atomic-move` to move the temporary file to the actual out path.

Running this on the azure benchmark for an hour, did not see any repeats of IOOBEs, so fairly happy.