### PR TITLE
Add manual Trivy scan workflow, updates to sample kubernetes XTDB deployment. 

### DIFF
--- a/.github/trivy/trivy-html-template.tpl
+++ b/.github/trivy/trivy-html-template.tpl
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+{{- if . }}
+    <title>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ now }} </title>
+  </head>
+  <body>
+    <h1>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ now }}</h1>
+    <table>
+    {{- range . }}
+      <tr class="group-header"><th colspan="6">{{ .Type | toString | escapeXML }}</th></tr>
+      {{- if (eq (len .Vulnerabilities) 0) }}
+      <tr><th colspan="6">No Vulnerabilities found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Package</th>
+        <th>Vulnerability ID</th>
+        <th>Severity</th>
+        <th>Installed Version</th>
+        <th>Fixed Version</th>
+        <th>Links</th>
+      </tr>
+        {{- range .Vulnerabilities }}
+      <tr class="severity-{{ escapeXML .Vulnerability.Severity }}">
+        <td class="pkg-name">{{ escapeXML .PkgName }}</td>
+        <td>{{ escapeXML .VulnerabilityID }}</td>
+        <td class="severity">{{ escapeXML .Vulnerability.Severity }}</td>
+        <td class="pkg-version">{{ escapeXML .InstalledVersion }}</td>
+        <td>{{ escapeXML .FixedVersion }}</td>
+        <td class="links" data-more-links="off">
+          {{- range .Vulnerability.References }}
+          <a href={{ escapeXML . | printf "%q" }}>{{ escapeXML . }}</a>
+          {{- end }}
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+      {{- if (eq (len .Misconfigurations ) 0) }}
+      <tr><th colspan="6">No Misconfigurations found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Type</th>
+        <th>Misconf ID</th>
+        <th>Check</th>
+        <th>Severity</th>
+        <th>Message</th>
+      </tr>
+        {{- range .Misconfigurations }}
+      <tr class="severity-{{ escapeXML .Severity }}">
+        <td class="misconf-type">{{ escapeXML .Type }}</td>
+        <td>{{ escapeXML .ID }}</td>
+        <td class="misconf-check">{{ escapeXML .Title }}</td>
+        <td class="severity">{{ escapeXML .Severity }}</td>
+        <td class="link" data-more-links="off"  style="white-space:normal;">
+          {{ escapeXML .Message }}
+          <br>
+            <a href={{ escapeXML .PrimaryURL | printf "%q" }}>{{ escapeXML .PrimaryURL }}</a>
+          </br>
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    </table>
+{{- else }}
+  </head>
+  <body>
+    <h1>Trivy Returned Empty Report</h1>
+{{- end }}
+  </body>
+</html>

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,29 @@
+name: Trivy Security Scan
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3     
+
+      - name: Run Trivy against sample XTDBk8s 
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          scan-ref: ./modules/azure/docs/azure-setup-guide/kubernetes/xtdb.yaml
+          scanners: "vuln,secret,misconfig"
+          format: 'template'
+          output: 'trivy-report.html'
+          template: '@.github/trivy/trivy-html-template.tpl'
+      
+      - name: HTML Trivy Report
+        shell: bash
+        if: always()
+        run: 'cat $TRIVY_OUTPUT >> $GITHUB_STEP_SUMMARY'

--- a/modules/azure/docs/azure-setup-guide/kubernetes/xtdb.yaml
+++ b/modules/azure/docs/azure-setup-guide/kubernetes/xtdb.yaml
@@ -81,6 +81,26 @@ spec:
         # If removed, will have a random suffix that will change on pod restart, which can be seen within logs
         - name: XTDB_NODE_ID
           value: "xtdb-node-$(ORDINAL_NUMBER)"
+          
+        # The following are adjustable based on the exact requirements of the deployment:
+        # startupProbe will wait for a while before checking if the pod is considered "started"
+        # We check that the node is started & "reasonably" caught up on it's indexes before considering it "started"
+        startupProbe:
+            httpGet:
+              path: /healthz/started
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 10 
+        # livenessProbe will check if the node is still alive, and if the indexer hasn't errored out
+        # It will run after the first successful startup probe
+        livenessProbe:
+          httpGet:
+            path: /healthz/alive
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 3
   volumeClaimTemplates:
   - metadata:
       name: xtdb-persistent-storage

--- a/modules/azure/docs/azure-setup-guide/kubernetes/xtdb.yaml
+++ b/modules/azure/docs/azure-setup-guide/kubernetes/xtdb.yaml
@@ -43,16 +43,33 @@ spec:
       # Depending on node pool being used within AKS
       nodeSelector:
         nodepool: "xtdbpool"
+      volumes: 
+      - name: "tmp"
+        emptyDir: {}
       # Waits for the AKS Kafka to be available before starting XTDB
       initContainers:
       - name: wait-for-kafka
-        image: busybox
+        image: busybox:1.37.0
         command: ['sh', '-c', 'until nc -z kafka-service.xtdb-deployment.svc.cluster.local 9092; do echo waiting for kafka; sleep 5; done;']
         resources:
           requests:
             memory: "256Mi"
+            cpu: '100m'
           limits:
             memory: "256Mi"
+            cpu: '100m'
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+
       containers:
       - name: xtdb-container
         # In more production like settings, should be pinned to a specific release
@@ -60,13 +77,17 @@ spec:
         volumeMounts:
         - name: xtdb-persistent-storage
           mountPath: /var/lib/xtdb/buffers
+        - name: "tmp"
+          mountPath: "/tmp"
         # Adjustable, but we would typical recommend XTDB to have 2GiB of Heap Memory, 2GiB of Direct Memory, 500MiB for the metaspace,
         # Alongside extra memory space on the container itself to avoid OoMKilled issues.
         resources:
           requests:
             memory: 6144Mi
+            cpu: '1000m'
           limits:
             memory: 6144Mi
+            cpu: '1000m'
         envFrom:
         - configMapRef:
             name: xtdb-env-config
@@ -81,6 +102,15 @@ spec:
         # If removed, will have a random suffix that will change on pod restart, which can be seen within logs
         - name: XTDB_NODE_ID
           value: "xtdb-node-$(ORDINAL_NUMBER)"
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
           
         # The following are adjustable based on the exact requirements of the deployment:
         # startupProbe will wait for a while before checking if the pod is considered "started"
@@ -101,6 +131,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 3
+
   volumeClaimTemplates:
   - metadata:
       name: xtdb-persistent-storage


### PR DESCRIPTION
Resolves #3953 

Adds:
- A manually triggered trivy scan workflow that checks `xtdb.yaml`.
- Adds in a number of config changes to address various Trivy Misconfigurations/Security Actions.
- Updates sample deployment with `startupProbe` and `livenessProbe` configs.

From the manual trivy workflow (see [**here**](https://github.com/xtdb/xtdb/actions/runs/12300618983)), the following actions remain:
![image](https://github.com/user-attachments/assets/cf791da7-9c92-4bc5-a243-d248851f0f3c)

We would need to add a user/group and the like to the dockerfiles and make changes to how we store things to support running as a nonrootuser, so I've left that out for now.