### PR TITLE
Option for disabling log catchup on node start

### DIFF
--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -62,6 +62,10 @@
 (defmethod apply-config! :healthz [config _ opts]
   (apply-config! config :xtdb/healthz opts))
 
+(defmethod apply-config! :node [^Xtdb$Config config _ {:keys [log-catchup?]}]
+  (cond-> config
+    (not log-catchup?) (.logCatchup log-catchup?)))
+
 (defmethod apply-config! ::default [_ k _]
   (log/warn "Unknown configuration key:" k))
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -38,6 +38,7 @@ interface Xtdb : AutoCloseable {
         val indexer: IndexerConfig = IndexerConfig(),
         val compactor: CompactorConfig = CompactorConfig(),
         var authn: Authenticator.Factory = UserTable(),
+        var logCatchup: Boolean = true
     ) {
         private val modules: MutableList<XtdbModule.Factory> = mutableListOf()
 
@@ -69,6 +70,8 @@ interface Xtdb : AutoCloseable {
         fun modules(modules: List<XtdbModule.Factory>) = apply { this.modules += modules }
 
         fun open(): Xtdb = requiringResolve("xtdb.node.impl/open-node").invoke(this) as Xtdb
+
+        fun logCatchup(logCatchup: Boolean) = apply { this.logCatchup = logCatchup }
     }
 
     companion object {

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -316,11 +316,13 @@
 
 (defn ->local-node ^xtdb.api.Xtdb [{:keys [^Path node-dir ^String buffers-dir
                                            rows-per-chunk log-limit page-limit instant-src
-                                           compactor? healthz-port]
-                                    :or {compactor? true buffers-dir "objects" healthz-port 8080}}]
+                                           compactor? healthz-port log-catchup?]
+                                    :or {compactor? true buffers-dir "objects" healthz-port 8080
+                                         log-catchup? true}}]
   (let [instant-src (or instant-src (->mock-clock))
         healthz-port (if (util/port-free? healthz-port) healthz-port (util/free-port))]
-    (xtn/start-node {:server {:port 0}
+    (xtn/start-node {:node {:log-catchup? log-catchup?}
+                     :server {:port 0}
                      :healthz {:port healthz-port}
                      :log [:local {:path (.resolve node-dir "log"), :instant-src instant-src}]
                      :storage [:local {:path (.resolve node-dir buffers-dir)}]


### PR DESCRIPTION
The possibility to disable log catchup on startup
```clj
(xtn/start-node {:node {:log-catchup? false}})
```
Maybe that should also be at the toplevel. I added it at a node key to be in line with all the other components.