### PR TITLE
Fix session params in pgwire

### DIFF
--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -20,6 +20,8 @@
            (java.sql Connection PreparedStatement Timestamp Types)
            (java.time Clock Instant LocalDate LocalDateTime OffsetDateTime ZoneId ZoneOffset)
            (java.util.concurrent CountDownLatch TimeUnit)
+           java.util.TimeZone
+           java.util.Calendar
            java.util.List
            (org.pg.enums OID)
            (org.pg.error PGError PGErrorResponse)
@@ -1674,7 +1676,11 @@
     (with-open [conn (jdbc-conn "prepareThreshold" -1)
                 stmt (.prepareStatement conn "SELECT ? AS v")]
 
-      (.setObject stmt 1 (Timestamp/from #xt.time/instant "2030-01-04T12:44:55Z"))
+      (.setTimestamp
+       stmt
+       1
+       (Timestamp/from #xt.time/instant "2030-01-04T12:44:55Z")
+       (Calendar/getInstance (TimeZone/getTimeZone "GMT")))
 
       (with-open [rs (.executeQuery stmt)]
 


### PR DESCRIPTION
Commit refactors session params so that they are correctly normalised as
per postgres documentation, updated at session startup and reported to
the user when their value changes.

Fix sql.Timestamp test by passing explicit cal, so test is independent of local tz