### PR TITLE
Add txId and txIdLag gauges

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -183,10 +183,10 @@
     (metrics/add-gauge metrics-registry "node.tx.latestSubmittedTxId" (fn [] (xtp/latest-submitted-tx-id node)))
     (metrics/add-gauge metrics-registry "node.tx.latestCompletedTxId" (fn [] (get-in (xtp/status node) [:latest-completed-tx :tx-id] -1)))
     (metrics/add-gauge metrics-registry "node.tx.lag.TxId" (fn []
-                                                            (let [{:keys [latest-completed-tx ^long latest-submitted-tx-id]} (xtp/status node)]
-                                                              (if (and latest-completed-tx (pos? latest-submitted-tx-id))
-                                                                (- latest-submitted-tx-id ^long (:tx-id latest-completed-tx))
-                                                                0))))
+                                                             (let [{:keys [latest-completed-tx ^long latest-submitted-tx-id]} (xtp/status node)]
+                                                               (if (and latest-completed-tx (pos? latest-submitted-tx-id))
+                                                                 (- latest-submitted-tx-id ^long (:tx-id latest-completed-tx))
+                                                                 0))))
     node))
 
 (defmethod ig/halt-key! :xtdb/node [_ node]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -181,7 +181,7 @@
                                    :query-timer (metrics/add-timer metrics-registry "query.timer"
                                                                    {:description "indicates the timings for queries"}))))]
     (metrics/add-gauge metrics-registry "node.tx.latestSubmittedTxId" (fn [] (xtp/latest-submitted-tx-id node)))
-    (metrics/add-gauge metrics-registry "node.tx.latestCompletedTxId" (fn [] (get-in (xtp/status node) [:latest-completed-tx :tx-id] 0)))
+    (metrics/add-gauge metrics-registry "node.tx.latestCompletedTxId" (fn [] (get-in (xtp/status node) [:latest-completed-tx :tx-id] -1)))
     (metrics/add-gauge metrics-registry "node.tx.lag.TxId" (fn []
                                                             (let [{:keys [latest-completed-tx ^long latest-submitted-tx-id]} (xtp/status node)]
                                                               (if (and latest-completed-tx (pos? latest-submitted-tx-id))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -176,10 +176,18 @@
          opts))
 
 (defmethod ig/init-key :xtdb/node [_ {:keys [metrics-registry] :as deps}]
-  (map->Node (-> deps
-                 (assoc :!latest-submitted-tx-id (atom -1)
-                        :query-timer (metrics/add-timer metrics-registry "query.timer"
-                                                        {:description "indicates the timings for queries"})))))
+  (let [node (map->Node (-> deps
+                            (assoc :!latest-submitted-tx-id (atom -1)
+                                   :query-timer (metrics/add-timer metrics-registry "query.timer"
+                                                                   {:description "indicates the timings for queries"}))))]
+    (metrics/add-gauge metrics-registry "node.tx.latestSubmittedTxId" (fn [] (xtp/latest-submitted-tx-id node)))
+    (metrics/add-gauge metrics-registry "node.tx.latestCompletedTxId" (fn [] (get-in (xtp/status node) [:latest-completed-tx :tx-id] 0)))
+    (metrics/add-gauge metrics-registry "node.tx.lag.TxId" (fn []
+                                                            (let [{:keys [latest-completed-tx ^long latest-submitted-tx-id]} (xtp/status node)]
+                                                              (if (and latest-completed-tx (pos? latest-submitted-tx-id))
+                                                                (- latest-submitted-tx-id ^long (:tx-id latest-completed-tx))
+                                                                0))))
+    node))
 
 (defmethod ig/halt-key! :xtdb/node [_ node]
   (util/try-close node))


### PR DESCRIPTION
Resolves #3871 

Adds in some basic txId gauges for the sake of monitoring:
- latestSubmittedTxId
- latestCompletedTxId
- txId lag.

Based on recent changes, behavior is as follows:
- Return whatever we get for `submittedTxId` (ie, even if it's -1/not yet set)
- Return whatever we get for `completedTxId`, or `0` if not found.
- When calculating the txId lag:
  - If submittedTxId < 0 (ie, it is unset), return lag as 0.
  - If completedTxId not set, return lag as 0.
  - Otherwise, return txId lag as `(submittedTxId - completedTxId)`.
 