### PR TITLE
'playground' creates a new node for every new database name

### DIFF
--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -73,7 +73,7 @@
     ;; Add common tag for the node
     (let [node-id (or (System/getenv "XTDB_NODE_ID") (random-node-id))
           ^List tags [(Tag/of "node-id" node-id)]]
-      (log/infof "Metrics server - tagging all metrics with node-id: %s" node-id)
+      (log/infof "tagging all metrics with node-id: %s" node-id)
       (-> (.config reg)
           (.commonTags tags)))
 

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -197,24 +197,25 @@
   (util/close modules))
 
 (defn node-system [^Xtdb$Config opts]
-  (-> {:xtdb/node {}
-       :xtdb/allocator {}
-       :xtdb/indexer {}
-       :xtdb.log/watcher {}
-       :xtdb.metadata/metadata-manager {}
-       :xtdb.operator.scan/scan-emitter {}
-       :xtdb.query/query-source {}
-       :xtdb/compactor {}
+  (let [srv-config (.getServer opts)]
+    (-> {:xtdb/node {}
+         :xtdb/allocator {}
+         :xtdb/indexer {}
+         :xtdb.log/watcher {}
+         :xtdb.metadata/metadata-manager {}
+         :xtdb.operator.scan/scan-emitter {}
+         :xtdb.query/query-source {}
+         :xtdb/compactor {}
 
-       :xtdb.pgwire/server (.getServer opts)
-       :xtdb/log (.getTxLog opts)
-       :xtdb/buffer-pool (.getStorage opts)
-       :xtdb.metrics/registry (.getMetrics opts)
-       :xtdb.indexer/live-index (.indexer opts)
-       :xtdb/modules (.getModules opts)
-       :xtdb/default-tz (.getDefaultTz opts)
-       :xtdb.stagnant-log-flusher/flusher (.indexer opts)}
-      (doto ig/load-namespaces)))
+         :xtdb/log (.getTxLog opts)
+         :xtdb/buffer-pool (.getStorage opts)
+         :xtdb.metrics/registry (.getMetrics opts)
+         :xtdb.indexer/live-index (.indexer opts)
+         :xtdb/modules (.getModules opts)
+         :xtdb/default-tz (.getDefaultTz opts)
+         :xtdb.stagnant-log-flusher/flusher (.indexer opts)}
+        (cond-> srv-config (assoc :xtdb.pgwire/server srv-config))
+        (doto ig/load-namespaces))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn open-node ^xtdb.api.Xtdb [opts]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -24,7 +24,7 @@ interface Xtdb : AutoCloseable {
 
     @Serializable
     data class Config(
-        val server : ServerConfig = ServerConfig(),
+        var server : ServerConfig? = ServerConfig(),
         var txLog: Log.Factory = inMemoryLog(),
         var storage: Storage.Factory = inMemoryStorage(),
         var metrics: Metrics.Factory? = null,
@@ -37,7 +37,7 @@ interface Xtdb : AutoCloseable {
         fun storage(storage: Storage.Factory) = apply { this.storage = storage }
 
         @JvmSynthetic
-        fun server(configure: ServerConfig.() -> Unit) = apply { server.configure() }
+        fun server(configure: ServerConfig.() -> Unit) = apply { (server ?: ServerConfig()).configure() }
 
         @JvmSynthetic
         fun indexer(configure: IndexerConfig.() -> Unit) = apply { indexer.configure() }


### PR DESCRIPTION
e.g.

```
# i.e. use it through the normal standalone Docker image, just add `--playground`.
$ docker run -ti --rm -p 5432:5432 ghcr.io/xtdb/xtdb:edge --playground

00:36:00 | INFO  xtdb.pgwire | Playground started on port: 5432

$ psql -h localhost foo

foo> -- do some sql here.

$ psql -h localhost foo

foo> -- the changes from your previous session are still visible because you connected to the same 'database'

$ psql -h localhost bar

bar> -- now you have a clean slate
```

I'd imagine usage of this to be predominantly for testing for non-JVM users - they would start this Docker image as part of their test run/dev container/etc, then each test would use a unique database name (UUID, probably).

(JVM users would continue to use the in-process API to create a new node for every test)