### PR TITLE
Catch ArithmeticException at EE boundary

### DIFF
--- a/http-server/src/test/clojure/xtdb/remote_test.clj
+++ b/http-server/src/test/clojure/xtdb/remote_test.clj
@@ -128,7 +128,7 @@
           body (decode-json body)]
       (t/is (= 200 status))
       (t/is (instance? xtdb.RuntimeException body))
-      (t/is (= "data exception — division by zero" (ex-message body)))
+      (t/is (= "data exception - division by zero" (ex-message body)))
       (t/is (= {:xtdb.error/error-key :xtdb.expression/division-by-zero}
                (ex-data body)))))
 

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -551,7 +551,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"]])
                           (xt/q tu/*node* '(from docs [name]))))
 
   (t/is (thrown-with-msg? xtdb.RuntimeException
-                          #"data exception — division by zero"
+                          #"data exception - division by zero"
                           (xt/q tu/*node* '(-> (rel [{}] [])
                                                (with {:foo (/ 1 0)})))))
 

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1392,15 +1392,17 @@
     (t/is (= {:res 3.0, :res-type [:union #{:f64 :decimal}]}
              (run-test 'greatest (double 3.0) (bigdec 2.0))))
 
+
     ;; TODO decide on behaviour
     ;; out of fixed precision range
-    (t/is (thrown? UnsupportedOperationException
+    (t/is (thrown? RuntimeException
                    (run-test '+ (bigdec 1E+19M) (bigdec 1E+19M))))
     ;; overflow
-    (t/is (thrown? UnsupportedOperationException
+    (t/is (thrown? RuntimeException
                    (run-test '+ (bigdec 1E+35M) (bigdec 1E-35M))))
+
     ;; underflow
-    (t/is (thrown? ArithmeticException
+    (t/is (thrown? RuntimeException
                    (run-test '/ (bigdec 1E-35M) (bigdec 1E+35M))))))
 
 (t/deftest test-throws-on-overflow


### PR DESCRIPTION
This catches `ArithmeticException`s at the Expression Engine boundary and turns them into runtime exceptions so that we don't fall over in the indexer.