### PR TITLE
Clear leftover `openArrowWriter` temp files on close

### DIFF
--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -329,3 +329,41 @@
   (tu/with-tmp-dirs #{tmp-dir}
     (with-open [bp (bp/open-local-storage tu/*allocator* (Storage/localStorage tmp-dir) (SimpleMeterRegistry.))]
       (test-list-objects bp))))
+
+(defn count-tmp-files [^Path tmp-dir]
+  (count (.listFiles (.toFile tmp-dir))))
+
+(t/deftest buffer-pool-clears-up-arrow-writer-temp-files
+  (with-open [bp (remote-test-buffer-pool)]
+    (let [^Path root-path (.getRootPath ^DiskCache (:disk-cache bp))
+          ^Path tmp-dir (.resolve root-path ".tmp")
+          schema (Schema. [(types/col-type->field "a" :i32)])]
+      (t/testing "successful uploads"
+        (with-open [rel (Relation. tu/*allocator* schema)
+                    w (.openArrowWriter bp (util/->path "aw") rel)]
+          ;; Arrow Writer Opened
+          (t/is (= 1 (count-tmp-files tmp-dir)) "temp file present")
+
+          ;; Write arrow file out
+          (let [v (.get rel "a")]
+            (.writeInt v 1)
+            (.writeBatch w)
+            (.end w))
+          
+          (t/is (= 0 (count-tmp-files tmp-dir)) "temp file removed")))
+
+      (t/testing "failing/erroring uploads"
+        (with-redefs [util/->mmap-path (fn [_] (throw (Exception. "Example error in upload arrow file")))]
+          (with-open [rel (Relation. tu/*allocator* schema)
+                      w (.openArrowWriter bp (util/->path "aw2") rel)]
+           ;; Arrow Writer Opened
+            (t/is (= 1 (count-tmp-files tmp-dir)) "temp file present")
+
+           ;; Write arrow file out, should error
+            (t/is (thrown-with-msg? Exception #"Example error in upload arrow file"
+                                    (let [v (.get rel "a")]
+                                      (.writeInt v 1)
+                                      (.writeBatch w)
+                                      (.end w)))) 
+            (t/is (= 1 (count-tmp-files tmp-dir)) "temp file still present")))
+        (t/is (= 0 (count-tmp-files tmp-dir)) "temp file removed after writer closed")))))

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -354,16 +354,17 @@
 
       (t/testing "failing/erroring uploads"
         (with-redefs [util/->mmap-path (fn [_] (throw (Exception. "Example error in upload arrow file")))]
-          (with-open [rel (Relation. tu/*allocator* schema)
-                      w (.openArrowWriter bp (util/->path "aw2") rel)]
-           ;; Arrow Writer Opened
-            (t/is (= 1 (count-tmp-files tmp-dir)) "temp file present")
-
-           ;; Write arrow file out, should error
+          (with-open [rel (Relation. tu/*allocator* schema)]
+            ;; Using `with-close-on-catch`, as we do in trie.clj where we use the arrow writer
             (t/is (thrown-with-msg? Exception #"Example error in upload arrow file"
-                                    (let [v (.get rel "a")]
-                                      (.writeInt v 1)
-                                      (.writeBatch w)
-                                      (.end w)))) 
-            (t/is (= 1 (count-tmp-files tmp-dir)) "temp file still present")))
-        (t/is (= 0 (count-tmp-files tmp-dir)) "temp file removed after writer closed")))))
+                                    (util/with-close-on-catch [w (.openArrowWriter bp (util/->path "aw2") rel)]
+                                      ;; Arrow Writer Opened
+                                      (t/is (= 1 (count-tmp-files tmp-dir)) "temp file present")
+
+                                     ;; Write arrow file out, should error
+                                      (let [v (.get rel "a")]
+                                        (.writeInt v 1)
+                                        (.writeBatch w)
+                                        (.end w)))))
+            
+            (t/is (= 0 (count-tmp-files tmp-dir)) "temp file removed after writer errored/closed")))))))


### PR DESCRIPTION
Resolves #3913 

Essentially, we were relying on the behaviour of the DiskCache to atomically move the temp file to the disk cache location - so if there was an error thrown inside of `.end` (ie, the file already existed on the object store when we called `upload-arrow-file`), the temp files would never get cleared up, leading to use eventually running out of disk space even with a generously low `maxDiskCachePercentage` size set. 

The approach taken to fix this is to rely on `close` being called on the `ArrowWriter` (which it should be, as we rely on it to close any open filechannels as well, and usages of open-arrow-writer are inside of `with-close-on-catch` blocks). 

Keen to test this against auctionmark (ie, setting persistent volume claim sizes smaller once again and keeping an eye on the size of `.tmp` directory).