### PR TITLE
Plan temporal period columns on base table directly

### DIFF
--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -656,7 +656,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
   people.1
   [:scan
    {:table public/people}
-   [age name _valid_from _valid_to {_id (= _id ?_0)}]]]]
+   [_valid_from {_id (= _id ?_0)} age name _valid_to]]]]
 "}]
            (xt/q tu/*node*
                  "SELECT name, age, _valid_from, _valid_to FROM people WHERE _id = ?"

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -552,7 +552,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
  [{_id u.1/_id} {foo u.1/foo}]
  [:rename
   u.1
-  [:select (= (+ a b) 12) [:scan {:table public/users} [b foo a _id]]]]]
+  [:select (= (+ a b) 12) [:scan {:table public/users} [a _id foo b]]]]]
 ")}]
            (-> (xt/q tu/*node*
                      "SELECT u._id, u.foo FROM users u WHERE u.a + u.b = 12"

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
@@ -9,4 +9,4 @@
     ms.2
     [:scan
      {:table public/movie_star}
-     [name {birthdate (= birthdate 1960)}]]]]]]
+     [{birthdate (= birthdate 1960)} name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
@@ -9,4 +9,4 @@
     ms.2
     [:scan
      {:table public/movie_star}
-     [name {birthdate (and (< birthdate 1960) (> birthdate 1950))}]]]]]]
+     [{birthdate (and (< birthdate 1960) (> birthdate 1950))} name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
@@ -9,4 +9,4 @@
     ms.2
     [:scan
      {:table public/movie_star}
-     [{name (= name "Foo")} {birthdate (< birthdate 1960)}]]]]]]
+     [{birthdate (< birthdate 1960)} {name (= name "Foo")}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-32.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-32.edn
@@ -1,9 +1,7 @@
 [:project
- [{_column_1 xt.values.1/_column_1}
-  {_column_2 xt.values.1/_column_2}]
+ [{_column_1 xt.values.1/_column_1} {_column_2 xt.values.1/_column_2}]
  [:rename
   xt.values.1
   [:table
    [_column_1 _column_2]
-   [{:_column_1 1, :_column_2 2}
-    {:_column_1 3, :_column_2 4}]]]]
+   [{:_column_1 1, :_column_2 2} {:_column_1 3, :_column_2 4}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
@@ -22,4 +22,4 @@
     (+ t1.1/e 1)
     444
     555)}]
- [:rename t1.1 [:scan {:table public/t1} [e d b c a]]]]
+ [:rename t1.1 [:scan {:table public/t1} [a e c b d]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
@@ -1,3 +1,3 @@
 [:project
  [{_column_1 (nullif t1.1/a t1.1/b)}]
- [:rename t1.1 [:scan {:table public/t1} [b a]]]]
+ [:rename t1.1 [:scan {:table public/t1} [a b]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
@@ -13,4 +13,4 @@
       ms.2
       [:scan
        {:table public/movie_star}
-       [name {birthdate (= birthdate 1960)}]]]]]]]]
+       [{birthdate (= birthdate 1960)} name]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
@@ -2,5 +2,5 @@
  [{movie_title si.2/movie_title}]
  [:mega-join
   [{m.1/title si.2/movie_title} {m.1/movie_year si.2/year}]
-  [[:rename m.1 [:scan {:table public/movie} [title movie_year]]]
+  [[:rename m.1 [:scan {:table public/movie} [movie_year title]]]
    [:rename si.2 [:scan {:table public/stars_in} [year movie_title]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
@@ -2,5 +2,5 @@
  [{movie_title si.2/movie_title}]
  [:left-outer-join
   [{m.1/title si.2/movie_title} {m.1/movie_year si.2/year}]
-  [:rename m.1 [:scan {:table public/movie} [title movie_year]]]
+  [:rename m.1 [:scan {:table public/movie} [movie_year title]]]
   [:rename si.2 [:scan {:table public/stars_in} [year movie_title]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
@@ -11,4 +11,4 @@
     [[:rename me.1 [:scan {:table public/movie_exec} [name cert]]]
      [:rename
       m.2
-      [:scan {:table public/movie} [producer length year]]]]]]]]
+      [:scan {:table public/movie} [producer year length]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
@@ -8,7 +8,7 @@
     customers.1
     [:scan
      {:table public/customers}
-     [custno {country (= country "Mexico")}]]]
+     [{country (= country "Mexico")} custno]]]
    [:project
     [{custno orders.3/custno}]
     [:rename orders.3 [:scan {:table public/orders} [custno]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
@@ -3,9 +3,9 @@
  [:map
   [{_sq_4 _row_count_7}]
   [:group-by
-   [customers.1/name
+   [customers.1/country
     customers.1/custno
-    customers.1/country
+    customers.1/name
     _sq_2
     _row_number_0
     {_row_count_7 (count _dep_countable_1)}]
@@ -19,7 +19,7 @@
        [{customers.1/country country}]
        [:rename
         customers.1
-        [:scan {:table public/customers} [name custno country]]]
+        [:scan {:table public/customers} [country custno name]]]
        [:project
         [{country salesp.3/country}]
         [:rename salesp.3 [:scan {:table public/salesp} [country]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
@@ -8,8 +8,8 @@
     [s.1/name
      s.1/id
      e.2/sid
-     e.2/course
      e.2/grade
+     e.2/course
      _row_number_0
      {_min_out_6 (min e2.4/grade)}]
     [:left-outer-join
@@ -21,5 +21,5 @@
        [[:rename s.1 [:scan {:table public/students} [name id]]]
         [:rename
          e.2
-         [:scan {:table public/exams} [sid course grade]]]]]]
+         [:scan {:table public/exams} [sid grade course]]]]]]
      [:rename e2.4 [:scan {:table public/exams} [sid grade]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
@@ -6,12 +6,12 @@
    [{_sq_3 (+ _avg_out_8 1)}]
    [:group-by
     [s.1/name
-     s.1/major
      s.1/year
+     s.1/major
      s.1/id
      e.2/sid
-     e.2/course
      e.2/grade
+     e.2/course
      _row_number_0
      {_avg_out_8 (avg e2.4/grade)}]
     [:left-outer-join
@@ -27,12 +27,12 @@
          [:scan
           {:table public/students}
           [name
-           {major (or (= major "CS") (= major "Games Eng"))}
            year
+           {major (or (= major "CS") (= major "Games Eng"))}
            id]]]
         [:rename
          e.2
-         [:scan {:table public/exams} [sid course grade]]]]]]
+         [:scan {:table public/exams} [sid grade course]]]]]]
      [:rename
       e2.4
-      [:scan {:table public/exams} [sid grade date curriculum]]]]]]]]
+      [:scan {:table public/exams} [sid date curriculum grade]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/limit-parens.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/limit-parens.edn
@@ -3,9 +3,9 @@
   {:skip nil, :limit 1}
   [:project
    [{_id bar.1/_id} {foo bar.1/foo}]
-   [:rename bar.1 [:scan {:table public/bar} [foo _id]]]]]
+   [:rename bar.1 [:scan {:table public/bar} [_id foo]]]]]
  [:top
   {:skip nil, :limit 1}
   [:project
    [{_id baz.2/_id} {foo baz.2/foo}]
-   [:rename baz.2 [:scan {:table public/baz} [foo _id]]]]]]
+   [:rename baz.2 [:scan {:table public/baz} [_id foo]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
@@ -8,7 +8,7 @@
     [{f.1/b xt.values.5/_column_1}]
     [:semi-join
      [{f.1/a xt.values.3/_column_1}]
-     [:rename f.1 [:scan {:table public/foo} [b {a (= a 42)}]]]
+     [:rename f.1 [:scan {:table public/foo} [{a (= a 42)} b]]]
      [:rename
       xt.values.3
       [:table [_column_1] [{:_column_1 1} {:_column_1 2}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
@@ -5,21 +5,25 @@
   {_system_to foo.1/_system_to}]
  [:rename
   foo.1
-  [:scan
-   {:table public/foo,
-    :for-system-time
-    [:in #xt/date "2001-01-01" #xt/date "2002-01-01"]}
-   [{_valid_from
-     (and
-      (<
-       _valid_from
-       (coalesce #xt/date "2004-01-01" xtdb/end-of-time))
-      (= _valid_from 4))}
-    {_system_from (= _system_from 20)}
-    {_valid_to
-     (and
-      (>
-       (coalesce _valid_to xtdb/end-of-time)
-       #xt/date "2000-01-01")
-      (> _valid_to 10))}
-    {_system_to (<= _system_to 23)}]]]]
+  [:project
+   [_valid_from
+    _system_from
+    _system_to
+    _valid_to
+    _valid_from
+    _valid_to
+    {_valid_time (period _valid_from _valid_to)}]
+   [:select
+    (overlaps?
+     (period _valid_from _valid_to)
+     (period #xt/date "2000-01-01" #xt/date "2004-01-01"))
+    [:scan
+     {:table public/foo,
+      :for-system-time
+      [:in #xt/date "2001-01-01" #xt/date "2002-01-01"]}
+     [{_valid_from (= _valid_from 4)}
+      {_system_from (= _system_from 20)}
+      {_system_to (<= _system_to 23)}
+      {_valid_to (> _valid_to 10)}
+      {_valid_from (= _valid_from 4)}
+      {_valid_to (> _valid_to 10)}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-1.edn
@@ -2,5 +2,5 @@
  [{title si.2/title} {length m.1/length} {films si.2/films}]
  [:mega-join
   [{m.1/title si.2/title}]
-  [[:rename m.1 [:scan {:table public/movie} [length title]]]
+  [[:rename m.1 [:scan {:table public/movie} [title length]]]
    [:rename si.2 [:scan {:table public/stars_in} [title films]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-2.edn
@@ -3,4 +3,4 @@
  [:left-outer-join
   [{si.2/title m.1/title}]
   [:rename si.2 [:scan {:table public/stars_in} [title films]]]
-  [:rename m.1 [:scan {:table public/movie} [length title]]]]]
+  [:rename m.1 [:scan {:table public/movie} [title length]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
@@ -4,7 +4,7 @@
   (or _sq_2 (= f.1/b 42))
   [:mark-join
    {_sq_2 [{f.1/a xt.values.3/_column_1}]}
-   [:rename f.1 [:scan {:table public/foo} [b a]]]
+   [:rename f.1 [:scan {:table public/foo} [a b]]]
    [:rename
     xt.values.3
     [:table [_column_1] [{:_column_1 1} {:_column_1 2}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -8,9 +8,9 @@
     [:apply
      :single-join
      {bar.2/b ?_sq_b_4}
-     [:rename bar.2 [:scan {:table public/bar} [b c]]]
+     [:rename bar.2 [:scan {:table public/bar} [c b]]]
      [:project
       [{_sq_3 foo.4/b}]
       [:rename
        foo.4
-       [:scan {:table public/foo} [b {a (= a ?_sq_b_4)}]]]]]]]]]
+       [:scan {:table public/foo} [{a (= a ?_sq_b_4)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -8,9 +8,9 @@
     [:apply
      {:mark-join {_sq_3 (= ?_needle b)}}
      {bar.2/b ?_sq_b_4, bar.2/c ?_needle}
-     [:rename bar.2 [:scan {:table public/bar} [b c]]]
+     [:rename bar.2 [:scan {:table public/bar} [c b]]]
      [:project
       [{b foo.4/b}]
       [:rename
        foo.4
-       [:scan {:table public/foo} [b {a (= a ?_sq_b_4)}]]]]]]]]]
+       [:scan {:table public/foo} [{a (= a ?_sq_b_4)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
@@ -6,8 +6,7 @@
   [:rename
    x.1
    [:scan
-    {:table public/x,
-     :for-system-time [:at #xt/date "3001-01-01"]}
+    {:table public/x, :for-system-time [:at #xt/date "3001-01-01"]}
     [y]]]
   [:rename
    y.4

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-2.edn
@@ -1,3 +1,3 @@
 [:project
  [{dyn_idx (nth u.1/b (- (nth u.1/a 0) 1))}]
- [:rename u.1 [:scan {:table public/u} [b a]]]]
+ [:rename u.1 [:scan {:table public/u} [a b]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -3,7 +3,7 @@
  [:apply
   :single-join
   {a.1/b ?_sq_b_3}
-  [:rename a.1 [:scan {:table public/a} [b {a (= a 42)}]]]
+  [:rename a.1 [:scan {:table public/a} [{a (= a 42)} b]]]
   [:group-by
    [{_sq_2 (vec_agg b1)}]
    [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
@@ -1,10 +1,14 @@
 [:project
- [{_column_1
-   (and
-    (< f.1/_valid_from (coalesce f.1/_system_to xtdb/end-of-time))
-    (> (coalesce f.1/_valid_to xtdb/end-of-time) f.1/_system_from))}]
+ [{_column_1 (overlaps? f.1/_valid_time f.1/_system_time)}]
  [:rename
   f.1
-  [:scan
-   {:table public/foo}
-   [_valid_from _system_from _valid_to _system_to]]]]
+  [:project
+   [_valid_from
+    _valid_to
+    _system_from
+    _system_to
+    {_valid_time (period _valid_from _valid_to)}
+    {_system_time (period _system_from _system_to)}]
+   [:scan
+    {:table public/foo}
+    [_valid_from _valid_to _system_from _system_to]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
@@ -2,4 +2,4 @@
  [{a foo.1/a}]
  [:rename
   foo.1
-  [:scan {:table public/foo} [{b (= b ?_0)} {c (= c ?_1)} a]]]]
+  [:scan {:table public/foo} [a {c (= c ?_1)} {b (= b ?_0)}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -4,7 +4,7 @@
   []
   [[:rename
     foo.1
-    [:scan {:table public/foo} [{b (= b ?_1)} {c (= c ?_2)} a]]]
+    [:scan {:table public/foo} [a {c (= c ?_2)} {b (= b ?_1)}]]]
    [:rename
     bar.3
     [:rename
@@ -13,4 +13,4 @@
       [{bar.2/b bar.2/b}]
       [:rename
        bar.2
-       [:scan {:table public/bar} [b {c (= c ?_0)}]]]]]]]]]
+       [:scan {:table public/bar} [{c (= c ?_0)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
@@ -3,7 +3,7 @@
  [:apply
   :single-join
   {c.1/_id ?_sq__id_3}
-  [:rename c.1 [:scan {:table public/customers} [name _id]]]
+  [:rename c.1 [:scan {:table public/customers} [_id name]]]
   [:group-by
    [{_sq_2 (array_agg _sq_2)}]
    [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
@@ -12,4 +12,4 @@
      c.3
      [:scan
       {:table public/customers}
-      [name {_id (= _id ?_sq_customer_id_3)}]]]]]]]
+      [{_id (= _id ?_sq_customer_id_3)} name]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
@@ -16,13 +16,13 @@
         [:table [_column_1] [{:_column_1 792} {:_column_1 14}]]]]
       [:semi-join
        [{t1.1/b1 xt.values.5/_column_1}]
-       [:rename t1.1 [:scan {:table public/t1} [b1 a1]]]
+       [:rename t1.1 [:scan {:table public/t1} [a1 b1]]]
        [:rename
         xt.values.5
         [:table [_column_1] [{:_column_1 532} {:_column_1 593}]]]]
       [:semi-join
        [{t2.2/b1 xt.values.7/_column_1}]
-       [:rename t2.2 [:scan {:table public/t2} [b1 a2]]]
+       [:rename t2.2 [:scan {:table public/t2} [a2 b1]]]
        [:rename
         xt.values.7
         [:table [_column_1] [{:_column_1 808} {:_column_1 662}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
@@ -4,4 +4,4 @@
   bar.2
   [:project
    [{a foo.1/a} {b foo.1/b}]
-   [:rename foo.1 [:scan {:table public/foo} [b a]]]]]]
+   [:rename foo.1 [:scan {:table public/foo} [a b]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
@@ -4,7 +4,7 @@
   []
   [:mega-join
    []
-   [[:rename foo.1 [:scan {:table public/foo} [name lastname]]]
+   [[:rename foo.1 [:scan {:table public/foo} [lastname name]]]
     [:rename bar.2 [:scan {:table public/bar} []]]]]
   [:project
    [{_sq_3 baz.4/frame}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
@@ -5,5 +5,5 @@
   {lastjame bar.2/lastjame}]
  [:mega-join
   []
-  [[:rename foo.1 [:scan {:table public/foo} [name lastname]]]
+  [[:rename foo.1 [:scan {:table public/foo} [lastname name]]]
    [:rename bar.2 [:scan {:table public/bar} [lastjame jame]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
@@ -2,5 +2,5 @@
  [{lastname foo.1/lastname} {name foo.1/name} {jame bar.2/jame}]
  [:mega-join
   []
-  [[:rename foo.1 [:scan {:table public/foo} [name lastname]]]
+  [[:rename foo.1 [:scan {:table public/foo} [lastname name]]]
    [:rename bar.2 [:scan {:table public/bar} [jame]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -4,15 +4,10 @@
   ({_iid foo.1/_iid}
    {_valid_from foo.1/_valid_from}
    {_valid_to foo.1/_valid_to}
-   {bar
-    (and
-     (< foo.1/_system_from (coalesce foo.1/_valid_to xtdb/end-of-time))
-     (>
-      (coalesce foo.1/_system_to xtdb/end-of-time)
-      foo.1/_valid_from))}
+   {bar (overlaps? foo.1/_system_time foo.1/_valid_time)}
    {baz foo.1/baz})
   [:rename
    foo.1
    [:scan
     {:table public/foo, :for-valid-time :all-time}
-    [_system_from _valid_to baz _valid_from _system_to _iid]]]]]
+    [_valid_to baz _system_time _valid_from _valid_time _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
@@ -1,11 +1,20 @@
 [:project
  [{foo_name foo.1/name} {bar_name bar.2/name}]
  [:mega-join
-  [(< foo.1/_system_from (coalesce bar.2/_system_to xtdb/end-of-time))
-   (> (coalesce foo.1/_system_to xtdb/end-of-time) bar.2/_system_from)]
+  [(overlaps? foo.1/_system_time bar.2/_system_time)]
   [[:rename
     foo.1
-    [:scan {:table public/foo} [name _system_from _system_to]]]
+    [:project
+     [name
+      _system_from
+      _system_to
+      {_system_time (period _system_from _system_to)}]
+     [:scan {:table public/foo} [name _system_from _system_to]]]]
    [:rename
     bar.2
-    [:scan {:table public/bar} [name _system_from _system_to]]]]]]
+    [:project
+     [name
+      _system_from
+      _system_to
+      {_system_time (period _system_from _system_to)}]
+     [:scan {:table public/bar} [name _system_from _system_to]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
@@ -2,18 +2,20 @@
  [{_column_1 _sq_2}]
  [:apply
   :single-join
-  {bar.1/_valid_from ?_sq__valid_from_3,
-   bar.1/_valid_to ?_sq__valid_to_4}
-  [:rename bar.1 [:scan {:table public/bar} [_valid_from _valid_to]]]
+  {bar.1/_valid_time ?_sq__valid_time_3}
+  [:rename
+   bar.1
+   [:project
+    [_valid_from
+     _valid_to
+     {_valid_time (period _valid_from _valid_to)}]
+    [:scan {:table public/bar} [_valid_from _valid_to]]]]
   [:project
-   [{_sq_2
-     (and
-      (<
-       foo.3/_valid_from
-       (coalesce ?_sq__valid_to_4 xtdb/end-of-time))
-      (>
-       (coalesce foo.3/_valid_to xtdb/end-of-time)
-       ?_sq__valid_from_3))}]
+   [{_sq_2 (overlaps? foo.3/_valid_time ?_sq__valid_time_3)}]
    [:rename
     foo.3
-    [:scan {:table public/foo} [_valid_from _valid_to]]]]]]
+    [:project
+     [_valid_from
+      _valid_to
+      {_valid_time (period _valid_from _valid_to)}]
+     [:scan {:table public/foo} [_valid_from _valid_to]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
@@ -2,19 +2,23 @@
  [{_column_1 _sq_2}]
  [:apply
   :single-join
-  {bar.1/_valid_from ?_sq__valid_from_3,
-   bar.1/_valid_to ?_sq__valid_to_4}
-  [:rename bar.1 [:scan {:table public/bar} [_valid_from _valid_to]]]
+  {bar.1/_valid_time ?_sq__valid_time_3}
+  [:rename
+   bar.1
+   [:project
+    [_valid_from
+     _valid_to
+     {_valid_time (period _valid_from _valid_to)}]
+    [:scan {:table public/bar} [_valid_from _valid_to]]]]
   [:project
    [{_sq_2 foo.3/name}]
    [:rename
     foo.3
-    [:scan
-     {:table public/foo}
+    [:project
      [name
-      {_valid_from
-       (< _valid_from (coalesce ?_sq__valid_to_4 xtdb/end-of-time))}
-      {_valid_to
-       (>
-        (coalesce _valid_to xtdb/end-of-time)
-        ?_sq__valid_from_3)}]]]]]]
+      _valid_from
+      _valid_to
+      {_valid_time (period _valid_from _valid_to)}]
+     [:select
+      (overlaps? (period _valid_from _valid_to) ?_sq__valid_time_3)
+      [:scan {:table public/foo} [name _valid_from _valid_to]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
@@ -44,15 +44,15 @@
       l.1
       [:scan
        {:table public/lineitem}
-       [{l_shipdate
+       [l_linestatus
+        l_tax
+        {l_shipdate
          (<=
           l_shipdate
           (-
            #xt/date "1998-12-01"
            (single-field-interval "90" "DAY" 2 6)))}
-        l_discount
-        l_quantity
         l_returnflag
         l_extendedprice
-        l_linestatus
-        l_tax]]]]]]]]
+        l_quantity
+        l_discount]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -28,25 +28,25 @@
      [:select
       (= ps.3/ps_supplycost _min_out_12)
       [:group-by
-       [p.1/p_partkey
-        p.1/p_type
-        p.1/p_size
+       [p.1/p_size
+        p.1/p_partkey
         p.1/p_mfgr
-        s.2/s_name
-        s.2/s_acctbal
-        s.2/s_address
-        s.2/s_nationkey
-        s.2/s_phone
+        p.1/p_type
         s.2/s_comment
+        s.2/s_name
+        s.2/s_address
+        s.2/s_phone
+        s.2/s_acctbal
         s.2/s_suppkey
+        s.2/s_nationkey
         ps.3/ps_partkey
-        ps.3/ps_suppkey
         ps.3/ps_supplycost
-        n.4/n_nationkey
+        ps.3/ps_suppkey
         n.4/n_name
         n.4/n_regionkey
-        r.5/r_name
+        n.4/n_nationkey
         r.5/r_regionkey
+        r.5/r_name
         _row_number_0
         {_min_out_12 (min ps.7/ps_supplycost)}]
        [:left-outer-join
@@ -62,36 +62,36 @@
             r.5
             [:scan
              {:table public/region}
-             [{r_name (= r_name "EUROPE")} r_regionkey]]]
+             [r_regionkey {r_name (= r_name "EUROPE")}]]]
            [:rename
             n.4
             [:scan
              {:table public/nation}
-             [n_nationkey n_name n_regionkey]]]
+             [n_name n_regionkey n_nationkey]]]
            [:rename
             ps.3
             [:scan
              {:table public/partsupp}
-             [ps_partkey ps_suppkey ps_supplycost]]]
+             [ps_partkey ps_supplycost ps_suppkey]]]
            [:rename
             p.1
             [:scan
              {:table public/part}
-             [p_partkey
-              {p_type (like p_type "%BRASS")}
-              {p_size (= p_size 15)}
-              p_mfgr]]]
+             [{p_size (= p_size 15)}
+              p_partkey
+              p_mfgr
+              {p_type (like p_type "%BRASS")}]]]
            [:rename
             s.2
             [:scan
              {:table public/supplier}
-             [s_name
-              s_acctbal
+             [s_comment
+              s_name
               s_address
-              s_nationkey
               s_phone
-              s_comment
-              s_suppkey]]]]]]
+              s_acctbal
+              s_suppkey
+              s_nationkey]]]]]]
         [:mega-join
          [{n.9/n_regionkey r.10/r_regionkey}
           {s.8/s_nationkey n.9/n_nationkey}
@@ -100,17 +100,17 @@
            r.10
            [:scan
             {:table public/region}
-            [{r_name (= r_name "EUROPE")} r_regionkey]]]
+            [r_regionkey {r_name (= r_name "EUROPE")}]]]
           [:rename
            n.9
-           [:scan {:table public/nation} [n_nationkey n_regionkey]]]
+           [:scan {:table public/nation} [n_regionkey n_nationkey]]]
           [:rename
            ps.7
            [:scan
             {:table public/partsupp}
-            [ps_partkey ps_suppkey ps_supplycost]]]
+            [ps_partkey ps_supplycost ps_suppkey]]]
           [:rename
            s.8
            [:scan
             {:table public/supplier}
-            [s_nationkey s_suppkey]]]]]]]]]]]]]
+            [s_suppkey s_nationkey]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
@@ -26,20 +26,20 @@
          l.3
          [:scan
           {:table public/lineitem}
-          [{l_shipdate (> l_shipdate #xt/date "1995-03-15")}
-           l_discount
-           l_orderkey
-           l_extendedprice]]]
+          [l_orderkey
+           {l_shipdate (> l_shipdate #xt/date "1995-03-15")}
+           l_extendedprice
+           l_discount]]]
         [:rename
          c.1
          [:scan
           {:table public/customer}
-          [{c_mktsegment (= c_mktsegment "BUILDING")} c_custkey]]]
+          [c_custkey {c_mktsegment (= c_mktsegment "BUILDING")}]]]
         [:rename
          o.2
          [:scan
           {:table public/orders}
-          [o_custkey
+          [{o_orderdate (< o_orderdate #xt/date "1995-03-15")}
+           o_orderkey
            o_shippriority
-           {o_orderdate (< o_orderdate #xt/date "1995-03-15")}
-           o_orderkey]]]]]]]]]]]
+           o_custkey]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
@@ -14,7 +14,8 @@
        o.1
        [:scan
         {:table public/orders}
-        [{o_orderdate
+        [o_orderpriority
+         {o_orderdate
           (and
            (<
             o_orderdate
@@ -22,8 +23,7 @@
              #xt/date "1993-07-01"
              (single-field-interval "3" "MONTH" 2 6)))
            (>= o_orderdate #xt/date "1993-07-01"))}
-         o_orderkey
-         o_orderpriority]]]
+         o_orderkey]]]
       [:project
        [{l_comment l.3/l_comment}
         {l_commitdate l.3/l_commitdate}
@@ -47,19 +47,19 @@
          (< l_commitdate l_receiptdate)
          [:scan
           {:table public/lineitem}
-          [l_partkey
-           l_shipinstruct
-           l_discount
+          [l_linestatus
            l_receiptdate
-           l_orderkey
-           l_returnflag
            l_commitdate
+           l_tax
+           l_orderkey
+           l_shipdate
+           l_comment
+           l_returnflag
            l_extendedprice
            l_linenumber
-           l_shipdate
            l_quantity
-           l_comment
+           l_shipinstruct
            l_suppkey
            l_shipmode
-           l_linestatus
-           l_tax]]]]]]]]]]]
+           l_discount
+           l_partkey]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
@@ -19,29 +19,28 @@
         r.6
         [:scan
          {:table public/region}
-         [{r_name (= r_name "ASIA")} r_regionkey]]]
+         [r_regionkey {r_name (= r_name "ASIA")}]]]
        [:rename
         n.5
         [:scan
          {:table public/nation}
-         [n_nationkey n_name n_regionkey]]]
+         [n_name n_regionkey n_nationkey]]]
        [:rename
         s.4
-        [:scan {:table public/supplier} [s_nationkey s_suppkey]]]
+        [:scan {:table public/supplier} [s_suppkey s_nationkey]]]
        [:rename
         l.3
         [:scan
          {:table public/lineitem}
-         [l_discount l_suppkey l_orderkey l_extendedprice]]]
+         [l_orderkey l_extendedprice l_suppkey l_discount]]]
        [:rename
         c.1
-        [:scan {:table public/customer} [c_nationkey c_custkey]]]
+        [:scan {:table public/customer} [c_custkey c_nationkey]]]
        [:rename
         o.2
         [:scan
          {:table public/orders}
-         [o_custkey
-          {o_orderdate
+         [{o_orderdate
            (and
             (<
              o_orderdate
@@ -49,4 +48,5 @@
               #xt/date "1994-01-01"
               (single-field-interval "1" "YEAR" 2 6)))
             (>= o_orderdate #xt/date "1994-01-01"))}
-          o_orderkey]]]]]]]]]]
+          o_orderkey
+          o_custkey]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
@@ -16,6 +16,6 @@
           #xt/date "1994-01-01"
           (single-field-interval "1" "YEAR" 2 6)))
         (>= l_shipdate #xt/date "1994-01-01"))}
+      l_extendedprice
       {l_quantity (< l_quantity 24)}
-      {l_discount (between l_discount 0.05 0.07)}
-      l_extendedprice]]]]]]
+      {l_discount (between l_discount 0.05 0.07)}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
@@ -37,29 +37,29 @@
         {s.1/s_suppkey l.2/l_suppkey}]
        [[:rename
          n2.6
-         [:scan {:table public/nation} [n_nationkey n_name]]]
+         [:scan {:table public/nation} [n_name n_nationkey]]]
         [:rename
          n1.5
-         [:scan {:table public/nation} [n_nationkey n_name]]]
+         [:scan {:table public/nation} [n_name n_nationkey]]]
         [:rename
          c.4
-         [:scan {:table public/customer} [c_nationkey c_custkey]]]
+         [:scan {:table public/customer} [c_custkey c_nationkey]]]
         [:rename
          o.3
-         [:scan {:table public/orders} [o_custkey o_orderkey]]]
+         [:scan {:table public/orders} [o_orderkey o_custkey]]]
         [:rename
          s.1
-         [:scan {:table public/supplier} [s_nationkey s_suppkey]]]
+         [:scan {:table public/supplier} [s_suppkey s_nationkey]]]
         [:rename
          l.2
          [:scan
           {:table public/lineitem}
-          [{l_shipdate
+          [l_orderkey
+           {l_shipdate
             (between
              l_shipdate
              #xt/date "1995-01-01"
              #xt/date "1996-12-31")}
-           l_discount
+           l_extendedprice
            l_suppkey
-           l_orderkey
-           l_extendedprice]]]]]]]]]]]
+           l_discount]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
@@ -33,36 +33,36 @@
           r.8
           [:scan
            {:table public/region}
-           [{r_name (= r_name "AMERICA")} r_regionkey]]]
+           [r_regionkey {r_name (= r_name "AMERICA")}]]]
          [:rename
           n2.7
-          [:scan {:table public/nation} [n_nationkey n_name]]]
+          [:scan {:table public/nation} [n_name n_nationkey]]]
          [:rename
           n1.6
-          [:scan {:table public/nation} [n_nationkey n_regionkey]]]
+          [:scan {:table public/nation} [n_regionkey n_nationkey]]]
          [:rename
           c.5
-          [:scan {:table public/customer} [c_nationkey c_custkey]]]
+          [:scan {:table public/customer} [c_custkey c_nationkey]]]
          [:rename
           o.4
           [:scan
            {:table public/orders}
-           [o_custkey
-            {o_orderdate
+           [{o_orderdate
              (between
               o_orderdate
               #xt/date "1995-01-01"
               #xt/date "1996-12-31")}
-            o_orderkey]]]
+            o_orderkey
+            o_custkey]]]
          [:rename
           l.3
           [:scan
            {:table public/lineitem}
-           [l_partkey
-            l_discount
+           [l_orderkey
+            l_extendedprice
             l_suppkey
-            l_orderkey
-            l_extendedprice]]]
+            l_discount
+            l_partkey]]]
          [:rename
           p.1
           [:scan
@@ -72,4 +72,4 @@
           s.2
           [:scan
            {:table public/supplier}
-           [s_nationkey s_suppkey]]]]]]]]]]]]
+           [s_suppkey s_nationkey]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
@@ -27,7 +27,7 @@
         {p.1/p_partkey l.3/l_partkey}]
        [[:rename
          n.6
-         [:scan {:table public/nation} [n_nationkey n_name]]]
+         [:scan {:table public/nation} [n_name n_nationkey]]]
         [:rename
          o.5
          [:scan {:table public/orders} [o_orderdate o_orderkey]]]
@@ -35,17 +35,17 @@
          ps.4
          [:scan
           {:table public/partsupp}
-          [ps_partkey ps_suppkey ps_supplycost]]]
+          [ps_partkey ps_supplycost ps_suppkey]]]
         [:rename
          l.3
          [:scan
           {:table public/lineitem}
-          [l_partkey
+          [l_orderkey
+           l_extendedprice
            l_quantity
-           l_discount
            l_suppkey
-           l_orderkey
-           l_extendedprice]]]
+           l_discount
+           l_partkey]]]
         [:rename
          p.1
          [:scan
@@ -55,4 +55,4 @@
          s.2
          [:scan
           {:table public/supplier}
-          [s_nationkey s_suppkey]]]]]]]]]]]
+          [s_suppkey s_nationkey]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
@@ -37,32 +37,31 @@
         {c.1/c_custkey o.2/o_custkey}]
        [[:rename
          n.4
-         [:scan {:table public/nation} [n_nationkey n_name]]]
+         [:scan {:table public/nation} [n_name n_nationkey]]]
         [:rename
          l.3
          [:scan
           {:table public/lineitem}
-          [l_discount
-           l_orderkey
+          [l_orderkey
            {l_returnflag (= l_returnflag "R")}
-           l_extendedprice]]]
+           l_extendedprice
+           l_discount]]]
         [:rename
          c.1
          [:scan
           {:table public/customer}
-          [c_address
-           c_comment
-           c_phone
-           c_name
-           c_nationkey
+          [c_phone
+           c_acctbal
+           c_address
            c_custkey
-           c_acctbal]]]
+           c_nationkey
+           c_comment
+           c_name]]]
         [:rename
          o.2
          [:scan
           {:table public/orders}
-          [o_custkey
-           {o_orderdate
+          [{o_orderdate
             (and
              (<
               o_orderdate
@@ -70,4 +69,5 @@
                #xt/date "1993-10-01"
                (single-field-interval "3" "MONTH" 2 6)))
              (>= o_orderdate #xt/date "1993-10-01"))}
-           o_orderkey]]]]]]]]]]]
+           o_orderkey
+           o_custkey]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
@@ -22,15 +22,15 @@
           n.3
           [:scan
            {:table public/nation}
-           [n_nationkey {n_name (= n_name "GERMANY")}]]]
+           [{n_name (= n_name "GERMANY")} n_nationkey]]]
          [:rename
           ps.1
           [:scan
            {:table public/partsupp}
-           [ps_partkey ps_availqty ps_suppkey ps_supplycost]]]
+           [ps_partkey ps_supplycost ps_availqty ps_suppkey]]]
          [:rename
           s.2
-          [:scan {:table public/supplier} [s_nationkey s_suppkey]]]]]]]
+          [:scan {:table public/supplier} [s_suppkey s_nationkey]]]]]]]
      [:project
       [{_sq_6 (* _sum_out_10 1.0E-4)}]
       [:group-by
@@ -44,14 +44,14 @@
            n.9
            [:scan
             {:table public/nation}
-            [n_nationkey {n_name (= n_name "GERMANY")}]]]
+            [{n_name (= n_name "GERMANY")} n_nationkey]]]
           [:rename
            ps.7
            [:scan
             {:table public/partsupp}
-            [ps_availqty ps_suppkey ps_supplycost]]]
+            [ps_supplycost ps_availqty ps_suppkey]]]
           [:rename
            s.8
            [:scan
             {:table public/supplier}
-            [s_nationkey s_suppkey]]]]]]]]]]]]]
+            [s_suppkey s_nationkey]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
@@ -31,7 +31,7 @@
        [{o.1/o_orderkey l.2/l_orderkey}]
        [[:rename
          o.1
-         [:scan {:table public/orders} [o_orderkey o_orderpriority]]]
+         [:scan {:table public/orders} [o_orderpriority o_orderkey]]]
         [:semi-join
          [{l.2/l_shipmode xt.values.4/_column_1}]
          [:rename
@@ -42,8 +42,7 @@
             (< l_shipdate l_commitdate))
            [:scan
             {:table public/lineitem}
-            [l_shipdate
-             {l_receiptdate
+            [{l_receiptdate
               (and
                (<
                 l_receiptdate
@@ -51,8 +50,9 @@
                  #xt/date "1994-01-01"
                  (single-field-interval "1" "YEAR" 2 6)))
                (>= l_receiptdate #xt/date "1994-01-01"))}
-             l_orderkey
              l_commitdate
+             l_orderkey
+             l_shipdate
              l_shipmode]]]]
          [:rename
           xt.values.4

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
@@ -17,4 +17,4 @@
        o.2
        [:scan
         {:table public/orders}
-        [o_custkey o_orderkey o_comment]]]]]]]]]
+        [o_comment o_orderkey o_custkey]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
@@ -15,8 +15,7 @@
       l.1
       [:scan
        {:table public/lineitem}
-       [l_partkey
-        {l_shipdate
+       [{l_shipdate
          (and
           (<
            l_shipdate
@@ -24,6 +23,7 @@
             #xt/date "1995-09-01"
             (single-field-interval "1" "MONTH" 2 6)))
           (>= l_shipdate #xt/date "1995-09-01"))}
+        l_extendedprice
         l_discount
-        l_extendedprice]]]
+        l_partkey]]]
      [:rename p.2 [:scan {:table public/part} [p_partkey p_type]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
@@ -43,9 +43,9 @@
                   #xt/date "1996-01-01"
                   (single-field-interval "3" "MONTH" 2 6)))
                 (>= l_shipdate #xt/date "1996-01-01"))}
-              l_discount
+              l_extendedprice
               l_suppkey
-              l_extendedprice]]]]]]]]]
+              l_discount]]]]]]]]]
      [:project
       [{_sq_6 _max_out_8}]
       [:group-by
@@ -70,6 +70,6 @@
                   #xt/date "1996-01-01"
                   (single-field-interval "3" "MONTH" 2 6)))
                 (>= l_shipdate #xt/date "1996-01-01"))}
-              l_discount
+              l_extendedprice
               l_suppkey
-              l_extendedprice]]]]]]]]]]]]]]
+              l_discount]]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
@@ -43,10 +43,10 @@
           p.2
           [:scan
            {:table public/part}
-           [p_partkey
-            {p_type (not (like p_type "MEDIUM POLISHED%"))}
-            {p_brand (<> p_brand "Brand#45")}
-            p_size]]]
+           [{p_brand (<> p_brand "Brand#45")}
+            p_size
+            p_partkey
+            {p_type (not (like p_type "MEDIUM POLISHED%"))}]]]
          [:rename
           xt.values.4
           [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -7,11 +7,11 @@
    [:map
     [{_sq_3 (* 0.2 _avg_out_6)}]
     [:group-by
-     [l.1/l_partkey
+     [l.1/l_extendedprice
       l.1/l_quantity
-      l.1/l_extendedprice
-      p.2/p_partkey
+      l.1/l_partkey
       p.2/p_brand
+      p.2/p_partkey
       p.2/p_container
       _row_number_0
       {_avg_out_6 (avg l.4/l_quantity)}]
@@ -25,14 +25,14 @@
           l.1
           [:scan
            {:table public/lineitem}
-           [l_partkey l_quantity l_extendedprice]]]
+           [l_extendedprice l_quantity l_partkey]]]
          [:rename
           p.2
           [:scan
            {:table public/part}
-           [p_partkey
-            {p_brand (= p_brand "Brand#23")}
+           [{p_brand (= p_brand "Brand#23")}
+            p_partkey
             {p_container (= p_container "MED BOX")}]]]]]]
       [:rename
        l.4
-       [:scan {:table public/lineitem} [l_partkey l_quantity]]]]]]]]]
+       [:scan {:table public/lineitem} [l_quantity l_partkey]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
@@ -30,17 +30,17 @@
        [{o.2/o_orderkey l.3/l_orderkey} {c.1/c_custkey o.2/o_custkey}]
        [[:rename
          l.3
-         [:scan {:table public/lineitem} [l_quantity l_orderkey]]]
+         [:scan {:table public/lineitem} [l_orderkey l_quantity]]]
         [:rename
          c.1
-         [:scan {:table public/customer} [c_name c_custkey]]]
+         [:scan {:table public/customer} [c_custkey c_name]]]
         [:semi-join
          [{o.2/o_orderkey l_orderkey}]
          [:rename
           o.2
           [:scan
            {:table public/orders}
-           [o_custkey o_orderdate o_orderkey o_totalprice]]]
+           [o_totalprice o_orderdate o_orderkey o_custkey]]]
          [:project
           [{l_orderkey l.5/l_orderkey}]
           [:select
@@ -51,4 +51,4 @@
              l.5
              [:scan
               {:table public/lineitem}
-              [l_quantity l_orderkey]]]]]]]]]]]]]]]
+              [l_orderkey l_quantity]]]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
@@ -58,17 +58,17 @@
              l.1
              [:scan
               {:table public/lineitem}
-              [l_partkey
-               l_discount
-               l_shipinstruct
+              [l_extendedprice
                l_quantity
-               l_extendedprice
-               l_shipmode]]]
+               l_shipinstruct
+               l_shipmode
+               l_discount
+               l_partkey]]]
             [:rename
              p.2
              [:scan
               {:table public/part}
-              [p_partkey p_brand p_size p_container]]]]]
+              [p_brand p_size p_partkey p_container]]]]]
           [:rename
            xt.values.10
            [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -14,7 +14,7 @@
         s.1
         [:scan
          {:table public/supplier}
-         [s_name s_address s_nationkey s_suppkey]]]
+         [s_name s_address s_suppkey s_nationkey]]]
        [:project
         [{ps_suppkey ps.4/ps_suppkey}]
         [:map
@@ -45,8 +45,7 @@
                l.8
                [:scan
                 {:table public/lineitem}
-                [l_partkey
-                 {l_shipdate
+                [{l_shipdate
                   (and
                    (<
                     l_shipdate
@@ -55,7 +54,8 @@
                      (single-field-interval "1" "YEAR" 2 6)))
                    (>= l_shipdate #xt/date "1994-01-01"))}
                  l_quantity
-                 l_suppkey]]]]]]]
+                 l_suppkey
+                 l_partkey]]]]]]]
           [:project
            [{p_partkey p.6/p_partkey}]
            [:rename
@@ -67,4 +67,4 @@
        n.2
        [:scan
         {:table public/nation}
-        [n_nationkey {n_name (= n_name "CANADA")}]]]]]]]]]
+        [{n_name (= n_name "CANADA")} n_nationkey]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
@@ -21,7 +21,7 @@
           n.4
           [:scan
            {:table public/nation}
-           [n_nationkey {n_name (= n_name "SAUDI ARABIA")}]]]
+           [{n_name (= n_name "SAUDI ARABIA")} n_nationkey]]]
          [:rename
           o.3
           [:scan
@@ -31,7 +31,7 @@
           s.1
           [:scan
            {:table public/supplier}
-           [s_name s_nationkey s_suppkey]]]
+           [s_name s_suppkey s_nationkey]]]
          [:semi-join
           [(<> l_suppkey l1.2/l_suppkey) {l1.2/l_orderkey l_orderkey}]
           [:anti-join
@@ -42,7 +42,7 @@
              (> l_receiptdate l_commitdate)
              [:scan
               {:table public/lineitem}
-              [l_receiptdate l_suppkey l_orderkey l_commitdate]]]]
+              [l_receiptdate l_commitdate l_orderkey l_suppkey]]]]
            [:project
             [{l_comment l3.10/l_comment}
              {l_commitdate l3.10/l_commitdate}
@@ -66,22 +66,22 @@
               (> l_receiptdate l_commitdate)
               [:scan
                {:table public/lineitem}
-               [l_partkey
-                l_shipinstruct
-                l_discount
+               [l_linestatus
                 l_receiptdate
-                l_orderkey
-                l_returnflag
                 l_commitdate
+                l_tax
+                l_orderkey
+                l_shipdate
+                l_comment
+                l_returnflag
                 l_extendedprice
                 l_linenumber
-                l_shipdate
                 l_quantity
-                l_comment
+                l_shipinstruct
                 l_suppkey
                 l_shipmode
-                l_linestatus
-                l_tax]]]]]]
+                l_discount
+                l_partkey]]]]]]
           [:project
            [{l_comment l2.6/l_comment}
             {l_commitdate l2.6/l_commitdate}
@@ -103,19 +103,19 @@
             l2.6
             [:scan
              {:table public/lineitem}
-             [l_partkey
-              l_shipinstruct
+             [l_linestatus
               l_receiptdate
-              l_discount
-              l_orderkey
-              l_returnflag
               l_commitdate
+              l_tax
+              l_orderkey
+              l_shipdate
+              l_comment
+              l_returnflag
               l_extendedprice
               l_linenumber
-              l_shipdate
               l_quantity
-              l_comment
+              l_shipinstruct
               l_suppkey
               l_shipmode
-              l_linestatus
-              l_tax]]]]]]]]]]]]]]
+              l_discount
+              l_partkey]]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
@@ -34,7 +34,7 @@
               c.1
               [:scan
                {:table public/customer}
-               [c_phone c_custkey c_acctbal]]]
+               [c_phone c_acctbal c_custkey]]]
              [:project
               [{o_clerk o.10/o_clerk}
                {o_comment o.10/o_comment}
@@ -49,15 +49,15 @@
                o.10
                [:scan
                 {:table public/orders}
-                [o_custkey
-                 o_shippriority
-                 o_orderdate
-                 o_orderstatus
-                 o_orderkey
+                [o_orderpriority
                  o_clerk
-                 o_orderpriority
+                 o_orderstatus
                  o_totalprice
-                 o_comment]]]]]]]
+                 o_orderdate
+                 o_comment
+                 o_orderkey
+                 o_shippriority
+                 o_custkey]]]]]]]
           [:rename
            xt.values.3
            [:table


### PR DESCRIPTION
I am planning the projection of  `_valid_time` and `_system_time` on the base table visit instead of doing something special when visiting a column reference. This fixes the case where any of these gets projected out from a derived table.