### PR TITLE
Add Implementation-Version and use in xtdb-server-version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,14 @@ allprojects {
             withSourcesJar()
         }
 
+        tasks.jar {
+            manifest {
+                attributes(
+                    "Implementation-Version" to project.version,
+                )
+            }
+        }
+
         if (plugins.hasPlugin("org.jetbrains.dokka"))
             tasks.register<Jar>("dokkaJavadocJar") {
                 dependsOn(tasks.dokkaJavadoc)

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -39,6 +39,8 @@
   ;; TODO this won't work if the user has XT in-process in their own git repo.
   (or (System/getenv "XTDB_VERSION")
 
+      (util/implementation-version)
+
       (when-let [git-sha (System/getenv "GIT_SHA")]
         (subs git-sha 0 7))
 

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -703,3 +703,11 @@
             (reset! last-time now)
             (reset! last-value (apply f args)))
           @last-value)))))
+
+(defn implementation-version []
+  (let [manifest (-> (ClassLoader/getSystemResource "META-INF/MANIFEST.MF")
+                     .openStream
+                     java.util.jar.Manifest.)
+        attributes (.getMainAttributes manifest)]
+    (when attributes
+      (.getValue attributes "Implementation-Version"))))

--- a/docker/aws/build.gradle.kts
+++ b/docker/aws/build.gradle.kts
@@ -20,6 +20,14 @@ application {
     mainClass.set("clojure.main")
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Version" to project.version,
+        )
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("xtdb")
     archiveVersion.set("")

--- a/docker/azure/build.gradle.kts
+++ b/docker/azure/build.gradle.kts
@@ -20,6 +20,14 @@ application {
     mainClass.set("clojure.main")
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Version" to project.version,
+        )
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("xtdb")
     archiveVersion.set("")

--- a/docker/google-cloud/build.gradle.kts
+++ b/docker/google-cloud/build.gradle.kts
@@ -20,6 +20,14 @@ application {
     mainClass.set("clojure.main")
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Version" to project.version,
+        )
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("xtdb")
     archiveVersion.set("")

--- a/docker/standalone/build.gradle.kts
+++ b/docker/standalone/build.gradle.kts
@@ -18,6 +18,14 @@ application {
     mainClass.set("clojure.main")
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Version" to project.version,
+        )
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("xtdb")
     archiveVersion.set("")


### PR DESCRIPTION
This resolves #3695 by putting the version under `Implementation-Version` in the META-INF/MANIFEST.MF of compiled jars, falling back to git or unknown otherwise.

tasks.jar has been added to the docker gradle files explicitly as anything at the root level triggered errors in the build, I haven't found a better approach for this.