### PR TITLE
add tx-ingest-benchmark, cut out O(n²) operation in DUV.splitAndTransfer

### DIFF
--- a/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
@@ -1,0 +1,48 @@
+(ns xtdb.bench.ingest-tx-overhead
+  (:require [xtdb.api :as xt]
+            [xtdb.bench :as bench]
+            [xtdb.node :as xtn]))
+
+(defn benchmark [{:keys [seed doc-count], :or {seed 0, doc-count 100000}}]
+  (letfn [(do-ingest [node table ^long per-batch]
+            (doseq [batch (partition-all per-batch (range doc-count))]
+              (xt/submit-tx node
+                            [(into [:put-docs table]
+                                   (map (fn [idx]
+                                          {:xt/id idx}))
+                                   batch)]))
+
+            (let [[{actual :doc-count}] (xt/q node (format "SELECT COUNT(*) doc_count FROM %s" (name table)))]
+              (assert (= actual doc-count)
+                      (format "failed for %s: expected: %d, got: %d" (name table) doc-count actual))))]
+
+    {:title "Ingest batch vs individual"
+     :seed seed
+     :tasks [{:t :call
+              :stage :ingest-batch-1000
+              :f (fn [{node :sut}]
+                   (do-ingest node :batched_1000 1000))}
+
+             {:t :call
+              :stage :ingest-batch-100
+              :f (fn [{node :sut}]
+                   (do-ingest node :batched_100 100))}
+
+             {:t :call
+              :stage :ingest-batch-10
+              :f (fn [{node :sut}]
+                   (do-ingest node :batched_10 10))}
+
+             {:t :call
+              :stage :ingest-batch-1
+              :f (fn [{node :sut}]
+                   (do-ingest node :batched_1 1))}]}))
+
+(comment
+  (let [f (bench/compile-benchmark (benchmark {})
+                                   @(requiring-resolve `xtdb.bench.measurement/wrap-task))]
+    (with-open [node (xtn/start-node {:server {:port 0}})]
+      (f node))
+
+    #_
+    (f dev/node)))


### PR DESCRIPTION
Adds a benchmark that simply ingests 100k simple docs (`{:xt/id n}`) in various batch sizes, and fixes some low-hanging fruit in Arrow's DUV.

Before (my machine):

- batches of 1000: 180ms
- batches of 100: 1092ms
- batches of 10: 3177ms
- individual: 26s

![before profile](https://github.com/user-attachments/assets/4b5253c8-38e0-43d6-b62e-b3b9997f8d36)

After:

- batches of 1000: 117ms
- batches of 100: 333ms
- batches of 10: 954ms
- individual: 6.5s

![after profile](https://github.com/user-attachments/assets/9aafbca5-8d31-4cd0-8713-c33992c9e3a9)

The performance improvement is a fast-path in DUV.splitAndTransfer when the transfer is for the whole vector - we don't need to scan the vector to create the target vector's offset buffer, because it'll be the same as the source vector.

Next up on this particular path would likely be trying to remove the necessity of eager watermarks introduced in #3335 (introduced for correctness, but took a performance hit).

(hopefully goes without saying, users should still try to batch puts wherever possible)
