### PR TITLE
Prometheus -> Healthz module & add healthchecking endpoints

### DIFF
--- a/.devcontainer/xtdb.yaml
+++ b/.devcontainer/xtdb.yaml
@@ -4,7 +4,7 @@ txLog: !Local
 storage: !Local
   path: "/var/lib/xtdb/buffers"
 
-prometheus:
+healthz:
   port: 8080
 
 modules:

--- a/cloud-benchmark/local/local-config-kafka.yaml
+++ b/cloud-benchmark/local/local-config-kafka.yaml
@@ -10,5 +10,5 @@ txLog: !Kafka
 storage: !Local
   path: !Env XTDB_STORAGE_DIR
 
-prometheus:
+healthz:
   port: 0

--- a/cloud-benchmark/local/local-config.yaml
+++ b/cloud-benchmark/local/local-config.yaml
@@ -5,5 +5,5 @@ txLog: !Local
 storage: !Local
   path: /var/lib/xtdb/local-buffers
 
-prometheus:
+healthz:
   port: 8080

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -1,4 +1,4 @@
-(ns xtdb.prometheus
+(ns xtdb.healthz
   (:require [clojure.tools.logging :as log]
             [juxt.clojars-mirrors.integrant.core :as ig]
             [reitit.http :as http]
@@ -16,14 +16,14 @@
            [java.lang AutoCloseable]
            org.eclipse.jetty.server.Server
            (xtdb.api Xtdb$Config)
-           (xtdb.api.metrics PrometheusConfig)
-           xtdb.api.Xtdb$Config))
+           (xtdb.api.metrics HealthzConfig)
+           xtdb.api.Xtdb$Config
+           xtdb.indexer.IIndexer))
 
 (def router
   (http/router [["/metrics" {:name :metrics
-                             :get (fn [{:keys [^PrometheusMeterRegistry prometheus-registry] :as req}]
+                             :get (fn [{:keys [^PrometheusMeterRegistry prometheus-registry]}]
                                     {:status 200, :body (.scrape prometheus-registry)})}]]
-
                {:data {:interceptors [[ri.exception/exception-interceptor
                                        (merge ri.exception/default-handlers
                                               {::ri.exception/wrap (fn [handler e req]
@@ -43,26 +43,26 @@
                      {:executor r.sieppari/executor
                       :interceptors [[with-opts opts]]}))
 
-(defmethod xtn/apply-config! :xtdb/prometheus [^Xtdb$Config config _ {:keys [^long port]}]
-  (.prometheus config (PrometheusConfig. port)))
+(defmethod xtn/apply-config! :xtdb/healthz [^Xtdb$Config config _ {:keys [^long port]}]
+  (.healthz config (HealthzConfig. port)))
 
-(defmethod ig/prep-key :xtdb/prometheus [_ ^PrometheusConfig config]
-  {:port (.getPort config)
+(defmethod ig/prep-key :xtdb/healthz [_ ^HealthzConfig config]
+  {:port (.getPort config) 
    :metrics-registry (ig/ref :xtdb.metrics/registry)})
 
-(defmethod ig/init-key :xtdb/prometheus [_ {:keys [^long port, ^CompositeMeterRegistry metrics-registry]}]
+(defmethod ig/init-key :xtdb/healthz [_ {:keys [^long port, ^CompositeMeterRegistry metrics-registry]}]
   (let [prometheus-registry (PrometheusMeterRegistry. io.micrometer.prometheus.PrometheusConfig/DEFAULT)
         ^Server server (j/run-jetty (handler {:prometheus-registry prometheus-registry})
                                     {:port port, :async? true, :join? false})]
 
     (.add metrics-registry prometheus-registry)
 
-    (log/info "Prometheus server started on port:" port)
+    (log/info "Healthz server started on port:" port)
 
     (reify AutoCloseable
       (close [_]
         (.stop server)
-        (log/info "Prometheus server stopped.")))))
+        (log/info "Healthz server stopped.")))))
 
-(defmethod ig/halt-key! :xtdb/prometheus [_ srv]
+(defmethod ig/halt-key! :xtdb/healthz [_ srv]
   (util/close srv))

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -691,6 +691,8 @@
                                  awaiters)
            (CompletableFuture/completedFuture (.latestCompletedTx this)))
          (cond-> timeout (.orTimeout (.toMillis timeout) TimeUnit/MILLISECONDS))))
+  
+  (indexerError [this] (.indexer-error this))
 
   Closeable
   (close [_]

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -56,8 +56,8 @@
 (defmethod apply-config! :server [config _ opts]
   (apply-config! config :xtdb.pgwire/server opts))
 
-(defmethod apply-config! :prometheus [config _ opts]
-  (apply-config! config :xtdb/prometheus opts))
+(defmethod apply-config! :healthz [config _ opts]
+  (apply-config! config :xtdb/healthz opts))
 
 (defmethod apply-config! ::default [_ k _]
   (log/warn "Unknown configuration key:" k))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -214,7 +214,7 @@
 
 (defn node-system [^Xtdb$Config opts]
   (let [srv-config (.getServer opts)
-        prometheus (.getPrometheus opts)]
+        healthz (.getHealthz opts)]
     (-> {:xtdb/node {}
          :xtdb/allocator {}
          :xtdb/indexer {}
@@ -232,7 +232,7 @@
          :xtdb/default-tz (.getDefaultTz opts)
          :xtdb.stagnant-log-flusher/flusher (.getIndexer opts)}
         (cond-> srv-config (assoc :xtdb.pgwire/server srv-config)
-                prometheus (assoc :xtdb/prometheus prometheus))
+                healthz (assoc :xtdb/healthz healthz))
         (doto ig/load-namespaces))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.UseSerializers
 import xtdb.ZoneIdSerde
 import xtdb.api.log.Log
 import xtdb.api.log.Logs.inMemoryLog
-import xtdb.api.metrics.PrometheusConfig
+import xtdb.api.metrics.HealthzConfig
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.inMemoryStorage
@@ -32,7 +32,7 @@ interface Xtdb : AutoCloseable {
         var server: ServerConfig? = ServerConfig(),
         var txLog: Log.Factory = inMemoryLog(),
         var storage: Storage.Factory = inMemoryStorage(),
-        var prometheus: PrometheusConfig? = null,
+        var healthz: HealthzConfig? = null,
         var defaultTz: ZoneId = ZoneOffset.UTC,
         val indexer: IndexerConfig = IndexerConfig(),
         val compactor: CompactorConfig = CompactorConfig()
@@ -51,11 +51,11 @@ interface Xtdb : AutoCloseable {
         @JvmSynthetic
         fun compactor(configure: CompactorConfig.() -> Unit) = apply { compactor.configure() }
 
-        fun prometheus(prometheus: PrometheusConfig) = apply { this.prometheus = prometheus }
+        fun healthz(healthz: HealthzConfig) = apply { this.healthz = healthz }
 
         @JvmSynthetic
-        fun prometheus(configure: PrometheusConfig.() -> Unit) =
-            prometheus(PrometheusConfig().also(configure))
+        fun healthz(configure: HealthzConfig.() -> Unit) =
+            healthz(HealthzConfig().also(configure))
 
         fun defaultTz(defaultTz: ZoneId) = apply { this.defaultTz = defaultTz }
 

--- a/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
@@ -3,6 +3,6 @@ package xtdb.api.metrics
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PrometheusConfig(var port: Int = 8080) {
+data class HealthzConfig(var port: Int = 8080) {
     fun port(port: Int) = apply { this.port = port }
 }

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -44,7 +44,7 @@ class YamlSerdeTest {
         indexer:
             logLimit: 65
             flushDuration: PT4H
-        prometheus:
+        healthz:
             port: 3000
         defaultTz: "America/Los_Angeles"
         """.trimIndent()
@@ -55,7 +55,7 @@ class YamlSerdeTest {
     @Test
     fun testMetricsConfigDecoding() {
         val input = """
-        prometheus: 
+        healthz: 
           port: 3000
         """.trimIndent()
 

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -59,7 +59,7 @@ class YamlSerdeTest {
           port: 3000
         """.trimIndent()
 
-        assertEquals(3000, nodeConfig(input).prometheus?.port)
+        assertEquals(3000, nodeConfig(input).healthz?.port)
 
         val awsInput = """
         modules: 

--- a/docker/aws/aws_config.yaml
+++ b/docker/aws/aws_config.yaml
@@ -9,7 +9,7 @@ storage: !Remote
     prefix: "xtdb-object-store"
   localDiskCache: /var/lib/xtdb/buffers
 
-prometheus:
+healthz:
   port: 8080
 
 modules:

--- a/docker/azure/azure_config.yaml
+++ b/docker/azure/azure_config.yaml
@@ -11,7 +11,7 @@ storage: !Remote
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
   localDiskCache: !Env XTDB_LOCAL_DISK_CACHE
 
-prometheus:
+healthz:
   port: 8080
 
 modules:

--- a/docker/azure/azure_config_private_auth.yaml
+++ b/docker/azure/azure_config_private_auth.yaml
@@ -15,7 +15,7 @@ storage: !Remote
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
   localDiskCache: !Env XTDB_LOCAL_DISK_CACHE
 
-prometheus:
+healthz:
   port: 8080
 
 modules:

--- a/docker/standalone/local_config.yaml
+++ b/docker/standalone/local_config.yaml
@@ -4,7 +4,7 @@ txLog: !Local
 storage: !Local
   path: "/var/lib/xtdb/buffers"
 
-prometheus:
+healthz:
   port: 8080
 
 modules: 

--- a/modules/bench/src/main/clojure/xtdb/bench/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/xtdb2.clj
@@ -40,7 +40,7 @@
   (let [node-dir (util/->path node-dir)]
     (xtn/start-node {:log [:local {:path (.resolve node-dir "log"), :instant-src instant-src}]
                      :storage [:local {:path (.resolve node-dir buffers-dir)}]
-                     :prometheus {:port 8080}
+                     :healthz {:port 8080}
                      :indexer (->> {:log-limit log-limit, :page-limit page-limit, :rows-per-chunk rows-per-chunk}
                                    (into {} (filter val)))
                      :server {:port 0}})))

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -39,7 +39,7 @@
                                       :keystore-password "password123"}}
                        :log [:local {:path (io/file dev-node-dir "log")}]
                        :storage [:local {:path (io/file dev-node-dir "objects")}]
-                       :prometheus {:port 8080}
+                       :healthz {:port 8080}
                        :http-server {}
                        :flight-sql-server {:port 52358}}}})
 

--- a/src/test/resources/test-config.yaml
+++ b/src/test/resources/test-config.yaml
@@ -7,5 +7,5 @@ storage: !InMemory
 server:
   port: 0
 
-prometheus:
+healthz:
   port: 8282


### PR DESCRIPTION
- Rename `prometheus` to `healthz`, change associated classes.
- Implements `indexerError` on indexer such that we can fetch it easily.
- Add in the `/healthz` endpoints.


