### PR TITLE
Add `cleanUp` method to metadata Manager

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -2,10 +2,11 @@
   (:require [clojure.tools.logging :as log]
             [integrant.core :as ig]
             [xtdb.bitemporal :as bitemp]
+            [xtdb.metadata]
+            [xtdb.metrics :as metrics]
             [xtdb.trie :as trie]
             [xtdb.types :as types]
-            [xtdb.util :as util]
-            [xtdb.metrics :as metrics])
+            [xtdb.util :as util])
   (:import (java.lang AutoCloseable)
            [java.nio.file Path]
            [java.time Duration]

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -355,7 +355,12 @@
             (.finishChunk metadata-mgr chunk-idx
                           {:latest-completed-tx latest-completed-tx
                            :next-chunk-idx next-chunk-idx
-                           :tables table-metadata}))))
+                           :tables table-metadata})
+            (future
+              (try
+                (.cleanUp metadata-mgr)
+                (catch Exception e
+                  (log/error e "Error while cleaning up the metadata manager.")))))))
 
       (.nextChunk row-counter)
 

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -3,7 +3,6 @@
             [integrant.core :as ig]
             [xtdb.bloom :as bloom]
             xtdb.buffer-pool
-            [xtdb.expression.comparator :as expr.comp]
             xtdb.expression.temporal
             [xtdb.serde :as serde]
             [xtdb.types :as types]
@@ -15,17 +14,16 @@
            java.nio.ByteBuffer
            (java.nio.file Path)
            (java.util HashMap HashSet Map NavigableMap TreeMap)
-           (java.util.function Function IntPredicate)
-           (java.util.stream IntStream)
            (org.apache.arrow.memory ArrowBuf)
-           (org.apache.arrow.vector.types.pojo ArrowType ArrowType$Binary ArrowType$Bool ArrowType$Date ArrowType$FixedSizeBinary ArrowType$FloatingPoint ArrowType$Int ArrowType$Interval ArrowType$List ArrowType$Null ArrowType$Struct ArrowType$Time ArrowType$Time ArrowType$Timestamp ArrowType$Union ArrowType$Utf8 Field FieldType)
-           (xtdb.arrow Relation VectorReader VectorWriter)
+           (org.apache.arrow.vector.types.pojo ArrowType Field FieldType)
+           (org.apache.arrow.vector.types.pojo ArrowType Field FieldType)
+           (xtdb.arrow Relation)
+           (xtdb.arrow Relation)
            xtdb.IBufferPool
            (xtdb.metadata ITableMetadata PageIndexKey)
            (xtdb.trie ArrowHashTrie HashTrie)
            (xtdb.util TemporalBounds TemporalDimension)
-           (xtdb.vector IVectorReader)
-           (xtdb.vector.extensions KeywordType SetType TransitType TsTzRangeType UriType UuidType)))
+           (xtdb.vector IVectorReader)))
 
 (def arrow-read-handlers
   {"xtdb/arrow-type" (transit/read-handler types/->arrow-type)
@@ -47,9 +45,6 @@
                                   (TransitFactory/taggedValue "array" [(.getName field) (.getFieldType field) (.getChildren field)])))})
 (set! *unchecked-math* :warn-on-boxed)
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(definterface IPageMetadataWriter
-  (^void writeMetadata [^Iterable cols]))
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface IMetadataManager
@@ -93,200 +88,6 @@
                     new-fields))
           fields
           tables))
-
-(def metadata-col-type
-  '[:list
-    [:struct
-     {col-name :utf8
-      root-col? :bool
-      count :i64
-      types [:struct {}]
-      bloom [:union #{:null :varbinary}]}]])
-
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(definterface ContentMetadataWriter
-  (^void writeContentMetadata []))
-
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(definterface NestedMetadataWriter
-  (^xtdb.metadata.ContentMetadataWriter appendNestedMetadata [^xtdb.arrow.VectorReader contentCol]))
-
-#_{:clj-kondo/ignore [:unused-binding]}
-(defprotocol MetadataWriterFactory
-  (type->metadata-writer [arrow-type write-col-meta! types-vec]))
-
-(defn- ->bool-type-handler [^VectorWriter types-wtr, arrow-type]
-  (let [bit-wtr (.keyWriter types-wtr (if (instance? ArrowType$FixedSizeBinary arrow-type)
-                                        "fixed-size-binary"
-                                        (name (types/arrow-type->leg arrow-type)))
-                            (FieldType/nullable #xt.arrow/type :bool))]
-    (reify NestedMetadataWriter
-      (appendNestedMetadata [_ _content-col]
-        (reify ContentMetadataWriter
-          (writeContentMetadata [_]
-            (.writeBoolean bit-wtr true)))))))
-
-(defn- ->min-max-type-handler [^VectorWriter types-wtr, arrow-type]
-  (let [struct-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type)) (FieldType/nullable #xt.arrow/type :struct))
-
-        min-wtr (.keyWriter struct-wtr "min" (FieldType/nullable arrow-type))
-        max-wtr (.keyWriter struct-wtr "max" (FieldType/nullable arrow-type))]
-
-    (reify NestedMetadataWriter
-      (appendNestedMetadata [_ content-col]
-        (reify ContentMetadataWriter
-          (writeContentMetadata [_]
-
-            (let [min-copier (.rowCopier content-col min-wtr)
-                  max-copier (.rowCopier content-col max-wtr)
-
-                  min-comparator (expr.comp/->comparator content-col content-col :nulls-last)
-                  max-comparator (expr.comp/->comparator content-col content-col :nulls-first)]
-
-              (loop [value-idx 0
-                     min-idx -1
-                     max-idx -1]
-                (if (= value-idx (.getValueCount content-col))
-                  (do
-                    (if (neg? min-idx)
-                      (.writeNull min-wtr)
-                      (.copyRow min-copier min-idx))
-                    (if (neg? max-idx)
-                      (.writeNull max-wtr)
-                      (.copyRow max-copier max-idx)))
-
-                  (recur (inc value-idx)
-                         (if (and (not (.isNull content-col value-idx))
-                                  (or (neg? min-idx)
-                                      (neg? (.applyAsInt min-comparator value-idx min-idx))))
-                           value-idx
-                           min-idx)
-                         (if (and (not (.isNull content-col value-idx))
-                                  (or (neg? max-idx)
-                                      (pos? (.applyAsInt max-comparator value-idx max-idx))))
-                           value-idx
-                           max-idx))))
-
-              (.endStruct struct-wtr))))))))
-
-(extend-protocol MetadataWriterFactory
-  ArrowType$Null (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
-  ArrowType$Bool (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
-  ArrowType$FixedSizeBinary (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
-  TransitType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
-  TsTzRangeType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type)))
-
-(extend-protocol MetadataWriterFactory
-  ArrowType$Int (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$FloatingPoint (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Utf8 (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Binary (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  KeywordType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  UriType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  UuidType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Timestamp (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Date (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Interval (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
-  ArrowType$Time (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type)))
-
-(extend-protocol MetadataWriterFactory
-  ArrowType$List
-  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
-    (let [list-type-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type))
-                                    (FieldType/nullable #xt.arrow/type :i32))]
-      (reify NestedMetadataWriter
-        (appendNestedMetadata [_ content-col]
-          (write-col-meta! (.elementReader ^VectorReader content-col))
-
-          (let [data-meta-idx (dec (.getValueCount types-wtr))]
-            (reify ContentMetadataWriter
-              (writeContentMetadata [_]
-                (.writeInt list-type-wtr data-meta-idx))))))))
-
-  SetType
-  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
-    (let [set-type-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type))
-                                   (FieldType/nullable #xt.arrow/type :i32))]
-      (reify NestedMetadataWriter
-        (appendNestedMetadata [_ content-col]
-          (write-col-meta! (.elementReader ^VectorReader content-col))
-
-          (let [data-meta-idx (dec (.getValueCount types-wtr))]
-            (reify ContentMetadataWriter
-              (writeContentMetadata [_]
-                (.writeInt set-type-wtr data-meta-idx))))))))
-
-  ArrowType$Struct
-  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
-    (let [struct-type-wtr (.keyWriter types-wtr
-                                      (str (name (types/arrow-type->leg arrow-type)) "-" (count (seq types-wtr)))
-                                      (FieldType/nullable #xt.arrow/type :list))
-          struct-type-el-wtr (.elementWriter struct-type-wtr (FieldType/nullable #xt.arrow/type :i32))]
-      (reify NestedMetadataWriter
-        (appendNestedMetadata [_ content-col]
-          (let [struct-keys (.getKeys content-col)
-                sub-col-idxs (IntStream/builder)]
-
-            (doseq [^String struct-key struct-keys]
-              (write-col-meta! (.keyReader content-col struct-key))
-              (.add sub-col-idxs (dec (.getValueCount types-wtr))))
-
-            (reify ContentMetadataWriter
-              (writeContentMetadata [_]
-                (doseq [sub-col-idx (.toArray (.build sub-col-idxs))]
-                  (.writeInt struct-type-el-wtr sub-col-idx))
-                (.endList struct-type-wtr)))))))))
-
-(defn ->page-meta-wtr ^xtdb.metadata.IPageMetadataWriter [^VectorWriter cols-wtr]
-  (let [col-wtr (.elementWriter cols-wtr)
-        col-name-wtr (.keyWriter col-wtr "col-name")
-        root-col-wtr (.keyWriter col-wtr "root-col?")
-        count-wtr (.keyWriter col-wtr "count")
-        types-wtr (.keyWriter col-wtr "types")
-        bloom-wtr (.keyWriter col-wtr "bloom")
-
-        type-metadata-writers (HashMap.)]
-
-    (letfn [(->nested-meta-writer [^VectorReader content-col]
-              (when-let [^Field field (first (-> (.getField content-col)
-                                                 (types/flatten-union-field)
-                                                 (->> (remove #(= ArrowType$Null/INSTANCE (.getType ^Field %))))
-                                                 (doto (-> count (<= 1) (assert (str (pr-str (.getField content-col)) "should just be nullable mono-vecs here"))))))]
-                (-> ^NestedMetadataWriter
-                    (.computeIfAbsent type-metadata-writers (.getType field)
-                                      (reify Function
-                                        (apply [_ arrow-type]
-                                          (type->metadata-writer arrow-type (partial write-col-meta! false) types-wtr))))
-                    (.appendNestedMetadata content-col))))
-
-            (write-col-meta! [root-col?, ^VectorReader content-col]
-              (let [content-writers (->> (if (instance? ArrowType$Union (.getType (.getField content-col)))
-                                           (->> (.getLegs content-col)
-                                                (mapv (fn [leg]
-                                                        (->nested-meta-writer (.legReader content-col leg)))))
-                                           [(->nested-meta-writer content-col)])
-                                         (remove nil?))]
-                (.writeBoolean root-col-wtr root-col?)
-                (.writeObject col-name-wtr (.getName content-col))
-                (.writeLong count-wtr (-> (IntStream/range 0 (.getValueCount content-col))
-                                          (.filter (reify IntPredicate
-                                                     (test [_ idx]
-                                                       (not (.isNull content-col idx)))))
-                                          (.count)))
-                (bloom/write-bloom bloom-wtr content-col)
-
-                (doseq [^ContentMetadataWriter content-writer content-writers]
-                  (.writeContentMetadata content-writer))
-                (.endStruct types-wtr)
-
-                (.endStruct col-wtr)))]
-
-      (reify IPageMetadataWriter
-        (writeMetadata [_ cols]
-          (doseq [^VectorReader col cols
-                  :when (pos? (.getValueCount col))]
-            (write-col-meta! true col))
-          (.endList cols-wtr))))))
 
 (defn ->table-metadata-idxs [^IVectorReader metadata-rdr]
   (let [page-idx-cache (HashMap.)

--- a/core/src/main/clojure/xtdb/metadata/trie.clj
+++ b/core/src/main/clojure/xtdb/metadata/trie.clj
@@ -1,0 +1,210 @@
+(ns xtdb.metadata.trie
+  (:require [xtdb.bloom :as bloom]
+            xtdb.buffer-pool
+            [xtdb.expression.comparator :as expr.comp]
+            xtdb.expression.temporal
+            [xtdb.types :as types])
+  (:import (java.util HashMap)
+           (java.util.function Function IntPredicate)
+           (java.util.stream IntStream)
+           (org.apache.arrow.vector.types.pojo ArrowType$Binary ArrowType$Bool ArrowType$Date ArrowType$FixedSizeBinary ArrowType$FloatingPoint ArrowType$Int ArrowType$Interval ArrowType$List ArrowType$Null ArrowType$Struct ArrowType$Time ArrowType$Time ArrowType$Timestamp ArrowType$Union ArrowType$Utf8 Field FieldType)
+           (xtdb.arrow VectorReader VectorWriter)
+           (xtdb.vector.extensions KeywordType SetType TransitType TsTzRangeType UriType UuidType)))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface IPageMetadataWriter
+  (^void writeMetadata [^Iterable cols]))
+
+(def metadata-col-type
+  '[:list
+    [:struct
+     {col-name :utf8
+      root-col? :bool
+      count :i64
+      types [:struct {}]
+      bloom [:union #{:null :varbinary}]}]])
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface ContentMetadataWriter
+  (^void writeContentMetadata []))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(definterface NestedMetadataWriter
+  (^xtdb.metadata.trie.ContentMetadataWriter appendNestedMetadata [^xtdb.arrow.VectorReader contentCol]))
+
+#_{:clj-kondo/ignore [:unused-binding]}
+(defprotocol MetadataWriterFactory
+  (type->metadata-writer [arrow-type write-col-meta! types-vec]))
+
+(defn- ->bool-type-handler [^VectorWriter types-wtr, arrow-type]
+  (let [bit-wtr (.keyWriter types-wtr (if (instance? ArrowType$FixedSizeBinary arrow-type)
+                                        "fixed-size-binary"
+                                        (name (types/arrow-type->leg arrow-type)))
+                            (FieldType/nullable #xt.arrow/type :bool))]
+    (reify NestedMetadataWriter
+      (appendNestedMetadata [_ _content-col]
+        (reify ContentMetadataWriter
+          (writeContentMetadata [_]
+            (.writeBoolean bit-wtr true)))))))
+
+(defn- ->min-max-type-handler [^VectorWriter types-wtr, arrow-type]
+  (let [struct-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type)) (FieldType/nullable #xt.arrow/type :struct))
+
+        min-wtr (.keyWriter struct-wtr "min" (FieldType/nullable arrow-type))
+        max-wtr (.keyWriter struct-wtr "max" (FieldType/nullable arrow-type))]
+
+    (reify NestedMetadataWriter
+      (appendNestedMetadata [_ content-col]
+        (reify ContentMetadataWriter
+          (writeContentMetadata [_]
+
+            (let [min-copier (.rowCopier content-col min-wtr)
+                  max-copier (.rowCopier content-col max-wtr)
+
+                  min-comparator (expr.comp/->comparator content-col content-col :nulls-last)
+                  max-comparator (expr.comp/->comparator content-col content-col :nulls-first)]
+
+              (loop [value-idx 0
+                     min-idx -1
+                     max-idx -1]
+                (if (= value-idx (.getValueCount content-col))
+                  (do
+                    (if (neg? min-idx)
+                      (.writeNull min-wtr)
+                      (.copyRow min-copier min-idx))
+                    (if (neg? max-idx)
+                      (.writeNull max-wtr)
+                      (.copyRow max-copier max-idx)))
+
+                  (recur (inc value-idx)
+                         (if (and (not (.isNull content-col value-idx))
+                                  (or (neg? min-idx)
+                                      (neg? (.applyAsInt min-comparator value-idx min-idx))))
+                           value-idx
+                           min-idx)
+                         (if (and (not (.isNull content-col value-idx))
+                                  (or (neg? max-idx)
+                                      (pos? (.applyAsInt max-comparator value-idx max-idx))))
+                           value-idx
+                           max-idx))))
+
+              (.endStruct struct-wtr))))))))
+
+(extend-protocol MetadataWriterFactory
+  ArrowType$Null (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
+  ArrowType$Bool (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
+  ArrowType$FixedSizeBinary (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
+  TransitType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type))
+  TsTzRangeType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->bool-type-handler metadata-root arrow-type)))
+
+(extend-protocol MetadataWriterFactory
+  ArrowType$Int (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$FloatingPoint (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Utf8 (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Binary (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  KeywordType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  UriType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  UuidType (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Timestamp (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Date (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Interval (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type))
+  ArrowType$Time (type->metadata-writer [arrow-type _write-col-meta! metadata-root] (->min-max-type-handler metadata-root arrow-type)))
+
+(extend-protocol MetadataWriterFactory
+  ArrowType$List
+  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
+    (let [list-type-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type))
+                                    (FieldType/nullable #xt.arrow/type :i32))]
+      (reify NestedMetadataWriter
+        (appendNestedMetadata [_ content-col]
+          (write-col-meta! (.elementReader ^VectorReader content-col))
+
+          (let [data-meta-idx (dec (.getValueCount types-wtr))]
+            (reify ContentMetadataWriter
+              (writeContentMetadata [_]
+                (.writeInt list-type-wtr data-meta-idx))))))))
+
+  SetType
+  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
+    (let [set-type-wtr (.keyWriter types-wtr (name (types/arrow-type->leg arrow-type))
+                                   (FieldType/nullable #xt.arrow/type :i32))]
+      (reify NestedMetadataWriter
+        (appendNestedMetadata [_ content-col]
+          (write-col-meta! (.elementReader ^VectorReader content-col))
+
+          (let [data-meta-idx (dec (.getValueCount types-wtr))]
+            (reify ContentMetadataWriter
+              (writeContentMetadata [_]
+                (.writeInt set-type-wtr data-meta-idx))))))))
+
+  ArrowType$Struct
+  (type->metadata-writer [arrow-type write-col-meta! ^VectorWriter types-wtr]
+    (let [struct-type-wtr (.keyWriter types-wtr
+                                      (str (name (types/arrow-type->leg arrow-type)) "-" (count (seq types-wtr)))
+                                      (FieldType/nullable #xt.arrow/type :list))
+          struct-type-el-wtr (.elementWriter struct-type-wtr (FieldType/nullable #xt.arrow/type :i32))]
+      (reify NestedMetadataWriter
+        (appendNestedMetadata [_ content-col]
+          (let [struct-keys (.getKeys content-col)
+                sub-col-idxs (IntStream/builder)]
+
+            (doseq [^String struct-key struct-keys]
+              (write-col-meta! (.keyReader content-col struct-key))
+              (.add sub-col-idxs (dec (.getValueCount types-wtr))))
+
+            (reify ContentMetadataWriter
+              (writeContentMetadata [_]
+                (doseq [sub-col-idx (.toArray (.build sub-col-idxs))]
+                  (.writeInt struct-type-el-wtr sub-col-idx))
+                (.endList struct-type-wtr)))))))))
+
+(defn ->page-meta-wtr ^xtdb.metadata.trie.IPageMetadataWriter [^VectorWriter cols-wtr]
+  (let [col-wtr (.elementWriter cols-wtr)
+        col-name-wtr (.keyWriter col-wtr "col-name")
+        root-col-wtr (.keyWriter col-wtr "root-col?")
+        count-wtr (.keyWriter col-wtr "count")
+        types-wtr (.keyWriter col-wtr "types")
+        bloom-wtr (.keyWriter col-wtr "bloom")
+
+        type-metadata-writers (HashMap.)]
+
+    (letfn [(->nested-meta-writer [^VectorReader content-col]
+              (when-let [^Field field (first (-> (.getField content-col)
+                                                 (types/flatten-union-field)
+                                                 (->> (remove #(= ArrowType$Null/INSTANCE (.getType ^Field %))))
+                                                 (doto (-> count (<= 1) (assert (str (pr-str (.getField content-col)) "should just be nullable mono-vecs here"))))))]
+                (-> ^NestedMetadataWriter
+                    (.computeIfAbsent type-metadata-writers (.getType field)
+                                      (reify Function
+                                        (apply [_ arrow-type]
+                                          (type->metadata-writer arrow-type (partial write-col-meta! false) types-wtr))))
+                    (.appendNestedMetadata content-col))))
+
+            (write-col-meta! [root-col?, ^VectorReader content-col]
+              (let [content-writers (->> (if (instance? ArrowType$Union (.getType (.getField content-col)))
+                                           (->> (.getLegs content-col)
+                                                (mapv (fn [leg]
+                                                        (->nested-meta-writer (.legReader content-col leg)))))
+                                           [(->nested-meta-writer content-col)])
+                                         (remove nil?))]
+                (.writeBoolean root-col-wtr root-col?)
+                (.writeObject col-name-wtr (.getName content-col))
+                (.writeLong count-wtr (-> (IntStream/range 0 (.getValueCount content-col))
+                                          (.filter (reify IntPredicate
+                                                     (test [_ idx]
+                                                       (not (.isNull content-col idx)))))
+                                          (.count)))
+                (bloom/write-bloom bloom-wtr content-col)
+
+                (doseq [^ContentMetadataWriter content-writer content-writers]
+                  (.writeContentMetadata content-writer))
+                (.endStruct types-wtr)
+
+                (.endStruct col-wtr)))]
+
+      (reify IPageMetadataWriter
+        (writeMetadata [_ cols]
+          (doseq [^VectorReader col cols
+                  :when (pos? (.getValueCount col))]
+            (write-col-meta! true col))
+          (.endList cols-wtr))))))

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -311,6 +311,9 @@
 
       (mapv :file-path !current-trie-keys))))
 
+(defn superseded-trie-files [file-names]
+  (set/difference (set file-names) (set (current-trie-files file-names))))
+
 (defrecord Segment [trie]
   ISegment
   (getTrie [_] trie))

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -1,8 +1,10 @@
 (ns xtdb.metadata-test
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
             [xtdb.buffer-pool :as bp]
+            [xtdb.compactor :as c]
             [xtdb.expression.metadata :as expr.meta]
             [xtdb.metadata :as meta]
             [xtdb.node :as xtn]
@@ -11,11 +13,11 @@
             [xtdb.time :as time]
             [xtdb.trie :as trie]
             [xtdb.util :as util]
-            [xtdb.vector.writer :as vw]
-            [xtdb.compactor :as c])
+            [xtdb.vector.writer :as vw])
   (:import (clojure.lang MapEntry)
-           (xtdb.util TemporalBounds TemporalDimension)
-           (xtdb.metadata IMetadataManager)))
+           (com.github.benmanes.caffeine.cache Cache)
+           (xtdb.metadata IMetadataManager MetadataManager)
+           (xtdb.util TemporalBounds TemporalDimension)))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 (t/use-fixtures :once tu/with-allocator)
@@ -225,3 +227,36 @@
 
               (t/is (= #{"_iid" "_id" "_system_from" "_valid_from" "_valid_to" "colours" "utf8"}
                        (.columnNames table-metadata))))))))))
+
+(deftest metadata-cleanup
+  (with-open [node (xtn/start-node {:server {:port 0}})]
+    (let [^MetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)
+          ^Cache table-metadata-idx-cache (.table-metadata-idx-cache metadata-mgr)]
+      (letfn [(submit-docs [] (xt/execute-tx node [(into [:put-docs :docs] (for [i (range 20)] {:xt/id i}))]))
+              (query [] (xt/q node '(from :docs [*])))
+              (docs-metadata-files []
+                (->> (.asMap table-metadata-idx-cache)
+                     keys
+                     (map str)
+                     (filter #(str/starts-with? % "tables/public$docs/"))))]
+
+        (submit-docs)
+        (tu/finish-chunk! node)
+        (query)
+
+        ;; L0
+        (t/is (= 1 (count (doto (docs-metadata-files)
+                            #_prn))))
+
+        (c/compact-all! node)
+        (query)
+
+        ;; L0 + L1
+        (t/is (= 2 (count (doto (docs-metadata-files)
+                            #_prn))))
+
+        (.cleanUp metadata-mgr)
+
+        ;; L1
+        (t/is (= 1 (count (doto (docs-metadata-files)
+                            #_prn))))))))


### PR DESCRIPTION
We are removing any retaining of buffers from the Metadata Manager and only cache the table metadata indices. 

Superseded metadata buffers were not getting cleared from the metadata manager. As the metadata manager does no longer hold on to those this should no longer be a problem. We are also adding a `cleanUp` method to the metadata manager to clear superseded metadata indices which are retained on heap. 

The first commit is just some reshuffling of metadata functions to not get a cyclic dependency with the trie namespace.

Todo:
- We could also pass to soft references for the table metadata indices to better deal with heap memory pressure.