### PR TITLE
Tag metrics with node id, add config for monitoring across nodes on Azure

### DIFF
--- a/cloud-benchmark/azure/README.adoc
+++ b/cloud-benchmark/azure/README.adoc
@@ -218,6 +218,12 @@ There is a helper script to do _all_ of the above, which can be run by:
 
 == Monitoring
 
+=== Setup
+
+To monitor the benchmark, we can use Azure Application Insights. We set up an applications insights resource in the terraform configuration, and output an instrumentation key. 
+
+=== Collecting metrics from node
+
 To see the benchmark metrics you need to supply an application insights instrumentation key via an environment variable in the `single-node-auctionmark.yaml` or `multi-node-auctionmark.yaml` file as below:
 
 ```yaml
@@ -238,3 +244,16 @@ terraform output -raw insights_instrumentation_key
 
 After a while you should be able to see the metrics in the Azure portal under the Application Insights resource, navigating to Monitoring > Metrics and looking under Metric Namespace > Custom.
 
+=== Observing metrics in the Dashboard
+
+We have made a custom dashboard for various XTDB, JVM and auctionmark metrics that we care about, with the ability to split them by node.
+
+To setup the dashboard itself, there's a few steps we must take:
+
+* Before anything else - ensure we can filter/split custom metrics. This can be found under the `usage and estimated costs` section of the Application Insights resource, and we should update this to allow "Alerting on Custom Metric Dimensions".
+* With that setup, we can create our custom dashboard.
+** Got to `Application Dashbard` on the Application Insights resource.
+** Create a new custom dashboard.
+** We can upload this from a template - you can use the template found within the `cloud-benchmark/azure` directory, `application-insights/dashboard.json`. 
+
+We already have a shared dashboard setup, under "Monitoring Dashboard"

--- a/cloud-benchmark/azure/application-insights/dashboard.json
+++ b/cloud-benchmark/azure/application-insights/dashboard.json
@@ -1,0 +1,1131 @@
+{
+  "properties": {
+    "lenses": [
+      {
+        "order": 0,
+        "parts": [
+          {
+            "position": {
+              "x": 0,
+              "y": 0,
+              "colSpan": 5,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "jvm_memory_used",
+                          "aggregationType": 3,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "jvm_memory_used",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "JVM -  Max Memory Usage Per Node",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "colorMap": {
+                          "xtdb-node-d39193": "#e3008c"
+                        },
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 5,
+              "y": 0,
+              "colSpan": 6,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "jvm_memory_used",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "jvm_memory_used",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "JVM - Average Memory Usage Per Node",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 11,
+              "y": 0,
+              "colSpan": 5,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "jvm_buffer_memory_used",
+                          "aggregationType": 3,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "jvm_buffer_memory_used",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "JVM - (Max) Buffer Memory used per Node",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 0,
+              "y": 3,
+              "colSpan": 5,
+              "rowSpan": 4
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "jvm_threads_started",
+                          "aggregationType": 3,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "jvm_threads_started",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "JVM - Max Live Threads Per Node ",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": {
+                "MsPortalFx_TimeRange": {
+                  "model": {
+                    "format": "utc",
+                    "granularity": "auto",
+                    "relative": "60m"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 5,
+              "y": 3,
+              "colSpan": 11,
+              "rowSpan": 4
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "jvm_threads_states",
+                          "aggregationType": 3,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "jvm_threads_states",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "JVM - Max Thread States",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": [
+                          "node-id",
+                          "state"
+                        ],
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 0,
+              "y": 7,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "get-comment",
+                          "aggregationType": 7,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "get-comment",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: get-comment by node",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 4,
+              "y": 7,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "get-item",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "get-item",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionark: get-item",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 8,
+              "y": 7,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "get-user-info",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "get-user-info",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: get-user-info",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 12,
+              "y": 7,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "index-item-status-groups",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "index-item-status-groups",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: index-item-status-groups",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 0,
+              "y": 10,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "new-comment",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "new-comment",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: new-comment",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 4,
+              "y": 10,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "new-item",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "new-item",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: new-item",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 8,
+              "y": 10,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "new-bid",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "new-bid",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: new-bid",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 12,
+              "y": 10,
+              "colSpan": 4,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "new-user",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "new-user",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Auctionmark: new-user",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 0,
+              "y": 13,
+              "colSpan": 8,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "query_timer",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "query_timer",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Average Query Timer",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "position": {
+              "x": 8,
+              "y": 13,
+              "colSpan": 8,
+              "rowSpan": 3
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "options",
+                  "isOptional": true
+                },
+                {
+                  "name": "sharedTimeRange",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+              "settings": {
+                "content": {
+                  "options": {
+                    "chart": {
+                      "metrics": [
+                        {
+                          "resourceMetadata": {
+                            "id": "/subscriptions/91804669-c60b-4727-afa2-d7021fe5055b/resourceGroups/cloud-benchmark-resources/providers/microsoft.insights/components/cloud-benchmark-insights"
+                          },
+                          "name": "tx_op_timer",
+                          "aggregationType": 4,
+                          "namespace": "azure.applicationinsights",
+                          "metricVisualization": {
+                            "displayName": "tx_op_timer",
+                            "resourceDisplayName": "cloud-benchmark-insights"
+                          }
+                        }
+                      ],
+                      "title": "Average tx-op timer",
+                      "titleKind": 2,
+                      "visualization": {
+                        "chartType": 2,
+                        "legendVisualization": {
+                          "isVisible": true,
+                          "position": 2,
+                          "hideHoverCard": false,
+                          "hideLabelNames": true
+                        },
+                        "axisVisualization": {
+                          "x": {
+                            "isVisible": true,
+                            "axisType": 2
+                          },
+                          "y": {
+                            "isVisible": true,
+                            "axisType": 1
+                          }
+                        },
+                        "disablePinning": true
+                      },
+                      "grouping": {
+                        "dimension": "node-id",
+                        "sort": 2,
+                        "top": 10
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "metadata": {
+      "model": {
+        "timeRange": {
+          "value": {
+            "relative": {
+              "duration": 24,
+              "timeUnit": 1
+            }
+          },
+          "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+        },
+        "filterLocale": {
+          "value": "en-us"
+        },
+        "filters": {
+          "value": {
+            "MsPortalFx_TimeRange": {
+              "model": {
+                "format": "utc",
+                "granularity": "auto",
+                "relative": "30m"
+              },
+              "displayCache": {
+                "name": "UTC Time",
+                "value": "Past 30 minutes"
+              },
+              "filteredPartIds": [
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102732",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102734",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102736",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102738",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102740",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a1027c2",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a1027f7",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a10296e",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102980",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a10298c",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102998",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102d35",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102d45",
+                "StartboardPart-MonitorChartPart-7dd40ff6-4568-40c3-bd27-aa6f9a102ff9",
+                "StartboardPart-MonitorChartPart-e4406d05-d1fc-4ad5-9235-a5f34bad71ef"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "name": "Monitoring Dashboard",
+  "type": "Microsoft.Portal/dashboards",
+  "location": "INSERT LOCATION",
+  "tags": {
+    "hidden-title": "Monitoring Dashboard"
+  },
+  "apiVersion": "2022-12-01-preview"
+}

--- a/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
@@ -23,6 +23,7 @@ data:
   XTDB_AZURE_STORAGE_CONTAINER: "xtdbazurebenchmarkcontainer"
   XTDB_AZURE_SERVICE_BUS_NAMESPACE: "cloud-benchmark-eventbus"
   XTDB_AZURE_SERVICE_BUS_TOPIC_NAME: "cloud-benchmark-servicebus-topic"
+  XTDB_AZURE_INSTRUMENTATION_KEY: "7859bb2f-b43c-4474-a51c-7357e551b3e5"
   KAFKA_BOOTSTRAP_SERVERS: "kafka-service.cloud-benchmark.svc.cluster.local:9092"
   XTDB_TX_TOPIC: "xtdb-tx-topic"
   XTDB_FILES_TOPIC: "xtdb-files-topic"
@@ -81,6 +82,8 @@ spec:
           value: "/var/lib/xtdb/buffers/disk-cache-lp"
         - name: AUCTIONMARK_LOAD_PHASE_ONLY
           value: "True"
+        - name: XTDB_NODE_ID
+          value: "bench-load-phase"
       containers:
       - name: xtdb-azure-bench-1
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
@@ -100,6 +103,8 @@ spec:
           value: "/var/lib/xtdb/buffers/disk-cache-1"
         - name: AUCTIONMARK_LOAD_PHASE
           value: "False"
+        - name: XTDB_NODE_ID
+          value: "bench-node-1"
       - name: xtdb-azure-bench-2
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
         volumeMounts:
@@ -118,6 +123,8 @@ spec:
           value: "/var/lib/xtdb/buffers/disk-cache-2"
         - name: AUCTIONMARK_LOAD_PHASE
           value: "False"
+        - name: XTDB_NODE_ID
+          value: "bench-node-2"
       - name: xtdb-azure-bench-3
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
         volumeMounts:
@@ -136,3 +143,5 @@ spec:
           value: "/var/lib/xtdb/buffers/disk-cache-3"
         - name: AUCTIONMARK_LOAD_PHASE
           value: "False"
+        - name: XTDB_NODE_ID
+          value: "bench-node-3"


### PR DESCRIPTION
Resolves #3701 

- Adds a common tag to all reported metrics, `node-id`. 
  - This is currently either grabbed from an environment variable or generated with a short uuid suffix.
  - We can use this `node-id` to filter metrics within azure.
  -  We use the env var to easily identify bench nodes 
- Setup a dashboard on azure application insights with relevant information for debugging auctionmark.
  - We split the above across nodes using the new node tag
  - Committed the current template within the repo - we could likely make a general purpose one for people to use too.
- Update instructions for setup.  

Preview of the dashboard on application insights:
![image](https://github.com/user-attachments/assets/9651508d-c2e8-4834-969b-2b55c1043d73)
