### PR TITLE
Propagate warnings through pg-wire - #3461

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -63,6 +63,7 @@
   ;; ... or at least raise questions about who then owns the params
   (^java.util.List paramFields [])
   (^java.util.List columnFields [])
+  (^java.util.List warnings [])
   (^xtdb.query.BoundQuery bind [queryOpts]
    "queryOpts :: {:params, :table-args, :basis, :default-tz}"))
 
@@ -153,7 +154,7 @@
                               {:plan query
                                :explain (s/explain-data ::lp/logical-plan query)})))
 
-    (let [{:keys [ordered-outer-projection param-count], :or {param-count 0}} (meta query)
+    (let [{:keys [ordered-outer-projection param-count warnings], :or {param-count 0}} (meta query)
           param-types-with-defaults (->> (concat
                                           (mapv #(if (= :default %) :utf8 %) param-types)
                                           (repeat :utf8))
@@ -186,6 +187,7 @@
           (let [{:keys [fields]} (emit-expr cache deps conformed-query scan-cols default-tz param-fields-by-name)]
             ;; could store column-fields in the cache/map too
             (->column-fields ordered-outer-projection fields)))
+        (warnings [_] warnings)
 
         (bind [_ {:keys [args params basis default-tz]
                   :or {default-tz default-tz}}]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -12,6 +12,7 @@
                (plan/->logical-plan)
                (vary-meta
                 assoc
+                :warnings (:warnings (meta plan))
                 :param-count (:param-count (meta plan))
                 :ordered-outer-projection col-syms)
                #_(doto clojure.pprint/pprint))))) ;; <<no-commit>>

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -2806,7 +2806,9 @@
              #_(doto clojure.pprint/pprint) ;; <<no-commit>>
              (optimise-stmt) ;; <<no-commit>>
              #_(doto clojure.pprint/pprint) ;; <<no-commit>>
-             (vary-meta assoc :param-count @!param-count)))))))
+             (vary-meta assoc
+                        :param-count @!param-count
+                        :warnings @!warnings)))))))
 
 (comment
   (plan-statement "WITH foo AS (SELECT id FROM bar WHERE id = 5)


### PR DESCRIPTION
This propagates warnings from the plan stage through to the pg-wire server and sends them as notice messages roughly with the following data:
```clj
{:msg :NoticeResponse,
 :verbosity "WARNING",
 :severity "WARNING",
 :code "01000",
 :message "Column not found: b"}
 ```
In psql it now looks like
![Selection_046](https://github.com/user-attachments/assets/b1c557b9-984d-4d24-bfac-0137695af0c3)

I added a warnings method to the `PreparedQuery` object, but there are potentially other ways to pass the warning/messages through to pg-wire.
 