### PR TITLE
Compactor OOM pt 1 #3825

### DIFF
--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -40,8 +40,6 @@ object Storage {
         fun open(allocator: BufferAllocator, meterRegistry: MeterRegistry = SimpleMeterRegistry()): BufferPool
     }
 
-    internal fun BufferAllocator.openStorageChildAllocator() = openChildAllocator("buffer-pool")
-
     internal fun arrowFooterCache(maxEntries: Long = 1024): Cache<Path, ArrowFooter> =
         Caffeine.newBuilder().maximumSize(maxEntries).build()
 

--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -67,6 +67,11 @@ class Relation(val vectors: SequencedMap<String, Vector>, override var rowCount:
         }
     }
 
+    fun append(rel: RelationReader) {
+        val copier = rowCopier(rel)
+        repeat(rel.rowCount) { copier.copyRow(it) }
+    }
+
     fun loadFromArrow(root: VectorSchemaRoot) {
         vectors.forEach { (name, vec) -> vec.loadFromArrow(root.getVector(name)) }
         rowCount = root.rowCount

--- a/core/src/main/kotlin/xtdb/buffer_pool/MemoryBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/buffer_pool/MemoryBufferPool.kt
@@ -9,7 +9,6 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import xtdb.BufferPool
 import xtdb.IEvictBufferTest
 import xtdb.api.storage.ObjectStore.StoredObject
-import xtdb.api.storage.Storage.openStorageChildAllocator
 import xtdb.arrow.ArrowUtil.openArrowBufView
 import xtdb.arrow.ArrowUtil.readArrowFooter
 import xtdb.arrow.ArrowUtil.toArrowRecordBatchView
@@ -17,7 +16,8 @@ import xtdb.arrow.ArrowUtil.toByteArray
 import xtdb.arrow.Relation
 import xtdb.trie.FileSize
 import xtdb.util.closeOnCatch
-import xtdb.util.registerMetrics
+import xtdb.util.openChildAllocator
+import xtdb.util.register
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels.newChannel
@@ -26,10 +26,10 @@ import java.util.*
 
 class MemoryBufferPool(
     allocator: BufferAllocator,
-    meterRegistry: MeterRegistry = SimpleMeterRegistry()
+    meterRegistry: MeterRegistry? = null
 ) : BufferPool, IEvictBufferTest {
 
-    private val allocator = allocator.openStorageChildAllocator().also { it.registerMetrics(meterRegistry) }
+    private val allocator = allocator.openChildAllocator("buffer-pool").also { meterRegistry?.register(it) }
 
     private val memoryStore: NavigableMap<Path, ArrowBuf> = TreeMap()
 

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -25,7 +25,6 @@ import java.util.function.Predicate
 import kotlin.math.min
 import kotlin.time.Duration.Companion.seconds
 
-private typealias InstantMicros = Long
 private typealias Selection = IntArray
 
 private typealias JobKey = Pair<TableName, TrieKey>

--- a/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
@@ -10,10 +10,10 @@ import org.apache.arrow.vector.complex.UnionVector
 internal fun BufferAllocator.openChildAllocator(name: String) =
     newChildAllocator(name, 0, Long.MAX_VALUE)
 
-internal fun BufferAllocator.registerMetrics(meterRegistry: MeterRegistry) = apply {
-    Gauge.builder("$name.allocator.allocated_memory", this) { al -> al.allocatedMemory.toDouble() }
+internal fun MeterRegistry.register(al: BufferAllocator) {
+    Gauge.builder("${al.name}.allocator.allocated_memory", al) { it.allocatedMemory.toDouble() }
         .baseUnit("bytes")
-        .register(meterRegistry)
+        .register(this@register)
 }
 
 fun ValueVector.openSlice(offset: Int = 0, len: Int = valueCount): ValueVector =

--- a/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
@@ -3,7 +3,6 @@ package xtdb.util
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.BaseFixedWidthVector
 import org.apache.arrow.vector.ValueVector
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.UnionVector
@@ -20,16 +19,10 @@ internal fun BufferAllocator.registerMetrics(meterRegistry: MeterRegistry) = app
 fun ValueVector.openSlice(offset: Int = 0, len: Int = valueCount): ValueVector =
     when {
         // see #3088
-        this is ListVector && offset == 0 && len == 0 ->
-            ListVector.empty(name, allocator)
+        this is ListVector && len == 0 -> ListVector.empty(name, allocator)
 
-        this is UnionVector && offset == 0 && len == 0 ->
-            UnionVector.empty(name, allocator)
-                .also { it.initializeChildrenFromFields(field.children) }
+        this is UnionVector && len == 0 ->
+            UnionVector.empty(name, allocator).also { it.initializeChildrenFromFields(field.children) }
 
-        // doesn't preserve nullability otherwise
-        this is BaseFixedWidthVector ->
-            getTransferPair(field, allocator).also { it.splitAndTransfer(offset, len) }.to
-
-        else -> getTransferPair(allocator).also { it.splitAndTransfer(offset, len) }.to
+        else -> getTransferPair(field, allocator).also { it.splitAndTransfer(offset, len) }.to
     }

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -1,11 +1,25 @@
 package xtdb.util
 
 import org.apache.arrow.vector.ipc.SeekableReadChannel
+import java.nio.channels.WritableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption.READ
+import java.nio.file.StandardOpenOption.*
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteIfExists
 
 internal fun Path.newSeekableByteChannel() = SeekableReadChannel(Files.newByteChannel(this, READ))
+
+internal fun Path.openWritableChannel(): WritableByteChannel = Files.newByteChannel(this, WRITE, CREATE)
+
+internal fun <R> useTempFile(prefix: String, suffix: String, block: (Path) -> R): R =
+    createTempFile(prefix, suffix).let {
+        try {
+            block(it)
+        } finally {
+            it.deleteIfExists()
+        }
+    }
 
 val String.asPath: Path
     get() = Path.of(this)


### PR DESCRIPTION
part 1 of #3825, wanted to get this landed separately as I've also been spending time migrating the imperative part of the compactor to Kotlin.

This PR writes out the merged segments lazily to a temp file, then eagerly reads them all back in to preserve the current behaviour. Next step will be to lazily read them back in too.