### PR TITLE
Multiple fixes for faster temporal resolution with skip lists. 

### DIFF
--- a/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
@@ -25,6 +25,21 @@ internal fun LongArrayList.reverseLinearSearch(needle: Long): Int {
     return -1
 }
 
+internal fun LongArrayList.binarySearch(needle: Long): Int {
+    var left = 0
+    var right = elementsCount
+    while (left < right) {
+        val mid = (left + right) / 2
+        val x = buffer[mid]
+        when {
+            x == needle -> return mid
+            x > needle -> left = mid + 1
+            else -> right = mid
+        }
+    }
+    return -left - 1
+}
+
 data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArrayList) {
     constructor() : this(LongArrayList(), LongArrayList()) {
         reset()
@@ -50,11 +65,11 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
     fun applyLog(systemFrom: Long, validFrom: Long, validTo: Long) {
         if (validFrom >= validTo) return
 
-        var end = validTimes.reverseLinearSearch(validTo)
+        var end = validTimes.binarySearch(validTo)
         val insertedEnd = end < 0
         if (insertedEnd) end = -(end + 1)
 
-        var start = validTimes.reverseLinearSearch(validFrom)
+        var start = validTimes.binarySearch(validFrom)
         val insertedStart = start < 0
         if (insertedStart) start = -(start + 1)
 

--- a/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Ceiling.kt
@@ -53,6 +53,19 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
 
     fun getSystemTime(rangeIdx: Int) = sysTimeCeilings[reverseIdx(rangeIdx) - 1]
 
+    /**
+     * @return the index (in reverse order) such that `validTimes[reverseIdx(idx)] <= validTime < validTimes[reverseIdx(idx + 1)]`
+     * or 0 if `validTime < validTimes[reverseIdx(0)]`
+     * or `validTimes.elementsCount - 1` if `validTime >= validTimes[reverseIdx(validTimes.elementsCount - 1)]`
+     */
+    fun getCeilingIndex(validTime: Long): Int {
+        var idx = validTimes.binarySearch(validTime)
+        if (idx < 0) idx = -(idx + 1)
+        if (idx < validTimes.elementsCount - 1 && validTime < validTimes[idx]) idx++
+        if (idx == validTimes.elementsCount) idx--
+        return reverseIdx(idx)
+    }
+
     @Suppress("MemberVisibilityCanBePrivate")
     fun reset() {
         validTimes.clear()
@@ -107,4 +120,5 @@ data class Ceiling(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
         validTimes.removeRange(end + 1, start)
         sysTimeCeilings.removeRange(end + 1, start)
     }
+
 }

--- a/core/src/main/kotlin/xtdb/bitemporal/Polygon.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/Polygon.kt
@@ -21,9 +21,9 @@ data class Polygon(val validTimes: LongArrayList, val sysTimeCeilings: LongArray
         validTimes.clear()
         sysTimeCeilings.clear()
 
-        var ceilIdx = 0
-
         var validTime = validFrom
+
+        var ceilIdx = ceiling.getCeilingIndex(validFrom)
 
         do {
             var ceilValidTo: Long

--- a/core/src/main/kotlin/xtdb/util/SkipList.kt
+++ b/core/src/main/kotlin/xtdb/util/SkipList.kt
@@ -1,0 +1,194 @@
+package xtdb.util
+
+import kotlin.random.Random
+
+class SkipListNode<T>(
+    var value: T?,
+    val level: Int
+) {
+    val next = Array<SkipListNode<T>?>(level) { null }
+    val span = IntArray(level) { 1 }  // Distance to the next node at each level
+}
+
+class SkipList<T : Comparable<T>> : Comparable<SkipList<T>> {
+    private val MAX_LEVEL = 32
+    private val P = 0.5
+
+    private val head = SkipListNode<T>(null, MAX_LEVEL)
+    private var level = 1
+    var size = 0
+    private val rand = Random(System.currentTimeMillis())
+
+    private fun randomLevel(): Int {
+        var lvl = 1
+        while (rand.nextDouble() < P && lvl < MAX_LEVEL) {
+            lvl++
+        }
+        return lvl
+    }
+
+    operator fun get(index: Int): T {
+        val node = getNode(index)
+        return node.value ?: throw IndexOutOfBoundsException()
+    }
+
+    operator fun set(index: Int, value: T) {
+        val node = getNode(index)
+        node.value = value
+    }
+
+    private fun getNode(index: Int): SkipListNode<T> {
+        if (index < 0 || index >= size) throw IndexOutOfBoundsException()
+        var x = head
+        var i = -1  // Start from position -1 because head is before the first element
+        for (k in level - 1 downTo 0) {
+            while (x.next[k] != null && i + x.span[k] <= index) {
+                i += x.span[k]
+                x = x.next[k]!!
+            }
+        }
+        return x
+    }
+
+    fun add(value: T) {
+        insert(size, value)
+    }
+
+    fun insert(pos: Int, value: T) {
+        if (pos < 0 || pos > size) throw IndexOutOfBoundsException("Index out of bounds: $pos")
+        val update = Array<SkipListNode<T>>(MAX_LEVEL) { head }
+        val rank = IntArray(MAX_LEVEL) { 0 }
+
+        var x = head
+        for (k in level - 1 downTo 0) {
+            rank[k] = if (k == level - 1) 0 else rank[k + 1]
+            while (x.next[k] != null && rank[k] + x.span[k] < pos + 1) {
+                rank[k] += x.span[k]
+                x = x.next[k]!!
+            }
+            update[k] = x
+        }
+
+        val lvl = randomLevel()
+        if (lvl > level) {
+            for (k in level until lvl) {
+                update[k] = head
+                update[k].span[k] = size + 1
+            }
+            level = lvl
+        }
+
+        val newNode = SkipListNode(value, lvl)
+        for (k in 0 until lvl) {
+            newNode.next[k] = update[k].next[k]
+            update[k].next[k] = newNode
+
+            newNode.span[k] = update[k].span[k] - (pos - rank[k])
+            update[k].span[k] = (pos - rank[k]) + 1
+        }
+
+        for (k in lvl until level) {
+            update[k].span[k]++
+        }
+
+        size++
+    }
+
+    fun clear() {
+        for (k in 0 until level) {
+            head.next[k] = null
+            head.span[k] = 1
+        }
+        level = 1
+        size = 0
+    }
+
+    fun removeRange(fromIndex: Int, toIndex: Int) {
+        if (fromIndex < 0 || toIndex > size) {
+            throw IndexOutOfBoundsException("Invalid range: $fromIndex to $toIndex")
+        }
+        val update = Array<SkipListNode<T>>(MAX_LEVEL) { head }
+        val rank = IntArray(MAX_LEVEL) { 0 }
+
+        var x = head
+        for (k in level - 1 downTo 0) {
+            rank[k] = if (k == level - 1) 0 else rank[k + 1]
+            while (x.next[k] != null && rank[k] + x.span[k] < fromIndex + 1) {
+                rank[k] += x.span[k]
+                x = x.next[k]!!
+            }
+            update[k] = x
+        }
+
+        var nodesToRemove = toIndex - fromIndex
+        for (k in 0 until level) {
+            if (update[k].next[k] != null) {
+                var node = update[k].next[k]
+                var spanSum = 0
+                while (node != null && spanSum < nodesToRemove) {
+                    spanSum += node.span[k]
+                    node = node.next[k]
+                }
+                update[k].next[k] = node
+                update[k].span[k] += spanSum - nodesToRemove
+            } else {
+                update[k].span[k] -= nodesToRemove
+            }
+        }
+
+        while (level > 1 && head.next[level - 1] == null) {
+            level--
+        }
+
+        size -= nodesToRemove
+    }
+
+    override fun compareTo(other: SkipList<T>): Int {
+        var node1 = this.head.next[0]
+        var node2 = other.head.next[0]
+        while (node1 != null && node2 != null) {
+            val cmp = node1.value!!.compareTo(node2.value!!)
+            if (cmp != 0) {
+                return cmp
+            }
+            node1 = node1.next[0]
+            node2 = node2.next[0]
+        }
+        return when {
+            node1 != null -> 1
+            node2 != null -> -1
+            else -> 0
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SkipList<*>) return false
+        return this.compareTo(other as SkipList<T>) == 0
+    }
+
+    override fun toString(): String {
+        val sb = StringBuilder()
+        var node = head.next[0]
+        sb.append("[")
+        while (node != null) {
+            sb.append(node.value)
+            node = node.next[0]
+            if (node != null) {
+                sb.append(", ")
+            }
+        }
+        sb.append("]")
+        return sb.toString()
+    }
+
+    companion object {
+        fun <T: Comparable<T>> from(vararg elements: T): SkipList<T>{
+            val skipList = SkipList<T>()
+            for (element in elements) {
+                skipList.add(element)
+            }
+            return skipList
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -4,6 +4,7 @@ import com.carrotsearch.hppc.LongArrayList
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import xtdb.util.SkipList
 import kotlin.Long.Companion.MAX_VALUE
 import com.carrotsearch.hppc.LongArrayList as longs
 import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
@@ -43,9 +44,9 @@ internal class CeilingTest {
 
     @Test
     fun testGetCeilingIndex() {
-        val list = longs.from(10, 8, 6, 4, 2)
-        // the second part shouldn't be used
-        val ceiling = Ceiling(list, LongArrayList())
+        val list = SkipList.from(10L, 8L, 6L, 4L, 2L)
+        // the ceilings part shouldn't be used in this test
+        val ceiling = Ceiling(list, SkipList())
         assertEquals(0, ceiling.getCeilingIndex(1))
         assertEquals(0, ceiling.getCeilingIndex(2))
         assertEquals(4, ceiling.getCeilingIndex(10))
@@ -55,38 +56,38 @@ internal class CeilingTest {
 
     @Test
     fun testAppliesLogs() {
-        assertEquals(longs.from(MAX_LONG, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(MAX_LONG), ceiling.sysTimeCeilings)
 
         ceiling.applyLog(4, 4, MAX_LONG)
-        assertEquals(longs.from(MAX_LONG, 4, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(4, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 4, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(4, MAX_LONG), ceiling.sysTimeCeilings)
 
         // lower the whole ceiling
         ceiling.applyLog(3, 2, MAX_LONG)
-        assertEquals(longs.from(MAX_LONG, 2, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(3, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 2, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(3, MAX_LONG), ceiling.sysTimeCeilings)
 
         // lower part of the ceiling
         ceiling.applyLog(2, 1, 4)
-        assertEquals(longs.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(3, 2, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(3, 2, MAX_LONG), ceiling.sysTimeCeilings)
 
         // replace a range exactly
         ceiling.applyLog(1, 1, 4)
-        assertEquals(longs.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(3, 1, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 4, 1, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(3, 1, MAX_LONG), ceiling.sysTimeCeilings)
 
         // replace the whole middle section
         ceiling.applyLog(0, 0, 6)
-        assertEquals(longs.from(MAX_LONG, 6, 0, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(3, 0, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 6, 0, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(3, 0, MAX_LONG), ceiling.sysTimeCeilings)
     }
 
     @Test
     fun `test replace within a range`() {
         ceiling.applyLog(4, 4, 6)
-        assertEquals(longs.from(MAX_LONG, 6, 4, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs.from(MAX_LONG, 4, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 6, 4, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(MAX_LONG, 4, MAX_LONG), ceiling.sysTimeCeilings)
     }
 }

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -29,6 +29,18 @@ internal class CeilingTest {
     }
 
     @Test
+    fun testBinarySearch() {
+        val list = longs.from(10, 8, 6, 4, 2)
+        assertEquals(0, list.binarySearch(10))
+        assertEquals(2, list.binarySearch(6))
+        assertEquals(4, list.binarySearch(2))
+        assertEquals(-2, list.binarySearch(9))
+        assertEquals(-1, list.binarySearch(11))
+        assertEquals(-5, list.binarySearch(3))
+        assertEquals(-6, list.binarySearch(1))
+    }
+
+    @Test
     fun testAppliesLogs() {
         assertEquals(longs.from(MAX_LONG, MIN_LONG), ceiling.validTimes)
         assertEquals(longs.from(MAX_LONG), ceiling.sysTimeCeilings)

--- a/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/CeilingTest.kt
@@ -1,5 +1,6 @@
 package xtdb.bitemporal
 
+import com.carrotsearch.hppc.LongArrayList
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,6 +39,18 @@ internal class CeilingTest {
         assertEquals(-1, list.binarySearch(11))
         assertEquals(-5, list.binarySearch(3))
         assertEquals(-6, list.binarySearch(1))
+    }
+
+    @Test
+    fun testGetCeilingIndex() {
+        val list = longs.from(10, 8, 6, 4, 2)
+        // the second part shouldn't be used
+        val ceiling = Ceiling(list, LongArrayList())
+        assertEquals(0, ceiling.getCeilingIndex(1))
+        assertEquals(0, ceiling.getCeilingIndex(2))
+        assertEquals(4, ceiling.getCeilingIndex(10))
+        assertEquals(4, ceiling.getCeilingIndex(11))
+        assertEquals(1, ceiling.getCeilingIndex(5))
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/bitemporal/PolygonTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/PolygonTest.kt
@@ -3,6 +3,7 @@ package xtdb.bitemporal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import xtdb.util.SkipList
 import com.carrotsearch.hppc.LongArrayList.from as longs
 import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
 import kotlin.Long.Companion.MIN_VALUE as MIN_LONG
@@ -136,8 +137,8 @@ internal class PolygonTest {
         ceiling.applyLog(8, 8, 10)
         ceiling.applyLog(6, 6, 8)
 
-        assertEquals(longs(MAX_LONG, 12, 10, 8, 6, MIN_LONG), ceiling.validTimes)
-        assertEquals(longs(MAX_LONG, 10, 8, 6, MAX_LONG), ceiling.sysTimeCeilings)
+        assertEquals(SkipList.from(MAX_LONG, 12, 10, 8, 6, MIN_LONG), ceiling.validTimes)
+        assertEquals(SkipList.from(MAX_LONG, 10, 8, 6, MAX_LONG), ceiling.sysTimeCeilings)
 
         applyEvent(4, 4, 6)
         assertEquals(longs(4, 6), polygon.validTimes)

--- a/core/src/test/kotlin/xtdb/util/SkipListTest.kt
+++ b/core/src/test/kotlin/xtdb/util/SkipListTest.kt
@@ -1,0 +1,219 @@
+package xtdb.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SkipListTest {
+
+    @Test
+    fun testAddAndGet() {
+        val skipList = SkipList<Int>()
+        skipList.add(1)
+        skipList.add(2)
+        skipList.add(3)
+        assertEquals(1, skipList[0])
+        assertEquals(2, skipList[1])
+        assertEquals(3, skipList[2])
+    }
+
+    @Test
+    fun testSet() {
+        val skipList = SkipList<Int>()
+        skipList.add(10)
+        skipList.add(20)
+        skipList.add(30)
+
+        skipList[1] = 25  // Update value at index 1
+        assertEquals(25, skipList[1])
+        assertEquals(3, skipList.size)
+
+        skipList[0] = 5   // Update value at index 0
+        assertEquals(5, skipList[0])
+
+        skipList[2] = 35  // Update value at index 2
+        assertEquals(35, skipList[2])
+    }
+
+    @Test
+    fun testSetOutOfBounds() {
+        val skipList = SkipList<Int>()
+        skipList.add(1)
+        skipList.add(2)
+
+        assertThrows<IndexOutOfBoundsException>() {
+            skipList[-1] = 0
+        }
+
+        assertThrows<IndexOutOfBoundsException> {
+            skipList[2] = 3
+        }
+    }
+
+    @Test
+    fun testInsert() {
+        val skipList = SkipList<Int>()
+        skipList.add(1)
+        skipList.add(3)
+        skipList.insert(1, 2) // Insert 2 at position 1
+        assertEquals(1, skipList[0])
+        assertEquals(2, skipList[1])
+        assertEquals(3, skipList[2])
+    }
+
+    @Test
+    fun testRemoveRange() {
+        val skipList = SkipList<Int>()
+        for (i in 1..5) {
+            skipList.add(i)
+        }
+        skipList.removeRange(1, 4) // Removes elements at positions 1 to 3
+        assertEquals(2, skipList.size)
+        assertEquals(1, skipList[0])
+        assertEquals(5, skipList[1])
+    }
+
+    @Test
+    fun testClear() {
+        val skipList = SkipList<Int>()
+        for (i in 1..5) {
+            skipList.add(i)
+        }
+        skipList.clear()
+        assertEquals(0, skipList.size)
+        assertThrows<IndexOutOfBoundsException>() {
+            skipList[0]
+        }
+    }
+
+    @Test
+    fun testOutOfBoundsAccess() {
+        val skipList = SkipList<Int>()
+        skipList.add(1)
+        assertThrows<IndexOutOfBoundsException>() {
+            skipList[-1]
+        }
+        assertThrows<IndexOutOfBoundsException>() {
+            skipList[1]
+        }
+    }
+
+    @Test
+    fun testInsertAtBounds() {
+        val skipList = SkipList<Int>()
+        skipList.add(1)
+        skipList.add(2)
+        skipList.insert(0, 0) // Insert at the beginning
+        skipList.insert(3, 3) // Insert at the end
+        assertEquals(0, skipList[0])
+        assertEquals(1, skipList[1])
+        assertEquals(2, skipList[2])
+        assertEquals(3, skipList[3])
+    }
+
+    @Test
+    fun testRemoveRangeFull() {
+        val skipList = SkipList<Int>()
+        for (i in 1..5) {
+            skipList.add(i)
+        }
+        skipList.removeRange(0, 5) // Removes all elements
+        assertEquals(0, skipList.size)
+        assertThrows<IndexOutOfBoundsException> {
+            skipList[0]
+        }
+    }
+
+    @Test
+    fun testSequentialOperations() {
+        val skipList = SkipList<String>()
+        skipList.add("a")
+        skipList.add("c")
+        skipList.insert(1, "b") // List is now ["a", "b", "c"]
+        assertEquals("b", skipList[1])
+        skipList[1] = "beta" // Update value at index 1
+        assertEquals("beta", skipList[1])
+        skipList.removeRange(0, 2) // Removes "a" and "beta"
+        assertEquals(1, skipList.size)
+        assertEquals("c", skipList[0])
+        skipList.clear()
+        assertEquals(0, skipList.size)
+        skipList.add("d")
+        assertEquals("d", skipList[0])
+    }
+
+    @Test
+    fun testLargeNumberOfElements() {
+        val skipList = SkipList<Int>()
+        val n = 1000
+        for (i in 0 until n) {
+            skipList.add(i)
+        }
+        assertEquals(n, skipList.size)
+        for (i in 0 until n) {
+            assertEquals(i, skipList[i])
+        }
+        // Update some values
+        for (i in 0 until n step 100) {
+            skipList[i] = -i
+        }
+        for (i in 0 until n) {
+            if (i % 100 == 0) {
+                assertEquals(-i, skipList[i])
+            } else {
+                assertEquals(i, skipList[i])
+            }
+        }
+        // Remove the middle 500 elements
+        skipList.removeRange(250, 750)
+        assertEquals(500, skipList.size)
+        for (i in 0 until 250) {
+            val expected = if (i % 100 == 0) -i else i
+            assertEquals(expected, skipList[i])
+        }
+        for (i in 250 until 500) {
+            val idx = i + 500
+            val expected = if (idx % 100 == 0) -idx else idx
+            assertEquals(expected, skipList[i])
+        }
+    }
+
+    @Test
+    fun testRandomOperations() {
+        val skipList = SkipList<Int>()
+        val list = mutableListOf<Int>()
+        val rand = kotlin.random.Random(0)
+        for (i in 0 until 100) {
+            val value = rand.nextInt(1000)
+            val pos = rand.nextInt(0, skipList.size + 1)
+            skipList.insert(pos, value)
+            list.add(pos, value)
+        }
+        // Randomly update some values
+        for (i in 0 until 50) {
+            val index = rand.nextInt(0, skipList.size)
+            val newValue = rand.nextInt(1000, 2000)
+            skipList[index] = newValue
+            list[index] = newValue
+        }
+        for (i in 0 until skipList.size) {
+            assertEquals(list[i], skipList[i])
+        }
+    }
+
+    @Test
+    fun testComparsion() {
+        val skipList1 = SkipList<Int>()
+        val skipList2 = SkipList<Int>()
+        skipList1.add(1)
+        skipList1.add(2)
+        skipList1.add(3)
+        skipList2.add(1)
+        skipList2.add(2)
+        skipList2.add(3)
+        assertEquals(skipList1, skipList2)
+        skipList2.add(4)
+        assertEquals(-1, skipList1.compareTo(skipList2))
+        assertEquals(1, skipList2.compareTo(skipList1))
+    }
+}


### PR DESCRIPTION
The same as #3760 but with the skip-list approach, which we decided to not include.