### PR TITLE
consistent application of 'params'/'args' naming

### DIFF
--- a/core/src/main/clojure/xtdb/bloom.clj
+++ b/core/src/main/clojure/xtdb/bloom.clj
@@ -98,7 +98,7 @@
                                                  (let [{:keys [param param-type]} value-expr]
                                                    {param param-type}))})
               {:keys [writer-bindings write-value-out!]} (expr/write-value-out-code return-type)]
-          (-> `(fn [~(-> expr/params-sym (expr/with-tag RelationReader))
+          (-> `(fn [~(-> expr/args-sym (expr/with-tag RelationReader))
                     ~(-> expr/out-vec-sym (expr/with-tag ValueVector))]
                  (let [~@(expr/batch-bindings emitted-expr)
                        ~@writer-bindings]

--- a/core/src/main/clojure/xtdb/expression/map.clj
+++ b/core/src/main/clojure/xtdb/expression/map.clj
@@ -92,7 +92,7 @@
           (-> `(fn [~(expr/with-tag left-rel RelationReader)
                     ~(expr/with-tag right-rel RelationReader)
                     ~(-> expr/schema-sym (expr/with-tag Map))
-                    ~(-> expr/params-sym (expr/with-tag RelationReader))]
+                    ~(-> expr/args-sym (expr/with-tag RelationReader))]
                  (let [~@(expr/batch-bindings emitted-expr)]
                    (reify IntBinaryOperator
                      (~'applyAsInt [_# ~left-idx ~right-idx]
@@ -174,7 +174,7 @@
    {:keys [key-col-names store-full-build-rel?
            build-fields probe-fields
            with-nil-row? nil-keys-equal?
-           theta-expr param-fields params]
+           theta-expr param-fields args]
     :as opts}]
   (let [param-types (update-vals param-fields types/field->col-type)
         build-key-col-names (get opts :build-key-col-names key-col-names)
@@ -219,7 +219,7 @@
                       ;; NOTE: we might not need to compute `comparator` if the caller never requires `addIfNotPresent` (e.g. joins)
                       !comparator (delay
                                     (->> (map (fn [build-col in-col]
-                                                (->equi-comparator in-col build-col params
+                                                (->equi-comparator in-col build-col args
                                                                    {:nil-keys-equal? nil-keys-equal?,
                                                                     :param-types param-types}))
                                               build-key-cols
@@ -253,14 +253,14 @@
 
                       ^IntBinaryOperator
                       comparator (->> (cond-> (map (fn [build-col probe-col]
-                                                     (->equi-comparator probe-col build-col params
+                                                     (->equi-comparator probe-col build-col args
                                                                         {:nil-keys-equal? nil-keys-equal?
                                                                          :param-types param-types}))
                                                    build-key-cols
                                                    probe-key-cols)
 
                                         (some? theta-expr)
-                                        (conj (->theta-comparator probe-rel build-rel theta-expr params
+                                        (conj (->theta-comparator probe-rel build-rel theta-expr args
                                                                   {:build-fields build-fields
                                                                    :probe-fields probe-fields
                                                                    :param-types param-types})))

--- a/core/src/main/clojure/xtdb/expression/metadata.clj
+++ b/core/src/main/clojure/xtdb/expression/metadata.clj
@@ -182,7 +182,7 @@
               {:keys [continue] :as emitted-expr} (expr/codegen-expr expr opts)]
           {:expr expr
            :f (-> `(fn [~(-> table-metadata-sym (expr/with-tag ITableMetadata))
-                        ~(-> expr/params-sym (expr/with-tag RelationReader))
+                        ~(-> expr/args-sym (expr/with-tag RelationReader))
                         [~@(keep :bloom-hash-sym (ewalk/expr-seq expr))]]
                      (let [~metadata-rdr-sym (VectorReader/from (.metadataReader ~table-metadata-sym))
                            ~cols-rdr-sym (.keyReader ~metadata-rdr-sym "columns")

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -288,7 +288,7 @@
             (finish [_]
               (with-open [sum (.finish sum-agg)
                           count (.finish count-agg)]
-                (.project projecter al (vr/rel-reader [sum count]) {} vw/empty-params)))
+                (.project projecter al (vr/rel-reader [sum count]) {} vw/empty-args)))
 
             Closeable
             (close [_]
@@ -335,7 +335,7 @@
             IAggregateSpec
             (aggregate [_ in-rel group-mapping]
               (let [in-vec (.readerForName in-rel (str from-name))]
-                (with-open [x2 (.project x2-projecter al (vr/rel-reader [in-vec]) {} vw/empty-params)]
+                (with-open [x2 (.project x2-projecter al (vr/rel-reader [in-vec]) {} vw/empty-args)]
                   (.aggregate sumx-agg in-rel group-mapping)
                   (.aggregate sumx2-agg (vr/rel-reader [x2]) group-mapping)
                   (.aggregate countx-agg in-rel group-mapping))))
@@ -347,7 +347,7 @@
                 (.project finish-projecter al
                           (vr/rel-reader [sumx sumx2 countx])
                           {}
-                          vw/empty-params)))
+                          vw/empty-args)))
 
             Closeable
             (close [_]
@@ -377,7 +377,7 @@
 
             (finish [_]
               (with-open [variance (.finish variance-agg)]
-                (.project finish-projecter al (vr/rel-reader [variance]) {} vw/empty-params)))
+                (.project finish-projecter al (vr/rel-reader [variance]) {} vw/empty-args)))
 
             Closeable
             (close [_]

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -18,7 +18,7 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype SelectCursor [^BufferAllocator allocator, ^ICursor in-cursor, ^SelectionSpec selector, schema, params]
+(deftype SelectCursor [^BufferAllocator allocator, ^ICursor in-cursor, ^SelectionSpec selector, schema, args]
   ICursor
   (tryAdvance [_ c]
     (let [advanced? (boolean-array 1)]
@@ -26,7 +26,7 @@
                                (reify Consumer
                                  (accept [_ in-rel]
                                    (let [^RelationReader in-rel in-rel]
-                                     (when-let [idxs (.select selector allocator in-rel schema params)]
+                                     (when-let [idxs (.select selector allocator in-rel schema args)]
                                        (when-not (zero? (alength idxs))
                                          (.accept c (.select in-rel idxs))
                                          (aset advanced? 0 true)))))))
@@ -43,6 +43,6 @@
                          :param-types (update-vals param-fields types/field->col-type)}
             selector (expr/->expression-selection-spec (expr/form->expr predicate input-types) input-types)]
         {:fields inner-fields
-         :->cursor (fn [{:keys [allocator params schema]} in-cursor]
-                     (-> (SelectCursor. allocator in-cursor selector schema params)
+         :->cursor (fn [{:keys [allocator args schema]} in-cursor]
+                     (-> (SelectCursor. allocator in-cursor selector schema args)
                          (coalesce/->coalescing-cursor allocator)))}))))

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -52,8 +52,8 @@
   (close [_]
     (.close in-cursor)))
 
-(defn- read-param [^RelationReader params param]
-  (let [v (some-> params (.readerForName (str param)) (.getObject 0))]
+(defn- read-param [^RelationReader args param]
+  (let [v (some-> args (.readerForName (str param)) (.getObject 0))]
     (if (nat-int? v)
       v
       (throw (err/illegal-arg :xtdb/expected-number
@@ -64,14 +64,14 @@
   (lp/unary-expr (lp/emit-expr relation args)
     (fn [fields]
       {:fields fields
-       :->cursor (fn [{:keys [params]} in-cursor]
+       :->cursor (fn [{:keys [args]} in-cursor]
                    (TopCursor. in-cursor
                                (case skip-tag
                                  :literal skip-arg
-                                 :param (read-param params skip-arg)
+                                 :param (read-param args skip-arg)
                                  nil 0)
                                (case limit-tag
                                  :literal limit-arg
-                                 :param (read-param params limit-arg)
+                                 :param (read-param args limit-arg)
                                  nil Long/MAX_VALUE)
                                0))})))

--- a/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
@@ -10,7 +10,7 @@ interface ProjectionSpec {
     val columnType: Any
 
     /**
-     * @param params a single-row indirect relation containing the params for this invocation - maybe a view over a bigger param relation.
+     * @param args a single-row indirect relation containing the args for this invocation - maybe a view over a bigger arg relation.
      */
-    fun project(allocator: BufferAllocator, readRelation: RelationReader, schema: Map<String, Any>, params: RelationReader): IVectorReader
+    fun project(allocator: BufferAllocator, readRelation: RelationReader, schema: Map<String, Any>, args: RelationReader): IVectorReader
 }

--- a/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
@@ -12,15 +12,13 @@
   (let [q (nth tpch-ra/queries i)
         stage-name (keyword (str (name stage-name) "-" (:name (meta q))))
         q @q
-        {::tpch-ra/keys [params table-args]} (meta q)]
+        {::tpch-ra/keys [args]} (meta q)]
     {:t :do
      :stage stage-name
      :tasks [{:t :call
               :f (fn [{:keys [sut]}]
                    (try
-                     (count (tu/query-ra q {:node sut
-                                            :params params
-                                            :table-args table-args}))
+                     (count (tu/query-ra q {:node sut, :args args}))
                      (catch Exception e
                        (.printStackTrace e))))}]}))
 

--- a/modules/bench/src/main/clojure/xtdb/bench/xtdb2.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/xtdb2.clj
@@ -130,7 +130,7 @@
 
   (defn q [open-id]
     (tu/query-ra ra-query {:node node
-                           :params {'?i_id open-id}}))
+                           :args {:i-id open-id}}))
   ;; ra query
   (time
    #(doseq [id (take 1000 (shuffle open-ids))]

--- a/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
+++ b/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
@@ -118,14 +118,14 @@
                                    (reify BiFunction
                                      (apply [_ _ps-id {:keys [^PreparedQuery prepd-query] :as ^Map ps}]
                                        ;; TODO we likely needn't take these out and put them back.
-                                       (util/with-close-on-catch [new-params (-> (first (flight-stream->rows flight-stream))
-                                                                                 (->> (sequence (map-indexed (fn [idx v]
-                                                                                                               (-> (vw/open-vec allocator (symbol (str "?_" idx)) [v])
-                                                                                                                   (vr/vec->reader))))))
-                                                                                 (vr/rel-reader 1))]
+                                       (util/with-close-on-catch [new-args (-> (first (flight-stream->rows flight-stream))
+                                                                               (->> (sequence (map-indexed (fn [idx v]
+                                                                                                             (-> (vw/open-vec allocator (symbol (str "?_" idx)) [v])
+                                                                                                                 (vr/vec->reader))))))
+                                                                               (vr/rel-reader 1))]
                                          (doto ps
                                            (some-> (.put :bound-query
-                                                         (.bind prepd-query {:params new-params}))
+                                                         (.bind prepd-query {:args new-args}))
                                                    util/try-close))))))
                 (throw (UnsupportedOperationException. "invalid ps-id"))))
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -43,7 +43,7 @@
            xtdb.api.query.IKeyFn
            xtdb.arrow.Relation
            xtdb.indexer.live_index.ILiveTable
-           (xtdb.query IQuerySource PreparedQuery)
+           (xtdb.query BoundQuery IQuerySource PreparedQuery)
            xtdb.types.ZonedDateTimeRange
            (xtdb.util RefCounter RowCounter TemporalBounds TemporalDimension)
            (xtdb.vector IVectorReader RelationReader)
@@ -206,8 +206,8 @@
 (defn open-rel ^xtdb.vector.RelationReader [vecs]
   (vw/open-rel vecs))
 
-(defn open-params ^xtdb.vector.RelationReader [params-map]
-  (vw/open-params *allocator* params-map))
+(defn open-args ^xtdb.vector.RelationReader [args]
+  (vw/open-args *allocator* args))
 
 (defn populate-root ^org.apache.arrow.vector.VectorSchemaRoot [^VectorSchemaRoot root rows]
   (.clear root)
@@ -272,35 +272,34 @@
 
 (defn query-ra
   ([query] (query-ra query {}))
-  ([query {:keys [allocator node params preserve-blocks? with-col-types? key-fn] :as query-opts
+  ([query {:keys [allocator node args preserve-blocks? with-col-types? key-fn] :as query-opts
            :or {key-fn (serde/read-key-fn :kebab-case-keyword)
                 allocator *allocator*}}]
    (let [indexer (util/component node :xtdb/indexer)
          query-opts (-> query-opts
                         (assoc :allocator allocator)
                         (cond-> node (-> (update :after-tx-id (fnil identity (xtp/latest-submitted-tx-id node)))
-                                         (doto (-> :after-tx-id (idx/await-tx node))))))]
+                                         (doto (-> :after-tx-id (idx/await-tx node))))))
 
-     (with-open [^RelationReader
-                 params-rel (if params
-                              (vw/open-params allocator params)
-                              vw/empty-params)]
-       (let [^PreparedQuery pq (if node
-                                 (let [^IQuerySource q-src (util/component node ::q/query-source)]
-                                   (.prepareRaQuery q-src query indexer query-opts))
-                                 (q/prepare-ra query {:ref-ctr (RefCounter.)
-                                                      :wm-src (reify IWatermarkSource
-                                                                (openWatermark [_]
-                                                                  (Watermark. nil nil {})))}))
-             bq (.bind pq (-> (select-keys query-opts [:snapshot-time :current-time :after-tx-id :table-args :default-tz])
-                              (assoc :params params-rel)))]
-         (util/with-open [res (.openCursor bq)]
-           (let [rows (-> (<-cursor res (serde/read-key-fn key-fn))
-                          (cond->> (not preserve-blocks?) (into [] cat)))]
-             (if with-col-types?
-               {:res rows, :col-types (->> (.columnFields bq)
-                                           (into {} (map (juxt #(symbol (.getName ^Field %)) types/field->col-type))))}
-               rows))))))))
+         ^PreparedQuery pq (if node
+                             (let [^IQuerySource q-src (util/component node ::q/query-source)]
+                               (.prepareRaQuery q-src query indexer query-opts))
+                             (q/prepare-ra query {:ref-ctr (RefCounter.)
+                                                  :wm-src (reify IWatermarkSource
+                                                            (openWatermark [_]
+                                                              (Watermark. nil nil {})))}))]
+     (util/with-open [^RelationReader args-rel (if args
+                                                 (vw/open-args allocator args)
+                                                 vw/empty-args)
+                      bq (.bind pq (-> (select-keys query-opts [:snapshot-time :current-time :after-tx-id :table-args :default-tz])
+                                       (assoc :args args-rel, :close-args? false)))
+                      res (.openCursor bq)]
+       (let [rows (-> (<-cursor res (serde/read-key-fn key-fn))
+                      (cond->> (not preserve-blocks?) (into [] cat)))]
+         (if with-col-types?
+           {:res rows, :col-types (->> (.columnFields bq)
+                                       (into {} (map (juxt #(symbol (.getName ^Field %)) types/field->col-type))))}
+           rows))))))
 
 (t/deftest round-trip-cursor
   (with-allocator

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -440,7 +440,7 @@
 
   (t/is (= #{{:table-name "beanie", :table-schema "public"}}
            (set (tu/query-ra '[:scan {:table information_schema/tables} [table_schema {table_name (= table_name ?tn)}]]
-                             {:node tu/*node* :params {'?tn "beanie"}})))
+                             {:node tu/*node*, :args {:tn "beanie"}})))
         "col-preds with params work")
 
 

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -55,12 +55,12 @@
   (t/is (= [{:num 4}]
            (tu/query-ra '[:scan {:table public/xt_docs}
                           [{num (= num ?x)}]]
-                        {:node tu/*node*, :params {'?x (byte 4)}})))
+                        {:node tu/*node*, :args {:x (byte 4)}})))
 
   (t/is (= [{:num 3}]
            (tu/query-ra '[:scan {:table public/xt_docs}
                           [{num (= num ?x)}]]
-                        {:node tu/*node*, :params {'?x (float 3)}}))))
+                        {:node tu/*node*, :args {:x (float 3)}}))))
 
 (deftest test-bloom-filter-for-datetime-types-2133
   (-> (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:timestamp #time/date "2010-01-01" :xt/id "a"}]
@@ -84,7 +84,7 @@
             {:timestamp #time/date-time "2010-01-01T00:00:00"}]
            (tu/query-ra '[:scan {:table public/xt_docs}
                           [{timestamp (= timestamp ?x)}]]
-                        {:node tu/*node*, :default-tz #time/zone "Z", :params {'?x #time/date "2010-01-01"}})))
+                        {:node tu/*node*, :default-tz #time/zone "Z", :args {:x #time/date "2010-01-01"}})))
 
   (t/is (= [{:timestamp #time/date "2010-01-01"}
             {:timestamp #time/zoned-date-time "2010-01-01T00:00Z"}
@@ -132,7 +132,7 @@
                                 (map (comp bucket->page-idx first)))
 
             ^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)
-            literal-selector (expr.meta/->metadata-selector '(and (< _id 11) (> _id 9)) '{_id :i64} vw/empty-params)]
+            literal-selector (expr.meta/->metadata-selector '(and (< _id 11) (> _id 9)) '{_id :i64} vw/empty-args)]
 
         (t/testing "L0"
           (let [meta-file-path (trie/->table-meta-file-path (util/->path "tables/public$xt_docs") (trie/->log-l0-l1-trie-key 0 0 21 20))]
@@ -175,7 +175,7 @@
   (tu/finish-chunk! tu/*node*)
 
   (let [^IMetadataManager metadata-mgr (tu/component tu/*node* ::meta/metadata-manager)
-        true-selector (expr.meta/->metadata-selector '(= boolean-or-int true) '{boolean-or-int :bool} vw/empty-params)]
+        true-selector (expr.meta/->metadata-selector '(= boolean-or-int true) '{boolean-or-int :bool} vw/empty-args)]
 
     (t/testing "L0"
       (let [meta-file-path (trie/->table-meta-file-path (util/->path "tables/public$xt_docs") (trie/->log-l0-l1-trie-key 0 0 2 1))]

--- a/src/test/clojure/xtdb/operator/apply_test.clj
+++ b/src/test/clojure/xtdb/operator/apply_test.clj
@@ -78,14 +78,14 @@
                           [:table [{:y 0} {:y 1}]]
                           [:select (= ?y a)
                            [:table ?x]]]
-                        {:params '{?x [{:a 1, :b 2}]}})))
+                        {:args {:x [{:a 1, :b 2}]}})))
 
   (t/is (thrown-with-msg? RuntimeException
                           #"cardinality violation"
                           (tu/query-ra '[:apply :single-join {}
                                          [:table [{:y 0}]]
                                          [:table ?x]]
-                                       {:params '{?x [{:a 1, :b 2} {:a 3, :b 4}]}}))
+                                       {:args {:x [{:a 1, :b 2} {:a 3, :b 4}]}}))
         "throws on cardinality > 1")
 
   (t/testing "returns null on empty"
@@ -93,13 +93,13 @@
              (tu/query-ra '[:apply :single-join {}
                             [:table [{:y 0}]]
                             [:table ?x]]
-                          {:params '{?x []}})))
+                          {:args {:x []}})))
 
     (t/is (= [{:y 0}]
              (tu/query-ra '[:apply :single-join {}
                             [:table [{:y 0}]]
                             [:table [a b] ?x]]
-                          {:params '{?x []}})))))
+                          {:args {:x []}})))))
 
 (t/deftest test-apply-empty-rel-bug-237
   (t/is (= {:res [{}], :col-types '{x3 [:union #{:null :i64}]}}

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -906,7 +906,7 @@
                  [{bar (- ?foo 0)}]
                  [[:table [{:bar 1}]]
                   [:table [{:baz 10}]]]]
-               {:params {'?foo 1}}))))
+               {:args {:foo 1}}))))
 
   (t/testing "empty input"
     (t/is (= []

--- a/src/test/clojure/xtdb/operator/order_by_test.clj
+++ b/src/test/clojure/xtdb/operator/order_by_test.clj
@@ -42,19 +42,19 @@
     (t/is (= [{:b 15}, {:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}]
              (tu/query-ra '[:order-by [[a {:null-ordering :nulls-first}]]
                             [:table ?table]]
-                          {:params {'?table table-with-nil}}))
+                          {:args {:table table-with-nil}}))
           "nulls first")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:b 15}]
              (tu/query-ra '[:order-by [[a {:null-ordering :nulls-last}]]
                             [:table ?table]]
-                          {:params {'?table table-with-nil}}))
+                          {:args {:table table-with-nil}}))
           "nulls last")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:b 15}]
              (tu/query-ra '[:order-by [[a]]
                             [:table ?table]]
-                          {:params {'?table table-with-nil}}))
+                          {:args {:table table-with-nil}}))
           "default nulls last")))
 
 (t/deftest test-order-by-spill

--- a/src/test/clojure/xtdb/operator/project_test.clj
+++ b/src/test/clojure/xtdb/operator/project_test.clj
@@ -24,7 +24,7 @@
                             [[{:a 12, :b 10}
                               {:a 0, :b 15}]
                              [{:a 100, :b 83}]]]]
-                          {:params '{?p 42}
+                          {:args {:p 42}
                            :preserve-blocks? true})))))
 
 (t/deftest test-project-row-number

--- a/src/test/clojure/xtdb/operator/select_test.clj
+++ b/src/test/clojure/xtdb/operator/select_test.clj
@@ -24,7 +24,7 @@
                               {:a 0, :b 15}]
                              [{:a 100, :b 83}]
                              [{:a 83, :b 100}]]]]
-                          {:params {'?b 50}
+                          {:args {:b 50}
                            :preserve-blocks? true})))))
 
 (deftest test-no-column-relation
@@ -39,4 +39,4 @@
   (t/is (= [{} {} {}]
            (tu/query-ra '[:select (= ?ap_n 2)
                           [:table [{} {} {}]]]
-                        {:params {'?ap_n 2}}))))
+                        {:args {:ap-n 2}}))))

--- a/src/test/clojure/xtdb/operator/top_test.clj
+++ b/src/test/clojure/xtdb/operator/top_test.clj
@@ -78,13 +78,13 @@
 
     (t/is (= [{:idx 1}, {:idx 2}]
              (tu/query-ra [:top '{:skip ?_0, :limit ?_1} blocks]
-                          {:params '{?_0 1, ?_1 2}})))
+                          {:args [1 2]})))
 
     (t/is (thrown-with-msg? IllegalArgumentException #"Expected: number, got: null"
                             (tu/query-ra [:top '{:skip ?_0, :limit ?_1} blocks]))
-          "missing params")
+          "missing args")
 
     (t/is (thrown-with-msg? IllegalArgumentException #"Expected: number, got: 1"
                             (tu/query-ra [:top '{:limit ?_0} blocks]
-                                         {:params '{?_0 "1"}}))
+                                         {:args ["1"]}))
           "got a string")))

--- a/src/test/clojure/xtdb/operator/unnest_test.clj
+++ b/src/test/clojure/xtdb/operator/unnest_test.clj
@@ -46,27 +46,27 @@
             {:a 2, :b [3 4 5], :b* 5}]
            (tu/query-ra '[:unnest {b* b}
                           [:table ?x]]
-                        {:params '{?x [{:a 1, :b [1 2]} {:a 2, :b [3 4 5]}]}})))
+                        {:args {:x [{:a 1, :b [1 2]} {:a 2, :b [3 4 5]}]}})))
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* 2}]
            (tu/query-ra '[:project [a b*]
                           [:unnest {b* b}
                            [:table ?x]]]
-                        {:params '{?x [{:a 1, :b [1 2]} {:a 2, :b []}]}}))
+                        {:args {:x [{:a 1, :b [1 2]} {:a 2, :b []}]}}))
         "skips rows with empty lists")
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* 2}]
            (tu/query-ra '[:project [a b*]
                           [:unnest {b* b}
                            [:table ?x]]]
-                        {:params '{?x [{:a 2, :b 1} {:a 1, :b [1 2]}]}}))
+                        {:args {:x [{:a 2, :b 1} {:a 1, :b [1 2]}]}}))
         "skips rows with non-list unnest column")
 
   (t/is (= [{:a 1, :b* 1} {:a 1, :b* "foo"}]
            (tu/query-ra '[:project [a b*]
                           [:unnest {b* b}
                            [:table ?x]]]
-                        {:params '{?x [{:a 1, :b [1 "foo"]}]}}))
+                        {:args {:x [{:a 1, :b [1 "foo"]}]}}))
         "handles multiple types")
 
   (t/is (= {{:a 1, :b* 1} 1, {:a 1, :b* "foo"} 1}
@@ -74,7 +74,7 @@
             (tu/query-ra '[:project [a b*]
                            [:unnest {b* b}
                             [:table ?x]]]
-                         {:params '{?x [{:a 1, :b #{1 "foo"}}]}})))
+                         {:args {:x [{:a 1, :b #{1 "foo"}}]}})))
         "handles sets")
 
   (t/is (= {{:a 1, :b* 1} 1, {:a 1, :b* "foo"} 1, {:a 3, :b* 2} 1, {:a 3, :b* "bar"} 1}
@@ -82,9 +82,9 @@
             (tu/query-ra '[:project [a b*]
                            [:unnest {b* b}
                             [:table ?x]]]
-                         {:params '{?x [{:a 1, :b #{1 "foo"}}
-                                        {:a 2, :b "not-a-set"}
-                                        {:a 3, :b #{2 "bar"}}]}})))
+                         {:args {:x [{:a 1, :b #{1 "foo"}}
+                                     {:a 2, :b "not-a-set"}
+                                     {:a 3, :b #{2 "bar"}}]}})))
         "handles mixed lists + sets + other things")
 
   (t/is (= [{:a 1, :b* 1, :ordinal 1}
@@ -95,6 +95,6 @@
            (tu/query-ra '[:project [a b* ordinal]
                           [:unnest {b* b} {:ordinality-column ordinal}
                            [:table ?x]]]
-                        {:params '{?x [{:a 1 :b [1 2]} {:a 2 :b [3 4 5]}]}
+                        {:args {:x [{:a 1 :b [1 2]} {:a 2 :b [3 4 5]}]}
                          :key-fn :snake-case-keyword}))
         "with ordinality"))

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -72,11 +72,10 @@
 (defn test-ra-query [n res]
   (when (contains? *qs* (inc n))
     (let [q @(nth tpch-ra/queries n)
-          {::tpch-ra/keys [params table-args]} (meta q)]
+          {::tpch-ra/keys [args]} (meta q)]
       (tu/with-allocator
         (fn []
-          (t/is (is-equal? res (tu/query-ra q {:node *node*, :params params, :table-args table-args
-                                               :key-fn :snake-case-keyword}))
+          (t/is (is-equal? res (tu/query-ra q {:node *node*, :args args, :key-fn :snake-case-keyword}))
                 (format "Q%02d" (inc n))))))))
 
 (t/deftest test-001-ra

--- a/src/test/clojure/xtdb/xtql_test.clj
+++ b/src/test/clojure/xtdb/xtql_test.clj
@@ -548,13 +548,13 @@
            (xt/q tu/*node* '(from :docs [xt/id {:set #{1 2 3}}]))))
 
   (t/is (= [{:xt/id 1}]
-           (xt/q tu/*node* '(from :docs [xt/id {:map {:foo $param}}])
-                 {:args {:param 1}})))
+           (xt/q tu/*node* '(from :docs [xt/id {:map {:foo $arg}}])
+                 {:args {:arg 1}})))
 
   #_ ; TODO `=` on sets
   (t/is (= [{:xt/id 1}]
-           (xt/q tu/*node* '(from :docs [xt/id {:set $param}])
-                 {:args {:param #{1 2 3}}}))))
+           (xt/q tu/*node* '(from :docs [xt/id {:set $arg}])
+                 {:args {:arg #{1 2 3}}}))))
 
 (deftest test-query-args
   (let [_tx (xt/submit-tx tu/*node* ivan+petr)]


### PR DESCRIPTION
params are placeholders, args are actual values

i.e. params are the static, compile-time names of the variables that will be fulfilled by the run-time, dynamic argument values

Also in this PR - an attempt to bring some coherence to the values passed to `bind` - previously this was either 'params' or 'args', and its behaviour/expected type/memory management behaviour depended on which one was passed. I've lost too much time and hair to this one, so t'was time to do something about it.