### PR TITLE
Unified ints and floats in pg-wire

### DIFF
--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -28,7 +28,6 @@ import xtdb.arrow.*;
 import xtdb.types.IntervalDayTime;
 import xtdb.types.IntervalMonthDayNano;
 import xtdb.types.IntervalYearMonth;
-import xtdb.types.RegClass;
 import xtdb.vector.extensions.*;
 import xtdb.vector.extensions.KeywordVector;
 import xtdb.vector.extensions.SetVector;
@@ -328,6 +327,18 @@ public class ValueVectorReader implements IVectorReader {
             public byte getByte(int idx) {
                 return v.get(idx);
             }
+            @Override
+            public short getShort(int idx) {
+                return v.get(idx);
+            }
+            @Override
+            public int getInt(int idx) {
+                return v.get(idx);
+            }
+            @Override
+            public long getLong(int idx) {
+                return v.get(idx);
+            }
         };
     }
 
@@ -337,6 +348,14 @@ public class ValueVectorReader implements IVectorReader {
             public short getShort(int idx) {
                 return v.get(idx);
             }
+            @Override
+            public int getInt(int idx) {
+                return v.get(idx);
+            }
+            @Override
+            public long getLong(int idx) {
+                return v.get(idx);
+            }
         };
     }
 
@@ -344,6 +363,10 @@ public class ValueVectorReader implements IVectorReader {
         return new ValueVectorReader(v) {
             @Override
             public int getInt(int idx) {
+                return v.get(idx);
+            }
+            @Override
+            public long getLong(int idx) {
                 return v.get(idx);
             }
         };
@@ -362,6 +385,10 @@ public class ValueVectorReader implements IVectorReader {
         return new ValueVectorReader(v) {
             @Override
             public float getFloat(int idx) {
+                return v.get(idx);
+            }
+            @Override
+            public double getDouble(int idx) {
                 return v.get(idx);
             }
         };
@@ -1042,6 +1069,12 @@ public class ValueVectorReader implements IVectorReader {
         @Override
         public long getLong(int idx) {
             return legReader(getLeg(idx)).getLong(idx);
+        }
+
+        @SuppressWarnings("resource")
+        @Override
+        public double getDouble(int idx) {
+            return legReader(getLeg(idx)).getDouble(idx);
         }
 
         @SuppressWarnings("resource")


### PR DESCRIPTION
This returns unified floats and ints in pg-wire (choosing a non-lossy supertype) even if the underlying columns are unions. This avoids JSON (or default) encoding.

The implementation is the "easy" approach of allowing to read super-types from the arrow vectors and `long`s and `double`'s  from DUV's directly. 