### PR TITLE
xtdb.arrow fixes around null handling

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -160,6 +160,13 @@ class DenseUnionVector(
             val leg = legVectors[i]
             if (leg.name == name) return LegWriter(i.toByte(), leg)
         }
+        // we try to find a nullable child vector
+        if (name == "null") {
+            for (i in legVectors.indices) {
+                val leg = legVectors[i]
+                if (leg.nullable) return LegWriter(i.toByte(), leg)
+            }
+        }
 
         TODO("auto-creation: $name vs ${legVectors.map { it.name }}")
     }

--- a/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
@@ -121,7 +121,6 @@ sealed class FixedWidthVector(allocator: BufferAllocator, val byteWidth: Int) : 
     override fun rowCopier0(src: VectorReader): RowCopier {
         require(src is FixedWidthVector)
         require(src.byteWidth == byteWidth)
-
         return RowCopier { srcIdx ->
             dataBuffer.writeBytes(src.dataBuffer, (srcIdx * byteWidth).toLong(), byteWidth.toLong())
             valueCount.also { writeNotNull() }

--- a/core/src/main/kotlin/xtdb/arrow/StructVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/StructVector.kt
@@ -59,7 +59,7 @@ class StructVector(
         val valueCount = valueCount
 
         children.sequencedValues().forEach { child ->
-            repeat(valueCount - child.valueCount) { child.writeNull() }
+            repeat(valueCount - child.valueCount) { child.writeUndefined() }
         }
     }
 

--- a/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
@@ -4,6 +4,7 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -92,4 +93,26 @@ class DenseUnionVectorTest {
             }
         }
     }
+
+
+    @Test
+    fun `from null into duv vector`() {
+        NullVector("v1" ).use { nullVector ->
+            nullVector.writeNull()
+            nullVector.writeNull()
+            nullVector.writeNull()
+
+            DenseUnionVector(allocator, "v2",
+                listOf(LongVector(allocator, "i64", true))).use { copy ->
+                val copier = nullVector.rowCopier(copy)
+                copier.copyRow(0)
+                copier.copyRow(1)
+                copier.copyRow(2)
+
+                assertEquals(3, copy.valueCount)
+                assertNull(copy.getObject(1))
+            }
+        }
+    }
+
 }

--- a/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
@@ -170,4 +170,26 @@ class StructVectorTest {
         }
     }
 
+    @Test
+    fun `from null into struct vector`() {
+        NullVector("v1" ).use { nullVector ->
+            nullVector.writeNull()
+            nullVector.writeNull()
+            nullVector.writeNull()
+
+            StructVector(allocator, "v2", true,
+                linkedMapOf(
+                    "i32" to IntVector(allocator, "i32", false),
+                    "utf8" to Utf8Vector(allocator, "utf8", true)
+                )).use { copy ->
+                val copier = nullVector.rowCopier(copy)
+                copier.copyRow(0)
+                copier.copyRow(1)
+                copier.copyRow(2)
+
+                assertEquals(3, copy.valueCount)
+                assertNull(copy.getObject(1))
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/xtdb/arrow/VariableWidthVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/VariableWidthVectorTest.kt
@@ -3,12 +3,11 @@ package xtdb.arrow
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class FixedWidthVectorTest {
+class VariableWidthVectorTest {
     private lateinit var allocator: BufferAllocator
 
     @BeforeEach
@@ -22,28 +21,13 @@ class FixedWidthVectorTest {
     }
 
     @Test
-    fun testIntVector() {
-        IntVector(allocator,"foo", false).use { vector ->
-            vector.writeInt(42)
-            vector.writeInt(43)
-            vector.writeInt(44)
-
-            assertEquals(3, vector.valueCount)
-
-            assertEquals(42, vector.getInt(0))
-            assertEquals(43, vector.getInt(1))
-            assertEquals(44, vector.getInt(2))
-        }
-    }
-
-    @Test
-    fun `from null into Int vector`() {
+    fun `from null into string vector - 3726`() {
         NullVector("v1" ).use { nullVector ->
             nullVector.writeNull()
             nullVector.writeNull()
             nullVector.writeNull()
 
-            IntVector(allocator, "v2", true).use { copy ->
+            Utf8Vector(allocator, "v2", true).use { copy ->
                 val copier = nullVector.rowCopier(copy)
                 copier.copyRow(0)
                 copier.copyRow(1)
@@ -54,7 +38,4 @@ class FixedWidthVectorTest {
             }
         }
     }
-
-
-
 }


### PR DESCRIPTION
The first fix handles copying from the `NullVector` into various other vectors. 
- This mostly means creating a special copier when the source is a `NullVector` in `VectorReader`.
- It also tries to find a suitable vector to write to (a nullable one) in a DUV.

The second fix is a bit controversial as I am adding `writeNull` to the DUV, which also tries to find a suitable leg to write the null. As in other cases this fails with a `TODO` if no suitable vector is found.

I did not touch auto promotion for DUVs. So whenever the target vector can't hold the `nulls` this still fails. Although I am not sure we should ever need that.  