### PR TITLE
Template friendly SQL - (almost) commas-as-whitespace in SELECT/WHERE

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -588,7 +588,7 @@ outerJoinType : 'LEFT' | 'RIGHT' | 'FULL' ;
 
 /// §7.8 <where clause>
 
-whereClause : 'WHERE' expr ;
+whereClause : 'WHERE' searchCondition ;
 
 /// §7.9 <group by clause>
 
@@ -601,7 +601,7 @@ groupingElement
 
 /// §7.10 <having clause>
 
-havingClause : 'HAVING' expr ;
+havingClause : 'HAVING' searchCondition ;
 
 /// §7.11 <window clause>
 
@@ -747,7 +747,7 @@ quantifier : 'ALL' | 'SOME' | 'ANY' ;
 
 /// §8.21 <search condition>
 
-searchCondition : expr ;
+searchCondition : expr? (',' expr?)* ;
 
 /// postgres access privilege predicates
 

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -636,9 +636,9 @@ windowFrameExclusion : 'EXCLUDE' 'CURRENT' 'ROW' | 'EXCLUDE' 'GROUP' | 'EXCLUDE'
 
 selectClause : 'SELECT' setQuantifier? selectList ;
 selectList
-  : (selectListAsterisk | selectSublist) (',' selectSublist)*
-  | selectSublist (',' selectSublist)* (',' selectListAsterisk)
-  ;
+    : selectListAsterisk (',' selectSublist?)*
+    | selectSublist? (',' selectSublist?)* (',' selectListAsterisk)?
+    ;
 
 selectListAsterisk : ASTERISK excludeClause? renameClause? ;
 

--- a/docs/src/content/docs/reference/main/sql/queries.adoc
+++ b/docs/src/content/docs/reference/main/sql/queries.adoc
@@ -55,10 +55,12 @@ return rr.Diagram(rr.Sequence("WITH", rr.OneOrMore(withClause, ",")))
 ----
 const selectClause = "<select clause>"
 const fromClause = "<from clause>"
-const whereClause = rr.Optional(rr.Sequence("WHERE", "<predicate>"), "skip")
+const predicates = rr.OneOrMore(rr.Optional('<predicate>', 'skip'), ',')
+const whereClause = rr.Optional(rr.Sequence("WHERE", predicates), "skip")
 const groupByClause = rr.Optional(rr.Sequence("GROUP", "BY", rr.OneOrMore("<value>", ",")), "skip")
-const selectFirst = rr.Sequence(selectClause, rr.Optional(fromClause), whereClause, groupByClause)
-const fromFirst = rr.Sequence(fromClause, whereClause, groupByClause, rr.Optional(selectClause, "skip"))
+const havingClause = rr.Optional(rr.Sequence("HAVING", predicates), "skip")
+const selectFirst = rr.Sequence(selectClause, rr.Optional(fromClause), whereClause, groupByClause, havingClause)
+const fromFirst = rr.Sequence(fromClause, whereClause, groupByClause, havingClause, rr.Optional(selectClause, "skip"))
 
 const colNames = rr.Sequence("(", rr.OneOrMore("<column name>", ","), ")")
 const doc = rr.Sequence("(", rr.OneOrMore("<value>", ","), ")")
@@ -75,6 +77,8 @@ NB:
 * `SELECT` is optional in XTDB - if not provided, it defaults to `SELECT *`
 * `SELECT` may be placed after `GROUP BY` in XTDB, so that the query clauses are written in the order that they're executed in practice.
 * `GROUP BY` is optional in XTDB - if not provided, it defaults to all of the columns used outside of an aggregate function.
+* Predicates can be comma-separated in XTDB, to aid with SQL generation - these are treated as conjuncts.
+  There may be an arbitrary number of commas at the start, between any two predicate expressions, or at the end.
 
 === <select clause>
 [railroad]

--- a/docs/src/content/docs/reference/main/sql/queries.adoc
+++ b/docs/src/content/docs/reference/main/sql/queries.adoc
@@ -83,7 +83,10 @@ NB:
 === <select clause>
 [railroad]
 ----
-return rr.Diagram("SELECT", rr.OneOrMore(rr.Choice(0, rr.Skip(), rr.Sequence('*', rr.Optional('<star exclude>', 'skip'), rr.Optional('<star rename>', 'skip')), rr.Sequence("<value>", rr.Optional(rr.Sequence(rr.Optional("AS", "skip"), "<column name>"), 'skip'))), ","))
+const starOpts = rr.Sequence(rr.Optional('<star exclude>', 'skip'), rr.Optional('<star rename>', 'skip'))
+const selectCol = rr.Sequence("<value>", rr.Optional(rr.Sequence(rr.Optional("AS", "skip"), "<column name>"), 'skip'))
+const qualifiedStar = rr.Sequence('<table name>', '.', '*', starOpts)
+return rr.Diagram("SELECT", rr.Stack(rr.Optional(rr.Sequence('*', starOpts), 'skip'), rr.OneOrMore(rr.Choice(0, rr.Skip(), selectCol, qualifiedStar), ",")))
 ----
 
 ==== <star exclude>


### PR DESCRIPTION
RFC: this one's for anyone who's ever had to get the right number of commas or `AND`s when generating a SQL SELECT/WHERE clause respectively :laughing: :raised_hand_with_fingers_splayed: 

* `WHERE` can now take a comma-separated list of predicates, with any number of commas at the start, in between any two predicates, or at the end - these are then treated as conjuncts.
  * e.g. `WHERE a = 1, b = 2`, but also `WHERE , b = 2` or `WHERE a = 1,`
* `SELECT` likewise (although it's already somewhat comma-separated)

Idea is that I don't now have to use a SQL generation tool (risking it not being willing/able to generate the SQL I want) if I have dynamic queries - I can simply use the string templating of my language (JS/Kotlin, or something like YeSQL/HugSQL), and render predicates/projections I don't want to enable as empty strings without worrying about commas or `AND`s.