### PR TITLE
Prevent double close on `watermark` on error in `openCursor`, fixes #3924

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -226,7 +226,6 @@
 
                      (catch Throwable t
                        (.release ref-ctr) 
-                       (util/try-close allocator)
                        (throw t)))))
 
                AutoCloseable

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -225,8 +225,7 @@
                            (wrap-cursor wm allocator clock ref-ctr fields)))
 
                      (catch Throwable t
-                       (.release ref-ctr)
-                       (util/try-close wm)
+                       (.release ref-ctr) 
                        (util/try-close allocator)
                        (throw t)))))
 


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions?query=branch%3Aunnest-error-3924

Resolves #3924 - essentially, in the case of an error within this section of `openCursor`, we could call `.close` on the watermark twice - this would break the `shared-wm` of the LiveIndex and cause any subsequent queries to fail as a result as any calls to `retain` would see the ref count already set to 0.