### PR TITLE
Add pg-wire interval support

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1815,6 +1815,7 @@
                                                                     "server_encoding" "UTF8"
                                                                     "client_encoding" "UTF8"
                                                                     "DateStyle" "ISO"
+                                                                    "IntervalStyle" "ISO_8601"
                                                                     "TimeZone" (str (.getZone ^Clock default-clock))
                                                                     "integer_datetimes" "on"}}))
                                 :ssl-ctx ssl-ctx})

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -339,19 +339,27 @@
               :typnamespace 2125819141,
               :typbasetype 0}
              {:typtypmod -1,
-               :oid 3910,
-               :typtype "b",
-               :typowner 1376455703,
-               :typnotnull false,
-               :typname "tstz-range",
-               :typnamespace 2125819141,
-               :typbasetype 0}
+              :oid 3910,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "tstz-range",
+              :typnamespace 2125819141,
+              :typbasetype 0}
              {:typtypmod -1,
               :oid 2205,
               :typtype "b",
               :typowner 1376455703,
               :typnotnull false,
               :typname "regclass",
+              :typnamespace 2125819141,
+              :typbasetype 0}
+             {:typtypmod -1,
+              :oid 1186,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "interval",
               :typnamespace 2125819141,
               :typbasetype 0}}
            (set (tu/query-ra '[:scan

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -25,7 +25,7 @@
            java.util.List
            (org.pg.enums OID)
            (org.pg.error PGError PGErrorResponse)
-           (org.postgresql.util PGobject PSQLException)
+           (org.postgresql.util PGobject PSQLException PGInterval)
            xtdb.JsonSerde))
 
 (set! *warn-on-reflection* false)
@@ -1951,3 +1951,15 @@ ORDER BY t.oid DESC LIMIT 1"
     (t/is (false?  (.execute stmt)))
     (let [rs (.getGeneratedKeys stmt)]
       (t/is (= [] (rs->maps rs))))))
+
+(deftest test-interval-encoding-3697
+  (t/testing "Intervals"
+    (with-open [conn (jdbc-conn)]
+      (t/is (= [{:i (PGInterval. "P1DT1H1M1.111111S")}]
+               (jdbc/execute! conn ["SELECT INTERVAL 'P1DT1H1M1.111111111S' AS i"])))
+
+      (t/is (= [{:i (PGInterval. "P12MT0S")}]
+               (jdbc/execute! conn ["SELECT INTERVAL 'P12MT0S' AS i"])))
+
+      (t/is (= [{:i (PGInterval. "P-22MT0S")}]
+               (jdbc/execute! conn ["SELECT INTERVAL 'P-22MT0S' AS i"]))))))


### PR DESCRIPTION
This adds supports for getting intervals out of XT via postgres.
It doesn't add binary encoding support as that seems to be not supported by `pg2` and `jdbc`.
Both `pg2` and `jdbc` don't support interval parameters. `psycopg` seems to support interval parameters by only in `postgres` IntervalStyle which XT currently doesn't support (XT is on `ISO_8601`).