### PR TITLE
Writing compacted pages out without bringing them into memory - #3825

### DIFF
--- a/core/src/main/kotlin/xtdb/buffer_pool/LocalBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/buffer_pool/LocalBufferPool.kt
@@ -20,7 +20,7 @@ import xtdb.cache.MemoryCache
 import xtdb.cache.PathSlice
 import xtdb.trie.FileSize
 import xtdb.util.*
-import xtdb.util.newSeekableByteChannel
+import xtdb.util.openArrowReadChannel
 import java.io.Closeable
 import java.nio.ByteBuffer
 import java.nio.channels.ClosedByInterruptException
@@ -72,14 +72,14 @@ class LocalBufferPool(
         arrowFooterCache.get(key) {
             val path = diskStore.resolve(key).orThrowIfMissing(key)
 
-            Relation.readFooter(path.newSeekableByteChannel())
+            Relation.readFooter(path.openArrowReadChannel())
         }
 
     override fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch {
         recordBatchRequests?.increment()
         val path = diskStore.resolve(key).orThrowIfMissing(key)
 
-        val footer = arrowFooterCache.get(key) { Relation.readFooter(path.newSeekableByteChannel()) }
+        val footer = arrowFooterCache.get(key) { Relation.readFooter(path.openArrowReadChannel()) }
 
         val arrowBlock = footer.recordBatches.getOrNull(idx)
             ?: throw IndexOutOfBoundsException("Record batch index out of bounds of arrow file")

--- a/core/src/main/kotlin/xtdb/buffer_pool/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/buffer_pool/RemoteBufferPool.kt
@@ -28,7 +28,7 @@ import xtdb.cache.PathSlice
 import xtdb.multipart.SupportsMultipart
 import xtdb.trie.FileSize
 import xtdb.util.*
-import xtdb.util.newSeekableByteChannel
+import xtdb.util.openArrowReadChannel
 import java.io.Closeable
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
@@ -158,7 +158,7 @@ class RemoteBufferPool(
                 diskCacheMisses?.increment()
                 objectStore.getObject(k, tmpFile)
             }.get()
-            .use { entry -> Relation.readFooter(entry.path.newSeekableByteChannel()) }
+            .use { entry -> Relation.readFooter(entry.path.openArrowReadChannel()) }
     }
 
     override fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch {

--- a/core/src/main/kotlin/xtdb/compactor/PageTree.kt
+++ b/core/src/main/kotlin/xtdb/compactor/PageTree.kt
@@ -1,0 +1,55 @@
+package xtdb.compactor
+
+import com.carrotsearch.hppc.ByteArrayList
+
+private const val BRANCH_FACTOR = 4
+
+sealed interface PageTree {
+    val rowCount: Int
+
+    data class Node(
+        val children: MutableList<PageTree?> = MutableList(BRANCH_FACTOR) { null },
+        override var rowCount: Int = 0
+    ) : PageTree {
+        override fun toString() = "(Node [${children.joinToString()}], $rowCount)"
+
+        override val leaves: List<Leaf> get() = children.flatMap { it?.leaves.orEmpty() }
+    }
+
+    data class Leaf(val pageIdx: Int, val part: ByteArrayList, override val rowCount: Int) : PageTree {
+        override fun toString() = "(Leaf #$pageIdx, $rowCount)"
+
+        override val leaves: List<Leaf> get() = listOf(this)
+    }
+
+    val leaves: List<Leaf>
+
+    companion object {
+        val List<Leaf>.asTree: PageTree?
+            get() {
+                if (isEmpty()) return null
+                singleOrNull()?.let { if (it.part.isEmpty) return it }
+
+                val rootNode = Node()
+
+                forEach { leaf ->
+                    val part = leaf.part
+                    val partLen = part.size()
+                    val rowCount = leaf.rowCount
+
+                    var node = rootNode
+
+                    for (depth in 0..<partLen - 1) {
+                        val partElem = part[depth].toInt()
+                        node.rowCount += rowCount
+                        node = node.children[partElem] as Node? ?: Node().also { node.children[partElem] = it }
+                    }
+
+                    node.rowCount += rowCount
+                    node.children[part[partLen - 1].toInt()] = leaf
+                }
+
+                return rootNode
+            }
+    }
+}

--- a/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
+++ b/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
@@ -1,9 +1,9 @@
 package xtdb.compactor
 
+import com.carrotsearch.hppc.ByteArrayList
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.Relation
-import xtdb.trie.DataRel
 import xtdb.trie.ISegment
 import xtdb.trie.Trie.dataRelSchema
 import xtdb.trie.toMergePlan
@@ -13,7 +13,6 @@ import xtdb.util.closeOnCatch
 import xtdb.util.openWritableChannel
 import xtdb.util.useTempFile
 import java.nio.channels.WritableByteChannel
-import java.nio.file.Path
 import java.util.*
 import java.util.function.Predicate
 import kotlin.math.min
@@ -32,45 +31,44 @@ class SegmentMerge(private val al: BufferAllocator) {
             }
     }
 
-    private fun List<ISegment<*>>.openOutRelation() =
-        Relation(al, logDataRelSchema(this.map { it.dataRel!!.schema }))
+    internal fun List<ISegment<*>>.mergeTo(ch: WritableByteChannel, pathFilter: ByteArray?): List<PageTree.Leaf> {
+        val schema = logDataRelSchema(this.map { it.dataRel!!.schema })
+        val mergePlan = this.toMergePlan(pathFilter?.toPathPredicate())
 
-    private fun List<ISegment<*>>.mergeTo(ch: WritableByteChannel, pathFilter: ByteArray?) {
-        openOutRelation().use { dataRel ->
+        return Relation(al, schema).use { dataRel ->
             dataRel.startUnload(ch).use { unloader ->
                 with(PageMerge(dataRel, pathFilter)) {
-                    toMergePlan(pathFilter?.toPathPredicate())
-                        .forEach { task ->
-                            if (Thread.interrupted()) throw InterruptedException()
+                    var idx = 0
+                    mergePlan.mapNotNull { task ->
+                        if (Thread.interrupted()) throw InterruptedException()
 
-                            mergePages(task)
+                        mergePages(task)
 
-                            unloader.writePage()
-                            dataRel.clear()
-                        }
-                }
+                        if (dataRel.rowCount == 0) return@mapNotNull null
 
-                unloader.end()
+                        unloader.writePage()
+                        PageTree.Leaf(idx++, ByteArrayList.from(*task.path), dataRel.rowCount)
+                            .also { dataRel.clear() }
+                    }
+                }.also { unloader.end() }
             }
         }
     }
 
-    private fun Path.readSegments() =
-        Relation.loader(al, this).use { inLoader ->
-            val schema = inLoader.schema
-            Relation(al, schema).closeOnCatch { outRel ->
-                Relation(al, schema).use { inRel ->
-                    while (inLoader.loadNextPage(inRel))
-                        outRel.append(inRel)
-                }
-
-                outRel
-            }
-        }
-
-    fun List<ISegment.Segment<*>>.mergeToRelation(part: ByteArray?) =
+    fun List<ISegment<*>>.mergeToRelation(part: ByteArray?) =
         useTempFile("merged-segments", ".arrow") { tempFile ->
             mergeTo(tempFile.openWritableChannel(), part)
-            tempFile.readSegments()
+
+            Relation.loader(al, tempFile).use { inLoader ->
+                val schema = inLoader.schema
+                Relation(al, schema).closeOnCatch { outRel ->
+                    Relation(al, schema).use { inRel ->
+                        while (inLoader.loadNextPage(inRel))
+                            outRel.append(inRel)
+                    }
+
+                    outRel
+                }
+            }
         }
 }

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -8,7 +8,7 @@ import java.nio.file.StandardOpenOption.*
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteIfExists
 
-internal fun Path.newSeekableByteChannel() = SeekableReadChannel(Files.newByteChannel(this, READ))
+internal fun Path.openArrowReadChannel() = SeekableReadChannel(Files.newByteChannel(this, READ))
 
 internal fun Path.openWritableChannel(): WritableByteChannel = Files.newByteChannel(this, WRITE, CREATE)
 

--- a/core/src/test/kotlin/xtdb/compactor/PageTreeTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/PageTreeTest.kt
@@ -1,0 +1,51 @@
+package xtdb.compactor
+
+import com.carrotsearch.hppc.ByteArrayList
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import xtdb.compactor.PageTree.Companion.asTree
+import xtdb.compactor.PageTree.Node
+
+class PageTreeTest {
+
+    private fun node(vararg children: PageTree?) =
+        Node(children.toMutableList(), children.sumOf { it?.rowCount ?: 0 })
+
+    @Test
+    fun `test batch tree construction`() {
+        assertNull(emptyList<PageTree.Leaf>().asTree)
+
+        PageTree.Leaf(0, ByteArrayList(), 12).let {
+            assertEquals(it, listOf(it).asTree)
+        }
+
+        PageTree.Leaf(0, ByteArrayList.from(1), 12).let {
+            assertEquals(node(null, it, null, null), listOf(it).asTree)
+        }
+
+        val leaf01 = PageTree.Leaf(0, ByteArrayList.from(0, 1), 8)
+        val leaf03 = PageTree.Leaf(1, ByteArrayList.from(0, 3), 12)
+        val leaf1 = PageTree.Leaf(2, ByteArrayList.from(1), 24)
+
+        assertEquals(
+            node(node(null, leaf01, null, leaf03), leaf1, null, null),
+            listOf(leaf01, leaf03, leaf1).asTree
+        )
+
+        val leaf22 = PageTree.Leaf(3, ByteArrayList.from(2, 2), 2)
+        val leaf232 = PageTree.Leaf(4, ByteArrayList.from(2, 3, 2), 10)
+        val leaf233 = PageTree.Leaf(5, ByteArrayList.from(2, 3, 3), 11)
+
+        assertEquals(
+            node(
+                node(null, leaf01, null, leaf03),
+                leaf1,
+                node(null, null, leaf22, node(null, null, leaf232, leaf233)),
+                null
+            ),
+            listOf(leaf01, leaf03, leaf1, leaf22, leaf232, leaf233).asTree
+        )
+
+    }
+}

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-rc-b00.arrow.json
@@ -192,25 +192,25 @@
     }]
   },
   "batches" : [{
-    "count" : 3,
+    "count" : 7,
     "columns" : [{
       "name" : "nodes",
-      "count" : 3,
-      "TYPE_ID" : [3,3,1],
-      "OFFSET" : [0,1,0],
+      "count" : 7,
+      "TYPE_ID" : [3,1,1,3,1,1,1],
+      "OFFSET" : [0,0,1,1,2,3,4],
       "children" : [{
         "name" : "nil",
         "count" : 0
       },{
         "name" : "branch-iid",
-        "count" : 1,
-        "VALIDITY" : [1],
-        "OFFSET" : [0,4],
+        "count" : 5,
+        "VALIDITY" : [1,1,1,1,1],
+        "OFFSET" : [0,4,8,12,16,20],
         "children" : [{
           "name" : "$data$",
-          "count" : 4,
-          "VALIDITY" : [0,1,1,0],
-          "DATA" : [0,0,1,0]
+          "count" : 20,
+          "VALIDITY" : [0,0,0,1,1,0,0,0,0,1,0,0,0,0,1,0,0,1,1,0],
+          "DATA" : [0,0,0,0,1,0,0,0,0,3,0,0,0,0,4,0,0,2,5,0]
         }]
       },{
         "name" : "branch-recency",


### PR DESCRIPTION
This is the second half of #4236, relating to fixing OOMs in the compactor (#3825).

We now lazily stream the spooled file back into the compactor, and update the compactor relation-writing to cope with a page at a time - this is done by building a tree of the pages that we spooled out in #4236 (see PageTree), then traversing it to write it out (see `writePageTree`).

Inside `writePageTree` we handle two cases specifically:
- when all of the sub-leaves of a branch node would fit inside one page, we coalesce them together
- when a single leaf overflows a page, we split it out.

I haven't yet tested this against the full cloud benchmarks, so I won't close the issue - but I'd like to get it landed both because I'm aware @FiV0 has related changes in flight, and because merging it (and having `edge` contain the fix) will make the fix more accessible to those who want to try it out.