### PR TITLE
Add support for uncorrelated full outer join

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -592,7 +592,7 @@ joinSpecification
     ;
 
 joinType : 'INNER' | outerJoinType 'OUTER'? ;
-outerJoinType : 'LEFT' | 'RIGHT';
+outerJoinType : 'LEFT' | 'RIGHT' | 'FULL';
 
 /// §7.8 <where clause>
 

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -190,6 +190,9 @@
     [:left-outer-join _ lhs rhs]
     (vec (mapcat relation-columns [lhs rhs]))
 
+    [:full-outer-join _ lhs rhs]
+    (vec (mapcat relation-columns [lhs rhs]))
+
     [:semi-join _ lhs _]
     (relation-columns lhs)
 
@@ -595,7 +598,7 @@
     ;;=>
     (when (and
             (contains?
-              #{:join :semi-join :anti-join :left-outer-join :single-join :mark-join}
+              #{:join :semi-join :anti-join :left-outer-join :single-join :mark-join} ;TODO full-outer-join
               join-op)
             (or push-correlated? (no-correlated-columns? predicate)))
       (cond
@@ -819,7 +822,7 @@
     (when (not-empty (expr-correlated-symbols predicate))
       [:select predicate [:join join-map lhs rhs]])
 
-    [:left-outer-join join-map lhs [:select predicate rhs]]
+    [:left-outer-join join-map lhs [:select predicate rhs]] ;;TODO full-outer-join but also is this correct for LOJ
     ;;=>
     (when (not-empty (expr-correlated-symbols predicate))
       [:select predicate [:left-outer-join join-map lhs rhs]])
@@ -1111,7 +1114,7 @@
 
 (defn- rewrite-equals-predicates-in-join-as-equi-join-map [z]
   (r/zcase z
-    (:join :semi-join :anti-join :left-outer-join :single-join :mark-join)
+    (:join :semi-join :anti-join :left-outer-join :single-join :mark-join :full-outer-join)
     (r/zmatch
       z
       [:mark-join projection lhs rhs]

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -2,6 +2,7 @@
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as w]
             [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.error :as err]
@@ -370,7 +371,7 @@
                                   (str/upper-case))
                       "LEFT" :left-outer-join
                       "RIGHT" :right-outer-join
-                      ;; "FULL" :full-outer-join
+                      "FULL" :full-outer-join
                       :join)
 
           [join-type l r] (if (= join-type :right-outer-join)
@@ -395,14 +396,23 @@
                                                                          :scope (->JoinConditionScope env (->SubqueryScope env l !lhs-refs) r)
                                                                          :!subqs !join-cond-subqs})))]
 
-                       [:apply (if (= join-type :join)
-                                 :cross-join
-                                 join-type)
-                        (into {} !lhs-refs)
-                        (plan-rel l)
-                        [:select join-pred
-                         (-> (plan-rel r)
-                             (apply-sqs !join-cond-subqs))]])))))))))
+                       (if (= join-type :full-outer-join)
+
+                         (if (.isEmpty !join-cond-subqs)
+                           [:full-outer-join
+                            [(w/postwalk-replace (set/map-invert !lhs-refs) join-pred)]
+                            (plan-rel l)
+                            (plan-rel r)]
+                           (add-err! env (->SubqueryDisallowed)))
+
+                         [:apply (if (= join-type :join)
+                                   :cross-join
+                                   join-type)
+                          (into {} !lhs-refs)
+                          (plan-rel l)
+                          [:select join-pred
+                           (-> (plan-rel r)
+                               (apply-sqs !join-cond-subqs))]]))))))))))
 
 (defrecord CrossJoinTable [env !sq-refs l r]
   Scope

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-full-outer-join-uncorrelated.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-full-outer-join-uncorrelated.edn
@@ -1,0 +1,6 @@
+[:project
+ [{foo d2.2/foo} {bar d1.1/bar}]
+ [:full-outer-join
+  [{d1.1/bar d2.2/foo}]
+  [:rename d1.1 [:scan {:table public/d1} [bar]]]
+  [:rename d2.2 [:scan {:table public/d2} [foo]]]]]


### PR DESCRIPTION
This logic is predicated on the idea that as long as `!join-cond-subqs` is empty (there are no subqueries in the join cond) then all left hand side references (`!lhs-refs`) present in the join condition can be safely rewriten to their column name in the LHS, as the join condition has access to both sides.

The only way this wouldn't be the case is if we supported a `FULL OUTER JOIN LATERAL` of some sort, which I'm not sure makes much sense. 