### PR TITLE
Catch integrant errors on `open-node` & rethrow - resolves #3915.

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -235,13 +235,16 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn open-node ^xtdb.api.Xtdb [opts]
-  (let [!closing (atom false)
-        system (-> (node-system opts)
-                   ig/prep
-                   ig/init)]
+  (try
+    (let [!closing (atom false)
+          system (-> (node-system opts)
+                     ig/prep
+                     ig/init)]
 
-    (-> (:xtdb/node system)
-        (assoc :system system
-               :close-fn #(when (compare-and-set! !closing false true)
-                            (ig/halt! system)
-                            #_(println (.toVerboseString ^RootAllocator (:xtdb/allocator system))))))))
+      (-> (:xtdb/node system)
+          (assoc :system system
+                 :close-fn #(when (compare-and-set! !closing false true)
+                              (ig/halt! system)
+                              #_(println (.toVerboseString ^RootAllocator (:xtdb/allocator system)))))))
+    (catch clojure.lang.ExceptionInfo e 
+      (throw (ex-cause e)))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -7,7 +7,8 @@
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
-  (:import org.testcontainers.containers.GenericContainer
+  (:import org.apache.kafka.common.KafkaException
+           org.testcontainers.containers.GenericContainer
            org.testcontainers.kafka.ConfluentKafkaContainer
            org.testcontainers.utility.DockerImageName
            [xtdb.api.log Log]
@@ -99,3 +100,12 @@
                                                   (re-find #"xtdb-tx-subscription" (.getName thread))) 
                                                 all-threads)]
             (t/is (= 0 (count tx-subscription-threads))))))))
+
+(t/deftest ^:kafka test-startup-errors-returned-with-no-system-map
+  (t/is (thrown-with-msg? KafkaException
+                          #"Failed to create new KafkaAdminClient"
+                          (xtn/start-node {:log [:kafka {:tx-topic "tx-topic"
+                                                         :files-topic "files-topic"
+                                                         :bootstrap-servers "nonresolvable:9092"
+                                                         :create-topic? false
+                                                         :some-secret "foobar"}]}))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -910,3 +910,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
               {:xt/id 1, :system-time #time/zoned-date-time "2020-01-01T00:00:00.000001Z[UTC]"}
               {:xt/id 2, :system-time #time/zoned-date-time "2021-01-01T00:00Z[UTC]"}]
              (xt/q node "SELECT _id, system_time FROM xt.txs ORDER BY _id")))))
+
+(t/deftest startup-error-doesnt-output-integrant-system
+  (t/is (thrown-with-msg? IllegalArgumentException
+                          #"Port value out of range: 99999"
+                          (xtn/start-node {:server {:port 99999}}))))


### PR DESCRIPTION
Resolves #3915 

Making this a PR such that there's a note of this decision - this will prevent us outputting the whole system when we have an error on startup, simply rethrowing the underlying error. We can always change the exact approach here should we want to, ie - rewrap the error however we want, augment with `:key` information, etc.