### PR TITLE
Multiple fixes for faster temporal resolution

### DIFF
--- a/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
@@ -25,6 +25,21 @@ internal fun LongArrayList.reverseLinearSearch(needle: Long): Int {
     return -1
 }
 
+internal fun LongArrayList.binarySearch(needle: Long): Int {
+    var left = 0
+    var right = elementsCount
+    while (left < right) {
+        val mid = (left + right) / 2
+        val x = buffer[mid]
+        when {
+            x == needle -> return mid
+            x > needle -> left = mid + 1
+            else -> right = mid
+        }
+    }
+    return -left - 1
+}
+
 data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArrayList) {
     constructor() : this(LongArrayList(), LongArrayList()) {
         reset()
@@ -50,11 +65,11 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
     fun applyLog(systemFrom: Long, validFrom: Long, validTo: Long) {
         if (validFrom >= validTo) return
 
-        var end = validTimes.reverseLinearSearch(validTo)
+        var end = validTimes.binarySearch(validTo)
         val insertedEnd = end < 0
         if (insertedEnd) end = -(end + 1)
 
-        var start = validTimes.reverseLinearSearch(validFrom)
+        var start = validTimes.binarySearch(validFrom)
         val insertedStart = start < 0
         if (insertedStart) start = -(start + 1)
 

--- a/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
@@ -53,6 +53,19 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
 
     fun getSystemTime(rangeIdx: Int) = sysTimeCeilings[reverseIdx(rangeIdx) - 1]
 
+    /**
+     * @return the index (in reverse order) such that `validTimes[reverseIdx(idx)] <= validTime < validTimes[reverseIdx(idx + 1)]`
+     * or 0 if `validTime < validTimes[reverseIdx(0)]`
+     * or `validTimes.elementsCount - 1` if `validTime >= validTimes[reverseIdx(validTimes.elementsCount - 1)]`
+     */
+    fun getCeilingIndex(validTime: Long): Int {
+        var idx = validTimes.binarySearch(validTime)
+        if (idx < 0) idx = -(idx + 1)
+        if (idx < validTimes.elementsCount - 1 && validTime < validTimes[idx]) idx++
+        if (idx == validTimes.elementsCount) idx--
+        return reverseIdx(idx)
+    }
+
     @Suppress("MemberVisibilityCanBePrivate")
     fun reset() {
         validTimes.clear()
@@ -107,4 +120,5 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
         validTimes.removeRange(end + 1, start)
         sysTimeCeilings.removeRange(end + 1, start)
     }
+
 }

--- a/core/src/main/kotlin/xtdb/bitemporal/Polygon.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Polygon.kt
@@ -21,9 +21,9 @@ data class Polygon(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
         validTimes.clear()
         sysTimeCeilings.clear()
 
-        var ceilIdx = 0
-
         var validTime = validFrom
+
+        var ceilIdx = ceiling.getCeilingIndex(validFrom)
 
         do {
             var ceilValidTo: Long

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -29,6 +29,18 @@ internal class CeilingTest {
     }
 
     @Test
+    fun testBinarySearch() {
+        val list = longs.from(10, 8, 6, 4, 2)
+        assertEquals(0, list.binarySearch(10))
+        assertEquals(2, list.binarySearch(6))
+        assertEquals(4, list.binarySearch(2))
+        assertEquals(-2, list.binarySearch(9))
+        assertEquals(-1, list.binarySearch(11))
+        assertEquals(-5, list.binarySearch(3))
+        assertEquals(-6, list.binarySearch(1))
+    }
+
+    @Test
     fun testAppliesLogs() {
         assertEquals(longs.from(MAX_LONG, MIN_LONG), ceiling.validTimes)
         assertEquals(longs.from(MAX_LONG), ceiling.sysTimeCeilings)

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -1,5 +1,6 @@
 package xtdb.bitemporal
 
+import com.carrotsearch.hppc.LongArrayList
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,6 +39,18 @@ internal class CeilingTest {
         assertEquals(-1, list.binarySearch(11))
         assertEquals(-5, list.binarySearch(3))
         assertEquals(-6, list.binarySearch(1))
+    }
+
+    @Test
+    fun testGetCeilingIndex() {
+        val list = longs.from(10, 8, 6, 4, 2)
+        // the second part shouldn't be used
+        val ceiling = Ceiling(list, LongArrayList())
+        assertEquals(0, ceiling.getCeilingIndex(1))
+        assertEquals(0, ceiling.getCeilingIndex(2))
+        assertEquals(4, ceiling.getCeilingIndex(10))
+        assertEquals(4, ceiling.getCeilingIndex(11))
+        assertEquals(1, ceiling.getCeilingIndex(5))
     }
 
     @Test


### PR DESCRIPTION
All of this was mostly unearthed by looking into https://github.com/xtdb/xtdb/issues/3751

For understanding most of the issues it's best to consider what I call the "degenerative backfill case". You have some sort of readings data (short time intervals for your entities) which you backfill your db with. Then you realize the backfill has gone wrong and you backfill again. The (full) temporal resolution that needs to be done (for a single entity) is then best shown by the following picture:
![degenerative_backfill_case excalidraw](https://github.com/user-attachments/assets/731ca62e-636c-41a4-8c90-e7b4f9cdc718)
Note that in a "normal" scenario the lower readings data will likely show the behavior of a step function, but the same problems will arise if one does large corrections of the past. This also affects the speed of compaction.

In our temporal resolution there are multiple places where we assume that vt ~ tt. For the above example this results in an $O(n^2)$ runtime (where $n$ is the number of versions) when doing the resolution of the lower row above.

All commits are fairly isolated and could go in by themselves. The first two mostly replace linear searches by binary searches. Once in the Ceiling calculation and once in the Polygon calculation.

The last commit is probably a controversial one as I am replacing the ArrayList implementation with a SkipList (courtesy of ChatGPT). The problem is/was that when resolving the lower row of versions above you all of sudden need to insert into array at the beginning (for the version most in the past), which results in an $O(n)$ copy every time one inserts. The SkipList is the $O( \log n)$ tradeoff for this case. It also has a lot of overhead and is making the general (without the overwritting slower). 

Some numbers for the snippet from https://github.com/xtdb/xtdb/issues/3751#issuecomment-2384091277. Instead of back filling 2024, I back filled 2023 as this would always take valid-time for recency showed even worse performance. I also forced compaction to happen. 

| Version | Simple Ingestion | Overwriting (degenerative case)|
|----------|----------|----------|
| `main` | 621.715427 msecs | 36531.686242 msecs |
| binary-search Ceiling| 258.688889 msecs | 10999.049459 msecs |
| binary-search Polygon + commit 1 | 207.67628 msecs | 6085.324092 msecs |
| skip-lists in Ceiling + commit 1 + commit 2  | 940.982672 msecs| 1911.270047 msecs|

I have not done any other performance comparison (yet). The `Simple Ingestion` should also be taken with a grain of salt as the JVM might not have been very warm yet.

Further considerations (without having thought to much about them):
- We could do linear search when we know `vt~st` for some notion of `~` (an hour, a day, etc...) and only switch to binary search when falling out of this window.
- Coalescing of ceilings or valid time ranges. This only works when the valid time intervals touch each other or the ceilings are the same.
- The query is `SELECT COUNT(*) FROM reading FOR VALID_TIME ALL` so we don't actually need to do the resolution for the lower row of versions, but I don't know how to best figure that out up front with our current primary index. As soon as there is a "hole" in the upper versions, one needs to look at big chunk of versions again. I still think there is value in persuing this angle as we can be a lot slower for `SYSTEM TIME` queries.
- Even if we don't do skip lists, I think some way to do quicker inserts into the middle of a sorted list is needed.