### PR TITLE
Handling, logging and rethrowing Azure SDK errors - updating logback level of `reactor`

### DIFF
--- a/cloud-benchmark/src/main/resources/logback.xml
+++ b/cloud-benchmark/src/main/resources/logback.xml
@@ -9,4 +9,5 @@
   </root>
   <logger name="xtdb" level="INFO" />
   <logger name="com.azure" level="ERROR" />
+  <logger name="reactor" level="ERROR" />
 </configuration>

--- a/docker/azure/src/main/resources/logback.xml
+++ b/docker/azure/src/main/resources/logback.xml
@@ -14,4 +14,5 @@
     <logger name="kafka" level="ERROR" />
     <logger name="org.apache.arrow" level="WARN" />
     <logger name="org.eclipse.jetty" level="WARN" />
+    <logger name="reactor" level="ERROR" />
 </configuration>

--- a/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/object_store.clj
@@ -15,20 +15,36 @@
            xtdb.api.storage.ObjectStore
            [xtdb.multipart IMultipartUpload SupportsMultipart]))
 
+(defmacro rethrowing-reactor-cause [form]
+  `(try
+     ~form
+     (catch Throwable e#
+       (throw (Exceptions/unwrap e#)))))
+
 (defn- get-blob 
   ([^BlobContainerClient blob-container-client blob-name]
    (try
-     (-> (.getBlobClient blob-container-client blob-name)
-         (.downloadContent)
-         (.toByteBuffer))
+     (rethrowing-reactor-cause
+      (-> (.getBlobClient blob-container-client blob-name)
+          (.downloadContent)
+          (.toByteBuffer)))
      (catch BlobStorageException e
        (if (= 404 (.getStatusCode e))
          (throw (os/obj-missing-exception blob-name))
-         (throw e)))))
+         (throw e)))
+     (catch InterruptedException e
+       (log/infof "Blob download to byte buffer interrupted for %s - terminating get operation" blob-name)
+        ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+       (Thread/interrupted)
+       (throw e))
+     (catch Exception e
+       (log/errorf "Exception thrown when downloading blob %s to byte buffer - %s" blob-name e)
+       (throw e))))
   ([^BlobContainerClient blob-container-client blob-name ^Path out-file]
    (try
-     (-> (.getBlobClient blob-container-client blob-name)
-         (.downloadToFile (str out-file) true))
+     (rethrowing-reactor-cause
+      (-> (.getBlobClient blob-container-client blob-name)
+          (.downloadToFile (str out-file) true)))
      (catch BlobStorageException e
        (if (= 404 (.getStatusCode e))
          (throw (os/obj-missing-exception blob-name))
@@ -38,43 +54,74 @@
          (if (instance? FileAlreadyExistsException cause)
            (do (log/debugf "File at getBlob already exists at output path %s, returning file path" out-file)
                out-file)
-           (throw e)))))))
+           (throw e))))
+     (catch InterruptedException e
+       (log/infof "Blob download to file interrupted for %s - terminating get operation" blob-name)
+        ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+       (Thread/interrupted)
+       (throw e))
+     (catch Exception e
+       (log/errorf "Exception thrown when downloading blob %s to file - %s" blob-name e)
+       (throw e)))))
 
 (defn- get-blob-range [^BlobContainerClient blob-container-client blob-name start len]
   (os/ensure-shared-range-oob-behaviour start len)
   (try
     ;; todo use async-client, azure sdk then defines exception behaviour, no need to block before fut
-    (let [cl (.getBlobClient blob-container-client blob-name)
-          out (ByteArrayOutputStream.)
-          res (.downloadStreamWithResponse cl out (BlobRange. start len) (DownloadRetryOptions.)  nil false nil nil)
-          status-code (.getStatusCode res)]
-      (cond
-        (<= 200 status-code 299) nil
-        (= 404 status-code) (throw (os/obj-missing-exception blob-name))
-        :else (throw (ex-info "Blob range request failure" {:status status-code})))
-      (ByteBuffer/wrap (.toByteArray out)))
+    (rethrowing-reactor-cause
+     (let [cl (.getBlobClient blob-container-client blob-name)
+           out (ByteArrayOutputStream.)
+           res (.downloadStreamWithResponse cl out (BlobRange. start len) (DownloadRetryOptions.)  nil false nil nil)
+           status-code (.getStatusCode res)]
+       (cond
+         (<= 200 status-code 299) nil
+         (= 404 status-code) (throw (os/obj-missing-exception blob-name))
+         :else (throw (ex-info "Blob range request failure" {:status status-code})))
+       (ByteBuffer/wrap (.toByteArray out))))
     (catch BlobStorageException e
       (if (= 404 (.getStatusCode e))
         (throw (os/obj-missing-exception blob-name))
-        (throw e)))))
+        (throw e)))
+    (catch InterruptedException e
+      (log/infof "Downloading blob range interrupted for %s - terminating get operation" blob-name)
+      ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+      (Thread/interrupted)
+      (throw e))
+    (catch Exception e
+      (log/errorf "Exception thrown when downloading blob range for %s - %s" blob-name e)
+      (throw e))))
 
 (defn- put-blob [^BlobContainerClient blob-container-client blob-name blob-buffer]
   (try
-    (-> (.getBlobClient blob-container-client blob-name)
-        (.upload (BinaryData/fromByteBuffer blob-buffer)))
+    (rethrowing-reactor-cause
+     (-> (.getBlobClient blob-container-client blob-name)
+         (.upload (BinaryData/fromByteBuffer blob-buffer))))
     (catch BlobStorageException e
       (if (= 409 (.getStatusCode e))
         (log/infof "Blob already exists for %s - terminating put operation" blob-name)
         (throw e)))
-    (catch Throwable e
-      (let [unwrapped-e (Exceptions/unwrap e)]
-        (when (instance? InterruptedException unwrapped-e)
-          (log/infof "Blob upload interrupted for %s - terminating put operation" blob-name))
-        (throw unwrapped-e)))))
+    (catch InterruptedException e
+      (log/infof "Blob upload interrupted for %s - terminating put operation" blob-name)
+      ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+      (Thread/interrupted)
+      (throw e))
+    (catch Exception e
+      (log/errorf "Exception thrown when uploading blob %s - %s" blob-name e)
+      (throw e))))
 
 (defn- delete-blob [^BlobContainerClient blob-container-client blob-name]
-  (-> (.getBlobClient blob-container-client blob-name)
-      (.deleteIfExists)))
+  (try
+    (rethrowing-reactor-cause
+     (-> (.getBlobClient blob-container-client blob-name)
+         (.deleteIfExists)))
+    (catch InterruptedException e
+      (log/infof "Blob delete interrupted for %s - terminating delete operation" blob-name)
+      ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+      (Thread/interrupted)
+      (throw e))
+    (catch Exception e
+      (log/errorf "Exception thrown when deleting blob %s - %s" blob-name e)
+      (throw e))))
 
 (def ^Base64$Encoder base-64-encoder (Base64/getEncoder))
 
@@ -86,36 +133,38 @@
   (uploadPart [_  buf]
     (CompletableFuture/completedFuture
      (try
-       (let [block-id (random-block-id)
-             binary-data (BinaryData/fromByteBuffer buf)]
-         (.stageBlock block-blob-client block-id binary-data)
-         (.add !staged-block-ids block-id))
-       (catch Throwable e
-         (let [unwrapped-e (Exceptions/unwrap e)]
-           (when (instance? InterruptedException unwrapped-e)
-             (log/infof "Multipart upload interrupted for %s - aborting multipart operation" (.getBlobUrl block-blob-client))
-             ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this to allow for
-             ;; the call within `abort` to succeed
-             (Thread/interrupted))
-           (throw unwrapped-e))))))
+       (rethrowing-reactor-cause
+        (let [block-id (random-block-id)
+              binary-data (BinaryData/fromByteBuffer buf)]
+          (.stageBlock block-blob-client block-id binary-data)
+          (.add !staged-block-ids block-id)))
+       (catch InterruptedException e
+         (log/infof "Staging block interrupted for %s - aborting multipart operation" (.getBlobUrl block-blob-client))
+         ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+         (Thread/interrupted)
+         (throw e))
+       (catch Exception e
+         (log/errorf "Exception thrown when staging block in multipart upload for %s - %s" (.getBlobUrl block-blob-client) e)
+         (throw e)))))
 
   (complete [_]
     (CompletableFuture/completedFuture
      ;; Commit the staged blocks - if already exists, abort the upload and complete
      (try
-       (.commitBlockList block-blob-client !staged-block-ids)
+       (rethrowing-reactor-cause
+        (.commitBlockList block-blob-client !staged-block-ids))
        (catch BlobStorageException e
          (if (= 409 (.getStatusCode e))
            (log/infof "Blob already exists for %s - aborting multipart upload" (.getBlobUrl block-blob-client))
            (throw e)))
-       (catch Throwable e
-         (let [unwrapped-e (Exceptions/unwrap e)]
-           (when (instance? InterruptedException unwrapped-e)
-             (log/infof "Multipart upload completion interrupted for %s - aborting multipart operation" (.getBlobUrl block-blob-client))
-             ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this to allow for
-             ;; the call within `abort` to succeed
-             (Thread/interrupted))
-           (throw unwrapped-e))))))
+       (catch InterruptedException e
+         (log/infof "Multipart upload completion interrupted for %s - aborting multipart operation" (.getBlobUrl block-blob-client))
+          ;; Reactor (used under the hood by the Azure SDK) leaves the thread interrupted - we need to clear this 
+         (Thread/interrupted)
+         (throw e))
+       (catch Exception e
+         (log/errorf "Exception thrown when completing mulipart upload for %s - %s" (.getBlobUrl block-blob-client) e)
+         (throw e)))))
 
   (abort [_]
     (CompletableFuture/completedFuture nil)))


### PR DESCRIPTION
Resolves #3703 

Should make a lot of the underlying HTTP connection/azure API calls a lot less chatty, and ensures we properly handle/log out any errors that actually matter to us.

Going to run against the Azure Benchmark, ensure it behaves itself.