### PR TITLE
Return error if duplicate columns are projected from query tail

### DIFF
--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -2157,10 +2157,15 @@
         ob-plan (some-> order-by-clause
                         (plan-order-by env scope
                                        (mapv :col-sym projected-cols)))]
+
+        (when-let [dup-cols (not-empty (dups (mapv :col-sym projected-cols)))]
+          (doseq [col dup-cols]
+            (add-err! env (->DuplicateColumnProjection col))))
+
     (reify
       Scope
       (available-cols [_]
-        (->insertion-ordered-set (mapv :col-sym (:projected-cols select-plan))))
+        (->insertion-ordered-set (mapv :col-sym projected-cols)))
 
       (-find-cols [this [col-name table-name] excl-cols]
         (when (nil? table-name)

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2796,3 +2796,9 @@ UNION ALL
                   SELECT d1.col1 t
                   WHERE t IS NOT NULL
                   ORDER BY t asc"))))
+
+(t/deftest test-duplicate-column-projection
+  (t/is (thrown-with-msg?
+         IllegalArgumentException
+         #"Duplicate column projection: a"
+         (plan-sql "SELECT 1 AS a, 2 AS a" {}))))


### PR DESCRIPTION
`SELECT 1 AS a, 2 AS a`