### PR TITLE
Micrometer version bumps

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
     api(libs.reitit.sieppari)
 
     // monitoring
-    api("io.micrometer", "micrometer-core", "1.12.2")
-    api("io.micrometer", "micrometer-registry-prometheus", "1.12.2")
+    api(libs.micrometer.core)
+    api(libs.micrometer.registry.prometheus)
 
     api(kotlin("stdlib-jdk8"))
     api("com.charleskorn.kaml", "kaml", "0.56.0")

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -12,7 +12,7 @@
             [xtdb.node :as xtn]
             [xtdb.util :as util])
   (:import io.micrometer.core.instrument.composite.CompositeMeterRegistry
-           (io.micrometer.prometheus PrometheusMeterRegistry)
+           (io.micrometer.prometheusmetrics PrometheusConfig PrometheusMeterRegistry)
            [java.lang AutoCloseable]
            org.eclipse.jetty.server.Server
            (xtdb.api Xtdb$Config)
@@ -66,7 +66,7 @@
    :pgwire-server (ig/ref :xtdb.pgwire/server)})
 
 (defmethod ig/init-key :xtdb/healthz [_ {:keys [^long port, ^CompositeMeterRegistry metrics-registry, ^IIndexer indexer pgwire-server]}]
-  (let [prometheus-registry (PrometheusMeterRegistry. io.micrometer.prometheus.PrometheusConfig/DEFAULT)
+  (let [prometheus-registry (PrometheusMeterRegistry. PrometheusConfig/DEFAULT)
         ^Server server (j/run-jetty (handler {:prometheus-registry prometheus-registry
                                               :indexer indexer})
                                     {:port port, :async? true, :join? false})]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ netty="4.1.110.Final"
 reitit="0.5.15"
 muuntaja="0.6.8"
 testcontainers="1.20.3"
+micrometer="1.14.1"
 
 [libraries]
 arrow-algorithm={ group="org.apache.arrow", name="arrow-algorithm", version.ref="arrow" }
@@ -42,3 +43,8 @@ jetty-alpn-server={ group="org.eclipse.jetty", name="jetty-alpn-server", version
 testcontainers={ group="org.testcontainers", name="testcontainers", version.ref="testcontainers" }
 testcontainers-kafka={ group="org.testcontainers", name="kafka", version.ref="testcontainers" }
 testcontainers-minio={ group="org.testcontainers", name="minio", version.ref="testcontainers" }
+
+micrometer-core={ group="io.micrometer", name="micrometer-core", version.ref="micrometer" }
+micrometer-registry-prometheus={ group="io.micrometer", name="micrometer-registry-prometheus", version.ref="micrometer" }
+micrometer-registry-cloudwatch2={ group="io.micrometer", name="micrometer-registry-cloudwatch2", version.ref="micrometer" }
+micrometer-registry-azuremonitor={ group="io.micrometer", name="micrometer-registry-azure-monitor", version.ref="micrometer" }

--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     api("software.amazon.awssdk", "s3", "2.25.50")
 
     // metrics
-    api("io.micrometer", "micrometer-registry-cloudwatch2", "1.12.2")
+    api(libs.micrometer.registry.cloudwatch2)
     api("software.amazon.awssdk", "cloudwatch", "2.25.50")
 
     api(kotlin("stdlib-jdk8"))

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     api("com.azure", "azure-core-management", "1.15.1")
 
     // metrics
-    api("io.micrometer", "micrometer-registry-azure-monitor", "1.12.2")
+    api(libs.micrometer.registry.azuremonitor)
 
     api(kotlin("stdlib-jdk8"))
 }


### PR DESCRIPTION
Github actions runs here: https://github.com/danmason/xtdb/actions?query=branch%3Amicrometer-version-bump

Resolves #3873 

Moves micrometer deps under `libs.versions.toml`, bumps their version & makes some small fixes to their usage.

Have verified/checked metrics reported properly:
- Prometheus still works and is scraped with current prometheus config (on both previous and latest version of grafana-otel) - scrapes just fine.
- Azure monitor receiving metrics fine.
- Cloudwatch metric also received fine. 