### PR TITLE
Add random pgwire server port to nightly tests, avoid binding errors.

### DIFF
--- a/src/test/clojure/xtdb/aws/s3_test.clj
+++ b/src/test/clojure/xtdb/aws/s3_test.clj
@@ -39,7 +39,8 @@
 
 (defn start-kafka-node [local-disk-cache prefix] 
   (xtn/start-node
-   {:storage [:remote
+   {:server {:port 0}
+    :storage [:remote
               {:object-store [:s3 {:bucket bucket
                                    :prefix (util/->path (str "xtdb.s3-test." prefix))}]
                :local-disk-cache local-disk-cache}]

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -82,7 +82,8 @@
 
 (defn start-kafka-node [local-disk-cache prefix]
   (xtn/start-node
-   {:storage [:remote
+   {:server {:port 0}
+    :storage [:remote
               {:object-store [:azure {:storage-account storage-account
                                       :container container
                                       :prefix (util/->path (str "xtdb.azure-test." prefix))}]

--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -69,7 +69,8 @@
 
 (defn start-kafka-node [local-disk-cache prefix]
   (xtn/start-node
-   {:storage [:remote
+   {:server {:port 0}
+    :storage [:remote
               {:object-store [:google-cloud {:project-id project-id
                                              :bucket test-bucket
                                              :prefix (str "xtdb.google-cloud-test." prefix)}]


### PR DESCRIPTION
Resolves #3755 
Nightly test run: https://github.com/xtdb/xtdb/actions/runs/11124393695

Will start a manual nightly test run against this and merge when it passes.