### PR TITLE
Defaulting pgwire and flight-sql to an unused port

### DIFF
--- a/.devcontainer/xtdb.yaml
+++ b/.devcontainer/xtdb.yaml
@@ -7,6 +7,9 @@ storage: !Local
 healthz:
   port: 8080
 
+server:
+  port: 5432
+
 modules:
 - !HttpServer
   port: 3000

--- a/cloud-benchmark/aws/aws-config.yaml
+++ b/cloud-benchmark/aws/aws-config.yaml
@@ -1,4 +1,6 @@
-# CONFIG FOR RUNNING WITH AWS INFRA
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/cloud-benchmark/azure/azure-config.yaml
+++ b/cloud-benchmark/azure/azure-config.yaml
@@ -1,8 +1,4 @@
-# Use any available port for PGWire Server.
-server: 
-  port: 0
-
-healthz: 
+healthz:
   port: !Env XTDB_HEALTHZ_PORT
 
 # CONFIG FOR RUNNING WITH AZURE INFRA

--- a/cloud-benchmark/google-cloud/google-cloud-config.yaml
+++ b/cloud-benchmark/google-cloud/google-cloud-config.yaml
@@ -1,4 +1,6 @@
-# CONFIG FOR RUNNING WITH GOOGLE CLOUD INFRA
+server:
+  port: 5432
+
 txLog: !Local
   path: !Env XTDB_GCP_LOCAL_LOG_PATH
 

--- a/cloud-benchmark/local/local-config.yaml
+++ b/cloud-benchmark/local/local-config.yaml
@@ -1,4 +1,6 @@
-# CONFIG FOR LOCAL STORES
+server:
+  port: 5432
+
 txLog: !Local
   path: /var/lib/xtdb/local-log
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1906,12 +1906,12 @@
 
   Options:
 
-  :port (default 5432). Provide '0' to open a socket on an unused port.
+  :port (default 0, opening the socket on an unused port).
   :num-threads (bounds the number of client connections, default 42)
   "
   (^Server [node] (serve node {}))
   (^Server [node {:keys [allocator port num-threads drain-wait ssl-ctx authn]
-                  :or {port 5432
+                  :or {port 0
                        num-threads 42
                        drain-wait 5000}}]
    (util/with-close-on-catch [accept-socket (ServerSocket. port)]
@@ -2001,7 +2001,7 @@
   (^xtdb.pgwire.Server [] (open-playground nil))
 
   (^xtdb.pgwire.Server [opts]
-   (let [{:keys [port] :as srv} (serve nil (merge {:port 0, :authn authn/default-authn}
+   (let [{:keys [port] :as srv} (serve nil (merge {:authn authn/default-authn}
                                                   opts
                                                   {:allocator (RootAllocator.)}))]
      (log/info "Playground started on port:" port)

--- a/core/src/main/kotlin/xtdb/api/ServerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/ServerConfig.kt
@@ -9,7 +9,7 @@ import xtdb.api.IntWithEnvVarSerde
 
 @Serializable
 data class ServerConfig(
-    var port: Int = 5432,
+    var port: Int = 0,
     var numThreads: Int = 42,
     var ssl: SslSettings? = null,
 ) {
@@ -21,18 +21,16 @@ data class ServerConfig(
     )
 
     /**
-     * Port to start the Pgwire server on. Default is 5432.
+     * Port to start the PG wire server on.
      *
-     * Specify '0' to have the server choose an available port.
+     * Default is 0, to have the server choose an available port.
      */
     fun port(port: Int) = apply { this.port = port }
-
-    fun anyAvailablePort() = port(0)
 
     fun numThreads(numThreads: Int) = apply { this.numThreads = numThreads }
 
     /**
-     * Enable SSL for the Pgwire server.
+     * Enable SSL for the PG wire server.
      *
      * @param keyStore path to the keystore file.
      * @param keyStorePassword password for the keystore.

--- a/docker/aws/aws_config.yaml
+++ b/docker/aws/aws_config.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/docker/azure/azure_config.yaml
+++ b/docker/azure/azure_config.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/docker/azure/azure_config_private_auth.yaml
+++ b/docker/azure/azure_config_private_auth.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/docker/google-cloud/google_cloud_config.yaml
+++ b/docker/google-cloud/google_cloud_config.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/docker/standalone/local_config.yaml
+++ b/docker/standalone/local_config.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Local
   path: "/var/lib/xtdb/log"
 

--- a/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
@@ -76,11 +76,11 @@
 (comment
   (let [f (bench/compile-benchmark (benchmark {:batch-sizes #{1000}})
                                    @(requiring-resolve `xtdb.bench.measurement/wrap-task))]
-    (with-open [in-mem (xtn/start-node {:server {:port 0}})
+    (with-open [in-mem (xtn/start-node)
 
                 ^AutoCloseable
                 node (case :xt-memory
-                       :xt-memory (xtn/start-node {:server {:port 0}})
+                       :xt-memory (xtn/start-node)
 
                        :xt-local (let [path (util/->path "/tmp/xt-tx-overhead-bench")]
                                    (util/delete-dir path)

--- a/modules/flight-sql/src/main/kotlin/xtdb/api/FlightSqlServer.kt
+++ b/modules/flight-sql/src/main/kotlin/xtdb/api/FlightSqlServer.kt
@@ -13,7 +13,7 @@ interface FlightSqlServer : XtdbModule {
     @Serializable
     data class Factory(
         var host: String = "127.0.0.1",
-        var port: Int = 9832,
+        var port: Int = 0,
     ) : XtdbModule.Factory {
         override val moduleKey = "xtdb.flight-sql-server"
 

--- a/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/modules/flight-sql/src/test/clojure/xtdb/flight_sql_test.clj
@@ -4,14 +4,14 @@
             [xtdb.flight-sql]
             [xtdb.test-util :as tu]
             [xtdb.types :as types])
-  (:import (org.apache.arrow.adbc.core AdbcConnection AdbcDatabase)
+  (:import (org.apache.arrow.adbc.core AdbcConnection)
            org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver
            (org.apache.arrow.flight CallOption FlightClient FlightEndpoint FlightInfo Location)
            (org.apache.arrow.flight.sql FlightSqlClient)
            (org.apache.arrow.vector VectorSchemaRoot)
            org.apache.arrow.vector.types.pojo.Schema
-           xtdb.arrow.Relation
-           xtdb.api.FlightSqlServer))
+           xtdb.api.FlightSqlServer
+           xtdb.arrow.Relation))
 
 (def ^:private ^:dynamic ^FlightSqlClient *client* nil)
 (def ^:private ^:dynamic *conn* nil)
@@ -20,7 +20,7 @@
 (t/use-fixtures :each
   tu/with-allocator
   (fn [f]
-    (tu/with-opts {:flight-sql-server {:port 0}}
+    (tu/with-opts {:flight-sql-server {}}
       f))
 
   tu/with-node

--- a/monitoring/docker-image/monitoring_config.yaml
+++ b/monitoring/docker-image/monitoring_config.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 5432
+
 txLog: !Kafka
   bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
   txTopic: !Env XTDB_TX_TOPIC

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -44,7 +44,7 @@
            xtdb.api.query.IKeyFn
            xtdb.arrow.Relation
            xtdb.indexer.live_index.ILiveTable
-           (xtdb.query BoundQuery IQuerySource PreparedQuery)
+           (xtdb.query IQuerySource PreparedQuery)
            xtdb.types.ZonedDateTimeRange
            (xtdb.util RefCounter RowCounter TemporalBounds TemporalDimension)
            (xtdb.vector IVectorReader RelationReader)
@@ -65,7 +65,7 @@
                      (.buffer *allocator* 10)
                      (throw (ex-info "boom!" {})))))))
 
-(def ^:dynamic *node-opts* {:server {:port 0}})
+(def ^:dynamic *node-opts* {})
 
 #_{:clj-kondo/ignore [:uninitialized-var]}
 (def ^:dynamic ^xtdb.api.Xtdb *node*)
@@ -320,8 +320,7 @@
                                     :or {compactor? true buffers-dir "objects" healthz-port 8080}}]
   (let [instant-src (or instant-src (->mock-clock))
         healthz-port (if (util/port-free? healthz-port) healthz-port (util/free-port))]
-    (xtn/start-node {:server {:port 0}
-                     :healthz {:port healthz-port}
+    (xtn/start-node {:healthz {:port healthz-port}
                      :log [:local {:path (.resolve node-dir "log"), :instant-src instant-src}]
                      :storage [:local {:path (.resolve node-dir buffers-dir)}]
                      :indexer (->> {:log-limit log-limit, :page-limit page-limit, :rows-per-chunk rows-per-chunk}

--- a/src/test/clojure/xtdb/aws/minio_test.clj
+++ b/src/test/clojure/xtdb/aws/minio_test.clj
@@ -47,7 +47,6 @@
                                            :credentials test-creds
                                            :endpoint "http://127.0.0.1:9000"}]
                        :local-disk-cache (.resolve node-dir "local-cache")}]
-    :server {:port 0}
     :log [:kafka {:tx-topic (str "xtdb.kafka-test.tx-" prefix)
                   :files-topic (str "xtdb.kafka-test.files-" prefix)
                   :bootstrap-servers "localhost:9092"}]}))

--- a/src/test/clojure/xtdb/aws/s3_test.clj
+++ b/src/test/clojure/xtdb/aws/s3_test.clj
@@ -36,8 +36,7 @@
 
 (defn start-kafka-node [local-disk-cache prefix]
   (xtn/start-node
-   {:server {:port 0}
-    :storage [:remote
+   {:storage [:remote
               {:object-store [:s3 {:bucket bucket
                                    :prefix (util/->path (str "xtdb.s3-test." prefix))}]
                :local-disk-cache local-disk-cache}]

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -78,8 +78,7 @@
 
 (defn start-kafka-node [local-disk-cache prefix]
   (xtn/start-node
-   {:server {:port 0}
-    :storage [:remote
+   {:storage [:remote
               {:object-store [:azure {:storage-account storage-account
                                       :container container
                                       :prefix (util/->path (str "xtdb.azure-test." prefix))}]

--- a/src/test/clojure/xtdb/google_cloud_test.clj
+++ b/src/test/clojure/xtdb/google_cloud_test.clj
@@ -64,8 +64,7 @@
 
 (defn start-kafka-node [local-disk-cache prefix]
   (xtn/start-node
-   {:server {:port 0}
-    :storage [:remote
+   {:storage [:remote
               {:object-store [:google-cloud {:project-id project-id
                                              :bucket test-bucket
                                              :prefix (str "xtdb.google-cloud-test." prefix)}]

--- a/src/test/clojure/xtdb/next/jdbc_test.clj
+++ b/src/test/clojure/xtdb/next/jdbc_test.clj
@@ -5,7 +5,7 @@
             [xtdb.node :as xtn]))
 
 (t/deftest uses-xtdb-node-as-jdbc-conn
-  (with-open [node (xtn/start-node {:server {:port 0}})
+  (with-open [node (xtn/start-node)
               conn (jdbc/get-connection node)]
     (jdbc/execute! conn ["INSERT INTO foo RECORDS {_id: 1}"])
     (t/is (= [{:xt/id 1}] (jdbc/execute! conn ["SELECT * FROM foo"]

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -900,8 +900,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
         "scan pred"))
 
 (t/deftest copes-with-log-time-going-backwards-3864
-  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock [#inst "2020" #inst "2019" #inst "2021"])}]
-                                    :server {:port 0}})]
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock [#inst "2020" #inst "2019" #inst "2021"])}]})]
     (t/is (= 0 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 0}]])))
     (t/is (= 1 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 1}]])))
     (t/is (= 2 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 2}]])))


### PR DESCRIPTION
Too many times I've seen `BindException: address already in use`

(Docker images all still default to 5432)