### PR TITLE
Add terraform and helm config for Google Cloud. 

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -32,3 +32,9 @@ jobs:
           helm package azure/helm --app-version $APP_VERSION \
           ${{ env.APP_VERSION == 'edge' && '--version 2.0.0-SNAPSHOT' || '' }}
           helm push helm-xtdb-azure-*.tgz oci://ghcr.io/xtdb/
+      
+      - name: Package & Push Google Cloud Helm Chart
+        run: |
+          helm package google-cloud/helm --app-version $APP_VERSION \
+          ${{ env.APP_VERSION == 'edge' && '--version 2.0.0-SNAPSHOT' || '' }}
+          helm push helm-xtdb-google-cloud-*.tgz oci://ghcr.io/xtdb/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -124,6 +124,7 @@ export default defineConfig({
                             items: [
                                 'ops/guides/starting-with-aws',
                                 'ops/guides/starting-with-azure',
+                                'ops/guides/starting-with-gcp',
                                 'ops/guides/monitoring-with-grafana'
                             ],
                         },

--- a/docs/src/content/docs/ops/google-cloud.adoc
+++ b/docs/src/content/docs/ops/google-cloud.adoc
@@ -4,6 +4,8 @@ title: Google Cloud
 
 XTDB provides modular support for Google Cloud environments, including a prebuilt Docker image, integrations with **Google Cloud Storage**, and configuration options for deploying onto Google Cloud infrastructure.
 
+NOTE: For more details on getting started with Google Cloud, see the link:guides/starting-with-gcp["Setting up a cluster on Google Cloud"^] guide.
+
 == Required Infrastructure
 
 In order to run a Google Cloud based XTDB cluster, the following infrastructure is required:
@@ -15,6 +17,140 @@ In order to run a Google Cloud based XTDB cluster, the following infrastructure 
 * XTDB nodes configured to communicate with the Kafka cluster and Google Cloud Storage.
 
 NOTE: We would recommend running XTDB in a Google Kubernetes Engine (GKE) cluster, which provides a managed Kubernetes environment in Google Cloud.
+
+[#terraform]
+== Terraform Templates
+
+To set up a basic version of the required infrastructure, we provide a set of Terraform templates specifically designed for Google Cloud.
+
+These can be fetched from the XTDB repository using the following command:
+
+```bash
+terraform init -from-module github.com/xtdb/xtdb.git//google-cloud/terraform
+```
+
+=== Required APIs
+
+To deploy the required infrastructure, we need to ensure the following APIs are enabled on the Google Cloud project:
+
+* Cloud Storage API
+* IAM API
+* Compute Engine API
+* Kubernetes Engine API
+
+=== Required Permissions
+
+In order for the terraform templates to setup the required infrastructure, the following permissions are required for the logged in user:
+
+* `Storage Admin` - Required for creating and managing Google Cloud Storage buckets.
+* `Service Account Admin` - Required for creating and managing service accounts.
+* `Kubernetes Engine Admin` - Required for creating and managing Google Kubernetes Engine clusters and their resources.
+
+=== Resources
+
+By default, running the templates will deploy the following infrastructure:
+
+* **IAM Service Account** for accessing required Google Cloud resources.
+* **Google Cloud Storage Bucket** for remote storage.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google/latest[**GoogleCloud/storage-bucket**^] Terraform module.
+** Adds required permissions to the Service Account.
+* **Virtual Private Cloud Network** for the XTDB GKE cluster.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/network/google/latest[**GoogleCloud/network**^] Terraform module.
+* **Google Kubernetes Engine Cluster** for running the XTDB resources.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest[**GoogleCloud/kubernetes-engine**^] Terraform module.
+
+=== Configuration
+
+In order to customize the deployment, we provide a number of pre-defined variables within the `terraform.tfvars` file.
+These variables can be modified to tailor the infrastructure to your specific needs.
+
+The following variables are **required** to be set:
+
+* `project_id`: The Google Cloud project ID to deploy the resources to.
+
+For more advanced usage, the Terraform templates themselves can be modified to suit your specific requirements.
+
+'''
+
+[#helm]
+== `xtdb-google-cloud` Helm Charts
+
+For setting up a production-ready XTDB cluster on Google Cloud, we provide a **Helm** chart built specifically for Google Cloud environments.
+
+=== Pre-requisites
+
+To enable XTDB nodes to access a Google Cloud Storage bucket securely, a Kubernetes Service Account (KSA) must be set up and linked to a Google Cloud IAM service account using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#using_from_your_code[**Workload Identity Federation**^].
+
+==== Setting Up the Kubernetes Service Account:
+
+Create the Kubernetes Service Account in the target namespace:
+
+```bash
+kubectl create serviceaccount xtdb-service-account --namespace xtdb-deployment
+```
+
+==== Binding the IAM Service Account
+
+Fetch the IAM service account email (in the format `<IAM_SA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com`) and bind the `roles/iam.workloadIdentityUser` role to the Kubernetes Service Account:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding <iam_service_account_email> \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:<project_id>.svc.id.goog[xtdb-deployment/xtdb-service-account]"
+```
+
+==== Annotating the Kubernetes Service Account
+
+Annotate the Kubernetes Service Account to establish the link between GKE and Google IAM:
+
+```bash
+kubectl annotate serviceaccount xtdb-service-account \
+  --namespace xtdb-deployment \
+  iam.gke.io/gcp-service-account=<iam_service_account_email>
+```
+
+=== Installation
+
+The Helm chart can be installed directly from the link:https://github.com/xtdb/xtdb/pkgs/container/helm-xtdb-google-cloud[**Github Container Registry** releases]. 
+
+This will use the default configuration for the deployment, setting any required values as needed:  
+
+```bash
+helm install xtdb-google-cloud oci://ghcr.io/xtdb/helm-xtdb-google-cloud \
+  --version 2.0.0-snapshot \
+  --namespace xtdb-deployment \
+  --set xtdbConfig.serviceAccount=xtdb-service-account \
+  --set xtdbConfig.gcpProjectId=<project_id> \
+  --set xtdbConfig.gcpBucket=<bucket_name> 
+```
+
+We provide a number of parameters for configuring numerous parts of the deployment, see the link:https://github.com/xtdb/xtdb/tree/main/google-cloud/helm[`values.yaml` file] or call `helm show values`:
+
+```bash
+helm show values oci://ghcr.io/xtdb/helm-xtdb-google-cloud \
+  --version 2.0.0-snapshot 
+```
+
+=== Resources
+
+By default, the following resources are deployed by the Helm chart:
+
+* A `StatefulSet` containing a configurable number of XTDB nodes, using the link:#docker-image[**xtdb-google-cloud** docker image]
+* A `PersistentVolumeClaim` for each member of the `StatefulSet` (default size of 50 GiB).
+* A `LoadBalancer` Kubernetes service to expose the XTDB cluster to the internet.
+* A `ClusterIP` service for exposing the **Prometheus** metrics from the nodes.
+
+=== Pulling the Chart Locally
+
+The chart can also be pulled from the **Github Container Registry**, allowing further configuration of the templates within:
+
+```bash
+helm pull oci://ghcr.io/xtdb/helm-xtdb-google-cloud \
+  --version 2.0.0-snapshot \
+  --untar
+```
+
+'''
 
 [#docker-image]
 == `xtdb-google-cloud` Docker Image

--- a/docs/src/content/docs/ops/guides/starting-with-gcp.adoc
+++ b/docs/src/content/docs/ops/guides/starting-with-gcp.adoc
@@ -1,0 +1,302 @@
+---
+title: Setting up a cluster on Google Cloud
+---
+
+This guide will walk you through the process of configuring and running an XTDB Cluster on Google Cloud. This setup includes:
+
+* Using **Google Cloud Storage** as the remote storage implementation.
+* Utilizing **Apache Kafka** as the shared message log implementation.
+* Exposing the cluster to the internet via a Postgres wire-compatible server and HTTP.
+ 
+The required Google Cloud infrastructure is provisioned using **Terraform**, and the XTDB cluster and it's resources are deployed on link:https://cloud.google.com/kubernetes-engine?hl=en[**Google Kubernetes Engine**^] using **Helm**.
+
+Although we provide numerous parameters to configure the templates, you are encouraged to edit them, use them as a foundation for more advanced use cases, and reuse existing infrastructure when suitable. 
+These templates serve as a simple starting point for running XTDB on Google Cloud and Kubernetes, and should be adapted to meet your specific needs, especially in production environments.
+
+This guide assumes that you are using the default templates.
+
+== Requirements 
+
+Before starting, ensure you have the following installed:
+
+* The **Google Cloud CLI** - See the link:https://cloud.google.com/sdk/docs/install[**Installation Instructions**^].
+* **Terraform** - See the link:https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli[**Installation Instructions**^].
+* **kubectl** - The Kubernetes CLI, used to interact with the AKS cluster. See the link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[**Installation Instructions**^].
+* **Helm** - The Kubernetes package manager, used to deploy numerous components to AKS. See the link:https://helm.sh/docs/intro/install/[**Installation Instructions**^].
+
+=== Requirements on Google Cloud
+
+Within Google Cloud, ensure that you have an existing Google Cloud project you can deploy into, and ensure the following APIs are enabled on the project:
+
+* Cloud Storage API
+* IAM API
+* Compute Engine API
+* Kubernetes Engine API
+
+Additionally, ensure that the following permissions are granted to the logged-in user (at a minimum):
+
+* `Storage Admin` - Required for creating and managing Google Cloud Storage buckets.
+* `Service Account Admin` - Required for creating and managing service accounts.
+* `Kubernetes Engine Admin` - Required for creating and managing Google Kubernetes Engine clusters and their resources.
+
+To login into the Google cloud project using the command line, run the following command and run through the steps to authenticate:
+
+```bash
+gcloud init
+```
+
+This allows you to perform necessary operations on Google Cloud - primarily, creating and managing infrastructure using Terraform.
+
+[#terraform]
+== Getting started with Terraform
+
+The following assumes that you are authenticated on the Google Cloud CLI, have Terraform installed on your machine, and are located within a directory that you wish to use as the root of the Terraform configuration.
+
+First, make the following `terraform init` call:
+```
+terraform init -from-module github.com/xtdb/xtdb.git//google-cloud/terraform
+```  
+
+This will download the Terraform files from the XTDB repository, and initialize the working directory.
+
+NOTE: For the sake of this guide, we store Terraform state locally. 
+However, to persist the state onto Google Cloud, you will need to configure a remote backend using Google Cloud Storage. 
+This allows you to share the state file across teams, maintain versioning, and ensure consistency during deployments. 
+For more info, see the link:https://developer.hashicorp.com/terraform/language/backend/gcs[**Terraform gcs backend**^] documentation.
+
+== What is being deployed on Google Cloud?
+
+The sample Terraform directory sets up a few distinct parts of the infrastructure required by XTDB. 
+If using the default configuration, the following will be created:
+
+* **IAM Service Account** for accessing required Google Cloud resources.
+* **Google Cloud Storage Bucket** for remote storage.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google/latest[**GoogleCloud/storage-bucket**^] Terraform module.
+** Adds required permissions to the Service Account.
+* **Virtual Private Cloud Network** for the XTDB GKE cluster.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/network/google/latest[**GoogleCloud/network**^] Terraform module.
+* **Google Kubernetes Engine Cluster** for running the XTDB resources.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest[**GoogleCloud/kubernetes-engine**^] Terraform module.
+
+The above infrastructure is designed for creating a starting point for running XTDB on Google Cloud & Kubernetes. 
+The VM sizes and resource tiers can & should be adjusted to suit your specific requirements and cost constraints, and the templates should be configured with any desired changes to security or networking configuration.
+
+=== GKE Machine Types
+
+By default, our terraform templates will create the GKE Cluster with:
+
+* A single node default node pool
+* A three node application node pool spread across three zones. 
+* All nodes using the `n2-highmem-2` machine type (`node_machine_type` in `terraform.tfvars`).
+
+
+`n2-highmem-2` is intended to work on most projects/accounts.
+Dependent on your project limits, you may wish to adjust this machine type:
+* We would recommend a machine type better suited for database loads, such as the `c3-*-lssd` instances.
+* For more information on the available machine types and their optimal workloads, see the link:https://cloud.google.com/compute/docs/general-purpose-machines[**Google Cloud Documentation**^].
+
+
+== Deploying the Google Cloud Infrastructure
+
+Before creating the Terraform resources, review and update the `terraform.tfvars` file to ensure the parameters are correctly set for your environment:
+
+* You are **required** to set the `project_id` parameter to the Google Cloud project ID you wish to deploy into. 
+* You may also wish to change resource tiers, the location of the resource group, or the VM sizes used by the Google Cloud cluster.
+
+To get a full list of the resources that will be deployed by the templates, run:
+```bash
+terraform plan
+```
+
+Finally, to create the resources, run:
+```bash
+terraform apply
+```
+
+This will create the necessary infrastructure on the Google Cloud Project.
+
+[#terraform-outputs]
+=== Fetching the Terraform Outputs
+
+The Terraform templates will generate several outputs required for setting up the XTDB nodes on the GKE cluster.
+
+To retrieve these outputs, execute the following command:
+```bash
+terraform output
+```
+
+This will return the following outputs:
+
+* `project_id` - The Google Cloud project ID.
+* `bucket_name` - The name of the Google Cloud Storage bucket.
+* `iam_service_account_email` - The email address of the IAM service account.
+
+== Deploying on Kubernetes
+
+With the infrastructure created on Google Cloud, we can now deploy the XTDB nodes and a simple Kafka instance on the Google Kubernetes Engine cluster.
+
+Prior to deploying the Kubernetes resources, ensure that the `kubectl` CLI is installed and configured to interact with the GKE cluster. Run the following command:
+
+```bash
+gcloud container clusters get-credentials xtdb-cluster --region us-central1
+```
+
+NOTE: The above will require `gke-gcloud-auth-plugin` to be installed - see instructions link:https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke[**here**^].
+
+Now that `kubectl` is authenticated with the GKE cluster, you can set up the namespace for the XTDB deployment:
+
+```bash
+kubectl create namespace xtdb-deployment
+```
+
+The GKE cluster is now ready for deployment,
+
+'''
+
+=== Deploying an example Kafka 
+
+To deploy a basic set of Kafka resources within GKE, you can make use of the `bitnami/kafka` Helm chart. Run the following command:
+
+```bash
+helm install kafka oci://registry-1.docker.io/bitnamicharts/kafka \
+  --namespace xtdb-deployment \
+  --set listeners.client.protocol=PLAINTEXT \
+  --set listeners.controller.protocol=PLAINTEXT \
+  --set controller.resourcesPreset=medium \
+  --set controller.nodeSelector.node_pool=xtdb-pool
+```
+
+This command will create:
+
+* A simple, **unauthenticated** Kafka deployment on the GKE cluster, which XTDB will use as its message log, along with its dependent infrastructure and persistent storage.
+* A Kubernetes service to expose the Kafka instance to the XTDB cluster.
+
+==== Considerations of the Kafka Deployment
+
+The Kafka instance set up above is for **demonstration purposes** and is **not recommended for production use**. 
+This example lacks authentication for the Kafka cluster and allows XTDB to manage Kafka topic creation and configuration itself.
+
+For production environments, consider the following:
+
+* Use a more robust Kafka deployment.
+* Pre-create the required Kafka topics.
+* Configure XTDB appropriately to interact with the production Kafka setup.
+
+Additional resources:
+
+* For further configuration options for the Helm chart, refer to the link:https://artifacthub.io/packages/helm/bitnami/kafka[**Bitnami Kafka Chart Documentation**^].
+* For detailed configuration guidance when using Kafka with XTDB, see the link:https://docs.xtdb.com/ops/config/log/kafka.html#_setup[**XTDB Kafka Setup Documentation**^].
+
+=== Verifying the Kafka Deployment
+
+After deployment, verify that the Kafka instance is running properly by checking its status and logs.
+
+To check the status of the Kafka deployment, run the following command:
+```bash
+kubectl get pods --namespace xtdb-deployment
+```
+
+To view the logs of the Kafka deployment, use the command:
+```bash
+kubectl logs -f statefulset/kafka-controller --namespace xtdb-deployment
+```
+
+By verifying the status and reviewing the logs, you can ensure the Kafka instance is correctly deployed and ready for use by XTDB.
+
+'''
+
+=== Setting up the XTDB Workload Identity
+
+In order for the XTDB nodes to access the Google Cloud Storage bucket, we need to set up a Kubernetes Service Account that can access the Google Cloud IAM service account using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#using_from_your_code[**Workload Identity Federation**^].
+We will use  to allow the AKS cluster to access the Azure Storage Account.
+
+To set up the Kubernetes Service Account, run the following command:
+
+```bash
+kubectl create serviceaccount xtdb-service-account --namespace xtdb-deployment
+```
+
+We fetch the IAM service account email from the Terraform outputs, `iam_service_account_email`. To create an IAM allow policy that gives the Kubernetes ServiceAccount access to impersonate the IAM service account, run the following command:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding <iam_service_account_email> \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:<project_id>.svc.id.goog[xtdb-deployment/xtdb-service-account]"
+```
+
+The member name must include the namespace and Kubernetes ServiceAccount name. 
+
+Finally, annotate the Kubernetes ServiceAccount so that GKE sees the link between the service accounts:
+
+```bash
+kubectl annotate serviceaccount xtdb-service-account \
+  --namespace xtdb-deployment \
+  iam.gke.io/gcp-service-account=<iam_service_account_email>
+```
+
+With the XTDB service account set up, we can now deploy the XTDB cluster to the GKE cluster.
+
+'''
+
+=== Deploying the XTDB cluster
+
+In order to deploy the XTDB cluster and it's constituent parts into the GKE cluster, we provide an `xtdb-google-cloud` Helm chart/directory.
+
+This can be found on the link:https://github.com/xtdb/xtdb/pkgs/container/helm-xtdb-google-cloud[**XTDB Github Container Registry**^], and can be used directly with `helm` commands.
+
+With the values from the link:#terraform-outputs[Terraform outputs], you can now deploy the XTDB cluster. 
+Run the following command, substituting the values as appropriate: 
+
+```bash
+helm install xtdb-google-cloud oci://ghcr.io/xtdb/helm-xtdb-google-cloud \
+  --version 2.0.0-snapshot \
+  --namespace xtdb-deployment \
+  --set xtdbConfig.serviceAccount=xtdb-service-account \
+  --set xtdbConfig.gcpProjectId=<project_id> \
+  --set xtdbConfig.gcpBucket=<bucket_name> 
+```
+
+The following are created by the templates:
+
+* A `StatefulSet` containing the XTDB nodes.
+* A `PersistentVolumeClaim` for each member of the `StatefulSet` (default size of 50 GiB).
+* A `LoadBalancer` Kubernetes service to expose the XTDB cluster to the internet.
+* A `ClusterIP` service for exposing the **Prometheus** metrics from the nodes.
+
+To check the status of the XTDB statefulset, run:
+```bash
+kubectl get statefulset --namespace xtdb-deployment
+```
+
+To view the logs of the first StatefulSet member, run:
+```bash
+kubectl logs -f xtdb-statefulset-0 --namespace xtdb-deployment
+```
+
+==== Customizing the XTDB Deployment
+
+The above deployment uses the `helm-xtdb-google-cloud` chart defaults, individually setting the terraform outputs as `xtdbConfig` settings using the command line. 
+
+For more information on the available configuration options and fetching the charts locally for customization, see the link:/ops/google-cloud#helm[`helm-xtdb-google-cloud` Helm documentation]
+
+'''
+
+=== Accessing the XTDB Cluster
+
+Once the XTDB cluster is up and running, you can access it via the LoadBalancer service that was created.
+
+To get the external IP of the LoadBalancer service, run:
+```bash
+kubectl get svc xtdb-service --namespace xtdb-deployment
+```
+
+This will return the external IP of the LoadBalancer service. 
+You can use this IP to access the XTDB cluster via the Postgres Wire Server (on port `5432`), or over the HTTP Server (on port `3000`). 
+
+To check the status of the XTDB cluster using the HTTP server, run:
+
+```bash
+curl -X POST http://$ExternalIP:3000/status
+```
+
+If the above command succeeds, you now have a load-balanced XTDB cluster accessible over the internet.

--- a/google-cloud/helm/Chart.yaml
+++ b/google-cloud/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm-xtdb-google-cloud
+description: A Helm chart for setting up a simple XTDB cluster on Google Cloud
+type: application
+version: 0.1.0
+appVersion: "2.0.0-beta5"

--- a/google-cloud/helm/README.md
+++ b/google-cloud/helm/README.md
@@ -1,0 +1,6 @@
+# XTDB Google Cloud Helm Chart
+
+This Helm chart deploys a simple XTDB cluster, backed by Google Cloud infrastructure, on Kubernetes.
+
+For more information on what infrastructure is required and what resources are deployed by the templates, see the [XTDB Google Cloud Documentation](https://docs.xtdb.com/ops/google-cloud.html)
+

--- a/google-cloud/helm/templates/NOTES.txt
+++ b/google-cloud/helm/templates/NOTES.txt
@@ -1,0 +1,33 @@
+
+# XTDB Service Access Instructions
+
+Thank you for installing the XTDB Google Cloud Helm Chart!
+
+Your deployment is now complete.
+
+To access the XTDB service:
+
+1. The service is running as a LoadBalancer service. Retrieve the external IP:
+   ```bash
+   kubectl get svc xtdb-service -n {{ .Release.Namespace }}
+   ```
+   Look for the `EXTERNAL-IP` column.
+
+2. Access the service via the Postgres Wire Server port:
+   ```
+   <EXTERNAL-IP>:{{ .Values.xtdbService.server.servicePort }}
+   ```
+3. If you are using the HTTP server port connect to the service at:
+   ```
+   http://<EXTERNAL-IP>:{{ .Values.xtdbService.httpServer.servicePort }}
+   ```
+
+## Additional Information
+
+Namespace: {{ .Release.Namespace }}
+Service Name: {{ .Release.Name }}
+
+To uninstall this chart:
+```bash
+helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
+```

--- a/google-cloud/helm/templates/metricservice.yaml
+++ b/google-cloud/helm/templates/metricservice.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xtdb-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: xtdb-statefulset
+spec:
+  type: {{ .Values.metricService.type }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      targetPort: {{ .Values.metricService.targetPort }}
+      port: {{ .Values.metricService.servicePort }}
+  clusterIP: None 
+  selector:
+    app: xtdb-statefulset

--- a/google-cloud/helm/templates/statefulset.yaml
+++ b/google-cloud/helm/templates/statefulset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: xtdb-statefulset
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: xtdb-statefulset
+spec:
+  serviceName: xtdb-service
+  replicas: {{ .Values.nodeCount }}
+  selector:
+    matchLabels:
+      app: xtdb-statefulset
+  template:
+    metadata:
+      labels:
+        app: xtdb-statefulset
+    spec:
+      # Requires the service account to be created & federated identity set up
+      serviceAccountName: {{ required (printf "xtdbConfig.serviceAccount is required - ensure you set it up on %s and federate with a Google Cloud IAM service account" .Release.Namespace) .Values.xtdbConfig.serviceAccount }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      volumes: 
+        - name: "tmp"
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: "local-disk-cache"
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+      containers:
+        - name: xtdb-container
+          image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ['-f', '/var/lib/xtdb-config/xtdbconfig.yaml']
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: "/var/lib/xtdb/buffers/"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: {{ .Values.xtdbConfig.jdkOptions }}
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ required "xtdbConfig.kafkaBootstrapServers is required." .Values.xtdbConfig.kafkaBootstrapServers }}
+            - name: KAFKA_LOG_TOPIC
+              value: {{ required "xtdbConfig.kafkaLogTopic is required." .Values.xtdbConfig.kafkaLogTopic }}
+            - name: GCP_PROJECT_ID
+              value: {{ required "xtdbConfig.gcpProjectId is required." .Values.xtdbConfig.gcpProjectId }}
+            - name: GCP_BUCKET
+              value: {{ required "xtdbConfig.gcpBucket is required." .Values.xtdbConfig.gcpBucket }}
+            {{- range $key, $value := .Values.xtdbConfig.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/google-cloud/helm/templates/xtdbservice.yaml
+++ b/google-cloud/helm/templates/xtdbservice.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xtdb-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: xtdb-statefulset
+spec:
+  type: {{ .Values.xtdbService.type }}
+  ports:
+  - port: {{ .Values.xtdbService.server.servicePort }}
+    targetPort: {{ .Values.xtdbService.server.targetPort }}
+    name: server
+  - port: {{ .Values.xtdbService.httpServer.servicePort }}
+    targetPort: {{ .Values.xtdbService.httpServer.targetPort }}
+    name: http
+  selector:
+    app: xtdb-statefulset

--- a/google-cloud/helm/templates/xtdbyamlconfig.yaml
+++ b/google-cloud/helm/templates/xtdbyamlconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: xtdb-yaml-config
+  namespace: {{ .Release.Namespace }}
+data:
+  xtdbconfig.yaml: |-
+    {{ .Values.xtdbConfig.nodeConfig | nindent 4 }}

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -1,0 +1,122 @@
+nodeCount: 3
+
+image:
+  repository: ghcr.io/xtdb/xtdb-google-cloud
+  # tag: 2.0.0-beta5
+  pullPolicy: IfNotPresent
+
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"
+  cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+  node_pool: "xtdb-pool"
+
+tolerations: []
+
+affinity: {}
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "10G"
+    ephemeral-storage: 100Gi
+  requests:
+    cpu: "750m"
+    memory: "10G"
+    ephemeral-storage: 100Gi
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+xtdbConfig:
+  # REQUIRED
+  # Kubernetes Service Account configured with Workload Identity Federation wih access to Google Cloud Storage
+  serviceAccount: ""
+  # Google Cloud Project ID 
+  gcpProjectId: ""
+  # Google Cloud Storage Bucket 
+  gcpBucket: "" 
+  # Kafka bootstrap servers
+  kafkaBootstrapServers: "kafka.xtdb-deployment.svc.cluster.local:9092"
+  # XTDB log topic on Kafka 
+  kafkaLogTopic: "xtdb-log"
+
+  # OPTIONAL
+  # JDK options - ensure that heap + direct memory + metaspace <= memory limit, and that some overhead is left for the OS
+  # See https://docs.oracle.com/cd/E13150_01/jrockit_jvm/jrockit/jrdocs/refman/optionX.html
+  jdkOptions: "-Xmx3000m -Xms3000m -XX:MaxDirectMemorySize=3000m -XX:MaxMetaspaceSize=500m"
+
+  # We mount and use the below YAML for configuring the XTDB nodes and their modules.
+  # The !Env values are set by Environment Variables set on the XTDB statefulset pods.
+  # See the XTDB configuration documentation for options: https://docs.xtdb.com/ops/config.html
+  nodeConfig: |-
+    server:
+      port: 5432
+
+    log: !Kafka
+      bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+      topic: !Env KAFKA_LOG_TOPIC
+
+    storage: !Remote
+      objectStore: !GoogleCloud
+        projectId: !Env GCP_PROJECT_ID
+        bucket: !Env GCP_BUCKET
+        prefix: xtdb-object-store
+      localDiskCache: /var/lib/xtdb/buffers/disk-cache
+
+    healthz:
+      port: 8080
+
+    modules:
+    - !HttpServer
+      port: 3000 
+
+  # Volume size settings for XTDB Local Disk Cache (uses ephemeral storage)
+  localDiskCache:
+    sizeLimit: "50Gi"
+
+  # Extra Env:
+  env:
+    # (ENV_VAR_NAME: Value)
+    XTDB_LOGGING_LEVEL: "info" # See https://docs.xtdb.com/ops/troubleshooting/overview.html
+
+startupProbe:
+  httpGet:
+    path: /healthz/started
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 10 
+
+livenessProbe:
+  httpGet:
+    path: /healthz/alive
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3
+
+xtdbService:
+  type: LoadBalancer
+  server:
+    # Port of the Postgres Wire Server on the nodes
+    targetPort: 5432
+    # Port exposed by the service
+    servicePort: 5432
+  httpServer:
+    # Port of the http server on the nodes
+    targetPort: 3000
+    # Port exposed by the service
+    servicePort: 3000
+
+metricService: 
+  type: ClusterIP
+  # Port of the metrics server on the nodes
+  targetPort: 8080
+  # Port exposed by the service
+  servicePort: 80

--- a/google-cloud/terraform/README.adoc
+++ b/google-cloud/terraform/README.adoc
@@ -1,0 +1,10 @@
+# XTDB Google Cloud Terraform Sample
+
+Contained within this directory are sample terraform files for deploying XTDB to Google Cloud. The samples are designed to be as simple as possible, and are intended to be used as a starting point for your own deployments.
+
+## Pulling the files locally
+
+We can fetch the contents of this folder using the terraform CLI:
+```
+terraform init -from-module github.com/xtdb/xtdb.git//google-cloud/terraform
+```  

--- a/google-cloud/terraform/main.tf
+++ b/google-cloud/terraform/main.tf
@@ -1,0 +1,97 @@
+resource "google_service_account" "xtdb_service_account" {
+  project = var.project_id
+
+  account_id   = var.service_account_name
+  display_name = "XTDB Service Account"
+}
+
+module "xtdb_storage" {
+  source  = "terraform-google-modules/cloud-storage/google"
+  version = "~> 9.0"
+
+  project_id = var.project_id
+
+  # Storage bucket settings
+  names         = [var.storage_bucket_name]
+  location      = var.storage_bucket_location
+  storage_class = var.storage_bucket_storage_class
+
+  # Role assignments
+  set_admin_roles = true
+  admins          = [google_service_account.xtdb_service_account.member]
+}
+
+module "xtdb_vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "10.0.0"
+
+  project_id   = var.project_id
+  network_name = var.vpc_name
+
+  subnets = [
+    {
+      subnet_name   = var.vpc_subnet_name
+      subnet_ip     = var.vpc_subnet_ip
+      subnet_region = var.vpc_subnet_region
+    }
+  ]
+}
+
+module "kubernetes_engine" {
+  source  = "terraform-google-modules/kubernetes-engine/google"
+  version = "35.0.1"
+
+  project_id = var.project_id
+
+  name   = var.kubernetes_cluster_name
+  region = var.kubernetes_cluster_region
+  zones  = var.kubernetes_cluster_zones
+
+  network           = module.xtdb_vpc.network_name
+  subnetwork        = module.xtdb_vpc.subnets_names[0]
+  ip_range_pods     = ""
+  ip_range_services = ""
+
+  # Default node pool count - uses same machine type as application node pool
+  initial_node_count = var.default_node_pool_count
+
+  node_pools = [
+    {
+      name                              = "xtdb-pool"
+      machine_type                      = var.node_machine_type
+      node_locations                    = var.application_node_pool_locations
+      min_count                         = var.application_node_pool_min_nodes_per_location
+      max_count                         = var.application_node_pool_max_nodes_per_location
+      disk_size_gb                      = var.application_node_pool_disk_size_gb
+      disk_type                         = var.application_node_pool_disk_type
+      auto_repair                       = true
+      auto_upgrade                      = true
+      local_ssd_ephemeral_storage_count = var.application_node_pool_local_ephemeral_ssd_count
+      service_account                   = google_service_account.xtdb_service_account.email
+    }
+  ]
+
+  node_pools_labels = {
+    all = {}
+
+    xtdb-pool = {
+      environment = "dev"
+    }
+  }
+
+  node_pools_taints = {
+    all = []
+
+    xtdb-pool = [
+      {
+        key    = "xtdb-pool"
+        value  = true
+        effect = "PREFER_NO_SCHEDULE"
+      },
+    ]
+  }
+
+  # We don't need to create a service account for the GKE cluster - we've already created one
+  create_service_account = false
+}
+

--- a/google-cloud/terraform/outputs.tf
+++ b/google-cloud/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "project_id" {
+  value = var.project_id
+}
+
+output "bucket_name" {
+  value = module.xtdb_storage.name
+}
+
+output "service_account_email" {
+  value = google_service_account.xtdb_service_account.email
+}

--- a/google-cloud/terraform/providers.tf
+++ b/google-cloud/terraform/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=1.3"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.43.0, < 7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}

--- a/google-cloud/terraform/terraform.tfvars
+++ b/google-cloud/terraform/terraform.tfvars
@@ -1,0 +1,37 @@
+# Google Cloud Project
+# project_id = "project-id"
+
+# Google Cloud Service Account Name
+service_account_name = "xtdb-service-account"
+
+# Google Cloud Storage Settings
+storage_bucket_name          = "xtdb-storage-bucket"
+storage_bucket_location      = "us-central1"
+storage_bucket_storage_class = "STANDARD"
+
+# VPC/Network naming for XTDB VPC
+vpc_name          = "xtdb-vpc"
+vpc_subnet_name   = "xtdb-vpc-public-subnet"
+vpc_subnet_ip     = "10.10.10.0/24"
+vpc_subnet_region = "us-central1"
+
+# Key GKE Config
+kubernetes_cluster_name   = "xtdb-cluster"
+kubernetes_cluster_region = "us-central1"
+kubernetes_cluster_zones  = ["us-central1-a"]
+
+## GKE Node Pool Settings
+### Initial node count for the default node pool
+default_node_pool_count = 1
+### Node machine type shared by default and application node pools
+node_machine_type           = "n2-highmem-2"
+
+
+## GKE Application Node Pool Settings
+application_node_pool_locations              = "us-central1-a,us-central1-b,us-central1-c"
+application_node_pool_min_nodes_per_location = 1
+application_node_pool_max_nodes_per_location = 1
+application_node_pool_disk_size_gb           = 50
+application_node_pool_disk_type              = "pd-standard"
+### Ephemeral SSDs used as scratch storage for the XTDB nodes - ie, for their local disk cache
+application_node_pool_local_ephemeral_ssd_count = 1

--- a/google-cloud/terraform/variables.tf
+++ b/google-cloud/terraform/variables.tf
@@ -1,0 +1,134 @@
+variable "project_id" {
+  description = "Existing Google Cloud Project ID to deploy the XTDB infrastructure into."
+  type        = string
+  validation {
+    condition     = length(var.project_id) >= 0
+    error_message = "The Google cloud project ID must be set."
+  }
+}
+
+variable "service_account_name" {
+  description = "The name of the Google Cloud service account used for XTDB deployment."
+  type        = string
+  default     = "xtdb-service-account"
+}
+
+variable "kubernetes_namespace" {
+  description = "Name of the Kubernetes namespace for XTDB"
+  type        = string
+  default     = "xtdb-deployment"
+}
+
+variable "kubernetes_service_account_name" {
+  description = "Name of the Kubernetes service account for XTDB"
+  type        = string
+  default     = "xtdb-service-account"
+}
+
+variable "storage_bucket_name" {
+  description = "The name of the Google Cloud Storage bucket used for XTDB data storage."
+  type        = string
+  default     = "xtdb-storage-bucket"
+}
+
+variable "storage_bucket_location" {
+  description = "The geographical region where the Google Cloud Storage bucket will be created."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "storage_bucket_storage_class" {
+  description = "The storage class for the Google Cloud Storage bucket, defining performance and cost (e.g., STANDARD, NEARLINE, COLDLINE)."
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "vpc_name" {
+  description = "The name of the Google Cloud VPC network for XTDB deployment."
+  type        = string
+  default     = "xtdb-vpc"
+}
+
+variable "vpc_subnet_name" {
+  description = "The name of the Google Cloud VPC subnet for XTDB deployment."
+  type        = string
+  default     = "xtdb-vpc-public-subnet"
+}
+
+variable "vpc_subnet_ip" {
+  description = "The IP range for the Google Cloud VPC subnet."
+  type        = string
+  default     = "10.10.10.0/24"
+}
+
+variable "vpc_subnet_region" {
+  description = "The region where the Google Cloud VPC subnet will be deployed."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "kubernetes_cluster_name" {
+  description = "The name of the Google Kubernetes Engine (GKE) cluster for XTDB deployment."
+  type        = string
+  default     = "xtdb-cluster"
+}
+
+variable "kubernetes_cluster_region" {
+  description = "The region where the GKE cluster will be deployed."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "kubernetes_cluster_zones" {
+  description = "The list of zones within the selected region where the GKE cluster nodes will be distributed."
+  type        = list(string)
+  default     = ["us-central1-a"]
+}
+
+variable "default_node_pool_count" {
+  description = "The initial number of nodes in the default node pool."
+  type        = number
+  default     = 1
+}
+
+variable "node_machine_type" {
+  description = "The machine type used by nodes setup in GKE."
+  type        = string
+  default     = "n2-highmem-4"
+}
+
+variable "application_node_pool_locations" {
+  description = "The specific zones where application node pool nodes will be deployed."
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "application_node_pool_min_nodes_per_location" {
+  description = "The minimum number of nodes per zone to maintain in the application node pool."
+  type        = number
+  default     = 1
+}
+
+variable "application_node_pool_max_nodes_per_location" {
+  description = "The maximum number of nodes per zone allowed in the application node pool."
+  type        = number
+  default     = 1
+}
+
+variable "application_node_pool_disk_size_gb" {
+  description = "The disk size (in GB) allocated to each node in the application node pool."
+  type        = number
+  default     = 50
+}
+
+variable "application_node_pool_disk_type" {
+  description = "The type of persistent disk used for application node pool nodes (e.g., pd-standard, pd-ssd)."
+  type        = string
+  default     = "pd-standard"
+}
+
+variable "application_node_pool_local_ephemeral_ssd_count" {
+  description = "The number of local SSDs to attach to each node in the application node pool, used as scratch space (for XTDB local disk caches)."
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Resolves #4113 
Docs Build: https://google-cloud-tf-and-helm.d2zcybuz6k9g4m.amplifyapp.com/

- Add a terraform file setting up all of the cloud infra XTDB requires and for setting up/running kubernetes:
  - Setting up an XTDB service account. 
  - Using [**GoogleCloud/storage-bucket**]( https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google/latest) for setting up storage bucket and perms.
  - Using [**GoogleCloud/network**](https://registry.terraform.io/modules/terraform-google-modules/network/google/latest) for setting up a simple VPC for the Kubernetes Engine infra.
  - Using [**GoogleCloud/kubernetes-engine**](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest) for setting up GKE with a system and application node pool.
  - Setting up everything else we need around those - using sensible variables to allow easy customisation with `terraform.tfvars`.
- Add helm config for google cloud:
  - Based on azure helm config.
  - Added to helm deploy task.
  - Deploying all necessary config to kubernetes,  
- Update the `Google Cloud` docs to include notes on using both terraform and helm.
- Add a "getting started with google cloud" guide.