### PR TITLE
Add monitoring for query failures

### DIFF
--- a/monitoring/grafana/dashboards/xtdb-monitoring.json
+++ b/monitoring/grafana/dashboards/xtdb-monitoring.json
@@ -834,12 +834,115 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(query_error_total)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "$xtdbnode",
+          "range": true,
+          "refId": "Node Average",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Query Errors",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 19
       },
       "id": 14,
       "panels": [],
@@ -913,7 +1016,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 13
+        "y": 20
       },
       "id": 15,
       "options": {
@@ -1016,7 +1119,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 13
+        "y": 20
       },
       "id": 16,
       "options": {
@@ -1136,7 +1239,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 13
+        "y": 20
       },
       "id": 17,
       "options": {
@@ -1239,7 +1342,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 13
+        "y": 20
       },
       "id": 18,
       "options": {
@@ -1298,6 +1401,109 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "query_error_total{node_id=\"$xtdbnode\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "$xtdbnode",
+          "range": true,
+          "refId": "Node Average",
+          "useBackend": false
+        }
+      ],
+      "title": "Query Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Current Percentage of CPU used by JVM process of the XTDB nodes. \n",
       "fieldConfig": {
         "defaults": {
@@ -1327,8 +1533,8 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
-        "y": 20
+        "x": 6,
+        "y": 27
       },
       "id": 12,
       "options": {
@@ -1436,8 +1642,8 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 6,
-        "y": 20
+        "x": 12,
+        "y": 27
       },
       "id": 11,
       "options": {
@@ -1561,9 +1767,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 20
+        "w": 6,
+        "x": 18,
+        "y": 27
       },
       "id": 13,
       "options": {
@@ -1669,6 +1875,6 @@
   "timezone": "browser",
   "title": "XTDB: Monitoring Dashboard",
   "uid": "be4j0zvqk6ygwc",
-  "version": 2,
+  "version": 4,
   "weekStart": ""
 }

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -1,0 +1,24 @@
+(ns xtdb.metrics-test
+  (:require [clojure.test :as t]
+            [next.jdbc :as jdbc]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]
+            [xtdb.types])
+  (:import io.micrometer.core.instrument.composite.CompositeMeterRegistry
+           io.micrometer.core.instrument.Counter))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node tu/with-simple-registry)
+
+(t/deftest test-error-and-warning-counter
+  (let [registry ^CompositeMeterRegistry (tu/component tu/*node* :xtdb.metrics/registry)]
+    (t/is (thrown-with-msg? Exception #"" (xt/q tu/*node* "SLECT 1")))
+    (t/is (thrown-with-msg? Exception #"" (jdbc/execute! tu/*conn* ["SLECT 1"])))
+    (t/is (thrown-with-msg? Exception #"" (xt/q tu/*node* "SELECT 1/0")))
+    (t/is (thrown-with-msg? Exception #"" (jdbc/execute! tu/*conn* ["SELECT 1/0"])))
+
+    (xt/q tu/*node* "SELECT foo FROM bar")
+    (jdbc/execute! tu/*conn* ["SELECT foo FROM bar"])
+
+    (t/is (= 4.0 (.count ^Counter (.counter (.find registry "query.error")))))
+
+    (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.warning")))))))


### PR DESCRIPTION
Adds `query.error` and `query.warning` metrics to pgwire and direct queries. Also adds `query.error` to the xtdb monitoring dashboard.

Tested with a variety of queries for each different phase `SLECT * FROM foo` for parsing, `SELECT 1/0;` for execution and `SELECT * FROM missing_table` for planning warnings.

Closes #3898 