### PR TITLE
Change azure instrumentation key to connection string

### DIFF
--- a/cloud-benchmark/azure/README.adoc
+++ b/cloud-benchmark/azure/README.adoc
@@ -220,11 +220,11 @@ There is a helper script to do _all_ of the above, which can be run by:
 
 === Setup
 
-To monitor the benchmark, we can use Azure Application Insights. We set up an applications insights resource in the terraform configuration, and output an instrumentation key. 
+To monitor the benchmark, we can use Azure Application Insights. We set up an applications insights resource in the terraform configuration, and output a connection string.
 
 === Collecting metrics from node
 
-To see the benchmark metrics you need to supply an application insights instrumentation key via an environment variable in the `single-node-auctionmark.yaml` or `multi-node-auctionmark.yaml` file as below:
+To see the benchmark metrics you need to supply an application insights connection string via an environment variable in the `single-node-auctionmark.yaml` or `multi-node-auctionmark.yaml` file as below:
 
 ```yaml
 apiVersion: "v1"
@@ -232,14 +232,14 @@ kind: "ConfigMap"
 metadata:
   ...
 data:
-  XTDB_AZURE_INSTRUMENTATION_KEY: "<instrumentation-key>"
+  XTDB_AZURE_APP_INSIGHTS_CONNECTION_STRING: "<connection-string>"
   ...
 ```
 
-You can retrieve the instrumentation key from terraform state as follows:
+You can retrieve the connection_string from terraform state as follows:
 
 ```bash
-terraform output -raw insights_instrumentation_key
+terraform output -raw insights_connection_string
 ```
 
 After a while you should be able to see the metrics in the Azure portal under the Application Insights resource, navigating to Monitoring > Metrics and looking under Metric Namespace > Custom.

--- a/cloud-benchmark/azure/azure-config.yaml
+++ b/cloud-benchmark/azure/azure-config.yaml
@@ -22,4 +22,4 @@ storage: !Remote
 
 modules:
   - !AzureMonitor
-    instrumentationKey: !Env XTDB_AZURE_INSTRUMENTATION_KEY
+    connectionString: !Env XTDB_AZURE_APP_INSIGHTS_CONNECTION_STRING

--- a/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
+++ b/cloud-benchmark/azure/kubernetes/multi-node-auctionmark.yaml
@@ -62,7 +62,7 @@ data:
   XTDB_AZURE_STORAGE_CONTAINER: "xtdbazurebenchmarkcontainer"
   XTDB_AZURE_SERVICE_BUS_NAMESPACE: "cloud-benchmark-eventbus"
   XTDB_AZURE_SERVICE_BUS_TOPIC_NAME: "cloud-benchmark-servicebus-topic"
-  XTDB_AZURE_INSTRUMENTATION_KEY: "7859bb2f-b43c-4474-a51c-7357e551b3e5"
+  XTDB_AZURE_APP_INSIGHTS_CONNECTION_STRING: ""
   KAFKA_BOOTSTRAP_SERVERS: "kafka-service.cloud-benchmark.svc.cluster.local:9092"
   XTDB_TX_TOPIC: "xtdb-tx-topic"
   XTDB_FILES_TOPIC: "xtdb-files-topic"

--- a/cloud-benchmark/azure/terraform/main.tf
+++ b/cloud-benchmark/azure/terraform/main.tf
@@ -145,7 +145,7 @@ output "storage_account_container" {
 }
 
 
-output "insights_instrumentation_key" {
+output "insights_connection_string" {
   sensitive = true
-  value = azurerm_application_insights.cloud_benchmark.instrumentation_key
+  value = azurerm_application_insights.cloud_benchmark.connection_string
 }

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -76,10 +76,10 @@ class YamlSerdeTest {
         val azureInput = """
         modules: 
           - !AzureMonitor
-            instrumentationKey: "azure.namespace" 
+            connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;" 
         """.trimIndent()
 
-        assertEquals("azure.namespace", nodeConfig(azureInput).findModule<AzureMonitorMetrics>()?.instrumentationKey)
+        assertEquals("InstrumentationKey=00000000-0000-0000-0000-000000000000;", nodeConfig(azureInput).findModule<AzureMonitorMetrics>()?.connectionString)
     }
 
     @Test

--- a/docs/src/content/docs/ops/azure.adoc
+++ b/docs/src/content/docs/ops/azure.adoc
@@ -197,9 +197,9 @@ To enable Application Insights monitoring, include the following in your node co
 ----
 modules:
   - !AzureMonitor
-    instrumentationKey: !Env XTDB_AZURE_INSTRUMENTATION_KEY
+    connectionString: !Env XTDB_AZURE_APP_INSIGHTS_CONNECTION_STRING
 ----
 
-Providing a valid `instrumentationKey` linked to a pre-existing Application Insights resource is required.
+Providing a valid `connectionString` linked to a pre-existing Application Insights resource is required.
 
 '''

--- a/modules/azure/src/main/clojure/xtdb/azure/monitor.clj
+++ b/modules/azure/src/main/clojure/xtdb/azure/monitor.clj
@@ -3,6 +3,5 @@
   (:import (xtdb.api Xtdb$Config)
            (xtdb.azure AzureMonitorMetrics)))
 
-(defmethod xtn/apply-config! ::metrics [^Xtdb$Config config _ {:keys [instrumentation-key]
-                                                               :or {instrumentation-key "xtdb.metrics"}}]
-  (.module config (AzureMonitorMetrics. instrumentation-key)))
+(defmethod xtn/apply-config! ::metrics [^Xtdb$Config config _ {:keys [connection-string]}]
+  (.module config (AzureMonitorMetrics. connection-string)))

--- a/modules/azure/src/main/kotlin/xtdb/azure/AzureMonitorMetrics.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/AzureMonitorMetrics.kt
@@ -12,7 +12,7 @@ import xtdb.api.Xtdb
 @Serializable
 @SerialName("!AzureMonitor")
 class AzureMonitorMetrics(
-    @Serializable(StringWithEnvVarSerde::class) val instrumentationKey: String = "xtdb.metrics",
+    @Serializable(StringWithEnvVarSerde::class) val connectionString: String,
 ) : XtdbModule.Factory {
 
     override val moduleKey = "xtdb.metrics.azure-monitor"
@@ -21,7 +21,7 @@ class AzureMonitorMetrics(
         val reg = AzureMonitorMeterRegistry(
             object : AzureMonitorConfig {
                 override fun get(key: String) = null
-                override fun instrumentationKey() = instrumentationKey
+                override fun connectionString() = connectionString
             },
             Clock.SYSTEM
         )


### PR DESCRIPTION
This resolves a deprecation notice on our azure metrics impl #3837, and looks like the right way ™ to do it with connection string.

Tested on the azure benchmark.

Closes #3837 