### PR TITLE
Add `IntWithEnvVarSerde`, use where port numbers can be set.

### DIFF
--- a/core/src/main/kotlin/xtdb/api/ServerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/ServerConfig.kt
@@ -1,7 +1,11 @@
+@file:UseSerializers(IntWithEnvVarSerde::class)
+
 package xtdb.api
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import java.nio.file.Path
+import xtdb.api.IntWithEnvVarSerde
 
 @Serializable
 data class ServerConfig(

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -120,6 +120,18 @@ object BooleanWithEnvVarSerde : KSerializer<Boolean> {
     }
 }
 
+object IntWithEnvVarSerde : KSerializer<Int> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BooleanWithEnvVars", PrimitiveKind.BOOLEAN)
+
+    override fun serialize(encoder: Encoder, value: Int) {
+        throw UnsupportedOperationException("YAML serialization of config is not supported.")
+    }
+    override fun deserialize(decoder: Decoder): Int {
+        val yamlInput: YamlInput = decoder as YamlInput
+        return handleEnvTag(yamlInput).toInt()
+    }
+}
+
 /**
  * @suppress
  */

--- a/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
@@ -1,6 +1,10 @@
+@file:UseSerializers(IntWithEnvVarSerde::class)
+
 package xtdb.api.metrics
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.api.IntWithEnvVarSerde
 
 @Serializable
 data class HealthzConfig(var port: Int = 8080) {

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -295,6 +295,21 @@ class YamlSerdeTest {
     }
 
     @Test
+    fun testPortSetWithEnvVar() {
+        mockkObject(EnvironmentVariableProvider)
+        every { EnvironmentVariableProvider.getEnvVariable("HEALTHZ_PORT") } returns "8081"
+
+        val input = """
+        healthz: 
+          port: !Env HEALTHZ_PORT
+        """.trimIndent()
+
+        assertEquals(8081, nodeConfig(input).healthz?.port)
+
+        unmockkObject(EnvironmentVariableProvider)
+    }
+
+    @Test
     fun testAuthnConfigDecoding() {
         val input = """
         authn: !UserTable

--- a/http-server/src/main/kotlin/xtdb/api/HttpServer.kt
+++ b/http-server/src/main/kotlin/xtdb/api/HttpServer.kt
@@ -1,7 +1,11 @@
+@file:UseSerializers(IntWithEnvVarSerde::class)
+
 package xtdb.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.api.IntWithEnvVarSerde
 import xtdb.api.module.XtdbModule
 import xtdb.util.requiringResolve
 


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aint-with-env-var-serde++

There's been a few different times where I wanted to manually configure port numbers using environment variables but could not do so due to a lack of `IntWithEnvVarSerde` - I've added this in and ensure it is used in any places where we set port numbers, ie:
- PGWire Server
- HTTP Server
- Healthz Server