### PR TITLE
Add STS dependency to AWS module classpath.

### DIFF
--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     // metrics
     api(libs.micrometer.registry.cloudwatch2)
     api("software.amazon.awssdk", "cloudwatch", "2.25.50")
+    api("software.amazon.awssdk", "sts", "2.25.50")
 
     api(kotlin("stdlib-jdk8"))
     api(libs.kotlinx.coroutines)


### PR DESCRIPTION
Github actions here: https://github.com/danmason/xtdb/actions/runs/13703530034

When using XTDB on EKS, and attempting to authenticate using a Kubernetes Service Account, we get back the following: 

```
5:56:27 | WARN  s.a.a.a.c.i.WebIdentityCredentialsUtils | To use web identity tokens, the 'sts' service module must be on the class path.
```

(See code [**here**](https://github.com/aws/aws-sdk-java-v2/blob/master/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/WebIdentityCredentialsUtils.java))

As such, I've added the **sts** module such that we can make use of Web Identity Federation on AWS. 
