### PR TITLE
Text array

### DIFF
--- a/lang/elixr/test/elixr_test.exs
+++ b/lang/elixr/test/elixr_test.exs
@@ -87,6 +87,13 @@ defmodule ElixrTest do
     assert ~D[2020-01-01] == dat
   end
 
+  test "should be able to read a text array", state do
+    pid = state[:xt]
+    result = Postgrex.query!(pid, "SELECT ARRAY['a', 'b', 'c']", [])
+    assert [[["a", "b", "c"]]] == result.rows
+
+  end
+
   # test "should be able to insert a JSON field and read it back", state do
   #   pid = state[:xt]
   #   json_field = %{"foo" => "bar"}

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -395,7 +395,15 @@
               :typnamespace 2125819141,
               :typname "bytea",
               :typowner 1376455703,
-              :oid 17}}
+              :oid 17}
+             {:typtypmod -1,
+              :oid 1009,
+              :typtype "b",
+              :typowner 1376455703,
+              :typnotnull false,
+              :typname "_text",
+              :typnamespace 2125819141,
+              :typbasetype 0}}
            (set (tu/query-ra '[:scan {:table pg_catalog/pg_type}
                                [oid typname typnamespace typowner typtype typbasetype typnotnull typtypmod]]
                              {:node tu/*node*})))))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -275,8 +275,6 @@
      ;; arrays
 
      {:sql "ARRAY []", :clj []}
-     {:sql "ARRAY ['foo']", :clj ["foo"]}
-     {:sql "ARRAY ['2022-01-02']", :clj ["2022-01-02"]}
      {:sql "ARRAY [ARRAY ['42'], 42, '42']", :clj [["42"] 42 "42"]}]))
 
 (deftest json-representation-test
@@ -2105,7 +2103,56 @@ ORDER BY t.oid DESC LIMIT 1"
         (t/is (= [{"arr" "_int8"}] (result-metadata stmt)))
 
         (with-open [rs (.executeQuery stmt)]
-          (t/is (= [{"arr" [1 2 3]}] (rs->maps rs))))))))
+          (t/is (= [{"arr" [1 2 3]}] (rs->maps rs)))))))
+
+  (t/testing "array as parameter"
+    (with-open [conn (jdbc-conn)
+                ps (jdbc/prepare conn ["INSERT INTO docs (_id, nums) VALUES (?, ?)"])]
+      (.setInt ps 1 1)
+      (.setArray ps 2 (.createArrayOf conn "int8" (into-array [1, 2, 3])))
+      (.executeUpdate ps)
+
+      (with-open [stmt (.prepareStatement conn "SELECT _id, nums FROM docs WHERE _id = 1")
+                  rs (.executeQuery stmt)]
+        (t/is (= [{"_id" "int8"}, {"nums" "_int8"}] (result-metadata stmt)))
+        (t/is (= [{"_id" 1, "nums" [1, 2, 3]}] (rs->maps rs)))))))
+
+(deftest test-text-array
+  (t/testing "array as subselect"
+    (with-open [conn (jdbc-conn)]
+      (jdbc/execute! conn ["INSERT INTO docs(_id, name) VALUES (1, 'a')"])
+      (jdbc/execute! conn ["INSERT INTO docs(_id, name) VALUES (2, 'b')"])
+
+      (with-open [stmt (.prepareStatement conn "SELECT ARRAY(SELECT name FROM docs ORDER BY name) AS names")]
+        (with-open [rs (.executeQuery stmt)]
+          (t/is (= [{"names" "_text"}]
+                   (result-metadata stmt)
+                   (result-metadata rs)))
+
+          (t/is (= [{"names" ["a" "b"]}] (rs->maps rs)))))))
+
+  (t/testing "array in select"
+    (with-open [conn (jdbc-conn)]
+      (with-open [stmt (.prepareStatement conn "SELECT ['a', 'b', 'c'] AS arr")]
+
+        (t/is (= [{"arr" "_text"}] (result-metadata stmt)))
+
+        (with-open [rs (.executeQuery stmt)]
+          (t/is (= [{"arr" ["a" "b" "c"]}] (rs->maps rs)))))))
+
+  (t/testing "text array as parameter"
+    (with-open [conn (jdbc-conn)
+                ;; intentionally using different table name to avoid union column type [:union [:utf8 [:list :utf8]]]
+                ;; which would render this to fallback type - JSON
+                ps (jdbc/prepare conn ["INSERT INTO docz (_id, name) VALUES (?, ?)"])]
+      (.setInt ps 1 1)
+      (.setArray ps 2 (.createArrayOf conn "text" (into-array ["aa", "bbb", "cccc"])))
+      (.executeUpdate ps)
+
+      (with-open [stmt (.prepareStatement conn "SELECT _id, name FROM docz WHERE _id = 1")
+                  rs (.executeQuery stmt)]
+        (t/is (= [{"_id" "int4"}, {"name" "_text"}] (result-metadata stmt)))
+        (t/is (= [{"_id" 1, "name" ["aa", "bbb", "cccc"]}] (rs->maps rs)))))))
 
 (deftest test-elixir-client-complex-array
   (with-open [conn (jdbc-conn)]


### PR DESCRIPTION
This PR adds support for flat (single dimension) text arrays - also known as text[] or datatype _text (oid 1009). it supports text and binary formats.
Anything that looks like [:list :utf8] will be treated as text array. A corresponding entry is added to pg_type to reflect this type.
To match postgres behaviour we're using the curly braces around arrays (unlike JSON square brackets).
This started off with matching behaviour of postgres current_schemas function https://github.com/xtdb/xtdb/issues/3432
It also fixes read-binary for integer arrays.