### PR TITLE
Decoupling caches in the buffer pool, #3770

### DIFF
--- a/core/src/main/kotlin/xtdb/cache/DiskCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/DiskCache.kt
@@ -1,0 +1,92 @@
+package xtdb.cache
+
+import com.github.benmanes.caffeine.cache.RemovalCause
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.Comparator.comparingLong
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletableFuture.completedFuture
+import kotlin.io.path.*
+import kotlin.math.max
+
+class DiskCache(
+    val rootPath: Path,
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    val maxSizeBytes: Long
+) {
+    val pinningCache = PinningCache<Entry>(maxSizeBytes)
+
+    val stats get() = pinningCache.stats
+
+    inner class Entry(
+        inner: PinningCache.IEntry,
+        val k: Path,
+        val path: Path,
+    ) : PinningCache.IEntry by inner, AutoCloseable {
+
+        override fun onEvict(k: Path, reason: RemovalCause) {
+            path.deleteIfExists()
+            println("Evicted $k due to $reason")
+            super.onEvict(k, reason)
+        }
+
+        constructor(k: Path, path: Path) : this(pinningCache.Entry(path.fileSize()), k, path)
+
+        override fun close() {
+            pinningCache.releaseEntry(k)
+        }
+    }
+
+    init {
+        val syncInnerCache = pinningCache.cache.synchronous()
+        Files.walk(rootPath)
+            .filter { Files.isRegularFile(it) }
+            .sorted(comparingLong { path ->
+                Files.readAttributes(path, BasicFileAttributes::class.java).let { attrs ->
+                    max(attrs.lastAccessTime().toMillis(), attrs.lastModifiedTime().toMillis())
+                }
+            })
+            .forEach { path ->
+                val k = rootPath.relativize(path)
+                syncInnerCache.put(k, Entry(k, path))
+            }
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun createTempPath(): Path =
+        Files.createTempFile(rootPath.resolve(".tmp").createDirectories(), "upload", ".arrow")
+
+    @FunctionalInterface
+    fun interface Fetch {
+        operator fun invoke(k: Path, tmpFile: Path): CompletableFuture<Path>
+    }
+
+    @Suppress("NAME_SHADOWING")
+    fun get(k: Path, fetch: Fetch) =
+        pinningCache.get(k) { k ->
+            val diskCachePath = rootPath.resolve(k)
+
+            if (diskCachePath.exists())
+                completedFuture(Entry(k, diskCachePath))
+            else
+                fetch(k, createTempPath())
+                    .thenApply { tmpPath ->
+                        tmpPath.moveTo(diskCachePath.createParentDirectories(), ATOMIC_MOVE, REPLACE_EXISTING)
+                        Entry(k, diskCachePath)
+                    }
+        }
+
+    @Suppress("NAME_SHADOWING")
+    fun put(k: Path, tmpFile: Path) {
+        pinningCache.cache.asMap()
+            .computeIfAbsent(k) { k ->
+                val diskCachePath = rootPath.resolve(k)
+                tmpFile.moveTo(diskCachePath.createParentDirectories(), ATOMIC_MOVE, REPLACE_EXISTING)
+                completedFuture(Entry(pinningCache.Entry(diskCachePath.fileSize()), k, diskCachePath))
+            }
+    }
+}

--- a/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
@@ -1,0 +1,104 @@
+@file:Suppress("SpellCheckingInspection")
+
+package xtdb.cache
+
+import com.github.benmanes.caffeine.cache.RemovalCause
+import io.netty.util.internal.PlatformDependent
+import org.apache.arrow.memory.ArrowBuf
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.ForeignAllocation
+import org.apache.arrow.memory.util.MemoryUtil
+import xtdb.cache.PinningCache.IEntry
+import java.nio.ByteBuffer
+import java.nio.channels.ClosedByInterruptException
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+
+/**
+ * NOTE: the allocation count metrics in the provided `allocator` WILL NOT be accurate
+ *   - we allocate a buffer in here for every _usage_, and don't take shared memory into account.
+ */
+class MemoryCache
+@JvmOverloads constructor(
+    private val allocator: BufferAllocator,
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    val maxSizeBytes: Long,
+    private val pathLoader: PathLoader = PathLoader()
+) : AutoCloseable {
+    private val pinningCache = PinningCache<Entry>(maxSizeBytes)
+
+    val stats get() = pinningCache.stats
+
+    interface PathLoader {
+        fun load(path: Path): ByteBuffer
+        fun tryFree(bbuf: ByteBuffer) {}
+
+        companion object {
+            operator fun invoke() = object : PathLoader {
+                override fun load(path: Path) =
+                    try {
+                        val ch = FileChannel.open(path)
+                        val size = ch.size()
+
+                        ch.map(FileChannel.MapMode.READ_ONLY, 0, size)
+                    } catch (e: ClosedByInterruptException) {
+                        throw InterruptedException(e.message)
+                    }
+
+                override fun tryFree(bbuf: ByteBuffer) {
+                    PlatformDependent.freeDirectBuffer(bbuf)
+                }
+            }
+        }
+    }
+
+    private inner class Entry(
+        val inner: IEntry,
+        val onEvict: AutoCloseable?,
+        val bbuf: ByteBuffer
+    ) : IEntry by inner {
+        override fun onEvict(k: Path, reason: RemovalCause) {
+            pathLoader.tryFree(bbuf)
+            onEvict?.close()
+        }
+    }
+
+    @FunctionalInterface
+    fun interface Fetch {
+        /**
+         * @return a pair containing the on-disk path and an optional cleanup action
+         */
+        operator fun invoke(k: Path): CompletableFuture<Pair<Path, AutoCloseable?>>
+    }
+
+    @Suppress("NAME_SHADOWING")
+    fun get(k: Path, fetch: Fetch): ArrowBuf {
+        val entry = pinningCache.get(k) { k ->
+            fetch(k).thenApplyAsync { (path, onEvict) ->
+                val bbuf = pathLoader.load(path)
+                Entry(pinningCache.Entry(bbuf.capacity().toLong()), onEvict, bbuf)
+            }
+        }.get()!!
+
+        val bbuf = entry.bbuf
+
+        // create a new ArrowBuf for each request.
+        // when the ref-count drops to zero, we release a ref-count in the cache.
+        return allocator.wrapForeignAllocation(
+            object : ForeignAllocation(bbuf.capacity().toLong(), MemoryUtil.getByteBufferAddress(bbuf)) {
+                override fun release0() {
+                    pinningCache.releaseEntry(k)
+                }
+            })
+    }
+
+    fun invalidate(k: Path) {
+        pinningCache.invalidate(k)
+    }
+
+    override fun close() {
+        pinningCache.close()
+    }
+}

--- a/core/src/main/kotlin/xtdb/cache/PinningCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/PinningCache.kt
@@ -1,0 +1,100 @@
+package xtdb.cache
+
+import com.github.benmanes.caffeine.cache.AsyncCache
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.RemovalCause
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+class PinningCache<V : PinningCache.IEntry>(
+    @Suppress("MemberVisibilityCanBePrivate")
+    val maxSizeBytes: Long
+) : AutoCloseable {
+
+    @Volatile
+    private var pinnedBytes: Long = 0
+
+    val stats: Stats
+        get() {
+            val pinnedBytes = maxSizeBytes - eviction.maximum
+            val evictableBytes = eviction.weightedSize().asLong
+            return Stats(pinnedBytes, evictableBytes, maxSizeBytes - pinnedBytes - evictableBytes)
+        }
+
+    interface IEntry {
+        val weight: Long
+
+        // NOTE: updates to this ref-count MUST be done within `cache.asMap().compute(k) { ... }`
+        // in order to take effect atomically in the cache eviction policy.
+        val refCount: AtomicInteger
+
+        fun onEvict(k: Path, reason: RemovalCause) {}
+    }
+
+    val cache: AsyncCache<Path, V> = Caffeine.newBuilder()
+        .maximumWeight(maxSizeBytes)
+        .evictionListener<Path, V> { key, value, cause -> value!!.onEvict(key!!, cause) }
+        .removalListener<Path, V> { key, value, cause -> if (!cause.wasEvicted()) value!!.onEvict(key!!, cause) }
+        .weigher<Path, V> { _, value -> if (value.refCount.get() > 0) 0 else value.weight.toInt() }
+        .buildAsync()
+
+    private val eviction = cache.synchronous().policy().eviction().get()
+
+    private val lock: Lock = ReentrantLock()
+
+    private fun updatePinnedBytes(delta: Long) {
+        lock.withLock {
+            pinnedBytes += delta
+            eviction.maximum = (maxSizeBytes - pinnedBytes).coerceAtLeast(0)
+        }
+    }
+
+    @Suppress("NAME_SHADOWING")
+    fun get(k: Path, f: (Path) -> CompletableFuture<V>): CompletableFuture<V> =
+        cache.asMap().compute(k) { k, fut ->
+            // NOTE: this MUST be thenApplyAsync rather than thenApply
+            // otherwise the entry is at risk of eviction
+            // see #3828 and ben-manes/caffeine#1791
+            // but tl;dr: the entry is not pinned before the setMaximum eviction runs
+
+            (fut ?: f(k))
+                .thenApplyAsync { entry ->
+                    if (0 == entry.refCount.getAndIncrement()) updatePinnedBytes(entry.weight)
+                    entry
+                }
+        }!!
+
+    fun invalidate(k: Path) {
+        cache.synchronous().run {
+            invalidate(k)
+            cleanUp()
+        }
+
+        ForkJoinPool.commonPool().awaitQuiescence(100, MILLISECONDS)
+    }
+
+    override fun close() {
+        cache.asMap().clear()
+        cache.synchronous().cleanUp()
+        ForkJoinPool.commonPool().awaitQuiescence(100, MILLISECONDS)
+    }
+
+    fun releaseEntry(k: Path) {
+        cache.asMap().compute(k) { _, fut ->
+            fut!!.thenApplyAsync { entry ->
+                if (0 == entry.refCount.decrementAndGet().also { check(it >= 0) }) updatePinnedBytes(-entry.weight)
+                entry
+            }
+        }
+    }
+
+    inner class Entry(override val weight: Long) : IEntry {
+        override val refCount = AtomicInteger(0)
+    }
+}

--- a/core/src/main/kotlin/xtdb/cache/Stats.kt
+++ b/core/src/main/kotlin/xtdb/cache/Stats.kt
@@ -1,0 +1,3 @@
+package xtdb.cache
+
+data class Stats(val pinnedBytes: Long, val evictableBytes: Long, val freeBytes: Long)

--- a/core/src/test/kotlin/xtdb/cache/MemoryCacheTest.kt
+++ b/core/src/test/kotlin/xtdb/cache/MemoryCacheTest.kt
@@ -1,0 +1,98 @@
+package xtdb.cache
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture.completedFuture
+import kotlin.io.path.pathString
+
+class MemoryCacheTest {
+
+    private lateinit var allocator: BufferAllocator
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    inner class PathLoader : MemoryCache.PathLoader {
+        private var idx = 0
+        override fun load(path: Path): ByteBuffer =
+            ByteBuffer.allocateDirect(path.last().pathString.toInt())
+                .also { it.put(0, (++idx).toByte()) }
+    }
+
+    @Test
+    fun `test memory cache`() {
+        // just a starter-for-ten here, intent is that we go further down the property/deterministic testing route
+        // significantly exercised E2E by the rest of the test-suite and benchmarks.
+
+        MemoryCache(allocator, 250, PathLoader()).use { cache ->
+
+            var t1Evicted = false
+
+            assertAll("get t1", {
+                val onEvict = AutoCloseable { t1Evicted = true }
+
+                cache.get(Path.of("t1/100")) { completedFuture(it to onEvict) }.use { b1 ->
+                    assertEquals(1, b1.getByte(0))
+
+                    assertEquals(Stats(100, 0, 150), cache.stats)
+                }
+
+                cache.get(Path.of("t1/100")) { completedFuture(it to onEvict) }.use { b1 ->
+                    assertEquals(1, b1.getByte(0))
+                }
+
+                Thread.sleep(50)
+                assertEquals(Stats(0, 100, 150), cache.stats)
+                assertFalse(t1Evicted)
+            })
+
+            var t2Evicted = false
+
+            assertAll("t2", {
+                val onEvict = AutoCloseable { t2Evicted = true }
+
+                cache.get(Path.of("t2/50")) { completedFuture(it to onEvict) }.use { b1 ->
+                    assertEquals(2, b1.getByte(0))
+
+                    assertEquals(Stats(50, 100, 100), cache.stats)
+                }
+
+                Thread.sleep(100)
+                assertEquals(Stats(0, 150, 100), cache.stats)
+            })
+
+            assertFalse(t1Evicted)
+            assertFalse(t2Evicted)
+
+            assertAll("t3 evicts t2/t1", {
+                cache.get(Path.of("t3/170")) { completedFuture(it to null) }.use { b1 ->
+                    assertEquals(3, b1.getByte(0))
+                    assertTrue(t1Evicted)
+
+                    // definitely needs to evict t1, may or may not evict t2
+                    val stats = cache.stats
+                    assertEquals(170, stats.pinnedBytes)
+                    assertEquals(80, stats.evictableBytes + stats.freeBytes)
+                }
+
+                Thread.sleep(100)
+                val stats = cache.stats
+                assertEquals(0, stats.pinnedBytes)
+                assertEquals(250, stats.evictableBytes + stats.freeBytes)
+            })
+        }
+    }
+}


### PR DESCRIPTION
resolves #3770, should also help with #3769.

Replaced the caches in the buffer-pool, extracting out the pinning functionality into a common component that can then be used by both the memory and disk caches.

We also lean more on the `compute` methods of the Caffeine cache to simplify our locking behaviour:

* with an AsyncCache, the `compute` method takes an entry-level lock both while the lambda is synchronously executing (likely to return immediately), and when the CF returned from the lambda completes (in order to update the cache metadata).
* while an update to an entry is in progress (i.e. between these two events), the entry is pinned by Caffeine, so that it's not evicted. (this is done by AsyncWeigher setting its weight to 0 for incomplete CFs).
* any update to the weights of the entries _must_ take place before the `compute` CF finishes in order to take effect in the cache.
* see ben-manes/caffeine#1791 for a longer discussion of the salient impl details.
* The `getBuffer` method is now significantly simpler - essentially `.computeIfAbsent` on the memory-cache, which in turn calls `.computeIfAbsent` on the disk-cache, which in turn uses the object-store to download the file.

We've also improved the memory accounting characteristics of the buffer-pool:
* previously, we stored ArrowBufs directly in the memory cache, with a ref-count of 1. 
  * when a user requested one, we incremented the ref-count and returned the buffer; the user then incremented/decremented the ref-count throughout their usage, and finally released it again to undo their original retain.
  * when the cache was under memory pressure, it simply decremented the ref-count (undoing the initial ref-count) and removed it from the cache
  * but the buffer itself may still have been in use - i.e. the cache's decrement might not have taken it to 0:
    * added into cache: ref-count 1
    * requested: ref-count 2
    * cache pressure: removed from cache, ref-count 1.
    * user releases: ref-count 0, buffer cleared
  * so this wouldn't have caused a memory leak, but does mean that the buffer-pool's stats weren't necessarily reflective of how many buffers were in flight
  * this inaccurate accounting may be the reason we went over our limits; hence #3769 (we hypothesise).
* we now only store the mmap'd ByteBuffers in the cache, and create a new ArrowBuf for each request.
  * this does mean that the allocator used in the caches counts the memory once for each _usage_ (i.e. doesn't take into account that the memory is shared), so its accounting figures are useless - the limits on the cache itself are correct, though, and we should use these in monitoring (fyi @tggreene)