### PR TITLE
Move table block metadata to new table-catalog component

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -256,6 +256,7 @@
          :xtdb/allocator {}
          :xtdb/indexer {}
          :xtdb/block-catalog {}
+         :xtdb/table-catalog {}
          :xtdb/trie-catalog {}
          :xtdb.log/processor opts
          :xtdb.metadata/metadata-manager {}

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -1,0 +1,108 @@
+(ns xtdb.table-catalog
+  (:require [integrant.core :as ig]
+            [xtdb.trie :as trie]
+            [xtdb.types :as types]
+            [xtdb.util :as util])
+  (:import (clojure.lang MapEntry)
+           (com.google.protobuf ByteString)
+           [java.nio ByteBuffer]
+           [java.nio.file Path]
+           [java.util ArrayList]
+           (org.apache.arrow.vector.types.pojo Field Schema)
+           (xtdb BufferPool)
+           (xtdb.block.proto TableBlock)
+           xtdb.catalog.BlockCatalog))
+
+(defprotocol PTableCatalog
+  (finish-block! [table-cat block-idx delta-tables->metadata])
+  (column-fields [table-cat table-name])
+  (row-count [table-cat table-name])
+  (column-field [table-cat talbe-name col-name])
+  (all-column-fields [table-cat]))
+
+(def ^java.nio.file.Path block-table-metadata-path (util/->path "blocks"))
+
+(defn ->table-block-metadata-obj-key [^Path table-path block-idx]
+  (.resolve (.resolve table-path block-table-metadata-path)
+            (format "b%s.binpb" (util/->lex-hex-string block-idx))))
+
+(defn write-table-block-data ^java.nio.ByteBuffer [^Schema table-schema ^long row-count]
+  (ByteBuffer/wrap (-> (doto (TableBlock/newBuilder)
+                         (.setArrowSchema (ByteString/copyFrom (.serializeAsMessage table-schema)))
+                         (.setRowCount row-count))
+                       (.build)
+                       (.toByteArray))))
+
+(defn <-table-block [^TableBlock table-block]
+  (let [^Schema schema
+        (Schema/deserializeMessage (ByteBuffer/wrap (.toByteArray (.getArrowSchema table-block))))]
+    {:row-count (.getRowCount table-block)
+     :fields (->> (for [^Field field (.getFields schema)]
+                    (MapEntry/create (.getName field) field))
+                  (into {}))}))
+
+(defn- merge-fields [old-fields new-fields]
+  (->> (merge-with types/merge-fields old-fields new-fields)
+       (map (fn [[col-name field]] [col-name (types/field-with-name field col-name)]))
+       (into {})))
+
+(defn- merge-tables [old-table {:keys [row-count fields] :as delta-table}]
+  (cond-> old-table
+    delta-table (-> (update :row-count (fnil + 0) row-count)
+                    (update :fields merge-fields fields))))
+
+(defn- new-tables-metadata [old-tables-metadata new-deltas-metadata]
+  (let [table-names (set (concat (keys old-tables-metadata) (keys new-deltas-metadata)))]
+    (->> table-names
+         (map (fn [table-name]
+                (MapEntry/create table-name
+                                 (merge-tables (get old-tables-metadata table-name)
+                                               (get new-deltas-metadata table-name)))))
+         (into {}))))
+
+(defn- load-tables-to-metadata ^java.util.Map [^BufferPool buffer-pool, ^BlockCatalog block-cat]
+  (when-let [block-idx (.getCurrentBlockIndex block-cat)]
+    (let [table-names (.getAllTableNames block-cat)]
+      [block-idx
+       (->> (for [table-name table-names
+                  :let [table-block-path (->table-block-metadata-obj-key (trie/table-name->table-path table-name) block-idx)
+                        table-block (TableBlock/parseFrom (.getByteArray buffer-pool table-block-path))]]
+              (MapEntry/create table-name (<-table-block table-block)))
+            (into {}))])))
+
+(deftype TableCatalog [^BufferPool buffer-pool
+                       ^:volatile-mutable ^long block-idx
+                       ^:volatile-mutable table->metadata]
+  PTableCatalog
+  (finish-block! [this block-idx delta-table->metadata]
+    (when (or (nil? (.block-idx this)) (< (.block-idx this) block-idx))
+      (let [new-table->metadata (new-tables-metadata table->metadata delta-table->metadata)
+            table-names (ArrayList.)]
+        (doseq [[table-name {:keys [row-count fields]}] new-table->metadata]
+          (let [fields (for [[col-name field] fields]
+                         (types/field-with-name field col-name))
+                table-block-path (->table-block-metadata-obj-key (trie/table-name->table-path table-name) block-idx)]
+            (.add table-names table-name)
+            (.putObject buffer-pool table-block-path
+                        (write-table-block-data (Schema. fields) row-count))))
+        (set! (.block-idx this) block-idx)
+        (set! (.table->metadata this) new-table->metadata)
+        (vec table-names))))
+
+  (column-fields [_ table-name] (get-in table->metadata [table-name :fields]))
+  (row-count [_ table-name] (get-in table->metadata [table-name :row-count]))
+  (column-field [_ table-name col-name]
+    (some-> (get-in table->metadata [table-name :fields])
+            (get col-name (types/->field col-name #xt.arrow/type :null true))))
+  (all-column-fields [_] (update-vals table->metadata :fields)))
+
+(defmethod ig/prep-key :xtdb/table-catalog [_ _]
+  {:buffer-pool (ig/ref :xtdb/buffer-pool)
+   :block-cat (ig/ref :xtdb/block-catalog)})
+
+(defmethod ig/init-key :xtdb/table-catalog [_ {:keys [buffer-pool block-cat]}]
+  (let [[block-idx table->metadata] (load-tables-to-metadata buffer-pool block-cat)]
+    (TableCatalog. buffer-pool (or block-idx -1) table->metadata)))
+
+(defn <-node [node]
+  (util/component node :xtdb/table-catalog))

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -4,7 +4,10 @@
             [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector.writer :as vw])
-  (:import com.carrotsearch.hppc.ByteArrayList
+  (:import (clojure.lang MapEntry)
+           com.carrotsearch.hppc.ByteArrayList
+           (com.google.protobuf ByteString)
+           (java.nio ByteBuffer)
            (java.nio.file Path)
            java.time.LocalDate
            (java.util ArrayList)
@@ -12,6 +15,7 @@
            (org.apache.arrow.vector VectorSchemaRoot)
            (org.apache.arrow.vector.types.pojo ArrowType$Union Field Schema)
            org.apache.arrow.vector.types.UnionMode
+           (xtdb.block.proto TableBlock)
            xtdb.BufferPool
            (xtdb.trie DataRel ISegment MemoryHashTrie MergePlanNode Trie Trie$Key)
            (xtdb.util TemporalBounds TemporalDimension)))
@@ -44,9 +48,6 @@
 
 (defn table-name->table-path ^java.nio.file.Path [^String table-name]
   (.resolve tables-dir (-> table-name (str/replace #"[\.\/]" "\\$"))))
-
-(defn table-dir->table-name ^String [^String table-dir]
-  (str/replace-first table-dir #"\$" "/" ))
 
 (defn ->table-data-file-path ^java.nio.file.Path [table-name trie-key]
   (-> (table-name->table-path table-name)

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -1,10 +1,11 @@
 (ns xtdb.indexer.live-table-test
   (:require [clojure.java.io :as io]
             [clojure.test :as t :refer [deftest]]
+            [xtdb.block-catalog :as block-cat]
             [xtdb.indexer.live-index :as li]
-            [xtdb.metadata :as meta]
             [xtdb.node :as xtn]
             [xtdb.serde :as serde]
+            [xtdb.table-catalog :as table-cat]
             [xtdb.test-json :as tj]
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie]
@@ -166,13 +167,14 @@
         table-name "foo"]
     (util/with-open [allocator (RootAllocator.)]
       (let [^BufferPool bp (tu/component tu/*node* :xtdb/buffer-pool)
-            mm (tu/component tu/*node* ::meta/metadata-manager)
+            block-cat (block-cat/<-node tu/*node*)
             log (tu/component tu/*node* :xtdb/log)
+            table-catalog (table-cat/<-node tu/*node*)
             trie-catalog (tu/component tu/*node* :xtdb/trie-catalog)
             live-index-allocator (util/->child-allocator allocator "live-index")]
-        (util/with-open [^LiveIndex live-index (li/->LiveIndex live-index-allocator bp mm
-                                                               log trie-catalog
-                                                               (Compactor/getNoop)
+        (util/with-open [^LiveIndex live-index (li/->LiveIndex live-index-allocator bp log (Compactor/getNoop)
+                                                               block-cat table-catalog trie-catalog
+
                                                                nil nil (HashMap.)
                                                                nil (StampedLock.)
                                                                (RefCounter.)


### PR DESCRIPTION
On top of #4195. This contains no functional change, but moves table block metadata creation from metadata manager to the trie catalog. 