### PR TITLE
Minor fix in the SQL Quickstart docs

### DIFF
--- a/docs/src/content/docs/quickstart/sql-overview.mdx
+++ b/docs/src/content/docs/quickstart/sql-overview.mdx
@@ -532,6 +532,9 @@ INSERT INTO people (_id, name, favorite_color, _valid_from)
   </Fiddle>
   <Card slot="2">
 ```sql
+user=> INSERT INTO people (_id, name, favorite_color, _valid_from)
+  VALUES (2, 'carol', 'red', DATE '2023-09-01');
+INSERT 0 0
 user=> SELECT name, favorite_color, _valid_from, _valid_to, _system_from, _system_to
 FROM people FOR VALID_TIME ALL FOR SYSTEM_TIME ALL;
  name  | favorite_color |          _valid_from          |      _valid_to      |         _system_from          |          _system_to


### PR DESCRIPTION
Hey! Hope you don't mind the drive-by PR for a minor fix in the docs. I'm happy send this some other way if you'd prefer. I'm working through the SQL Quickstart and noticed that the psql version of the "When did you know it?" section is missing the `INSERT` command. PS I like the SQL interface in the v2 changes. I saw yall at HYTRADBOI a few years ago but didn't get very far into testing it out at the time. Starting with SQL is easier for me.