### PR TITLE
Make RecordBatch (Page) the main unit of memory handed out by the BufferPool

### DIFF
--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -7,32 +7,30 @@
             [xtdb.object-store :as os]
             [xtdb.util :as util])
   (:import (clojure.lang PersistentQueue)
-           (com.github.benmanes.caffeine.cache AsyncCache Cache Caffeine)
+           (com.github.benmanes.caffeine.cache Cache Caffeine)
            [io.micrometer.core.instrument MeterRegistry]
            [io.micrometer.core.instrument.simple SimpleMeterRegistry]
            [java.io ByteArrayOutputStream Closeable]
            [java.lang AutoCloseable]
            (java.nio ByteBuffer)
-           (java.nio.channels Channels ClosedByInterruptException FileChannel$MapMode SeekableByteChannel)
+           (java.nio.channels Channels ClosedByInterruptException)
            [java.nio.file FileVisitOption Files LinkOption OpenOption Path StandardOpenOption]
            [java.nio.file.attribute FileAttribute]
            [java.util NavigableMap SortedMap TreeMap]
            (java.util NavigableMap)
-           (java.util.function Function)
            [java.util.concurrent CompletableFuture ConcurrentSkipListMap]
            kotlin.Pair
-           (org.apache.arrow.flatbuf Footer Message RecordBatch)
            [org.apache.arrow.memory ArrowBuf BufferAllocator]
            (org.apache.arrow.vector VectorSchemaRoot)
            (org.apache.arrow.vector.ipc SeekableReadChannel)
-           (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter ArrowRecordBatch )
+           (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter)
+           (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter)
            (xtdb ArrowWriter IBufferPool)
            (xtdb.api.log FileListCache FileListCache$Subscriber)
            (xtdb.api.storage ObjectStore Storage Storage$Factory Storage$LocalStorageFactory Storage$RemoteStorageFactory)
            xtdb.api.Xtdb$Config
-           (xtdb.arrow Relation)
-           (xtdb.cache DiskCache DiskCache$Entry MemoryCache)
-           (org.apache.arrow.vector.ipc.message ArrowBlock ArrowFooter MessageSerializer)
+           (xtdb.arrow ArrowUtil Relation)
+           (xtdb.cache DiskCache DiskCache$Entry MemoryCache PathSlice)
            (xtdb.multipart IMultipartUpload SupportsMultipart)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -48,19 +46,17 @@
 
 (def ^java.nio.file.Path storage-root (util/->path version))
 
-(defn- retain [^ArrowBuf buf] (.retain (.getReferenceManager buf)) buf)
-
 (defn ->buffer-pool-child-allocator [^BufferAllocator allocator, ^MeterRegistry metrics-registry]
   (let [child-allocator (.newChildAllocator allocator "buffer-pool" 0 Long/MAX_VALUE)]
     (when metrics-registry
       (metrics/add-allocator-gauge metrics-registry "buffer-pool.allocator.allocated_memory" child-allocator))
     child-allocator))
 
-(defn copy-bb ^ByteBuffer [^ByteBuffer bb]
-  (let [copy (ByteBuffer/allocate (.remaining bb))]
-    (.put copy bb)
-    (.flip copy)
-    copy))
+(defn arrow-buf->ba ^bytes [^ArrowBuf arrow-buf]
+  (let [bb (.nioBuffer arrow-buf 0 (.capacity arrow-buf))
+        ba (byte-array (.remaining bb))]
+    (.get bb ba)
+    ba))
 
 (defrecord MemoryBufferPool [allocator, ^NavigableMap memory-store]
   IBufferPool
@@ -70,11 +66,11 @@
             (some-> (.get memory-store k) retain))
           (throw (os/obj-missing-exception k)))))
 
-  (getByteBuffer [_ path]
+  (getByteArray [_ path]
     (let [^ArrowBuf arrow-buf (or (locking memory-store
                                     (some-> (.get memory-store path)))
                                   (throw (os/obj-missing-exception path)))]
-      (copy-bb (.nioBuffer arrow-buf 0 (.capacity arrow-buf)))))
+      (arrow-buf->ba arrow-buf)))
 
   (getFooter [_ path]
     (let [arrow-buf (or (locking memory-store
@@ -164,47 +160,33 @@
     (aset opts 0 StandardOpenOption/READ)
     (SeekableReadChannel. (Files/newByteChannel path opts))))
 
-(defn ->record-batch ^org.apache.arrow.vector.ipc.message.ArrowRecordBatch
-  [^BufferAllocator alloc ^ArrowBlock block, ^Path path]
-  (let [buffer (util/->mmap-path path FileChannel$MapMode/READ_ONLY (.getOffset block)
-                                 (+ (.getMetadataLength block) (.getBodyLength block)))]
-    (util/with-open [arrow-buf (util/->arrow-buf-view alloc buffer)]
-      (let [prefix-size (if (= (.getInt arrow-buf 0) MessageSerializer/IPC_CONTINUATION_TOKEN) 8 4)
-            ^RecordBatch batch (.header (Message/getRootAsMessage
-                                         (.nioBuffer arrow-buf
-                                                     prefix-size
-                                                     (- (.getMetadataLength block) prefix-size)))
-                                        (RecordBatch.))
-            body-buffer (doto (.slice arrow-buf
-                                      (.getMetadataLength block)
-                                      (.getBodyLength block))
-                          (-> (.getReferenceManager) (.retain)))]
-        (MessageSerializer/deserializeRecordBatch batch body-buffer)))))
+(defn ->resolved-path-slice ^PathSlice [^PathSlice path-slice ^Path new-path]
+  (PathSlice. new-path (.getOffset path-slice) (.getLength path-slice)))
 
 (defrecord LocalBufferPool [allocator, ^MemoryCache memory-cache, ^Path disk-store, ^Cache arrow-footer-cache]
   IBufferPool
   (getBuffer [_ k]
     (when k
-      (.get memory-cache k
-            (fn [^Path k]
-              (let [buffer-cache-path (.resolve disk-store k)]
+      (.get memory-cache (PathSlice. k)
+            (fn [^PathSlice path-slice]
+              (let [buffer-cache-path (.resolve disk-store (.getPath path-slice))]
                 (when-not (util/path-exists buffer-cache-path)
                   (throw (os/obj-missing-exception k)))
 
                 (CompletableFuture/completedFuture
-                 (Pair. buffer-cache-path nil)))))))
+                 (Pair. (->resolved-path-slice path-slice buffer-cache-path) nil)))))))
 
-  (getByteBuffer [_ k]
+  (getByteArray [_ k]
     (when k
-      (util/with-open [arrow-buf (.get memory-cache k
-                                       (fn [^Path k]
-                                         (let [buffer-cache-path (.resolve disk-store k)]
+      (util/with-open [arrow-buf (.get memory-cache (PathSlice. k)
+                                       (fn [^PathSlice path-slice]
+                                         (let [buffer-cache-path (.resolve disk-store (.getPath path-slice))]
                                            (when-not (util/path-exists buffer-cache-path)
                                              (throw (os/obj-missing-exception k)))
 
                                            (CompletableFuture/completedFuture
-                                            (Pair. buffer-cache-path nil)))))]
-        (copy-bb (.nioBuffer arrow-buf 0 (.capacity arrow-buf))))))
+                                            (Pair. (->resolved-path-slice path-slice buffer-cache-path) nil)))))]
+        (arrow-buf->ba arrow-buf))))
 
   (getFooter [_ k]
     (let [path (.resolve disk-store k)]
@@ -218,16 +200,23 @@
       (when-not (util/path-exists path)
         (throw (os/obj-missing-exception path)))
 
-      (try
-        (let [^ArrowFooter footer (.get arrow-footer-cache k
-                                        (fn [_] (Relation/readFooter (path->seekable-byte-channel path))))
-              blocks (.getRecordBatches footer)
-              block (nth blocks block-idx nil)]
-          (if-not block
-            (throw (IndexOutOfBoundsException. "Record batch index out of bounds of arrow file"))
-            (->record-batch allocator block path)))
-        (catch Exception e
-          (throw (ex-info (format "Failed opening record batch '%s'" path) {:path path :block-idx block-idx} e))))))
+      (let [^ArrowFooter footer (.get arrow-footer-cache k
+                                      (fn [_] (Relation/readFooter (path->seekable-byte-channel path))))
+            blocks (.getRecordBatches footer)
+            ^ArrowBlock block (nth blocks block-idx nil)]
+        (if-not block
+          (throw (IndexOutOfBoundsException. "Record batch index out of bounds of arrow file"))
+          (util/with-open [arrow-buf (.get memory-cache (PathSlice. k (.getOffset block)
+                                                                    (+ (.getMetadataLength block) (.getBodyLength block)))
+                                           (fn [^PathSlice path-slice]
+                                             (let [buffer-cache-path (.resolve disk-store (.getPath path-slice))]
+                                               (when-not (util/path-exists buffer-cache-path)
+                                                 (throw (os/obj-missing-exception k)))
+
+                                               (CompletableFuture/completedFuture
+                                                (Pair. (->resolved-path-slice path-slice buffer-cache-path) nil)))))]
+            (ArrowUtil/arrowBufToRecordBatch arrow-buf 0 (.getMetadataLength block) (.getBodyLength block)
+                                             (format "Failed opening record batch '%s' at block-idx %d" path block-idx)))))))
 
   (putObject [_ k buffer]
     (try
@@ -284,7 +273,7 @@
 
   EvictBufferTest
   (evict-cached-buffer! [_ k]
-    (.invalidate memory-cache k))
+    (.invalidate memory-cache (PathSlice. k)))
 
   Closeable
   (close [_]
@@ -390,6 +379,7 @@
 (defrecord RemoteBufferPool [allocator
                              ^MemoryCache memory-cache
                              ^DiskCache disk-cache
+                             ^Cache arrow-footer-cache
                              ^FileListCache file-list-cache
                              ^ObjectStore object-store
                              ^SortedMap !os-files
@@ -397,8 +387,8 @@
   IBufferPool
   (getBuffer [_ k]
     (when k
-      (.get memory-cache k
-            (fn [k]
+      (.get memory-cache (PathSlice. k)
+            (fn [^PathSlice path-slice]
               (-> (.get disk-cache k
                         (fn [^Path k, ^Path tmp-file]
                           (.getObject object-store k tmp-file)))
@@ -406,7 +396,50 @@
                   (.thenApply (fn [^DiskCache$Entry entry]
                                 ;; cleanup action - when the entry is evicted from the memory cache,
                                 ;; release one count on the disk-cache entry.
-                                (Pair. (.getPath entry) entry))))))))
+                                (Pair. (->resolved-path-slice path-slice (.getPath entry)) entry))))))))
+
+  (getByteArray [_ k]
+    (when k
+      (util/with-open [arrow-buf (.get memory-cache (PathSlice. k)
+                                       (fn [^PathSlice path-slice]
+                                         (-> (.get disk-cache k
+                                                   (fn [^Path k, ^Path tmp-file]
+                                                     (.getObject object-store k tmp-file)))
+
+                                             (.thenApply (fn [^DiskCache$Entry entry]
+                                                           ;; cleanup action - when the entry is evicted from the memory cache,
+                                                           ;; release one count on the disk-cache entry.
+                                                           (Pair. (->resolved-path-slice path-slice (.getPath entry)) entry))))))]
+        (arrow-buf->ba arrow-buf))))
+
+
+  (getFooter [_ k]
+    (.get arrow-footer-cache k (fn [_]
+                                 (util/with-open [^DiskCache$Entry entry @(.get disk-cache k
+                                                                                (fn [^Path k, ^Path tmp-file]
+                                                                                  (.getObject object-store k tmp-file)))]
+                                   (Relation/readFooter (path->seekable-byte-channel (.getPath entry)))))))
+
+  (getRecordBatch [_ k block-idx]
+    (util/with-close-on-catch [^DiskCache$Entry entry @(.get disk-cache k
+                                                             (fn [^Path k, ^Path tmp-file]
+                                                               (.getObject object-store k tmp-file)))]
+      (let [path (.getPath entry)
+            ^ArrowFooter footer (.get arrow-footer-cache k
+                                      (fn [_] (Relation/readFooter (path->seekable-byte-channel path))))
+            blocks (.getRecordBatches footer)
+            ^ArrowBlock block (nth blocks block-idx nil)]
+        (if-not block
+          (throw (IndexOutOfBoundsException. "Record batch index out of bounds of arrow file"))
+          (util/with-open [arrow-buf (.get memory-cache (PathSlice. k (.getOffset block)
+                                                                    (+ (.getMetadataLength block) (.getBodyLength block)))
+                                           (fn [^PathSlice path-slice]
+                                             (CompletableFuture/completedFuture
+                                              ;; cleanup action - when the entry is evicted from the memory cache,
+                                              ;; release one count on the disk-cache entry.
+                                              (Pair. (->resolved-path-slice path-slice path) entry))))]
+            (ArrowUtil/arrowBufToRecordBatch arrow-buf 0 (.getMetadataLength block) (.getBodyLength block)
+                                             (format "Failed opening record batch '%s' at block-idx %d" path block-idx)))))))
 
   (listAllObjects [_]
     (vec (.sequencedKeySet !os-files)))
@@ -447,7 +480,7 @@
 
   EvictBufferTest
   (evict-cached-buffer! [_ k]
-    (.invalidate memory-cache k))
+    (.invalidate memory-cache (PathSlice. k)))
 
   (close [_]
     (util/close memory-cache)
@@ -495,6 +528,7 @@
         (->RemoteBufferPool (->buffer-pool-child-allocator allocator metrics-registry)
                             memory-cache
                             disk-cache
+                            (->arrow-footer-cache 1024)
                             file-list-cache object-store !os-files !os-file-name-subscription)))))
 
 (defmulti ->object-store-factory

--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -60,12 +60,6 @@
 
 (defrecord MemoryBufferPool [allocator, ^NavigableMap memory-store]
   IBufferPool
-  (getBuffer [_ k]
-    (when k
-      (or (locking memory-store
-            (some-> (.get memory-store k) retain))
-          (throw (os/obj-missing-exception k)))))
-
   (getByteArray [_ path]
     (let [^ArrowBuf arrow-buf (or (locking memory-store
                                     (some-> (.get memory-store path)))
@@ -165,17 +159,6 @@
 
 (defrecord LocalBufferPool [allocator, ^MemoryCache memory-cache, ^Path disk-store, ^Cache arrow-footer-cache]
   IBufferPool
-  (getBuffer [_ k]
-    (when k
-      (.get memory-cache (PathSlice. k)
-            (fn [^PathSlice path-slice]
-              (let [buffer-cache-path (.resolve disk-store (.getPath path-slice))]
-                (when-not (util/path-exists buffer-cache-path)
-                  (throw (os/obj-missing-exception k)))
-
-                (CompletableFuture/completedFuture
-                 (Pair. (->resolved-path-slice path-slice buffer-cache-path) nil)))))))
-
   (getByteArray [_ k]
     (when k
       (util/with-open [arrow-buf (.get memory-cache (PathSlice. k)
@@ -385,19 +368,6 @@
                              ^SortedMap !os-files
                              ^AutoCloseable !os-files-subscription]
   IBufferPool
-  (getBuffer [_ k]
-    (when k
-      (.get memory-cache (PathSlice. k)
-            (fn [^PathSlice path-slice]
-              (-> (.get disk-cache k
-                        (fn [^Path k, ^Path tmp-file]
-                          (.getObject object-store k tmp-file)))
-
-                  (.thenApply (fn [^DiskCache$Entry entry]
-                                ;; cleanup action - when the entry is evicted from the memory cache,
-                                ;; release one count on the disk-cache entry.
-                                (Pair. (->resolved-path-slice path-slice (.getPath entry)) entry))))))))
-
   (getByteArray [_ k]
     (when k
       (util/with-open [arrow-buf (.get memory-cache (PathSlice. k)

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -411,7 +411,7 @@
 (defn- load-chunks-metadata ^java.util.NavigableMap [{:keys [^IBufferPool buffer-pool]}]
   (let [cm (TreeMap.)]
     (doseq [cm-obj-key (.listObjects buffer-pool chunk-metadata-path)]
-      (with-open [is (ByteArrayInputStream. (.array (.getByteBuffer buffer-pool cm-obj-key)))]
+      (with-open [is (ByteArrayInputStream. (.getByteArray buffer-pool cm-obj-key))]
         (let [rdr (transit/reader is :json {:handlers (merge serde/transit-read-handlers
                                                              arrow-read-handlers)})]
           (.put cm (obj-key->chunk-idx cm-obj-key) (transit/read rdr)))))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -345,11 +345,12 @@
 (defrecord ArrowMergePlanPage [data-file-path ^IntPredicate page-idx-pred ^long page-idx ^ITableMetadata table-metadata]
   MergePlanPage
   (load-page [_mpg buffer-pool vsr-cache]
-    (util/with-open [rb (bp/open-record-batch buffer-pool data-file-path page-idx)]
-      (let [vsr (cache-vsr vsr-cache data-file-path)
-            loader (VectorLoader. vsr)]
-        (.load loader rb)
-        (vr/<-root vsr))))
+    (let [^IBufferPool bp buffer-pool]
+      (util/with-open [rb (.getRecordBatch bp data-file-path page-idx)]
+        (let [vsr (cache-vsr vsr-cache data-file-path)
+              loader (VectorLoader. vsr)]
+          (.load loader rb)
+          (vr/<-root vsr)))))
 
   (test-metadata [_mpg]
     (.test page-idx-pred page-idx))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -455,7 +455,7 @@
      (.wrapForeignAllocation allocator
                              (proxy [ForeignAllocation] [(.remaining nio-buffer) (MemoryUtil/getByteBufferAddress nio-buffer)]
                                (release0 []
-                                (try-free-direct-buffer nio-buffer)
+                                 (try-free-direct-buffer nio-buffer)
                                  (when release-fn
                                    (release-fn))))))))
 

--- a/core/src/main/kotlin/xtdb/IBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/IBufferPool.kt
@@ -1,12 +1,35 @@
 package xtdb
 
 import org.apache.arrow.memory.ArrowBuf
+import org.apache.arrow.vector.ipc.message.ArrowFooter
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import xtdb.arrow.Relation
 import java.nio.ByteBuffer
 import java.nio.file.Path
 
 interface IBufferPool : AutoCloseable {
     fun getBuffer(key: Path): ArrowBuf
+
+    /**
+     * Get the whole file as an on-heap ByteBuffer.
+     *
+     * This should only be used for small files (metadata) or testing purposes.
+     */
+    fun getByteBuffer(key: Path): ByteBuffer
+
+    /**
+     * Returns the footer of the given arrow file.
+     *
+     * Throws if not an arrow file.
+     */
+    fun getFooter (key: Path): ArrowFooter
+
+    /**
+     * Returns a record batch of the given arrow file.
+     *
+     * Throws if not an arrow file or the record batch is out of bounds.
+     */
+    fun getRecordBatch(key: Path, blockIdx: Int): ArrowRecordBatch
 
     fun putObject(k: Path, buffer: ByteBuffer)
 

--- a/core/src/main/kotlin/xtdb/IBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/IBufferPool.kt
@@ -11,11 +11,11 @@ interface IBufferPool : AutoCloseable {
     fun getBuffer(key: Path): ArrowBuf
 
     /**
-     * Get the whole file as an on-heap ByteBuffer.
+     * Get the whole file as an on-heap byte array.
      *
      * This should only be used for small files (metadata) or testing purposes.
      */
-    fun getByteBuffer(key: Path): ByteBuffer
+    fun getByteArray(key: Path): ByteArray
 
     /**
      * Returns the footer of the given arrow file.

--- a/core/src/main/kotlin/xtdb/IBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/IBufferPool.kt
@@ -8,8 +8,6 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 
 interface IBufferPool : AutoCloseable {
-    fun getBuffer(key: Path): ArrowBuf
-
     /**
      * Get the whole file as an on-heap byte array.
      *

--- a/core/src/main/kotlin/xtdb/arrow/ArrowUtil.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ArrowUtil.kt
@@ -1,0 +1,34 @@
+package xtdb.arrow
+
+import org.apache.arrow.flatbuf.Message
+import org.apache.arrow.flatbuf.RecordBatch
+import org.apache.arrow.memory.ArrowBuf
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
+import org.apache.arrow.vector.ipc.message.MessageSerializer
+
+object ArrowUtil {
+
+    @JvmStatic
+    @JvmOverloads
+    fun arrowBufToRecordBatch(
+        buf: ArrowBuf,
+        offset: Long,
+        metadataLength: Int,
+        bodyLength: Long,
+        errorString: String? = null,
+    ) : ArrowRecordBatch {
+        val prefixSize =
+            if (buf.getInt(offset) == MessageSerializer.IPC_CONTINUATION_TOKEN) 8L else 4L
+
+        val metadataBuf = buf.nioBuffer(offset + prefixSize, (metadataLength - prefixSize).toInt())
+
+        val bodyBuf = buf.slice(offset + metadataLength, bodyLength)
+            .also { it.referenceManager.retain() }
+
+        val msg = Message.getRootAsMessage(metadataBuf.asReadOnlyBuffer())
+        val recordBatchFB = RecordBatch().also { msg.header(it) }
+
+        return MessageSerializer.deserializeRecordBatch(recordBatchFB, bodyBuf
+            ?: error(errorString ?: "Failed to deserialize record batch at offset $offset"))
+    }
+}

--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -202,7 +202,8 @@ class Relation(val vectors: SequencedMap<String, Vector>, override var rowCount:
     }
 
     companion object {
-        private fun readFooter(ch: SeekableReadChannel): ArrowFooter {
+        @JvmStatic
+        fun readFooter(ch: SeekableReadChannel): ArrowFooter {
             val buf = ByteBuffer.allocate(Int.SIZE_BYTES + MAGIC.size)
             val footerLengthOffset = ch.size() - buf.remaining()
             ch.setPosition(footerLengthOffset)
@@ -234,7 +235,8 @@ class Relation(val vectors: SequencedMap<String, Vector>, override var rowCount:
             return ChannelLoader(al, readCh, readFooter(readCh))
         }
 
-        private fun readFooter(buf: ArrowBuf): ArrowFooter {
+        @JvmStatic
+        fun readFooter(buf: ArrowBuf): ArrowFooter {
             val magicBytes = ByteArray(Int.SIZE_BYTES + MAGIC.size)
             val footerLengthOffset = buf.capacity() - magicBytes.size
             buf.getBytes(footerLengthOffset, magicBytes)
@@ -272,6 +274,14 @@ class Relation(val vectors: SequencedMap<String, Vector>, override var rowCount:
 
         @JvmStatic
         fun fromRoot(vsr: VectorSchemaRoot) = Relation(vsr.fieldVectors.map(Vector::fromArrow), vsr.rowCount)
+
+        @JvmStatic
+        fun fromRecordBatch (allocator: BufferAllocator, schema: Schema, recordBatch: ArrowRecordBatch) : Relation {
+            val rel = Relation(allocator, schema)
+            // this load retains the buffers
+            rel.load(recordBatch)
+            return rel
+        }
     }
 
     /**

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -1,5 +1,6 @@
 (ns xtdb.test-util
   (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]
             [clojure.test :as t]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
@@ -531,3 +532,8 @@
    (->> (for [i (range (.valueCount rdr))]
           (.getObject rdr i key-fn))
         (into []))))
+
+(defn get-extension [^Path path]
+  (let [name (str (.getFileName path))]
+    (when-let [idx (str/last-index-of name ".")]
+      (subs name (inc idx)))))

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -196,9 +196,10 @@
 
         (t/is @multipart-branch-taken true)
         (t/is (= [:upload :upload :complete] (get-remote-calls bp)))
-        (util/with-open [buf (.getBuffer bp (util/->path "aw"))]
-          (let [{:keys [root]} (util/read-arrow-buf buf)]
-            (util/close root)))))))
+        (util/with-open [rb (.getRecordBatch bp path 0)]
+          (let [footer (.getFooter bp path)
+                rel (Relation/fromRecordBatch tu/*allocator* (.getSchema footer) rb)]
+            (util/close rel)))))))
 
 (defn file-info [^Path dir]
   (let [files (filter #(.isFile ^File %) (file-seq (.toFile dir)))]

--- a/src/test/clojure/xtdb/concurrent_node_test.clj
+++ b/src/test/clojure/xtdb/concurrent_node_test.clj
@@ -45,8 +45,8 @@
                    :xtdb/buffer-pool (Storage/localStorage (.resolve (.toPath node-dir) "objects"))}
     (fn []
       (let [^IBufferPool buffer-pool (:xtdb/buffer-pool tu/*sys*)
-            objs (.listAllObjects buffer-pool)
-            get-item #(with-open [_buf (.getBuffer buffer-pool (rand-nth objs))]
+            objs (filter #(= "arrow" (tu/get-extension %)) (.listAllObjects buffer-pool))
+            get-item #(with-open [_rb (.getRecordBatch buffer-pool (rand-nth objs) 0)]
                         (Thread/sleep 10))
             f-call #(future
                       (dotimes [_ 300]

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -74,11 +74,11 @@
     (t/testing "finish chunk"
       (li/finish-chunk! live-index)
 
-      (let [trie-buf (.getByteBuffer buffer-pool (util/->path "tables/my-table/meta/log-l00-fr00-nr32ee0-rs2ee0.arrow"))
-            leaf-buf (.getByteBuffer buffer-pool (util/->path "tables/my-table/data/log-l00-fr00-nr32ee0-rs2ee0.arrow"))]
-        (util/with-open [trie-loader (Relation/loader allocator (util/->seekable-byte-channel trie-buf))
+      (let [trie-ba (.getByteArray buffer-pool (util/->path "tables/my-table/meta/log-l00-fr00-nr32ee0-rs2ee0.arrow"))
+            leaf-ba (.getByteArray buffer-pool (util/->path "tables/my-table/data/log-l00-fr00-nr32ee0-rs2ee0.arrow"))]
+        (util/with-open [trie-loader (Relation/loader allocator (util/->seekable-byte-channel (ByteBuffer/wrap trie-ba)))
                          trie-rel (Relation. allocator (.getSchema trie-loader))
-                         leaf-rdr (ArrowFileReader. (util/->seekable-byte-channel leaf-buf) allocator)]
+                         leaf-rdr (ArrowFileReader. (util/->seekable-byte-channel (ByteBuffer/wrap leaf-ba)) allocator)]
           (let [iid-vec (.getVector (.getVectorSchemaRoot leaf-rdr) "_iid")]
             (.loadBatch trie-loader 0 trie-rel)
             (t/is (= iid-bytes


### PR DESCRIPTION
The BufferPool interface essentially passes from:
```kotlin
    fun getBuffer(key: Path): ArrowBuf
```
to 
```kotlin
    fun getByteBuffer(key: Path): ByteBuffer

    fun getFooter (key: Path): ArrowFooter

    fun getRecordBatch(key: Path, blockIdx: Int): ArrowRecordBatch
```

Most of the heavy lifting happens in `getRecordBatch`.  For building up a `xtdb.arrow.Relation` we sometimes need a `Schema`, this is the main reason for the extra `getFooter` call.  Some files (only `transit` as far as I know) don't know anything about arrow, hence the `getByteBuffer` method. The `getByteBuffer` method should only be used on smallish files and for testing. Both `getFooter` and `getByteBuffer` don't have any impact on the direct memory footprint of the buffer pool and allocate their object on the heap (albeit they have an impact on disk cache). 

Things to consider / to do:
- I mostly just added stuff to `xtdb.arrow.Relation` to make things work. It would probably be good to figure out what we want from `Relation` and from which objects it can be instantiated.
- The buffer pool code has grown quite a bit and I suspect that things can be refactored, but I want to do that once the interfaces have settled.
- I am really unhappy about the interaction between `BufferPool`, `MemoryCache` and `DiskCache`. The way their respective interfaces interact with one another is very non transparent and one has to essentially look at the implementations to figure things out. I wonder if there is not some way to make things simpler (you should not need to know anything about the disk cache when writing some function for the memory cache). I might open a another card for that.
- Apart from some tests in `buffer-pool-test` nothing is really testing the interaction of `MemoryCache` and `DiskCache` in the standard suite. It would probably be good to add another test for that.
