### PR TITLE
Plan `SELECT` subqueries before group-by

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -2166,6 +2166,8 @@
              plan]
             plan)
 
+          (-> plan (apply-sqs (:subqs select-plan)))
+
           (cond-> plan
             grouped-table? (wrap-aggs aggs group-invariant-cols))
 
@@ -2174,8 +2176,6 @@
                 (apply-sqs subqs)
                 (wrap-predicates predicate))
             plan)
-
-          (-> plan (apply-sqs (:subqs select-plan)))
 
           (cond-> plan
             windows (wrap-windows windows))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2586,3 +2586,18 @@ UNION ALL
                             SELECT _id
                             ORDER BY _id"))
         "we can filter on window functions"))
+
+(t/deftest plan-subqueries-before-group-by-3821
+  (xt/submit-tx tu/*node* [[:put-docs :docs
+                            {:xt/id 1 :name "alan" :sysadmin true}
+                            {:xt/id 2 :name "ada" :sysadmin true}
+                            {:xt/id 3 :name "claude" :sysadmin false}]])
+
+  (t/is (= 3 (-> (xt/q tu/*node* "SELECT COUNT((SELECT 1)) v FROM docs") first :v )))
+
+  (t/is (= 2 (-> (xt/q tu/*node* "SELECT COUNT(CASE WHEN _id IN (1, 2) THEN _id END) v FROM docs") first :v)))
+
+  (t/is (= [{:sysadmin true, :xt/column-2 ["ada" "alan"]}
+            {:sysadmin false, :xt/column-2 ["claude"]}]
+
+           (xt/q tu/*node* "SELECT sysadmin, ARRAY_AGG(name) FROM docs GROUP BY sysadmin"))))


### PR DESCRIPTION
Maybe we are wrong, but @mbutlerw and me couldn't think of an example where the select subqueries need to run after the group by.