### PR TITLE
Add "idx" to uploadPart method, use for Part Numbers in AWS to ensure part ordering.

### DIFF
--- a/core/src/main/kotlin/xtdb/buffer_pool/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/buffer_pool/RemoteBufferPool.kt
@@ -80,9 +80,9 @@ class RemoteBufferPool(
             val upload = startMultipart(key).await()
 
             try {
-                val waitingParts = nioBuffers.map {
+                val waitingParts = nioBuffers.mapIndexed { idx, it ->
                     async(multipartUploadDispatcher) {
-                        upload.uploadPart(it).await()
+                        upload.uploadPart(idx, it).await()
                     }
                 }
 

--- a/core/src/main/kotlin/xtdb/multipart/IMultipartUpload.kt
+++ b/core/src/main/kotlin/xtdb/multipart/IMultipartUpload.kt
@@ -8,7 +8,7 @@ interface IMultipartUpload<Part> {
     /**
      * Asynchronously uploads a part to the multipart request and adds it to the internal list of completed parts.
      */
-    fun uploadPart(buf: ByteBuffer): CompletableFuture<Part>
+    fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<Part>
 
     /**
      * Asynchronously completes the multipart request.

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -151,7 +151,7 @@ class BlobStorage(factory: Factory, private val prefix: Path) : ObjectStore, Sup
             private val b64 = Base64.getEncoder()
             private val newBlockId get() = randomUUID().asBytes.let { b64.encodeToString(it) }
 
-            override fun uploadPart(buf: ByteBuffer) = scope.future {
+            override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<String> = scope.future {
                 try {
                     unwrappingReactorException {
                         val blockId = newBlockId

--- a/src/main/kotlin/xtdb/api/storage/SimulatedObjectStore.kt
+++ b/src/main/kotlin/xtdb/api/storage/SimulatedObjectStore.kt
@@ -58,7 +58,7 @@ class SimulatedObjectStore(
 
     override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> {
         val upload = object : IMultipartUpload<ByteBuffer> {
-            override fun uploadPart(buf: ByteBuffer): CompletableFuture<ByteBuffer> {
+            override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<ByteBuffer> {
                 calls.add(StoreOperation.UPLOAD)
                 return completedFuture(copyByteBuffer(buf))
             }

--- a/src/test/clojure/xtdb/aws/minio_test.clj
+++ b/src/test/clojure/xtdb/aws/minio_test.clj
@@ -114,8 +114,8 @@
           file-part-2 (os-test/generate-random-byte-buffer part-size)
 
           parts [;; Uploading parts to multipart upload
-                 (.uploadPart multipart-upload file-part-1)
-                 (.uploadPart multipart-upload file-part-2)]]
+                 (.uploadPart 0 multipart-upload file-part-1)
+                 (.uploadPart 1 multipart-upload file-part-2)]]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the upload list"
         @(.complete multipart-upload (mapv deref parts))

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -148,8 +148,8 @@
           file-part-2 ^ByteBuffer (os-test/generate-random-byte-buffer part-size)
 
           parts [;; Uploading parts to multipart upload
-                 @(.uploadPart multipart-upload file-part-1)
-                 @(.uploadPart multipart-upload file-part-2)]]
+                 @(.uploadPart multipart-upload 0 file-part-1)
+                 @(.uploadPart multipart-upload 1 file-part-2)]]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the uncomitted list"
         @(.complete multipart-upload parts)
@@ -199,10 +199,10 @@
     (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os (util/->path "test-larger-multi-put"))
           part-size 500
           parts (doall
-                 (for [_ (range 20)]
+                 (for [i (range 20)]
                    (let [buf ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
                      {:buf buf
-                      :!part (.uploadPart multipart-upload buf)})))]
+                      :!part (.uploadPart multipart-upload i buf)})))]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the uncomitted list"
         @(.complete multipart-upload (mapv (comp deref :!part) parts))
@@ -225,7 +225,7 @@
               parts (doall
                      (for [_ (range 2)]
                        (let [file-part ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
-                         (.uploadPart initial-multipart-upload file-part))))]
+                         (.uploadPart initial-multipart-upload 0 file-part))))]
 
           @(.complete initial-multipart-upload (mapv deref parts))
 
@@ -237,9 +237,9 @@
       (t/testing "Attempt to multipart upload to an existing object shouldn't throw, should abort and remove uncomitted blobs"
         (let [second-multipart-upload ^IMultipartUpload @(.startMultipart os (util/->path "test-multipart"))
               parts (doall
-                     (for [_ (range 3)]
+                     (for [i (range 3)]
                        (let [file-part ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
-                         (.uploadPart second-multipart-upload file-part))))]
+                         (.uploadPart second-multipart-upload i file-part))))]
 
           @(.complete second-multipart-upload (mapv deref parts))
 

--- a/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
@@ -63,8 +63,8 @@ class BlobStorageTest : ObjectStoreTest() {
         val part2 = randomByteBuffer(500)
 
         val parts = awaitAll(
-            async { multipart.uploadPart(part1).await() },
-            async { multipart.uploadPart(part2).await() }
+            async { multipart.uploadPart(0, part1).await() },
+            async { multipart.uploadPart(1, part2).await() }
         )
 
         multipart.complete(parts).await()
@@ -95,10 +95,10 @@ class BlobStorageTest : ObjectStoreTest() {
             buffer.flip()
         }
 
-        val uploadedParts = parts.map {
+        val uploadedParts = parts.mapIndexed { idx, it ->
             async(dispatcher) {
                 Thread.sleep(Random.nextLong(100L..200L))
-                upload.uploadPart(it).await()
+                upload.uploadPart(idx, it).await()
             }
         }
 


### PR DESCRIPTION
Resolves #4241 

Github actions run: https://github.com/danmason/xtdb/actions/runs/13763534590

Essentially  - we were seeing issues specifically within S3 due to atomically incrementing the part number in multiple async jobs - so the part number itself would be incorrect, though the actual parts were in order. Have added "idx" as a parameter to the uploadPart function to ensure this is consistent and in correct order.