### PR TITLE
Add transaction error counter

### DIFF
--- a/monitoring/grafana/dashboards/xtdb-monitoring.json
+++ b/monitoring/grafana/dashboards/xtdb-monitoring.json
@@ -615,6 +615,109 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 5
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(tx_error_total)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "$xtdbnode",
+          "range": true,
+          "refId": "Node Average",
+          "useBackend": false
+        }
+      ],
+      "title": "Cluster Transaction Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "How many Queries are taking place per second?",
       "fieldConfig": {
         "defaults": {
@@ -675,7 +778,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 5
       },
       "id": 9,
@@ -778,8 +881,8 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 18,
-        "y": 5
+        "x": 0,
+        "y": 12
       },
       "id": 10,
       "options": {
@@ -898,7 +1001,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 12
       },
       "id": 20,
@@ -1178,6 +1281,109 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 20
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "tx_error_total{node_id=\"$xtdbnode\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "$xtdbnode",
+          "range": true,
+          "refId": "Node Average",
+          "useBackend": false
+        }
+      ],
+      "title": "Transaction Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "How many Queries are taking place per second?",
       "fieldConfig": {
         "defaults": {
@@ -1238,7 +1444,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 20
       },
       "id": 17,
@@ -1341,8 +1547,8 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 18,
-        "y": 20
+        "x": 0,
+        "y": 27
       },
       "id": 18,
       "options": {
@@ -1461,7 +1667,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 27
       },
       "id": 19,
@@ -1533,7 +1739,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 6,
+        "x": 12,
         "y": 27
       },
       "id": 12,
@@ -1642,7 +1848,7 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 27
       },
       "id": 11,
@@ -1768,8 +1974,8 @@
       "gridPos": {
         "h": 7,
         "w": 6,
-        "x": 18,
-        "y": 27
+        "x": 0,
+        "y": 34
       },
       "id": 13,
       "options": {

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -9,16 +9,50 @@
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node tu/with-simple-registry)
 
-(t/deftest test-error-and-warning-counter
+(t/deftest test-query-error-and-warning-counter
   (let [registry ^CompositeMeterRegistry (tu/component tu/*node* :xtdb.metrics/registry)]
-    (t/is (thrown-with-msg? Exception #"" (xt/q tu/*node* "SLECT 1")))
-    (t/is (thrown-with-msg? Exception #"" (jdbc/execute! tu/*conn* ["SLECT 1"])))
-    (t/is (thrown-with-msg? Exception #"" (xt/q tu/*node* "SELECT 1/0")))
-    (t/is (thrown-with-msg? Exception #"" (jdbc/execute! tu/*conn* ["SELECT 1/0"])))
+    (t/is (thrown? Exception (xt/q tu/*node* "SLECT 1"))
+          "parsing error via the node")
+    (t/is (thrown? Exception (jdbc/execute! tu/*conn* ["SLECT 1"]))
+          "parsing error via pgwire")
+    (t/is (thrown? Exception (xt/q tu/*node* "SELECT 1/0"))
+          "runtime error via the node")
+    (t/is (thrown? Exception (jdbc/execute! tu/*conn* ["SELECT 1/0"]))
+          "runtime error via pgwire")
 
+    ;; producing some unknown column/table warnings
     (xt/q tu/*node* "SELECT foo FROM bar")
     (jdbc/execute! tu/*conn* ["SELECT foo FROM bar"])
 
     (t/is (= 4.0 (.count ^Counter (.counter (.find registry "query.error")))))
-
     (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.warning")))))))
+
+(t/deftest test-transaction-exception-counter
+  (let [registry ^CompositeMeterRegistry (tu/component tu/*node* :xtdb.metrics/registry)]
+    (t/is (thrown? Exception (jdbc/execute! tu/*conn* ["INSERT INTO foo (a) VALUES (42)"]))
+          "presubmit error via pgwire")
+
+    (t/testing "producing errors on transaction commit"
+      (jdbc/execute! tu/*conn* ["START TRANSACTION"])
+      (jdbc/execute! tu/*conn* ["INSERT INTO foo (a) VALUES (42)"])
+      (t/is (thrown? Exception (jdbc/execute! tu/*conn* ["COMMIT"]))))
+
+    (t/is (thrown? Exception (xt/execute-tx tu/*node* ["INSERT INTO foo (a) VALUES (42)"]))
+          "presubmit error via the node")
+    (t/is (thrown? Exception (jdbc/execute! tu/*conn* ["INSERT INTO docs SELECT 1/0 AS _id"]))
+          "runtime error in the indexer")
+
+    (t/is (= 0.0 (.count ^Counter (.counter (.find registry "query.error")))))
+    (t/is (= 0.0 (.count ^Counter (.counter (.find registry "query.warning")))))
+    (t/is (= 4.0 (.count ^Counter (.counter (.find registry "tx.error")))))))
+
+(t/deftest test-transaction-exception-counter-on-submit-tx
+  (let [registry ^CompositeMeterRegistry (tu/component tu/*node* :xtdb.metrics/registry)]
+    (t/is (thrown? Exception (xt/submit-tx tu/*node* ["INSERT INTO foo (a) VALUES (42)"]))
+          "presubmit error via the node (submit-tx)")
+
+    (t/testing "async errors in the indexer"
+      (xt/submit-tx tu/*node* ["INSERT foo"])
+      (Thread/sleep 200))
+
+    (t/is (= 2.0 (.count ^Counter (.counter (.find registry "tx.error")))))))


### PR DESCRIPTION
Adds `tx.error`, picks up errors in indexer, submit-tx and pgwire when dealing with DML.

There is the possibility that bad queries like `INSERT foo` will be treated as query errors in pgwire but this might be acceptable as there's no inherent meaning (i.e. this is definitely DML) to `INSERT foo`.

We're catching IllegalArugmentExceptions on the node level (in submit-tx) to ensure we capture errors that occur during pre-submit phase simplifying inserts.