### PR TITLE
Multi-stmt SQL, #3242

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -21,7 +21,7 @@ directlyExecutableStatement
     | eraseStatementSearched #EraseStmt
     | 'ASSERT' searchCondition #AssertStatement
     | ('START' 'TRANSACTION' | 'BEGIN') transactionCharacteristics? # StartTransactionStatement
-    | 'SET' 'LOCAL'? 'TRANSACTION' transactionCharacteristics # SetTransactionStatement
+    | 'SET' 'TRANSACTION' 'ISOLATION' 'LEVEL' levelOfIsolation # SetTransactionStatement
     | 'COMMIT' # CommitStatement
     | 'ROLLBACK' # RollbackStatement
     | 'SET' 'SESSION' 'CHARACTERISTICS' 'AS' sessionCharacteristic (',' sessionCharacteristic)* # SetSessionCharacteristicsStatement

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -11,6 +11,7 @@ options {
 /// §22.1 <direct SQL statement>
 
 directSqlStatement : directlyExecutableStatement ';'? EOF ;
+multiSqlStatement : directlyExecutableStatement ( ';' directlyExecutableStatement )* ';'? EOF ;
 
 directlyExecutableStatement
     : settingQueryVariables? queryExpression #QueryExpr

--- a/core/src/main/clojure/xtdb/antlr.clj
+++ b/core/src/main/clojure/xtdb/antlr.clj
@@ -29,9 +29,17 @@
       (add-throwing-error-listener)))
 
 (defn parse-statement ^xtdb.antlr.Sql$DirectlyExecutableStatementContext [sql]
-  (.get parser-cache sql
-        (fn [sql]
+  (.get parser-cache [sql :single]
+        (fn [[sql _]]
           (let [parser (->parser sql)]
             (-> (.directSqlStatement parser)
-                (.directlyExecutableStatement)
-                #_(doto (-> (.toStringTree parser) read-string (clojure.pprint/pprint)))))))) ; <<no-commit>>
+                #_(doto (-> (.toStringTree parser) read-string (clojure.pprint/pprint))) ; <<no-commit>>
+                (.directlyExecutableStatement))))))
+
+(defn parse-multi-statement [sql]
+  (.get parser-cache [sql :multi]
+        (fn [[sql _]]
+          (let [parser (->parser sql)]
+            (-> (.multiSqlStatement parser)
+                #_(doto (-> (.toStringTree parser) read-string (clojure.pprint/pprint))) ; <<no-commit>>
+                (.directlyExecutableStatement))))))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -756,14 +756,6 @@
     (tx! conn ["INSERT INTO foo (_id, a) VALUES (?, ?)" 42 "hello, world"])
     (is (= [{:a "hello, world"}] (q conn ["SELECT a FROM foo where _id = 42"])))))
 
-(deftest begin-in-a-transaction-error-test
-  (with-open [conn (jdbc-conn)]
-    (q conn ["BEGIN"])
-    (is (thrown-with-msg?
-         PSQLException
-         #"ERROR\: invalid transaction state \-\- active SQL\-transaction"
-         (q conn ["BEGIN"])))))
-
 (deftest test-current-time
   ;; no support for setting current-time so need to interact with clock directly
   (let [custom-clock (Clock/fixed (Instant/parse "2000-08-16T11:08:03Z") (ZoneId/of "GMT"))]
@@ -1078,7 +1070,8 @@
 
        (send "BEGIN READ WRITE;\n")
        (read)
-       ;; no-id
+
+       ;; no id
        (send "INSERT INTO foo (x) values (42);\n")
        (read)
 


### PR DESCRIPTION
resolves #3242 

This allows us to accept multiple SQL statements in one (so-called) 'simple' query message.

e.g.

* `SELECT 1 one; SELECT 2 two` - yields two separate result-sets
* `INSERT INTO foo RECORDS {_id: 1}; COMMIT; SELECT * FROM foo` - means you can exec all three of these in one block.

Notes:
* I couldn't get either pgjdbc nor psql not to split the queries up before handing them over to the server, so the tests are necessarily checking the low-level messages rather than an E2E.
* I've confirmed the above examples manually on VSCode SQLTools.
* `SET TRANSACTION` is a casualty here - in the SQL spec it says that the options set here should affect the 'subsequent transaction'; in [Postgres](https://www.postgresql.org/docs/current/sql-set-transaction.html) it says both that:
  * "The SET TRANSACTION command sets the characteristics of the current transaction. It has no effect on any subsequent transactions."
  * "If SET TRANSACTION is executed without a prior START TRANSACTION or BEGIN, it emits a warning and otherwise has no effect."
  * "It is possible to dispense with SET TRANSACTION by instead specifying the desired transaction_modes in BEGIN or START TRANSACTION."

  so I've taken an executive decision that it's not worth the complexity it was bringing us, and removed it.
* 'Simple' queries are now executed in an implicit transaction, regardless of how many statements are present. We can't send command-complete messages (e.g. `BEGIN`, `COMMIT`) back to the client for an implicit tx, so those have moved out of `cmd-begin`, `cmd-commit` respectively. Otherwise, behaviour is as described in the [Postgres multi-stmt docs](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-MULTI-STATEMENT)