### PR TITLE
Ignore RETURNING at the end of DML statements - fix #3668

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -748,6 +748,9 @@ nullOrdering : 'NULLS' 'FIRST' | 'NULLS' 'LAST' ;
 
 /// §14 Data manipulation
 
+/// Postgres return statements
+returningStatement : 'RETURNING' selectList # DmlReturningStatement;
+
 /// §14.9 <delete statement: searched>
 
 deleteStatementSearched
@@ -755,6 +758,7 @@ deleteStatementSearched
       dmlStatementValidTimeExtents?
       ( 'AS'? correlationName )?
       ( 'WHERE' searchCondition )?
+      returningStatement?
     ;
 
 dmlStatementValidTimeExtents
@@ -766,7 +770,7 @@ eraseStatementSearched : 'ERASE' 'FROM' tableName ( 'AS'? correlationName )? ('W
 
 /// §14.11 <insert statement>
 
-insertStatement : 'INSERT' 'INTO' tableName insertColumnsAndSource ;
+insertStatement : 'INSERT' 'INTO' tableName insertColumnsAndSource returningStatement?;
 insertColumnsAndSource
     : ( '(' columnNameList ')' )? tableValueConstructor # InsertValues
     | ( '(' columnNameList ')' )? recordsValueConstructor # InsertRecords
@@ -781,6 +785,7 @@ updateStatementSearched
       ( 'AS'? correlationName )?
       'SET' setClauseList
       ( 'WHERE' searchCondition )?
+      returningStatement?
     ;
 
 /// §14.15 <set clause list>
@@ -820,4 +825,3 @@ levelOfIsolation
     | 'REPEATABLE' 'READ' # RepeatableReadIsolation
     | 'SERIALIZABLE' # SerializableIsolation
     ;
-

--- a/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
+++ b/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
@@ -276,6 +276,7 @@ RENAME : 'RENAME' ;
 REPEATABLE : 'REPEATABLE' ;
 REPLACE : 'REPLACE' ;
 RESPECT : 'RESPECT' ;
+RETURNING : 'RETURNING';
 RIGHT : 'RIGHT' ;
 ROLLBACK : 'ROLLBACK' ;
 ROW : 'ROW' ;
@@ -354,4 +355,3 @@ DELIMITED_IDENTIFIER
     : '"' ('"' '"' | ~'"')* '"'
     | '`' ('`' '`' | ~'`')* '`'
     ;
-

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1944,3 +1944,10 @@ ORDER BY t.oid DESC LIMIT 1"
       (pg/execute conn "SELECT 2 AS b FROM docs GROUP BY b")
       (t/is (= #{"Table not found: docs" "Column not found: b"}
                (set @warns))))))
+
+(deftest test-ignore-returning-keys-3668
+  (with-open [conn (jdbc-conn)
+              stmt (.prepareStatement conn "INSERT INTO people (_id, name) VALUES (6, 'fred')" Statement/RETURN_GENERATED_KEYS)]
+    (t/is (false?  (.execute stmt)))
+    (let [rs (.getGeneratedKeys stmt)]
+      (t/is (= [] (rs->maps rs))))))


### PR DESCRIPTION
This ignores and `RETURNING` statement at the end of `UPDATE`, `DELETE` or `INSERT` statements.