### PR TITLE
Add metric gauges for child-allocators in XTDB.

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -694,6 +694,7 @@
 
 (defmethod ig/init-key :xtdb/indexer [_ {:keys [allocator metadata-mgr, q-src, live-index metrics-registry]}]
   (util/with-close-on-catch [allocator (util/->child-allocator allocator "indexer")]
+    (metrics/add-allocator-gauge metrics-registry "indexer.allocator.allocated_memory" allocator)
     (->Indexer allocator metadata-mgr q-src live-index
 
                nil ;; indexer-error

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -11,6 +11,7 @@
            (java.util.function Supplier)
            java.util.List
            (java.util.stream Stream)
+           (org.apache.arrow.memory BufferAllocator)
            (xtdb.api Xtdb$Config)
            (xtdb.api.metrics Metrics Metrics$Factory PrometheusMetrics$Factory)))
 
@@ -41,6 +42,9 @@
           (get [_] (f))))
        (cond-> (:unit opts) (.baseUnit (str (:unit opts))))
        (.register reg))))
+
+(defn add-allocator-gauge [reg meter-name ^BufferAllocator allocator]
+  (add-gauge reg meter-name (fn [] (.getAllocatedMemory allocator)) {:unit "bytes"}))
 
 (defmethod xtn/apply-config! :xtdb.metrics/prometheus [^Xtdb$Config config _ {:keys [port], :or {port 8080}}]
   (.setMetrics config (PrometheusMetrics$Factory. port)))

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -2,6 +2,7 @@
 
 package xtdb.api.storage
 
+import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -21,7 +22,7 @@ object Storage {
      */
     @Serializable
     sealed interface Factory {
-        fun openStorage(allocator: BufferAllocator, log: Log): IBufferPool
+        fun openStorage(allocator: BufferAllocator, log: Log, metricsRegistry: MeterRegistry): IBufferPool
     }
 
     /**
@@ -32,8 +33,8 @@ object Storage {
     @SerialName("!InMemory")
     data object InMemoryStorageFactory : Factory {
 
-        override fun openStorage(allocator: BufferAllocator, log: Log) =
-            requiringResolve("xtdb.buffer-pool/open-in-memory-storage").invoke(allocator) as IBufferPool
+        override fun openStorage(allocator: BufferAllocator, log: Log, metricsRegistry: MeterRegistry) =
+            requiringResolve("xtdb.buffer-pool/open-in-memory-storage").invoke(allocator, metricsRegistry) as IBufferPool
     }
 
     @JvmStatic
@@ -66,8 +67,8 @@ object Storage {
         fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
         fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
 
-        override fun openStorage(allocator: BufferAllocator, log: Log) =
-            requiringResolve("xtdb.buffer-pool/open-local-storage").invoke(allocator, this) as IBufferPool
+        override fun openStorage(allocator: BufferAllocator, log: Log, metricsRegistry: MeterRegistry) =
+            requiringResolve("xtdb.buffer-pool/open-local-storage").invoke(allocator, this, metricsRegistry) as IBufferPool
     }
 
     @JvmStatic
@@ -121,8 +122,8 @@ object Storage {
         fun maxDiskCachePercentage(maxDiskCachePercentage: Long) = apply { this.maxDiskCachePercentage = maxDiskCachePercentage }
         fun maxDiskCacheBytes(maxDiskCacheBytes: Long) = apply { this.maxDiskCacheBytes = maxDiskCacheBytes }
 
-        override fun openStorage(allocator: BufferAllocator, log: Log) =
-            requiringResolve("xtdb.buffer-pool/open-remote-storage").invoke(allocator, this, log) as IBufferPool
+        override fun openStorage(allocator: BufferAllocator, log: Log, metricsRegistry: MeterRegistry) =
+            requiringResolve("xtdb.buffer-pool/open-remote-storage").invoke(allocator, this, log, metricsRegistry) as IBufferPool
     }
 
     @JvmStatic

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -39,7 +39,8 @@
 
 (deftest ^:integration concurrent-buffer-pool-test
   (populate-node node-opts)
-  (tu/with-system {:xtdb/allocator {}
+  (tu/with-system {:xtdb.metrics/registry nil
+                   :xtdb/allocator {}
                    :xtdb/log (Logs/localLog (.resolve (.toPath node-dir) "logs"))
                    :xtdb/buffer-pool (Storage/localStorage (.resolve (.toPath node-dir) "objects"))}
     (fn []

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -26,6 +26,7 @@
 
 (def with-live-index
   (partial tu/with-system {:xtdb/allocator {}
+                           :xtdb.metrics/registry nil
                            :xtdb.indexer/live-index (IndexerConfig.)
                            :xtdb/log (Logs/inMemoryLog)
                            :xtdb/buffer-pool Storage$InMemoryStorageFactory/INSTANCE


### PR DESCRIPTION
Resolves #3702 

Allows us to keep track of allocated direct memory on a per child allocator basis:
- Needed to pass `metrics/registry` down to a lot of the XTDB modules, so makes a dependency between the two (might allow for further monitoring gauges, if appropriate).
  - More complex in buffer pool but not dissimilar to us passing down the "file cache"/log.
- Passes tests and have tested against `azure_test`, seems to work well.
- Gauges getting added as expected, have seen these looking at `localhost:8080` on the dev node. 