### PR TITLE
Add `grafana` & prometheus scraping to Kubernetes based `cloud-benchmark`

### DIFF
--- a/cloud-benchmark/azure/README.adoc
+++ b/cloud-benchmark/azure/README.adoc
@@ -216,7 +216,7 @@ There is a helper script to do _all_ of the above, which can be run by:
 ./scripts/clear-azure-bench.sh
 ```
 
-== Monitoring
+== Monitoring With Azure Monitor
 
 === Setup
 
@@ -257,3 +257,39 @@ To setup the dashboard itself, there's a few steps we must take:
 ** We can upload this from a template - you can use the template found within the `cloud-benchmark/azure` directory, `application-insights/dashboard.json`. 
 
 We already have a shared dashboard setup, under "Monitoring Dashboard"
+
+== Monitoring with Grafana
+
+Within here are also some provided templates for setting up a Grafana-Otel deployment which shall scrape the pods from the XTDB benchmark Job.
+
+To deploy grafana, simply run:
+```
+kubectl apply -f kubernetes/grafana.yaml
+```
+
+To access the Grafana instance, you can use the external IP of the LoadBalancer service created for Grafana:
+```bash
+kubectl get svc grafana-service --namespace cloud-benchmark
+```
+
+The Grafana dashboard can be accessed via the external IP of the LoadBalancer service, on port `3001`. The default credentials are `admin`/`admin`.
+
+With this up and runing, you can then import the XTDB dashboards (the cluster monitoring dashboard and node debugging dashboard) from `monitoring/grafana/dashboards`, and use these to monitor the benchmark pods.
+
+== Trailing the Logs
+
+You can trail the logs of each node within the job by running:
+
+```
+kubectl logs job.batch/xtdb-multi-node-auctionmark --namespace cloud-benchmark -c <container-name> -f
+```
+
+For example, to see the logs from the load-phase, run:
+```
+kubectl logs job.batch/xtdb-multi-node-auctionmark --namespace cloud-benchmark -c load-phase -f
+```
+
+To see the logs of one of the nodes, run:
+```
+kubectl logs job.batch/xtdb-multi-node-auctionmark --namespace cloud-benchmark -c xtdb-bench-1 -f
+```

--- a/cloud-benchmark/azure/azure-config.yaml
+++ b/cloud-benchmark/azure/azure-config.yaml
@@ -2,6 +2,9 @@
 server: 
   port: 0
 
+healthz: 
+  port: !Env XTDB_HEALTHZ_PORT
+
 # CONFIG FOR RUNNING WITH AZURE INFRA
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS

--- a/cloud-benchmark/azure/kubernetes/grafana.yaml
+++ b/cloud-benchmark/azure/kubernetes/grafana.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  name: grafana-service-account
+  namespace: cloud-benchmark
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-benchmark-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-benchmark-pod-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: grafana-service-account
+    namespace: cloud-benchmark
+roleRef:
+  kind: ClusterRole
+  name: cloud-benchmark-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-otel-config
+  namespace: cloud-benchmark
+data:
+  otelcol-config.yaml: |
+    receivers:
+      prometheus/collector:
+        config:
+          global:
+            scrape_interval: 5s
+          scrape_configs:
+            - job_name: 'xtdb'
+              metrics_path: /metrics
+              authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: pod
+
+    processors:
+      batch:
+
+    exporters:
+      otlphttp/metrics:
+        endpoint: http://localhost:9090/api/v1/otlp
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus/collector]
+          processors: [batch]
+          exporters: [otlphttp/metrics]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+  namespace: cloud-benchmark
+spec:
+  accessModes: ['ReadWriteOnce']
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-deployment
+  namespace: cloud-benchmark
+  labels:
+    app: "grafana-deployment"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "grafana-deployment"
+  template:
+    metadata:
+      labels:
+        app: "grafana-deployment"
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: grafana-service-account
+      containers:
+        - name: grafana-deployment
+          image: grafana/otel-lgtm:0.8.0 
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+            - containerPort: 3100
+              protocol: TCP
+            - containerPort: 4317
+              name: grpc-receiver
+              protocol: TCP
+            - containerPort: 4318
+              name: http-receiver
+            - containerPort: 9090
+              name: prometheus
+          resources:
+            requests:
+              cpu: 250m
+              memory: 750Mi
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana-pv
+            - mountPath: /otel-lgtm/otelcol-config.yaml
+              name: config-volume
+              subPath: otelcol-config.yaml 
+          env:
+          - name: ENABLE_LOGS_PROMETHEUS
+            value: "true"
+      volumes:
+        - name: grafana-pv
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+        - name: config-volume
+          configMap:
+            name: grafana-otel-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: cloud-benchmark
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3001
+      protocol: TCP
+      targetPort: http-grafana
+  selector:
+    app: grafana-deployment

--- a/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
@@ -132,6 +132,12 @@ spec:
           value: "True"
         - name: XTDB_NODE_ID
           value: "bench-load-phase"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8080"
+        ports:
+          - name: metrics 
+            containerPort: 8080
+            hostPort: 8080
       containers:
       - name: xtdb-azure-bench-1
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
@@ -153,6 +159,12 @@ spec:
           value: "False"
         - name: XTDB_NODE_ID
           value: "bench-node-1"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8081"
+        ports: 
+        - name: metrics 
+          containerPort: 8081
+          hostPort: 8081
       - name: xtdb-azure-bench-2
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
         volumeMounts:
@@ -173,6 +185,12 @@ spec:
           value: "False"
         - name: XTDB_NODE_ID
           value: "bench-node-2"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8082"
+        ports: 
+        - name: metrics 
+          containerPort: 8082
+          hostPort: 8082
       - name: xtdb-azure-bench-3
         image: cloudbenchmarkregistry.azurecr.io/xtdb-azure-bench:latest
         volumeMounts:
@@ -193,3 +211,9 @@ spec:
           value: "False"
         - name: XTDB_NODE_ID
           value: "bench-node-3"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8083"
+        ports: 
+        - name: metrics 
+          containerPort: 8083
+          hostPort: 8083

--- a/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/single-node-auctionmark.yaml
@@ -101,3 +101,11 @@ spec:
         env:
         - name: "XTDB_LOCAL_DISK_CACHE"
           value: "/var/lib/xtdb/buffers/disk-cache-1"
+        - name: "XTDB_NODE_ID"
+          value: "bench-node-1"
+        - name: "XTDB_HEALTHZ_PORT"
+          value: "8080"
+        ports:
+          - name: "metrics"
+            containerPort: 8080
+            hostPort: 8080

--- a/cloud-benchmark/azure/scripts/clear-azure-bench.sh
+++ b/cloud-benchmark/azure/scripts/clear-azure-bench.sh
@@ -16,5 +16,10 @@ set -e
   kubectl delete pvc xtdb-pvc-local-cache-2 --namespace cloud-benchmark || true
   kubectl delete pvc xtdb-pvc-local-cache-3 --namespace cloud-benchmark || true
   kubectl delete pvc kafka-pvc --namespace cloud-benchmark || true
+
+  echo Clearing Grafana...
+  kubectl delete deployment grafana-deployment --namespace cloud-benchmark || true
+  kubectl delete pvc grafana-pvc --namespace cloud-benchmark || true
+  echo Done
 )
 

--- a/cloud-benchmark/local/README.adoc
+++ b/cloud-benchmark/local/README.adoc
@@ -70,6 +70,22 @@ minikube kubectl -- get pods --namespace xtdb-benchmark
 
 You should now have a running benchmark on your local Kubernetes cluster.
 
+=== Monitoring with Grafana
+
+Within here are also some provided templates for setting up a Grafana-Otel deployment which shall scrape the pods from the XTDB benchmark Job.
+
+To deploy grafana, simply run:
+```
+minikube kubectl -- apply -f kubernetes/grafana.yaml
+```
+
+To connect to the grafana page, run:
+```
+minikube service grafana-service --namespace xtdb-benchmark
+```
+
+With this up and runing, you can then import the XTDB dashboards (the cluster monitoring dashboard and node debugging dashboard) from `monitoring/grafana/dashboards`, and use these to monitor the benchmark pods.
+
 === Trailing the Logs
 
 You can trail the logs of each node within the job by running:

--- a/cloud-benchmark/local/kubernetes/grafana.yaml
+++ b/cloud-benchmark/local/kubernetes/grafana.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  name: grafana-service-account
+  namespace: xtdb-benchmark
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xtdb-benchmark-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xtdb-benchmark-pod-reader-binding
+subjects:
+  - kind: ServiceAccount
+    name: grafana-service-account
+    namespace: xtdb-benchmark
+roleRef:
+  kind: ClusterRole
+  name: xtdb-benchmark-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-otel-config
+  namespace: xtdb-benchmark
+data:
+  otelcol-config.yaml: |
+    receivers:
+      prometheus/collector:
+        config:
+          global:
+            scrape_interval: 5s
+          scrape_configs:
+            - job_name: 'xtdb'
+              metrics_path: /metrics
+              authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: pod
+
+    processors:
+      batch:
+
+    exporters:
+      otlphttp/metrics:
+        endpoint: http://localhost:9090/api/v1/otlp
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus/collector]
+          processors: [batch]
+          exporters: [otlphttp/metrics]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+  namespace: xtdb-benchmark
+spec:
+  accessModes: ['ReadWriteOnce']
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-deployment
+  namespace: xtdb-benchmark
+  labels:
+    app: "grafana-deployment"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "grafana-deployment"
+  template:
+    metadata:
+      labels:
+        app: "grafana-deployment"
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: grafana-service-account
+      containers:
+        - name: grafana-deployment
+          image: grafana/otel-lgtm:0.8.0 
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+            - containerPort: 3100
+              protocol: TCP
+            - containerPort: 4317
+              name: grpc-receiver
+              protocol: TCP
+            - containerPort: 4318
+              name: http-receiver
+            - containerPort: 9090
+              name: prometheus
+          resources:
+            requests:
+              cpu: 250m
+              memory: 750Mi
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana-pv
+            - mountPath: /otel-lgtm/otelcol-config.yaml
+              name: config-volume
+              subPath: otelcol-config.yaml 
+          env:
+          - name: ENABLE_LOGS_PROMETHEUS
+            value: "true"
+      volumes:
+        - name: grafana-pv
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+        - name: config-volume
+          configMap:
+            name: grafana-otel-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: xtdb-benchmark
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3001
+      protocol: TCP
+      targetPort: http-grafana
+  selector:
+    app: grafana-deployment

--- a/cloud-benchmark/local/kubernetes/multi-node-auctionmark.yaml
+++ b/cloud-benchmark/local/kubernetes/multi-node-auctionmark.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: "xtdb-benchmark"
   labels:
     app: "xtdb-multi-node-auctionmark"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   completions: 1
   parallelism: 1
@@ -75,6 +77,12 @@ spec:
           value: "True"
         - name: XTDB_NODE_ID
           value: "bench-load-phase"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8080"
+        ports:
+          - name: metrics 
+            containerPort: 8080
+            hostPort: 8080
       containers:
       - name: xtdb-bench-1
         image: xtdb-local-auctionmark:latest
@@ -99,9 +107,14 @@ spec:
           value: "bench-node-1"
         - name: YOURKIT_PORT
           value: "10001"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8081"
         ports: 
         - containerPort: 10001
           hostPort: 10001
+        - name: metrics 
+          containerPort: 8081
+          hostPort: 8081
       - name: xtdb-bench-2
         image: xtdb-local-auctionmark:latest
         imagePullPolicy: Never
@@ -125,9 +138,14 @@ spec:
           value: "bench-node-2"
         - name: YOURKIT_PORT
           value: "10002"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8082"
         ports: 
         - containerPort: 10002
           hostPort: 10002
+        - name: metrics 
+          containerPort: 8082
+          hostPort: 8082
       - name: xtdb-bench-3
         image: xtdb-local-auctionmark:latest
         imagePullPolicy: Never
@@ -151,6 +169,11 @@ spec:
           value: "bench-node-3"
         - name: YOURKIT_PORT
           value: "10003"
+        - name: XTDB_HEALTHZ_PORT
+          value: "8083"
         ports: 
         - containerPort: 10003
           hostPort: 10003
+        - name: metrics 
+          containerPort: 8083
+          hostPort: 8083

--- a/cloud-benchmark/local/local-config-kafka.yaml
+++ b/cloud-benchmark/local/local-config-kafka.yaml
@@ -11,4 +11,4 @@ storage: !Local
   path: !Env XTDB_STORAGE_DIR
 
 healthz:
-  port: 0
+  port: !Env XTDB_HEALTHZ_PORT

--- a/cloud-benchmark/local/scripts/clear-kubernetes.sh
+++ b/cloud-benchmark/local/scripts/clear-kubernetes.sh
@@ -4,6 +4,8 @@ set -e
 (
   minikube kubectl -- delete jobs xtdb-multi-node-auctionmark --namespace xtdb-benchmark || true
   minikube kubectl -- delete deployment kafka-app --namespace xtdb-benchmark || true 
+  minikube kubectl -- delete deployment grafana-deployment --namespace xtdb-benchmark || true 
   minikube kubectl -- delete pvc xtdb-pvc-local-storage --namespace xtdb-benchmark || true
   minikube kubectl -- delete pvc kafka-pvc --namespace xtdb-benchmark || true
+  minikube kubectl -- delete pvc grafana-pvc --namespace xtdb-benchmark || true
 )


### PR DESCRIPTION
Resolves #3904 

Using `grafana-otel` and it's built in prometheus server (alongside `kubernetes_sd_config`) to scrape the containers `/metrics` paths (each `healthz` server hosted on a seperate port using `IntWithEnvVarSerde`. Includes instructions for running `grafana`, and adds it to both `local` and `azure` cloud-benchmark implementations.

TODO:
- [x] Running and testing against `local`
- [x] Running and testing against `azure`.  