### PR TITLE
Add support for `rank`, `dense-rank` and multiple window functions to window operator

### DIFF
--- a/src/test/clojure/xtdb/operator/window_test.clj
+++ b/src/test/clojure/xtdb/operator/window_test.clj
@@ -6,14 +6,15 @@
 
 (deftest test-window-operator
   (letfn [(run-test
-            [window-spec projection-specs blocks]
-            (let [window-name (gensym "window")]
-              (-> (tu/query-ra [:window {:windows {window-name window-spec}
-                                         :projections (mapv (fn [[col-name projection]]
-                                                              {col-name {:window-name window-name
-                                                                         :window-agg projection}}) projection-specs) }
-                                [::tu/blocks '{a :i64, b :i64} blocks]])
-                  set)))]
+            ([window-spec projection-specs blocks] (run-test window-spec projection-specs blocks set))
+            ([window-spec projection-specs blocks into-fn]
+             (let [window-name (gensym "window")]
+               (-> (tu/query-ra [:window {:windows {window-name window-spec}
+                                          :projections (mapv (fn [[col-name projection]]
+                                                               {col-name {:window-name window-name
+                                                                          :window-agg projection}}) projection-specs) }
+                                 [::tu/blocks '{a :i64, b :i64} blocks]])
+                   into-fn))))]
 
     (t/is (= #{} (run-test '{:partition-cols [a]
                              :order-specs [[b]]}
@@ -84,4 +85,52 @@
                          {:a 2 :b 70}
                          {:a 3 :b 80}
                          {:a 3 :b 90}]]))
-          "partition by + order-by")))
+          "partition by + order-by")
+
+    (t/is (= [{:a 1, :b 10, :dr 0}
+              {:a 1, :b 10, :dr 0}
+              {:a 1, :b 50, :dr 1}
+              {:a 1, :b 60, :dr 2}
+              {:a 2, :b 30, :dr 0}
+              {:a 2, :b 40, :dr 1}
+              {:a 2, :b 40, :dr 1}
+              {:a 3, :b 80, :dr 0}
+              {:a 3, :b 90, :dr 1}]
+             (run-test '{:partition-cols [a]
+                         :order-specs [[b]]}
+                       '{dr (dense-rank)}
+                       [[{:a 1 :b 10}
+                         {:a 1 :b 10}
+                         {:a 2 :b 30}
+                         {:a 2 :b 40}]
+                        [{:a 1 :b 50}
+                         {:a 1 :b 60}
+                         {:a 2 :b 40}
+                         {:a 3 :b 80}
+                         {:a 3 :b 90}]]
+                       (partial sort-by (juxt :a :b))))
+          "testing dense-rank")
+
+    (t/is (= [{:a 1, :b 10, :r 0}
+              {:a 1, :b 10, :r 0}
+              {:a 1, :b 50, :r 2}
+              {:a 1, :b 60, :r 3}
+              {:a 2, :b 30, :r 0}
+              {:a 2, :b 40, :r 1}
+              {:a 2, :b 40, :r 1}
+              {:a 2, :b 40, :r 1}
+              {:a 2, :b 50, :r 4}]
+             (run-test '{:partition-cols [a]
+                         :order-specs [[b]]}
+                       '{r (rank)}
+                       [[{:a 1 :b 10}
+                         {:a 1 :b 10}
+                         {:a 2 :b 30}
+                         {:a 2 :b 40}]
+                        [{:a 1 :b 50}
+                         {:a 1 :b 60}
+                         {:a 2 :b 40}
+                         {:a 2 :b 40}
+                         {:a 2 :b 50}]]
+                       (partial sort-by (juxt :a :b))))
+          "testing rank")))


### PR DESCRIPTION
This adds:
- use `hccp.LongArrayList` instead of `LongLongHashMap` in `row-number` and all subsequent functions
- support for the `rank` and `dense-rank` functions
- multiple window functions

Previously the window columns would get filled per the order the rows were coming into the operator and we would sort the incoming relation based on the window sorting. With multiple window functions this approach became a mess (I tried). Instead we now fill the window column according to the sorting and then all window columns can just be appended to the relation coming into the window operator. 