### PR TITLE
(WIP) Implementing txId Lag

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -216,6 +216,12 @@
   (xtp/status node))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn tx-lag
+  "Returns the Transaction ID lag of the node as a long"
+  [node]
+  (xtp/tx-lag node))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro template
   "This macro quotes the given query, but additionally allows you to use Clojure's unquote (`~`) and unquote-splicing (`~@`) forms within the quoted form.
 

--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -11,12 +11,17 @@
 
 (defprotocol PStatus
   (latest-submitted-tx [node])
-  (status [node]))
+  (status [node])
+  (tx-lag [node]))
 
 (def http-routes
   [["/status" {:name :status
                :summary "Status"
                :description "Get status information from the node"}]
+
+   ["/tx-lag" {:name :tx-lag
+               :summary "Transaction Lag"
+               :description "Get transaction id lag from the node"}]
 
    ["/tx" {:name :tx
            :summary "Transaction"

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -422,3 +422,6 @@
     (.appendTx log (serialize-tx-ops allocator tx-ops
                                      {:default-tz (or (some-> opts .getDefaultTz) default-tz)
                                           :system-time system-time}))))
+
+(defn latest-submitted-tx& [{:keys [log]}]
+  (.latestSubmittedTx log))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -194,6 +194,7 @@
     ;; TODO seems to create heap memory pressure, disabled for now
     #_(metrics/add-gauge registry "node.tx.lag.seconds"
                          (gauge-lag-secs-fn node))
+    (metrics/add-gauge metrics-registry "node.tx.lag" (fn [] (or (xtp/tx-lag node) 0)))
     node))
 
 (defmethod ig/halt-key! :xtdb/node [_ node]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -123,6 +123,11 @@
   (status [this]
     {:latest-completed-tx (.latestCompletedTx indexer)
      :latest-submitted-tx (xtp/latest-submitted-tx this)})
+  (tx-lag [this]
+    (let [latest-completed-tx (.latestCompletedTx indexer)
+          latest-submitted-tx (xtp/latest-submitted-tx this)]
+      (when (and latest-completed-tx latest-submitted-tx)
+        (- (.getTxId latest-submitted-tx) (.getTxId latest-completed-tx)))))
 
   IXtdbInternal
   (^PreparedQuery prepareQuery [this ^String query, query-opts]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -181,8 +181,9 @@
         0.0))))
 
 (defmethod ig/init-key :xtdb/node [_ {:keys [metrics-registry] :as deps}]
-  (let [node (map->Node (-> deps
-                            (assoc :!latest-submitted-tx (atom nil)
+  (let [latest-submitted-tx (log/latest-submitted-tx& deps)
+        node (map->Node (-> deps
+                            (assoc :!latest-submitted-tx (atom latest-submitted-tx)
                                    :query-timer (metrics/add-timer metrics-registry "query.timer"
                                                                    {:description "indicates the timings for queries"}))))]
     ;; TODO seems to create heap memory pressure, disabled for now

--- a/core/src/main/kotlin/xtdb/api/log/TxLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/TxLog.kt
@@ -8,6 +8,7 @@ interface TxLog {
     fun appendTx(record: ByteBuffer): CompletableFuture<TransactionKey>
     fun readTxs(afterTxId: Long?, limit: Int): List<Record>
     fun subscribeTxs(afterTxId: Long?, subscriber: Subscriber)
+    fun latestSubmittedTx(): TransactionKey
 
     class Record(val txKey: TransactionKey, val record: ByteBuffer)
 

--- a/http-client-jvm/src/main/clojure/xtdb/client/impl.clj
+++ b/http-client-jvm/src/main/clojure/xtdb/client/impl.clj
@@ -110,9 +110,10 @@
 
   xtp/PStatus
   (latest-submitted-tx [_] @!latest-submitted-tx)
-
   (status [client]
     (:body (request client :get :status)))
+  (tx-lag [client]
+    (:body (request client :get :tx-lag)))
 
   AutoCloseable
   (close [_]

--- a/http-server/src/main/clojure/xtdb/server.clj
+++ b/http-server/src/main/clojure/xtdb/server.clj
@@ -98,6 +98,10 @@
    :get (fn [{:keys [node] :as _req}]
           {:status 200, :body (xtp/status node)})})
 
+(defmethod route-handler :tx-lag [_]
+  {:get (fn [{:keys [node] :as _req}]
+          {:status 200, :body (xtp/tx-lag node)})})
+
 (defn- json-tx-encoder []
   (reify
     mf/EncodeToBytes


### PR DESCRIPTION
Currently heavily WIP - needs to potentially be implemented for each log.

Idea being this could be used like this within K8s, for example:
```
readinessProbe:
  exec:
    command:
      - /bin/sh
      - -c
      - |
        LAG=$(curl -s http://localhost:3000/txLag)
        if [ "$LAG" -lt 5 ]; then
          exit 0
        else
          exit 1
        fi
  initialDelaySeconds: 30    # Wait 30 seconds before starting the first probe
  periodSeconds: 20          # Check every 20 seconds
  failureThreshold: 5        # Allow up to 5 consecutive failures before marking as unhealthy
  successThreshold: 1        # One successful probe will mark the container as ready
  timeoutSeconds: 10         # Allow 10 seconds for each probe to complete
```