### PR TITLE
Add `XTDB_SKIP_TXS` and implement/test transaction skipping.

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -329,11 +329,12 @@
    :log (ig/ref :xtdb/log)
    :trie-catalog (ig/ref :xtdb/trie-catalog)
    :metrics-registry (ig/ref :xtdb.metrics/registry)
-   :block-flush-duration (.getFlushDuration (.getIndexer opts))})
+   :block-flush-duration (.getFlushDuration (.getIndexer opts))
+   :skip-txs (.getSkipTxs (.getIndexer opts))})
 
-(defmethod ig/init-key :xtdb.log/processor [_ {:keys [allocator indexer log live-idx trie-catalog metrics-registry block-flush-duration] :as deps}]
+(defmethod ig/init-key :xtdb.log/processor [_ {:keys [allocator indexer log live-idx trie-catalog metrics-registry block-flush-duration skip-txs] :as deps}]
   (when deps
-    (LogProcessor. allocator indexer live-idx log trie-catalog metrics-registry block-flush-duration)))
+    (LogProcessor. allocator indexer live-idx log trie-catalog metrics-registry block-flush-duration (set skip-txs))))
 
 (defmethod ig/halt-key! :xtdb.log/processor [_ ^LogProcessor log-processor]
   (util/close log-processor))

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -36,12 +36,13 @@
 (defmethod apply-config! :storage [config _ opts]
   (apply-config! config :xtdb.buffer-pool/storage opts))
 
-(defmethod apply-config! :indexer [^Xtdb$Config config _ {:keys [rows-per-block page-limit log-limit flush-duration]}]
+(defmethod apply-config! :indexer [^Xtdb$Config config _ {:keys [rows-per-block page-limit log-limit flush-duration skip-txs]}]
   (cond-> (.getIndexer config)
     rows-per-block (.rowsPerBlock rows-per-block)
     page-limit (.pageLimit page-limit)
     log-limit (.logLimit log-limit)
-    flush-duration (.flushDuration (time/->duration flush-duration))))
+    flush-duration (.flushDuration (time/->duration flush-duration))
+    skip-txs (.skipTxs skip-txs)))
 
 (defmethod apply-config! :compactor [^Xtdb$Config config _ {:keys [threads]}]
   (cond-> (.getCompactor config)

--- a/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
@@ -5,6 +5,7 @@ package xtdb.api
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
+import xtdb.api.log.LogOffset
 import java.time.Duration
 
 @Serializable
@@ -13,9 +14,17 @@ data class IndexerConfig(
     var pageLimit: Long = 1024L,
     var rowsPerBlock: Long = 102400L,
     var flushDuration: Duration = Duration.ofHours(4),
+    var skipTxs: List<LogOffset> = System.getenv("XTDB_SKIP_TXS")?.let(::parseSkipTxsEnv).orEmpty()
 ) {
     fun logLimit(logLimit: Long) = apply { this.logLimit = logLimit }
     fun pageLimit(pageLimit: Long) = apply { this.pageLimit = pageLimit }
     fun rowsPerBlock(rowsPerBlock: Long) = apply { this.rowsPerBlock = rowsPerBlock }
     fun flushDuration(flushDuration: Duration) = apply { this.flushDuration = flushDuration }
+    fun skipTxs(skipTxs: List<LogOffset>) = apply { this.skipTxs = skipTxs.sorted() }
+
+    companion object {
+        private fun parseSkipTxsEnv(skipTxs: String): List<LogOffset> =
+            skipTxs.split(",").map { it.trim().toLong() }.sorted()
+    }
 }
+

--- a/docs/src/content/docs/ops/troubleshooting/overview.adoc
+++ b/docs/src/content/docs/ops/troubleshooting/overview.adoc
@@ -50,3 +50,24 @@ This is a strict requirement because inconsistencies in node states can lead to 
 If you encounter an `Ingestion Stopped: ... some cause ...` error, it means we were unable to guarantee this
 requirement and had to stop ingestion.
 Please raise an issue with the full stack trace at link:https://github.com/xtdb/xtdb/issues[XTDB Issues].
+
+// === Skipping Transactions
+
+// When encountering a deterministic ingestion stopping issue, we provide `XTDB_SKIP_TXS` as a mechanism to move ingestion past particular errant/erroneous transactions.
+
+// WARNING: This should _only_ be done if you are entirely certain that the issue is deterministic and causes all nodes to stop ingestion at the same point. This change _must_ be applied atomically - ie, all nodes must be stopped, the change applied, and then all nodes restarted. We _cannot_ risk  one node committing a transaction and another rolling the same transaction back.
+
+// The process of using `XTDB_SKIP_TXS` is as follows:
+
+// . Verify that ingestion stops at the same transaction on all nodes - identify this errant transaction. This is available within the logs.
+// . Scale down all nodes within the XTDB cluster.
+// . Set `XTDB_SKIP_TXS="<txId>,<txId2>..."` as an environment variable on all of the nodes.
+// . Restart all nodes within the XTDB cluster.
+// . When the errant transaction has been skipped, you will see a `WARN` Log within the node's logs.
+// .. "Skipping transaction offset 2109 - within XTDB_SKIP_TXS"
+// . Once the next block has been written, you will see a `INFO` Log from `xtdb.indexer.live-index`:
+// .. "All XTDB_SKIP_TXS have been skipped and block has been finished - it is safe to remove the XTDB_SKIP_TXS environment variable."
+// . Once it is safe to remove the `XTDB_SKIP_TXS` environment variable, scale down all nodes within the XTDB cluster.
+// . Remove the `XTDB_SKIP_TXS` environment variable from all nodes.
+// . Restart all nodes within the XTDB cluster.
+

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -177,7 +177,8 @@
                                                                nil (StampedLock.)
                                                                (RefCounter.)
                                                                (RowCounter. 0) 102400
-                                                               64 1024)]
+                                                               64 1024
+                                                               [])]
           (let [tx-key (serde/->TxKey 0 (.toInstant #inst "2000"))
                 live-index-tx (.startTx live-index tx-key)
                 live-table-tx (.liveTable live-index-tx table-name)

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -1,6 +1,7 @@
 (ns ^:kafka xtdb.kafka-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.log :as log]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])


### PR DESCRIPTION
Resolves #4154 

- Could do with a check over the "block finished" behavior. 
  - This log may/will be returned multiple times - I decided that was likely fine, XTDB_SKIP_TXS shouldn't really be kept around much longer than it has to.  
- Will require documenting along with Caveats.