### PR TITLE
Resolve reflection warnings for GCP and Azure

### DIFF
--- a/modules/azure/src/main/clojure/xtdb/azure.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure.clj
@@ -20,10 +20,10 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn open-object-store [^AzureBlobStorage$Factory factory] 
-  (let [storage-account-endpoint (cond
-                                   (.getStorageAccountEndpoint factory) (.getStorageAccountEndpoint factory)
-                                   (.getStorageAccount factory) (format "https://%s.blob.core.windows.net" (.getStorageAccount factory))
-                                   :else (throw (err/illegal-arg :xtdb/missing-storage-account {::err/message "At least one of storageAccount or storageAccountEndpoint must be provided."})))
+  (let [^String storage-account-endpoint (cond
+                                           (.getStorageAccountEndpoint factory) (.getStorageAccountEndpoint factory)
+                                           (.getStorageAccount factory) (format "https://%s.blob.core.windows.net" (.getStorageAccount factory))
+                                           :else (throw (err/illegal-arg :xtdb/missing-storage-account {::err/message "At least one of storageAccount or storageAccountEndpoint must be provided."})))
         user-managed-identity-id (.getUserManagedIdentityClientId factory)
         credential (.build (cond-> (DefaultAzureCredentialBuilder.)
                              user-managed-identity-id (.managedIdentityClientId user-managed-identity-id))) 

--- a/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
+++ b/modules/google-cloud/src/main/clojure/xtdb/google_cloud/object_store.clj
@@ -77,7 +77,7 @@
         blob-id (BlobId/of bucket-name (str prefixed-key))]
     (.delete storage-service blob-id)))
 
-(defrecord GoogleCloudStorageObjectStore [^Storage storage-service bucket-name prefix]
+(defrecord GoogleCloudStorageObjectStore [^Storage storage-service bucket-name ^Path prefix]
   ObjectStore
   (getObject [this k]
     (CompletableFuture/completedFuture

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -19,6 +19,7 @@
            (java.nio.file Files Path)
            (java.time Duration)
            (xtdb.api.storage AzureBlobStorage ObjectStore)
+           (xtdb.azure.object_store AzureBlobObjectStore)
            (xtdb.buffer_pool RemoteBufferPool)
            (xtdb.multipart IMultipartUpload SupportsMultipart)))
 
@@ -141,9 +142,10 @@
                                                            (.prefix (util/->path (str prefix))))))))
 
     (t/testing "storageAccountEndpoint specified - should work correctly"
-      (with-open [os (azure/open-object-store (-> (AzureBlobStorage/azureBlobStorage nil container)
-                                                  (.prefix (util/->path (str prefix)))
-                                                  (.storageAccountEndpoint "https://xtdbteststorageaccount.blob.core.windows.net")))]
+      (with-open [os ^AzureBlobObjectStore (azure/open-object-store 
+                                            (-> (AzureBlobStorage/azureBlobStorage nil container)
+                                                (.prefix (util/->path (str prefix)))
+                                                (.storageAccountEndpoint "https://xtdbteststorageaccount.blob.core.windows.net")))]
         (os-test/put-edn os (util/->path "alice") :alice)
         (t/is (= (mapv util/->path ["alice"]) (.listAllObjects ^ObjectStore os)))))))
 

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -39,7 +39,7 @@
   (byte-buf->bytes @(.getObjectRange obj-store k start len)))
 
 ;; Generates a byte buffer of random characters
-(defn generate-random-byte-buffer [buffer-size]
+(defn generate-random-byte-buffer ^ByteBuffer [buffer-size]
   (let [random         (java.util.Random.)
         byte-buffer    (ByteBuffer/allocate buffer-size)]
     (loop [i 0]


### PR DESCRIPTION
Additionally clean up some of the reflection warnings in the metrics and cli_test namespaces.

Closes #3711