### PR TITLE
XTDB JDBC module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,6 +225,7 @@ dependencies {
 
     projectDep(":xtdb-api")
     projectDep(":xtdb-core")
+    projectDep(":xtdb-jdbc")
 
     projectDep(":xtdb-http-server")
     projectDep(":xtdb-http-client-jvm")
@@ -248,6 +249,7 @@ dependencies {
     api("org.postgresql", "postgresql", "42.7.3")
     api("pro.juxt.clojars-mirrors.integrant", "integrant", "0.8.0")
     api(project(":xtdb-core"))
+    api(project(":xtdb-jdbc"))
 
     testImplementation("org.clojure", "data.csv", "1.0.1")
     testImplementation("org.clojure", "tools.cli", "1.0.206")

--- a/docs/src/content/docs/drivers/clojure.adoc
+++ b/docs/src/content/docs/drivers/clojure.adoc
@@ -7,14 +7,18 @@ Additionally, there is an XTDB Clojure API for both SQL and XTQL queries.
 
 == JDBC
 
-SQL queries can be executed using the PostgreSQL JDBC driver:
+SQL queries can be executed using the XTDB JDBC driver:
 
 [source,clojure]
 ----
-{:deps {org.postgresql/postgresql {:mvn/version "42.7.4"}
 
-        ;; other JDBC/Postgres libraries are available
-        com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}}}
+
+{:deps {;; https://mvnrepository.com/artifact/com.xtdb/xtdb-jdbc
+        com.xtdb/xtdb-jdbc {:mvn/version "XTDB_VERSION"}
+
+        ;; https://mvnrepository.com/artifact/com/github/seancorfield/next.jdbc
+        ;; other JDBC libraries are available
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.955"}}}
 ----
 
 Then, once you've link:/intro/installation-via-docker[started the XTDB node], follow the usual Clojure JDBC process for connecting to a PostgreSQL database:
@@ -23,18 +27,10 @@ Then, once you've link:/intro/installation-via-docker[started the XTDB node], fo
 ----
 (require '[next.jdbc :as jdbc])
 
-(def db
-  {:dbtype "postgresql"
-   :dbname "xtdb"
-   :user "xtdb"
-   :password "xtdb"
-   :host "localhost"
-   :port 5432})
-
 ;; this is relatively low-level code - the usual connection pooling
 ;; and SQL abstraction libraries can be used too.
 
-(with-open [conn (jdbc/get-connection db)]
+(with-open [conn (jdbc/get-connection "jdbc:xtdb://localhost/xtdb")]
   (jdbc/execute! conn ["INSERT INTO users RECORDS {_id: 'jms', name: 'James'}, {_id: 'joe', name: 'Joe'}"])
 
   (prn (jdbc/execute! conn ["SELECT * FROM users"])))

--- a/docs/src/content/docs/drivers/java.adoc
+++ b/docs/src/content/docs/drivers/java.adoc
@@ -6,16 +6,16 @@ In Java, you can talk to a running XTDB node using standard https://docs.oracle.
 
 == Install
 
-To install the Postgres driver, add the following dependency to your Maven `pom.xml`:
+To install the XTDB JDBC driver, add the following dependency to your Maven `pom.xml`:
 
 [source,xml]
 ----
-<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+<!-- https://mvnrepository.com/artifact/com.xtdb/xtdb-jdbc -->
 
 <dependency>
-    <groupId>org.postgresql</groupId>
-    <artifactId>postgresql</artifactId>
-    <version>42.7.4</version>
+    <groupId>com.xtdb</groupId>
+    <artifactId>xtdb-jdbc</artifactId>
+    <version>$XTDB_VERSION</version>
 </dependency>
 ----
 
@@ -23,7 +23,7 @@ Or, for Gradle:
 
 [source,kotlin]
 ----
-implementation("org.postgresql:postgresql:42.7.4")
+implementation("com.xtdb:xtdb-jdbc:$XTDB_VERSION")
 ----
 
 == Connect
@@ -42,7 +42,7 @@ public class XtdbHelloWorld {
 
   public static void main(String[] args) throws SqlException {
     try (var connection =
-           DriverManager.getConnection("jdbc:postgresql://localhost:5432/xtdb", "xtdb", "xtdb");
+           DriverManager.getConnection("jdbc:xtdb://localhost:5432/xtdb", "xtdb", "xtdb");
          var statement = connection.createStatement()) {
 
       statement.execute("INSERT INTO users RECORDS {_id: 'jms', name: 'James'}, {_id: 'joe', name: 'Joe'}");

--- a/docs/src/content/docs/drivers/kotlin.adoc
+++ b/docs/src/content/docs/drivers/kotlin.adoc
@@ -6,11 +6,13 @@ In Kotlin, you can talk to a running XTDB node using standard https://docs.oracl
 
 == Install
 
-To install the Postgres driver, add the following dependency to your Gradle `build.gradle.kts`:
+To install the XTDB JDBC driver, add the following dependency to your Gradle `build.gradle.kts`:
 
 [source,kotlin]
 ----
-implementation("org.postgresql:postgresql:42.7.4")
+// https://mvnrepository.com/artifact/com.xtdb/xtdb-jdbc
+
+implementation("com.xtdb:xtdbjdbc:$XTDB_VERSION")
 ----
 
 Or, for Maven:
@@ -18,9 +20,9 @@ Or, for Maven:
 [source,xml]
 ----
 <dependency>
-    <groupId>org.postgresql</groupId>
-    <artifactId>postgresql</artifactId>
-    <version>42.7.4</version>
+    <groupId>com.xtdb</groupId>
+    <artifactId>xtdbjdbc</artifactId>
+    <version>$XTDB_VERSION</version>
 </dependency>
 ----
 
@@ -37,7 +39,7 @@ import java.sql.DriverManager
 // and JDBC abstraction libraries.
 
 fun main() {
-    DriverManager.getConnection("jdbc:postgresql://localhost:5432/xtdb").use { connection ->
+    DriverManager.getConnection("jdbc:xtdb://localhost:5432/xtdb").use { connection ->
         connection.createStatement().use { statement ->
             statement.execute("INSERT INTO users RECORDS {_id: 'jms', name: 'James'}, {_id: 'joe', name: 'Joe'}")
 

--- a/jdbc/build.gradle.kts
+++ b/jdbc/build.gradle.kts
@@ -1,0 +1,42 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    id("dev.clojurephant.clojure")
+    `maven-publish`
+    signing
+    kotlin("jvm")
+}
+
+publishing {
+    publications.create("maven", MavenPublication::class) {
+        pom {
+            name.set("XTDB JDBC")
+            description.set("JDBC driver for XTDB")
+        }
+    }
+}
+
+dependencies {
+    compileOnlyApi(files("src/main/resources"))
+    api(kotlin("stdlib-jdk8"))
+    implementation("org.postgresql:postgresql:42.2.23")
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+tasks.compileJava {
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
+}
+
+tasks.compileTestJava {
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}

--- a/jdbc/src/main/kotlin/xtdb/jdbc/Driver.kt
+++ b/jdbc/src/main/kotlin/xtdb/jdbc/Driver.kt
@@ -1,0 +1,24 @@
+package xtdb.jdbc
+
+import org.postgresql.PGConnection
+import org.postgresql.jdbc.PgConnection
+import java.sql.DriverManager
+import java.util.*
+
+class Driver : org.postgresql.Driver() {
+
+    companion object {
+        init {
+            DriverManager.registerDriver(Driver())
+        }
+    }
+
+    private val String.asPgUrl get() = replace(Regex("^jdbc:xtdb:"), "jdbc:postgresql:")
+
+    override fun acceptsURL(url: String) = super.acceptsURL(url.asPgUrl)
+
+    class Connection(conn: PgConnection) : PGConnection by conn, java.sql.Connection by conn
+
+    override fun connect(url: String, info: Properties?) =
+        (super.connect(url.asPgUrl, info) as? PgConnection)?.let(::Connection)
+}

--- a/jdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/jdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+xtdb.jdbc.Driver

--- a/modules/kafka-connect/src/test/clojure/xtdb/kafka/sink_connector_test.clj
+++ b/modules/kafka-connect/src/test/clojure/xtdb/kafka/sink_connector_test.clj
@@ -9,21 +9,21 @@
                    (->config {}))))
   (t/testing "Missing id.mode"
     (t/is (thrown? ConfigException
-                   (->config {"jdbcUrl" "jdbc:postgresql://localhost:5432/xtdb"}))))
+                   (->config {"jdbcUrl" "jdbc:xtdb://localhost:5432/xtdb"}))))
   (t/testing "Invalid id.mode"
     (t/is (thrown? ConfigException
-                   (->config {"jdbcUrl" "jdbc:postgresql://localhost:5432/xtdb"
+                   (->config {"jdbcUrl" "jdbc:xtdb://localhost:5432/xtdb"
                               "id.mode" "invalid"}))))
   (t/testing "record_key"
     (t/testing "Valid config"
-      (->config {"jdbcUrl" "jdbc:postgresql://localhost:5432/xtdb"
+      (->config {"jdbcUrl" "jdbc:xtdb://localhost:5432/xtdb"
                  "id.mode" "record_key"})))
   (t/testing "record_value"
     (t/testing "Missing id.field"
       (t/is (thrown? ConfigException
-                     (->config {"jdbcUrl" "jdbc:postgresql://localhost:5432/xtdb"
+                     (->config {"jdbcUrl" "jdbc:xtdb://localhost:5432/xtdb"
                                 "id.mode" "record_value"}))))
     (t/testing "Valid config"
-      (->config {"jdbcUrl" "jdbc:postgresql://localhost:5432/xtdb"
+      (->config {"jdbcUrl" "jdbc:xtdb://localhost:5432/xtdb"
                  "id.mode" "record_value"
                  "id.field" "xt/id"}))))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,9 +8,10 @@ pluginManagement {
 
 rootProject.name = "xtdb"
 
-include("api", "core")
+include("api", "core", "jdbc")
 project(":api").name = "xtdb-api"
 project(":core").name = "xtdb-core"
+project(":jdbc").name = "xtdb-jdbc"
 
 include("http-server", "http-client-jvm")
 project(":http-server").name = "xtdb-http-server"

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -79,10 +79,8 @@
 
 (defn with-node [f]
   (util/with-open [node (xtn/start-node *node-opts*)
-                   conn (jdbc/get-connection {:dbtype "postgresql"
-                                              :host "localhost"
-                                              :port (.getServerPort node)
-                                              :database "xtdb"
+                   conn (jdbc/get-connection {:jdbcUrl (format "jdbc:xtdb://localhost:%d/xtdb"
+                                                               (.getServerPort node))
                                               :options "-c fallback_output_format=transit"})]
     (binding [*node* node, *conn* conn]
       (f))))

--- a/src/test/clojure/xtdb/docker_test.clj
+++ b/src/test/clojure/xtdb/docker_test.clj
@@ -168,7 +168,7 @@
           (.destroy p))))))
 
 (defn- q [sql]
-  (->> (jdbc/execute! (format "jdbc:postgresql://:%s/xtdb" *pgwire-port*) [sql])
+  (->> (jdbc/execute! (format "jdbc:xtdb://:%s/xtdb" *pgwire-port*) [sql])
        (mapv (fn [r] (update-vals r (fn [o] (if (instance? PGobject o) (json/read-str (str o)) o)))))))
 
 (deftest run-and-connect-test

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -77,7 +77,7 @@
 
 (defn- jdbc-url [& params]
   (let [param-str (when (seq params) (str "?" (str/join "&" (for [[k v] (partition 2 params)] (str k "=" v)))))]
-    (format "jdbc:postgresql://localhost:%s/xtdb%s" *port* (or param-str ""))))
+    (format "jdbc:xtdb://localhost:%s/xtdb%s" *port* (or param-str ""))))
 
 (defn- jdbc-conn ^Connection [& params]
   (jdbc/get-connection (apply jdbc-url params)))

--- a/src/test/java/xtdb/api/XtdbHelloWorld.kt
+++ b/src/test/java/xtdb/api/XtdbHelloWorld.kt
@@ -10,7 +10,7 @@ class XtdbHelloWorld {
     @Test
     fun `hello world`() {
         Xtdb.openNode(Xtdb.Config(ServerConfig(0))).use { xtdb ->
-            DriverManager.getConnection("jdbc:postgresql://localhost:${xtdb.serverPort}/xtdb").use { conn ->
+            DriverManager.getConnection("jdbc:xtdb://localhost:${xtdb.serverPort}/xtdb").use { conn ->
                 conn.createStatement().use { statement ->
                     statement.execute("INSERT INTO users RECORDS {_id: 'jms', name: 'James'}, {_id: 'joe', name: 'Joe'}")
 

--- a/src/test/java/xtdb/api/XtdbHelloWorldTest.java
+++ b/src/test/java/xtdb/api/XtdbHelloWorldTest.java
@@ -22,7 +22,7 @@ public class XtdbHelloWorldTest {
         try (var node = Xtdb.openNode(config);
              var connection =
                      DriverManager.getConnection(
-                             format("jdbc:postgresql://localhost:%d/xtdb", node.getServerPort()),
+                             format("jdbc:xtdb://localhost:%d/xtdb", node.getServerPort()),
                              "xtdb", "xtdb"
                      );
              var statement = connection.createStatement()) {


### PR DESCRIPTION
Don't get too excited about the JDBC Driver here - it's literally just wrapping the Postgres one :sweat_smile: 

Main point of this is to create the `xtdb-jdbc` module, to which we'll add the next.jdbc helpers for #3844 

...

but you can now replace `jdbc:postgres://localhost/your_db` with `jdbc:xtdb://localhost/your_db`, so that's nice I guess :relaxed: 