### PR TITLE
Check earlier pages of tries for overlapping system time. Fix #4097

### DIFF
--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -341,7 +341,8 @@
           ^long valid-from-idx (.get page-idx-cache (PageIndexKey. "_valid_from" page-idx))
           ^long valid-to-idx (.get page-idx-cache (PageIndexKey. "_valid_to" page-idx))]
       (TemporalBounds. (TemporalDimension. (.getLong min-rdr valid-from-idx) (.getLong max-rdr valid-to-idx))
-                       (TemporalDimension. (.getLong min-rdr system-from-idx) Long/MAX_VALUE))))
+                       (TemporalDimension. (.getLong min-rdr system-from-idx) Long/MAX_VALUE)
+                       (.getLong max-rdr system-from-idx))))
 
   AutoCloseable
   (close [_]

--- a/core/src/main/kotlin/xtdb/util/TemporalBounds.kt
+++ b/core/src/main/kotlin/xtdb/util/TemporalBounds.kt
@@ -27,8 +27,11 @@ data class TemporalDimension(
 
 data class TemporalBounds(
     val validTime: TemporalDimension = TemporalDimension(),
-    val systemTime: TemporalDimension = TemporalDimension()
+    val systemTime: TemporalDimension = TemporalDimension(),
+    val maxSystemFrom: Long = Long.MAX_VALUE,
 ){
+    constructor(validTime: TemporalDimension, systemTime: TemporalDimension) : this(validTime, systemTime, Long.MAX_VALUE)
+
     fun intersects(other: TemporalBounds) = this.validTime.intersects(other.validTime) && this.systemTime.intersects(other.systemTime)
     fun intersects(validFrom: Long, validTo: Long, systemFrom: Long, systemTo: Long) =
         (this.validTime.intersects(validFrom, validTo) && this.systemTime.intersects(systemFrom, systemTo))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -356,9 +356,10 @@
 
 (defn ->min-max-page-bounds
   ([min max] (->min-max-page-bounds min max min))
-  ([vt-min vt-max st-min] (->min-max-page-bounds vt-min vt-max st-min Long/MAX_VALUE))
-  ([vt-min vt-max st-min st-max]
-   (TemporalBounds. (TemporalDimension. vt-min vt-max) (TemporalDimension. st-min st-max))))
+  ([vf-min vt-max sf-min] (->min-max-page-bounds vf-min vt-max sf-min Long/MAX_VALUE sf-min))
+  ([vf-min vt-max sf-min st-max] (TemporalBounds. (TemporalDimension. vf-min vt-max) (TemporalDimension. sf-min st-max)))
+  ([vf-min vt-max sf-min st-max max-valid-from]
+   (TemporalBounds. (TemporalDimension. vf-min vt-max) (TemporalDimension. sf-min st-max) max-valid-from)))
 
 (defn ->page-bounds-fn [page-idx-pred->bounds]
   (let [page-idx-pred->bounds (update-vals page-idx-pred->bounds #(apply ->min-max-page-bounds %))]

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -167,7 +167,7 @@
     (util/with-open [table-metadata (.openTableMetadata metadata-mgr meta-file-path)]
       (let [sys-time-micros (time/instant->micros #xt/instant "2020-01-01T00:00:00.000000Z")
             temporal-dimension (TemporalDimension. sys-time-micros Long/MAX_VALUE)
-            metadata-bounds (TemporalBounds. temporal-dimension temporal-dimension)]
+            metadata-bounds (TemporalBounds. temporal-dimension temporal-dimension sys-time-micros)]
         (t/is (= metadata-bounds (.temporalBounds table-metadata 0)))))))
 
 (t/deftest test-boolean-metadata


### PR DESCRIPTION
There are two levels of granularity when resolving data for a query, files and pages within those files. With our current approach we should always be able to strictly order files (for a given IID because that is what is important) according to system time. Meaning there is a list of files $f_1$ to $f_n$ where system time increases across these files, i.e. max_system_from($f_{n-1}$) <= min_system_from($f_n$). As #4097 shows this does not hold for pages within a given file $f_n$. It's possible that max_system_from($p_{n-1}$) > min_system_from($p_n$). If a metadata predicate than matches $p_n$ we must take $p_{n-1}$ to assure correct bitemporal splitting. The commit tries to address this issue.

The approach currently taken:
1. Find all pages that match metadata and query bound filters. Let that be set $S$
2. Find all pages not yet taken that can bound valid-to from $S$ (up to here this is what we do on `main`). We take $p_n$ if it is a non taken page and $p_n$ intersects the query bounds and can bound an event of $S$ in the query range.
3. Find all pages not yet taken that can affect resolution of pages taken so far, i.e. take page $p_n$ if min_system_from($S$) <= max_system_from($p_n$).

Do 2. and 3. need to be applied recursively until they are exhausted or can one apply 2. + 3. in any order and only on $S$?

There are lots of optimizations one can do here. For example 3 only needs to be applied on per file level where as 2 needs to be applied across files. One could do the steps only based on the original $S$ (I think this is sound) or apply them on expanding sets (definitely not incorrect, maybe just more work later).

### **UPDATE**
I am now doing the following:
1.  Find all pages that match metadata and query bound filters. Let that be set $S$

All other pages that still need to be taken only get taken to potentially split rows in $S$. To split rows in $S$ the following two requirements are needed for a page $P$ not yet in $S$.
- min_system_from($S$) <= max_system_from($P$)
-  valid_time($S$) $\cap$ valid_time($P$) $\not= \emptyset$  

Where `valid_time` is the interval on min_valid_from to max_valid_to across all rows in the set.

I am also now using `max_system_from` which is not part of `TemporalBounds` so I am wondering if we have some wrong abstraction here?