### PR TITLE
Elixir support

### DIFF
--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -56,7 +56,9 @@
                         "typtype" (types/col-type->field "typtype" :utf8)
                         "typbasetype" (types/col-type->field "typbasetype" :i32)
                         "typnotnull" (types/col-type->field "typnotnull" :bool)
-                        "typtypmod" (types/col-type->field "typtypmod" :i32)}
+                        "typtypmod" (types/col-type->field "typtypmod" :i32)
+                        "typsend" (types/col-type->field "typsend" :utf8)
+                        "typreceive" (types/col-type->field "typreceive" :utf8)}
    'pg_catalog/pg_class {"oid" (types/col-type->field "oid" :i32)
                          "relname" (types/col-type->field "relname" :utf8)
                          "relnamespace" (types/col-type->field "relnamespace" :i32)
@@ -167,7 +169,7 @@
   rel-wtr)
 
 (defn pg-type [^IRelationWriter rel-wtr]
-  (doseq [{:keys [oid typname] :as x} (remove #(= 0 (:oid %)) (vals types/pg-types))]
+  (doseq [{:keys [oid typname typsend typreceive] :as x} (remove #(= 0 (:oid %)) (vals types/pg-types))]
     (.startRow rel-wtr)
     (doseq [[col ^IVectorWriter col-wtr] rel-wtr]
       (case col
@@ -178,7 +180,9 @@
         "typtype" (.writeObject col-wtr "b")
         "typbasetype" (.writeInt col-wtr 0)
         "typnotnull" (.writeBoolean col-wtr false)
-        "typtypmod" (.writeInt col-wtr -1)))
+        "typtypmod" (.writeInt col-wtr -1)
+        "typsend" (.writeObject col-wtr typsend)
+        "typreceive" (.writeObject col-wtr typreceive)))
     (.endRow rel-wtr))
   (.syncRowCount rel-wtr)
   rel-wtr)

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -796,6 +796,8 @@
             :col-type :i64
             :oid 20
             :typlen typlen
+            :typsend "int8send"
+            :typreceive "int8recv"
             :read-binary (fn [_env ba] (-> ba ByteBuffer/wrap .getLong))
             :read-text (fn [_env ba] (-> ba read-utf8 Long/parseLong))
             :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -809,6 +811,8 @@
             :col-type :i32
             :oid 23
             :typlen typlen
+            :typsend "int4send"
+            :typreceive "int4recv"
             :read-binary (fn [_env ba] (-> ba ByteBuffer/wrap .getInt))
             :read-text (fn [_env ba] (-> ba read-utf8 Integer/parseInt))
             :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -822,6 +826,8 @@
             :col-type :i16
             :oid 21
             :typlen typlen
+            :typsend "int2send"
+            :typreceive "int2recv"
             :read-binary (fn [_env ba] (-> ba ByteBuffer/wrap .getShort))
             :read-text (fn [_env ba] (-> ba read-utf8 Short/parseShort))
             :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -851,6 +857,8 @@
               :col-type :f32
               :oid 700
               :typlen typlen
+              :typsend "float4send"
+              :typreceive "float4recv"
               :read-binary (fn [_env ba] (-> ba ByteBuffer/wrap .getFloat))
               :read-text (fn [_env ba] (-> ba read-utf8 Float/parseFloat))
               :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -864,6 +872,8 @@
               :col-type :f64
               :oid 701
               :typlen typlen
+              :typsend "float8send"
+              :typreceive "float8recv"
               :read-binary (fn [_env ba] (-> ba ByteBuffer/wrap .getDouble))
               :read-text (fn [_env ba] (-> ba read-utf8 Double/parseDouble))
               :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -877,6 +887,8 @@
             :col-type :uuid
             :oid 2950
             :typlen typlen
+            :typsend "uuid_send"
+            :typreceive "uuid_recv"
             :read-binary (fn [_env ba] (util/byte-buffer->uuid (ByteBuffer/wrap ba)))
             :read-text (fn [_env ba] (UUID/fromString (read-utf8 ba)))
             :write-binary (fn [_env ^IVectorReader rdr idx]
@@ -891,6 +903,8 @@
                  :col-type [:timestamp-local :micro]
                  :oid 1114
                  :typlen typlen
+                 :typsend "timestamp_send"
+                 :typreceive "timestamp_recv"
                  :read-binary (fn [_env ba] ;;not sent via pgjdbc, reverse engineered
                                 (let [micros (+ (-> ba ByteBuffer/wrap .getLong) unix-pg-epoch-diff-in-micros)]
                                   (LocalDateTime/ofInstant (time/micros->instant micros) (ZoneId/of "UTC"))))
@@ -919,6 +933,8 @@
                    ;;could try to emit expression for zone agnostic tstz
                    :oid 1184
                    :typlen typlen
+                   :typsend "timestamptz_send"
+                   :typreceive "timestamptz_recv"
                    :read-binary (fn [_env ba] ;; not sent via pgjdbc, reverse engineered
                                   ;;unsure how useful binary tstz inputs are and if therefore if any drivers actually send them, as AFAIK
                                   ;;the wire format for tstz contains no offset, unlike the text format. Therefore we have to
@@ -955,6 +971,8 @@
 
    :tstz-range {:typname "tstz-range"
                 :oid 3910
+                :typsend "range_send"
+                :typreceive "range_recv"
                 :read-text (fn [_env ba]
                              (letfn [(parse-datetime [s]
                                        (when s
@@ -982,6 +1000,8 @@
             :col-type [:date :day]
             :oid 1082
             :typlen typlen
+            :typsend "date_send"
+            :typreceive "date_recv"
             :read-binary (fn [_env ba] ;;not sent via pgjdbc, reverse engineered
                            (let [days (+
                                        (-> ba ByteBuffer/wrap .getInt)
@@ -1001,6 +1021,8 @@
    :varchar {:typname "varchar"
              :col-type :utf8
              :oid 1043
+             :typsend "varcharsend"
+             :typreceive "varcharrecv"
              :read-text (fn [_env ba] (read-utf8 ba))
              :write-text (fn [_env ^IVectorReader rdr idx]
                            (let [bb (.getBytes rdr idx)
@@ -1012,6 +1034,8 @@
    :text {:typname "text"
           :col-type :utf8
           :oid 25
+          :typsend "textsend"
+          :typreceive "textrecv"
           :read-text (fn [_env ba] (read-utf8 ba))
           :write-text (fn [_env ^IVectorReader rdr idx]
                         (let [bb (.getBytes rdr idx)
@@ -1022,6 +1046,8 @@
    :regclass {:typname "regclass"
               :col-type :regclass
               :oid 2205
+              :typsend "regclasssend"
+              :typreceive "regclassrecv"
               ;;skipping read impl, unsure if anything can/would send a regclass param
               :write-text (fn [_env ^IVectorReader rdr idx]
                             ;;postgres returns the table name rather than a string of the
@@ -1033,6 +1059,8 @@
              :col-type :bool
              :typlen 1
              :oid 16
+             :typsend "boolsend"
+             :typreceive "boolrecv"
              :read-binary (fn [_env ba]
                             (case (-> ba ByteBuffer/wrap .get)
                               1 true
@@ -1057,6 +1085,8 @@
               :col-type [:interval :month-day-nano]
               :typlen 16
               :oid 1186
+              :typsend "interval_send"
+              :typreceive "interval_recv"
               :read-binary (fn [_env _ba]
                              (throw (IllegalArgumentException. "Interval parameters currently unsupported")))
               :read-text (fn [_env _ba]
@@ -1069,21 +1099,27 @@
                                   p (.period itvl)
                                   d (trunc-duration-to-micros  (.duration itvl))]
                               ;; we use the standard toString for encoding
-                              (utf8 (IntervalMonthDayNano. p d) )))}
+                              (utf8 (IntervalMonthDayNano. p d))))}
 
    ;; json-write-text is essentially the default in send-query-result so no need to specify here
    :json {:typname "json"
           :oid 114
+          :typsend "json_send"
+          :typreceive "json_recv"
           :read-text (fn [_env ba]
                        (JsonSerde/decode (ByteArrayInputStream. ba)))}
 
    :jsonb {:typname "jsonb"
            :oid 3802
+           :typsend "jsonb_send"
+           :typreceive "jsonb_recv"
            :read-text (fn [_env ba]
                         (JsonSerde/decode (ByteArrayInputStream. ba)))}
 
    :transit {:typname "transit"
              :oid transit-oid
+             :typsend "transit_send"
+             :typreceive "transit_recv"
              :read-text (fn [_env ^bytes ba] (serde/read-transit ba :json))
              :write-text (fn [_env ^IVectorReader rdr idx]
                            (serde/write-transit (.getObject rdr idx) :json))}})

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -1132,6 +1132,7 @@
               :read-text (fn [_env _ba]
                            (throw (IllegalArgumentException. "Interval parameters currently unsupported")))
               :write-binary (fn [_env ^IVectorReader rdr idx]
+                            ;; Postgres only has month-day-micro intervals so we truncate the nanos
                               (let [^IntervalMonthDayNano itvl (.getObject rdr idx)
                                     p (.period itvl)
                                     d (trunc-duration-to-micros  (.duration itvl))]
@@ -1152,22 +1153,29 @@
           :typsend "json_send"
           :typreceive "json_recv"
           :read-text (fn [_env ba]
-                       (JsonSerde/decode (ByteArrayInputStream. ba)))}
+                       (JsonSerde/decode (ByteArrayInputStream. ba)))
+          :read-binary (fn [_env ba]
+                         (JsonSerde/decode (ByteArrayInputStream. ba)))}
 
    :jsonb {:typname "jsonb"
            :oid 3802
            :typsend "jsonb_send"
            :typreceive "jsonb_recv"
            :read-text (fn [_env ba]
-                        (JsonSerde/decode (ByteArrayInputStream. ba)))}
+                        (JsonSerde/decode (ByteArrayInputStream. ba)))
+           :read-binary (fn [_env ba]
+                          (JsonSerde/decode (ByteArrayInputStream. ba)))}
 
    :transit {:typname "transit"
              :oid transit-oid
              :typsend "transit_send"
              :typreceive "transit_recv"
              :read-text (fn [_env ^bytes ba] (serde/read-transit ba :json))
+             :read-binary (fn [_env ^bytes ba] (serde/read-transit ba :json))
              :write-text (fn [_env ^IVectorReader rdr idx]
-                           (serde/write-transit (.getObject rdr idx) :json))}})
+                           (serde/write-transit (.getObject rdr idx) :json))
+             :write-binary (fn [_env ^IVectorReader rdr idx]
+                             (serde/write-transit (.getObject rdr idx) :json))}})
 
 (def pg-types-by-oid (into {} (map #(hash-map (:oid (val %)) (val %))) pg-types))
 

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -973,6 +973,20 @@
                 :oid 3910
                 :typsend "range_send"
                 :typreceive "range_recv"
+                :read-binary (fn [_env ba]
+                               (letfn [(parse-datetime [s]
+                                         (when s
+                                           (let [ts (time/parse-sql-timestamp-literal s)]
+                                             (cond
+                                               (instance? ZonedDateTime ts) ts
+                                               (instance? OffsetDateTime ts) (.toZonedDateTime ^OffsetDateTime ts)
+                                               :else ::malformed-date-time))))]
+                                 (when-let [[_ from to] (re-matches #"\[([^,]*),([^\)]*)\)" (read-utf8 ba))]
+                                   (let [from (parse-datetime from)
+                                         to (parse-datetime to)]
+                                     (when-not (or (= ::malformed-date-time from)
+                                                   (= ::malformed-date-time to))
+                                       (ZonedDateTimeRange. from to))))))
                 :read-text (fn [_env ba]
                              (letfn [(parse-datetime [s]
                                        (when s
@@ -993,7 +1007,14 @@
                                 (utf8
                                  (str "[" (-> (.getFrom tstz-range) (.format iso-offset-date-time-formatter-with-space))
                                       "," (some-> (.getTo tstz-range) (.format iso-offset-date-time-formatter-with-space))
-                                      ")"))))}
+                                      ")"))))
+                :write-binary (fn [_env ^IVectorReader rdr idx]
+                                (let [^ZonedDateTimeRange tstz-range (.getObject rdr idx)]
+                                  (byte-array
+                                   (.getBytes
+                                    (str "[" (-> (.getFrom tstz-range) (.format iso-offset-date-time-formatter-with-space))
+                                         "," (some-> (.getTo tstz-range) (.format iso-offset-date-time-formatter-with-space))
+                                         ")")))))}
 
    :date (let [typlen 4]
            {:typname "date"
@@ -1024,11 +1045,17 @@
              :typsend "varcharsend"
              :typreceive "varcharrecv"
              :read-text (fn [_env ba] (read-utf8 ba))
+             :read-binary (fn [_env ba] (read-utf8 ba))
              :write-text (fn [_env ^IVectorReader rdr idx]
                            (let [bb (.getBytes rdr idx)
                                  ba ^bytes (byte-array (.remaining bb))]
                              (.get bb ba)
-                             ba))}
+                             ba))
+             :write-binary (fn [_env ^IVectorReader rdr idx]
+                             (let [bb (.getBytes rdr idx)
+                                   ba ^bytes (byte-array (.remaining bb))]
+                               (.get bb ba)
+                               ba))}
    ;;same as varchar which makes this technically lossy in roundtrip
    ;;text is arguably more correct for us than varchar
    :text {:typname "text"
@@ -1037,11 +1064,17 @@
           :typsend "textsend"
           :typreceive "textrecv"
           :read-text (fn [_env ba] (read-utf8 ba))
+          :read-binary (fn [_env ba] (read-utf8 ba))
           :write-text (fn [_env ^IVectorReader rdr idx]
                         (let [bb (.getBytes rdr idx)
                               ba ^bytes (byte-array (.remaining bb))]
                           (.get bb ba)
-                          ba))}
+                          ba))
+          :write-binary (fn [_env ^IVectorReader rdr idx]
+                          (let [bb (.getBytes rdr idx)
+                                ba ^bytes (byte-array (.remaining bb))]
+                            (.get bb ba)
+                            ba))}
 
    :regclass {:typname "regclass"
               :col-type :regclass
@@ -1054,7 +1087,14 @@
                             ;;oid here, however regclass is usually not returned from queries
                             ;;could reimplement oid -> table name resolution here or in getObject
                             ;;if the user cannot adjust the query to cast to varchar/text
-                            (utf8 (Integer/toUnsignedString (.getInt rdr idx))))}
+                            (utf8 (Integer/toUnsignedString (.getInt rdr idx))))
+              :write-binary (fn [_env ^IVectorReader rdr idx]
+                            ;;postgres returns the table name rather than a string of the
+                            ;;oid here, however regclass is usually not returned from queries
+                            ;;could reimplement oid -> table name resolution here or in getObject
+                            ;;if the user cannot adjust the query to cast to varchar/text
+                              (byte-array
+                               (utf8 (Integer/toUnsignedString (.getInt rdr idx)))))}
    :boolean {:typname "boolean"
              :col-type :bool
              :typlen 1
@@ -1092,7 +1132,12 @@
               :read-text (fn [_env _ba]
                            (throw (IllegalArgumentException. "Interval parameters currently unsupported")))
               :write-binary (fn [_env ^IVectorReader rdr idx]
-                              (throw (IllegalArgumentException. "Interval binary encoding currently unsupported")))
+                              (let [^IntervalMonthDayNano itvl (.getObject rdr idx)
+                                    p (.period itvl)
+                                    d (trunc-duration-to-micros  (.duration itvl))]
+                                ;; we use the standard toString for encoding
+                                (byte-array
+                                 (utf8 (IntervalMonthDayNano. p d)))))
               :write-text (fn [_env ^IVectorReader rdr idx]
                             ;; Postgres only has month-day-micro intervals so we truncate the nanos
                             (let [^IntervalMonthDayNano itvl (.getObject rdr idx)


### PR DESCRIPTION
This adds typsend and typreceive columns to information_schema.pg_type table to enable smooth integration with elixir-ecto/postgrex and missing [write/read]-binary to text, varchar, transit. Read binary for JSON (any reason write is not supported?)