### PR TITLE
SQL clause pipelining - multiple WHEREs/SELECTs in one query

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -682,11 +682,16 @@ queryExpressionBody
 
 queryTerm
     : selectClause fromClause? whereClause? groupByClause? havingClause? windowClause? # QuerySpecification
-    | fromClause whereClause? (groupByClause? havingClause? selectClause)? windowClause? # QuerySpecification
+    | fromClause queryTail* windowClause? # QuerySpecification
     | tableValueConstructor # ValuesQuery
     | recordsValueConstructor # RecordsQuery
     | '(' queryExpressionNoWith ')' # WrappedQuery
     | queryTerm 'INTERSECT' (ALL | DISTINCT)? queryTerm # IntersectQuery
+    ;
+
+queryTail
+    : whereClause (groupByClause? havingClause? selectClause)?
+    | groupByClause? havingClause? selectClause
     ;
 
 orderByClause : 'ORDER' 'BY' sortSpecificationList ;

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -682,7 +682,7 @@ queryExpressionBody
 
 queryTerm
     : selectClause fromClause? whereClause? groupByClause? havingClause? windowClause? # QuerySpecification
-    | fromClause whereClause? groupByClause? havingClause? selectClause? windowClause? # QuerySpecification
+    | fromClause whereClause? (groupByClause? havingClause? selectClause)? windowClause? # QuerySpecification
     | tableValueConstructor # ValuesQuery
     | recordsValueConstructor # RecordsQuery
     | '(' queryExpressionNoWith ')' # WrappedQuery

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -158,8 +158,10 @@
                                            :star (let [[col-name _star] (first arg)]
                                                    (->star-projection-spec col-name [:struct (update-vals inner-fields types/field->col-type)]))
 
-                                           :rename (let [[to-name from-name] (first arg)]
-                                                     (->rename-projection-spec to-name from-name (get inner-fields from-name)))
+                                           :rename (let [[to-name from-name] (first arg)
+                                                         field (get inner-fields from-name)]
+                                                     (assert field (format "Field %s not found in relation, available %s" from-name (pr-str (keys inner-fields))))
+                                                     (->rename-projection-spec to-name from-name field))
 
                                            :extend (let [[col-name form] (first arg)
                                                          input-types {:col-types (update-vals inner-fields types/field->col-type)

--- a/docs/src/content/docs/reference/main/sql/queries.adoc
+++ b/docs/src/content/docs/reference/main/sql/queries.adoc
@@ -60,7 +60,7 @@ const whereClause = rr.Optional(rr.Sequence("WHERE", predicates), "skip")
 const groupByClause = rr.Optional(rr.Sequence("GROUP", "BY", rr.OneOrMore("<value>", ",")), "skip")
 const havingClause = rr.Optional(rr.Sequence("HAVING", predicates), "skip")
 const selectFirst = rr.Sequence(selectClause, rr.Optional(fromClause), whereClause, groupByClause, havingClause)
-const fromFirst = rr.Sequence(fromClause, whereClause, groupByClause, havingClause, rr.Optional(selectClause, "skip"))
+const fromFirst = rr.Sequence(fromClause, rr.OneOrMore(rr.Sequence(whereClause, rr.Optional(rr.Sequence(groupByClause, havingClause, selectClause), 'skip'))))
 
 const colNames = rr.Sequence("(", rr.OneOrMore("<column name>", ","), ")")
 const doc = rr.Sequence("(", rr.OneOrMore("<value>", ","), ")")
@@ -77,6 +77,7 @@ NB:
 * `SELECT` is optional in XTDB - if not provided, it defaults to `SELECT *`
 * `SELECT` may be placed after `GROUP BY` in XTDB, so that the query clauses are written in the order that they're executed in practice.
 * `GROUP BY` is optional in XTDB - if not provided, it defaults to all of the columns used outside of an aggregate function.
+* If you start your query with `FROM`, you may then include arbitrarily many sets of `WHERE`/`GROUP BY`/`SELECT` clauses, which will be evaluated in order.
 * Predicates can be comma-separated in XTDB, to aid with SQL generation - these are treated as conjuncts.
   There may be an arbitrary number of commas at the start, between any two predicate expressions, or at the end.
 

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -144,8 +144,6 @@
 (defn slurp-sql-query [query-no]
   (slurp (io/resource (str "xtdb/sql/tpch/" (format "q%02d.sql" query-no)))))
 
-;; TODO unable to decorr Q19, select stuck under this top/union exists thing
-
 (def tpch-table-info
   {"public/customer" #{"c_custkey" "c_name" "c_address" "c_nationkey" "c_phone" "c_acctbal" "c_mktsegment" "c_comment"}
    "public/lineitem" #{"l_orderkey" "l_partkey" "l_suppkey" "l_linenumber" "l_quantity" "l_extendedprice" "l_discount" "l_tax" "l_returnflag" "l_linestatus" "l_shipdate" "l_commitdate" "l_receiptdate" "l_shipinstruct" "l_shipmode" "l_comment"}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
@@ -1,5 +1,5 @@
 [:project
- [{_column_1 film.3/_unnest.4} {films si.1/films}]
+ [{films si.1/films} {_column_2 film.3/_unnest.4}]
  [:unnest
   {film.3/_unnest.4 unnest}
   [:map

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
@@ -1,7 +1,7 @@
 [:project
- [{_column_1 film.3/_unnest.4}
-  {_column_2 film.3/_ordinal.5}
-  {films si.1/films}]
+ [{films si.1/films}
+  {_column_2 film.3/_unnest.4}
+  {_column_3 film.3/_ordinal.5}]
  [:unnest
   {film.3/_unnest.4 unnest}
   {:ordinality-column film.3/_ordinal.5}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-1.edn
@@ -1,5 +1,5 @@
 [:project
- [{b1 b.2/b1} {a1 a.1/a1} {a2 a.1/a2}]
+ [{a1 a.1/a1} {a2 a.1/a2} {b1 b.2/b1}]
  [:mega-join
   []
   [[:rename a.1 [:scan {:table public/a} [a2 a1]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -10,7 +10,7 @@
     [:rename
      {bar.2/b b}
      [:project
-      [bar.2/b]
+      [{bar.2/b bar.2/b}]
       [:rename
        bar.2
        [:scan {:table public/bar} [b {c (= c ?_0)}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
@@ -17,7 +17,7 @@
      {_column_2 145}
      {_column_3 7797}
      {_column_4 #xt/date "1998-01-03"}
-     tmp.3/app_start]
+     {tmp.3/app_start tmp.3/app_start}]
     [:rename
      tmp.3
      [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
@@ -1,8 +1,8 @@
 [:project
- [{jame bar.2/jame}
-  {lastjame bar.2/lastjame}
-  {lastname foo.1/lastname}
-  {name foo.1/name}]
+ [{lastname foo.1/lastname}
+  {name foo.1/name}
+  {jame bar.2/jame}
+  {lastjame bar.2/lastjame}]
  [:mega-join
   []
   [[:rename foo.1 [:scan {:table public/foo} [name lastname]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
@@ -1,27 +1,20 @@
-[:project
- [{c_count c_orders.5/c_count} custdist]
- [:order-by
-  [[custdist {:direction :desc, :null-ordering :nulls-first}]
-   [c_orders.5/c_count
-    {:direction :desc, :null-ordering :nulls-first}]]
-  [:project
-   [c_orders.5/c_count {custdist _row_count_6}]
-   [:group-by
-    [c_orders.5/c_count {_row_count_6 (row-count)}]
-    [:rename
-     c_orders.5
-     [:rename
-      {c.1/c_custkey c_custkey, _column_2 c_count}
-      [:project
-       [c.1/c_custkey {_column_2 _count_out_3}]
-       [:group-by
-        [c.1/c_custkey {_count_out_3 (count o.2/o_orderkey)}]
-        [:left-outer-join
-         [{c.1/c_custkey o.2/o_custkey}
-          (not (like o.2/o_comment "%special%requests%"))]
-         [:rename c.1 [:scan {:table public/customer} [c_custkey]]]
-         [:rename
-          o.2
-          [:scan
-           {:table public/orders}
-           [o_custkey o_orderkey o_comment]]]]]]]]]]]]
+[:order-by
+ [[custdist {:direction :desc, :null-ordering :nulls-first}]
+  [c_count {:direction :desc, :null-ordering :nulls-first}]]
+ [:project
+  [c_count {custdist _row_count_4}]
+  [:group-by
+   [c_count {_row_count_4 (row-count)}]
+   [:project
+    [c.1/c_custkey {c_count _count_out_3}]
+    [:group-by
+     [c.1/c_custkey {_count_out_3 (count o.2/o_orderkey)}]
+     [:left-outer-join
+      [{c.1/c_custkey o.2/o_custkey}
+       (not (like o.2/o_comment "%special%requests%"))]
+      [:rename c.1 [:scan {:table public/customer} [c_custkey]]]
+      [:rename
+       o.2
+       [:scan
+        {:table public/orders}
+        [o_custkey o_orderkey o_comment]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/unnest-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/unnest-query-1.edn
@@ -1,5 +1,5 @@
 [:project
- [{film film.3/film} {film_ord film.3/film_ord} {films si.1/films}]
+ [{films si.1/films} {film film.3/film} {film_ord film.3/film_ord}]
  [:unnest
   {film.3/film unnest}
   {:ordinality-column film.3/film_ord}

--- a/src/test/resources/xtdb/sql/tpch/q04.sql
+++ b/src/test/resources/xtdb/sql/tpch/q04.sql
@@ -1,18 +1,12 @@
-SELECT
-  o.o_orderpriority,
-  COUNT(*) AS order_count
-FROM orders AS  o
-WHERE
-  o.o_orderdate >= DATE '1993-07-01'
+SELECT o.o_orderpriority, COUNT(*) AS order_count
+FROM orders AS o
+WHERE o.o_orderdate >= DATE '1993-07-01'
   AND o.o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
-AND EXISTS (
-SELECT *
-FROM lineitem AS l
-WHERE
-l.l_orderkey = o.o_orderkey
-AND l.l_commitdate < l.l_receiptdate
-)
-GROUP BY
-o.o_orderpriority
-ORDER BY
-o.o_orderpriority
+  AND EXISTS (
+    SELECT *
+    FROM lineitem AS l
+    WHERE l.l_orderkey = o.o_orderkey
+      AND l.l_commitdate < l.l_receiptdate
+  )
+GROUP BY o.o_orderpriority
+ORDER BY o.o_orderpriority

--- a/src/test/resources/xtdb/sql/tpch/q13.sql
+++ b/src/test/resources/xtdb/sql/tpch/q13.sql
@@ -1,20 +1,6 @@
-SELECT
-  c_orders.c_count,
-  COUNT(*) AS custdist
-FROM (
-       SELECT
-         c.c_custkey,
-         COUNT(o.o_orderkey)
-       FROM
-         customer AS c
-         LEFT OUTER JOIN orders AS o ON
-                                  c.c_custkey = o.o_custkey
-                                  AND o.o_comment NOT LIKE '%special%requests%'
-       GROUP BY
-         c.c_custkey
-     ) AS c_orders (c_custkey, c_count)
-GROUP BY
-  c_orders.c_count
-ORDER BY
-  custdist DESC,
-  c_orders.c_count DESC
+FROM customer AS c
+  LEFT JOIN orders AS o
+    ON c.c_custkey = o.o_custkey AND o.o_comment NOT LIKE '%special%requests%'
+SELECT c.c_custkey, COUNT(o.o_orderkey) AS c_count
+SELECT c_count, COUNT(*) AS custdist
+ORDER BY custdist DESC, c_count DESC


### PR DESCRIPTION
(based atop #3985, will merge that first)

This PR adds support for creating a pipeline of SQL operators (like in XTQL) - in addition to spec-compliant SQL top-level queries (SELECT, FROM, WHERE, GROUP BY, etc), we also now support:

- FROM/JOIN
- 0..N of ( WHERE? (GROUP BY?, HAVING?, SELECT)? )
- ORDER BY, LIMIT, OFFSET

This reduces the need for subqueries when you want to do operations in a different order to the normal SQL clause order.

e.g.:

```sql
-- double aggregate - the frequency distribution one
FROM foo
SELECT v, COUNT(*) AS v_count
SELECT v_count, COUNT(*) AS freq

-- (before)
SELECT v_count, COUNT(*) AS freq
FROM (SELECT v, COUNT(*) AS v_count
      FROM foo
      GROUP BY v) counts
GROUP BY v_count


-- allowing filtering by the results of window functions (again, requires subqs in standard SQL):
FROM foo
SELECT _id, ROW_NUMBER () OVER (PARTITION BY v ORDER BY _id) row_num
WHERE row_num = 0 -- N.B. WHERE applied after SELECT
SELECT _id
```