### PR TITLE
 Add terraform and helm config for AWS.

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -3,7 +3,7 @@ name: Helm Charts
 on:
   workflow_call:
     inputs:
-      appVersion: 
+      appVersion:
         required: true
         type: string
 
@@ -26,15 +26,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Package & Push Azure Helm Chart
         run: |
           helm package azure/helm --app-version $APP_VERSION \
           ${{ env.APP_VERSION == 'edge' && '--version 2.0.0-SNAPSHOT' || '' }}
           helm push helm-xtdb-azure-*.tgz oci://ghcr.io/xtdb/
-      
+
       - name: Package & Push Google Cloud Helm Chart
         run: |
           helm package google-cloud/helm --app-version $APP_VERSION \
           ${{ env.APP_VERSION == 'edge' && '--version 2.0.0-SNAPSHOT' || '' }}
           helm push helm-xtdb-google-cloud-*.tgz oci://ghcr.io/xtdb/
+
+      - name: Package & Push AWS Helm Chart
+        run: |
+          helm package aws/helm --app-version $APP_VERSION \
+          ${{ env.APP_VERSION == 'edge' && '--version 2.0.0-SNAPSHOT' || '' }}
+          helm push helm-xtdb-aws-*.tgz oci://ghcr.io/xtdb/

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,11 @@ buildRepl
 
 /.kotlin/
 
+# Terraform
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl
+
 # This directory should only contain data not checked in
 src/test/resources/data/

--- a/aws/helm/Chart.yaml
+++ b/aws/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm-xtdb-aws
+description: A Helm chart for setting up a simple XTDB cluster on AWS
+type: application
+version: 0.1.0
+appVersion: "2.0.0-beta6"

--- a/aws/helm/README.md
+++ b/aws/helm/README.md
@@ -1,0 +1,6 @@
+# XTDB AWS Helm Chart
+
+This Helm chart deploys a simple XTDB cluster, backed by AWS infrastructure, on Kubernetes.
+
+For more information on what infrastructure is required and what resources are deployed by the templates, see the [XTDB AWS Documentation](https://docs.xtdb.com/ops/aws.html)
+

--- a/aws/helm/templates/NOTES.txt
+++ b/aws/helm/templates/NOTES.txt
@@ -1,0 +1,33 @@
+
+# XTDB Service Access Instructions
+
+Thank you for installing the XTDB AWS Helm Chart!
+
+Your deployment is now complete.
+
+To access the XTDB service:
+
+1. The service is running as a LoadBalancer service. Retrieve the external IP:
+   ```bash
+   kubectl get svc xtdb-service -n {{ .Release.Namespace }}
+   ```
+   Look for the `EXTERNAL-IP` column.
+
+2. Access the service via the Postgres Wire Server port:
+   ```
+   <EXTERNAL-IP>:{{ .Values.xtdbService.server.servicePort }}
+   ```
+3. If you are using the HTTP server port connect to the service at:
+   ```
+   http://<EXTERNAL-IP>:{{ .Values.xtdbService.httpServer.servicePort }}
+   ```
+
+## Additional Information
+
+Namespace: {{ .Release.Namespace }}
+Service Name: {{ .Release.Name }}
+
+To uninstall this chart:
+```bash
+helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
+```

--- a/aws/helm/templates/statefulset.yaml
+++ b/aws/helm/templates/statefulset.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: xtdb-statefulset
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: xtdb-statefulset
+spec:
+  serviceName: xtdb-service
+  replicas: {{ .Values.nodeCount }}
+  selector:
+    matchLabels:
+      app: xtdb-statefulset
+  template:
+    metadata:
+      labels:
+        app: xtdb-statefulset
+    spec:
+      # Requires the service account to be created & federated identity set up
+      serviceAccountName: {{ required (printf "xtdbConfig.serviceAccount is required - ensure you set it up on %s and link to an IAM role using IAM Roles for Service Accounts (IRSA)" .Release.Namespace) .Values.xtdbConfig.serviceAccount }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      volumes: 
+        - name: "tmp"
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: "local-disk-cache"
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+      containers:
+        - name: xtdb-container
+          image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ['-f', '/var/lib/xtdb-config/xtdbconfig.yaml']
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: "/var/lib/xtdb/buffers/"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: {{ .Values.xtdbConfig.jdkOptions }}
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ required "xtdbConfig.kafkaBootstrapServers is required." .Values.xtdbConfig.kafkaBootstrapServers }}
+            - name: KAFKA_LOG_TOPIC
+              value: {{ required "xtdbConfig.kafkaLogTopic is required." .Values.xtdbConfig.kafkaLogTopic }}
+            - name: AWS_S3_BUCKET
+              value: {{ required "xtdbConfig.s3Bucket is required." .Values.xtdbConfig.s3Bucket }}
+            {{- range $key, $value := .Values.xtdbConfig.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/aws/helm/templates/xtdbservice.yaml
+++ b/aws/helm/templates/xtdbservice.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xtdb-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: xtdb-statefulset
+  annotations:
+    {{- with .Values.xtdbService.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.xtdbService.type }}
+  
+  ports:
+  - port: {{ .Values.xtdbService.server.servicePort }}
+    targetPort: {{ .Values.xtdbService.server.targetPort }}
+    name: server
+  - port: {{ .Values.xtdbService.httpServer.servicePort }}
+    targetPort: {{ .Values.xtdbService.httpServer.targetPort }}
+    name: http
+  - port: {{ .Values.xtdbService.healthzServer.servicePort }}
+    targetPort: {{ .Values.xtdbService.healthzServer.targetPort }}
+    name: healthz
+  selector:
+    app: xtdb-statefulset

--- a/aws/helm/templates/xtdbyamlconfig.yaml
+++ b/aws/helm/templates/xtdbyamlconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: xtdb-yaml-config
+  namespace: {{ .Release.Namespace }}
+data:
+  xtdbconfig.yaml: |-
+    {{ .Values.xtdbConfig.nodeConfig | nindent 4 }}

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -1,0 +1,120 @@
+nodeCount: 3
+
+image:
+  repository: ghcr.io/xtdb/xtdb-aws
+  # tag: 2.0.0-beta6
+  pullPolicy: IfNotPresent
+
+nodeSelector:
+  node_pool: "xtdbpool"
+
+tolerations: []
+
+affinity: {}
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "10G"
+    ephemeral-storage: 100Gi
+  requests:
+    cpu: "750m"
+    memory: "10G"
+    ephemeral-storage: 100Gi
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+xtdbConfig:
+  # REQUIRED
+  # Kubernetes Service Account configured with Workload Identity Federation wih access to Azure Storage
+  serviceAccount: ""
+  # AWS S3 Bucket Name
+  s3Bucket: ""
+
+  # Kafka bootstrap servers
+  kafkaBootstrapServers: "kafka.xtdb-deployment.svc.cluster.local:9092"
+  # XTDB log topic on Kafka 
+  kafkaLogTopic: "xtdb-log"
+
+  # OPTIONAL
+  # JDK options - ensure that heap + direct memory + metaspace <= memory limit, and that some overhead is left for the OS
+  # See https://docs.oracle.com/cd/E13150_01/jrockit_jvm/jrockit/jrdocs/refman/optionX.html
+  jdkOptions: "-Xmx3000m -Xms3000m -XX:MaxDirectMemorySize=3000m -XX:MaxMetaspaceSize=500m"
+
+  # We mount and use the below YAML for configuring the XTDB nodes and their modules.
+  # The !Env values are set by Environment Variables set on the XTDB statefulset pods.
+  # See the XTDB configuration documentation for options: https://docs.xtdb.com/ops/config.html
+  nodeConfig: |-
+    server:
+      port: 5432
+
+    log: !Kafka
+      bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+      topic: !Env KAFKA_LOG_TOPIC
+
+    storage: !Remote
+      objectStore: !S3
+        bucket: !Env AWS_S3_BUCKET
+        prefix: xtdb-object-store
+      localDiskCache: /var/lib/xtdb/buffers/disk-cache
+
+    healthz:
+      port: 8080
+
+    modules:
+    - !HttpServer
+      port: 3000 
+
+  # Volume size settings for XTDB Local Disk Cache (uses ephemeral storage)
+  localDiskCache:
+    sizeLimit: "50Gi"
+
+  # Extra Env:
+  env:
+    # (ENV_VAR_NAME: Value)
+    XTDB_LOGGING_LEVEL: "info" # See https://docs.xtdb.com/ops/troubleshooting/overview.html
+
+startupProbe:
+  httpGet:
+    path: /healthz/started
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 10 
+
+livenessProbe:
+  httpGet:
+    path: /healthz/alive
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3
+
+xtdbService:
+  type: LoadBalancer
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+  server:
+    # Port of the Postgres Wire Server on the nodes
+    targetPort: 5432
+    # Port exposed by the service
+    servicePort: 5432
+  httpServer:
+    # Port of the http server on the nodes
+    targetPort: 3000
+    # Port exposed by the service
+    servicePort: 3000
+  healthzServer:
+    # Port of the healthz server on the nodes
+    targetPort: 8080
+    # Port exposed by the service
+    servicePort: 8080

--- a/aws/terraform/README.adoc
+++ b/aws/terraform/README.adoc
@@ -1,0 +1,11 @@
+# XTDB AWS Terraform Sample
+
+Contained within this directory are sample terraform files for deploying XTDB to AWS. 
+The samples are designed to be as simple as possible, and are intended to be used as a starting point for your own deployments.
+
+## Pulling the files locally
+
+We can fetch the contents of this folder using the terraform CLI:
+```
+terraform init -from-module github.com/xtdb/xtdb.git//aws/terraform
+```  

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -1,0 +1,194 @@
+# Sets up storage bucket used by XTDB
+# For more configuration options, see:
+# https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws/latest
+module "xtdb_storage" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.5.0"
+
+  bucket = var.s3_bucket_name
+  acl    = var.s3_acl
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
+  versioning = {
+    enabled = false
+  }
+
+  tags = {
+    terraform = "true"
+    managed_by = "XTDB Terraform"
+  }
+}
+
+# Creates an IAM Policy for S3 Access
+# For more configuration options, see:
+# https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest/submodules/iam-policy
+module "xtdb_s3_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.52.2"
+
+  name        = "xtdb-s3-access-policy"
+  description = "Policy granting XTDB access to the specified S3 bucket"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:AbortMultipartUpload",
+          "s3:ListBucketMultipartUploads"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.s3_bucket_name}",
+          "arn:aws:s3:::${var.s3_bucket_name}/*"
+        ]
+      }
+    ]
+  })
+  tags = {
+    terraform = "true"
+    managed_by = "XTDB Terraform"
+  }
+}
+
+
+# Sets up VPC used by EKS cluster
+# For more configuration options, see:
+# https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
+module "xtdb_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.19.0"
+
+  name                 = var.vpc_name
+  cidr                 = var.vpc_cidr
+  azs                  = var.vpc_availability_zones
+  public_subnets       = var.vpc_public_subnets
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  map_public_ip_on_launch = true
+  enable_nat_gateway   = false
+  enable_vpn_gateway   = false
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  tags = {
+    terraform = "true"
+    managed_by = "XTDB Terraform"
+  }
+}
+
+# Sets up an EKS cluster to be used by XTDB
+# For more configuration options, see:
+# https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
+module "xtdb_eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.33.1"
+
+  cluster_name    = var.eks_cluster_name
+  cluster_version = var.eks_cluster_version
+
+  cluster_endpoint_public_access           = var.eks_public_access
+  enable_cluster_creator_admin_permissions = var.eks_enable_creator_admin_permissions
+  create_cloudwatch_log_group              = var.eks_create_cloudwatch_log_group
+
+  vpc_id     = module.xtdb_vpc.vpc_id
+  subnet_ids = module.xtdb_vpc.public_subnets
+
+  # Optional
+  cluster_compute_config = {
+    enabled    = true
+    node_pools = ["system"]
+  }
+
+  cluster_addons = {
+    coredns = {
+      most_recent       = true
+    }
+
+    eks-pod-identity-agent = {
+      most_recent       = true
+      before_compute    = true
+    }
+    kube-proxy             = {
+      most_recent       = true
+      before_compute    = true
+    }
+    vpc-cni                = {
+      most_recent       = true
+      before_compute    = true
+    }
+    
+    aws-ebs-csi-driver     = {
+      most_recent       = true
+      before_compute    = false
+      service_account_role_arn = module.irsa_ebs_csi.iam_role_arn
+    }
+  }
+
+  eks_managed_node_groups = {
+    application = {
+      name           = "xtdbpool"
+      instance_types = [var.application_node_pool_machine_type]
+      min_size       = var.application_node_pool_min_count
+      max_size       = var.application_node_pool_max_count
+      desired_size   = var.application_node_pool_desired_count
+
+      # Mount instance store volumes in RAID-0 for kubelet and containerd
+      # https://github.com/awslabs/amazon-eks-ami/blob/master/doc/USER_GUIDE.md#raid-0-for-kubelet-and-containerd-raid0
+      # We recommend using IO optimized instances for this configuration, so want to ensure that the instance store is used for the RAID0
+      pre_bootstrap_user_data = <<-EOT
+          #!/usr/bin/env bash
+          # Mount instance store volumes in RAID-0 for kubelet and containerd
+          # https://github.com/awslabs/amazon-eks-ami/blob/master/doc/USER_GUIDE.md#raid-0-for-kubelet-and-containerd-raid0
+
+          /bin/setup-local-disks raid0
+        EOT
+        
+      cloudinit_pre_nodeadm = [
+        {
+          content_type = "application/node.eks.aws"
+          content      = <<-EOT
+            ---
+            apiVersion: node.eks.aws/v1alpha1
+            kind: NodeConfig
+            spec:
+              instance:
+                localStorage:
+                  strategy: RAID0
+          EOT
+        }
+      ]
+      
+      labels = {
+        "node_pool" = "xtdbpool"
+      }
+
+      iam_role_additional_policies = { AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" }
+    }
+  }
+
+  tags = {
+    terraform = "true"
+    managed_by = "XTDB Terraform"
+  }
+}
+
+# Required for using EBS CSI driver + volumes
+module "irsa_ebs_csi" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.52.2"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFEBSCSIRole-${module.xtdb_eks.cluster_name}"
+  provider_url                  = module.xtdb_eks.oidc_provider
+  role_policy_arns              = ["arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+}

--- a/aws/terraform/outputs.tf
+++ b/aws/terraform/outputs.tf
@@ -1,0 +1,23 @@
+output "eks_cluster_name" {
+  value = module.xtdb_eks.cluster_name
+}
+
+output "s3_bucket_name" {
+  value = module.xtdb_storage.s3_bucket_id
+}
+
+output "s3_access_policy_arn" {
+  value = module.xtdb_s3_policy.arn
+}
+
+output "oidc_provider" {
+  value = module.xtdb_eks.oidc_provider
+}
+
+output "oidc_provider_arn" {
+  value = module.xtdb_eks.oidc_provider_arn
+}
+
+output "aws_region" {
+  value = var.aws_region
+}

--- a/aws/terraform/providers.tf
+++ b/aws/terraform/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">=1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/aws/terraform/terraform.tfvars
+++ b/aws/terraform/terraform.tfvars
@@ -1,0 +1,24 @@
+aws_region = "us-east-1"
+
+# S3 Storage
+# s3_bucket_name = "unique-bucket-name"
+s3_acl         = "private"
+
+# VPC
+vpc_name               = "xtdb-vpc"
+vpc_cidr               = "10.0.0.0/16"
+vpc_availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+vpc_public_subnets     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+# EKS Cluster
+eks_cluster_name                     = "xtdb-cluster"
+eks_cluster_version                  = "1.32"
+eks_public_access                    = true
+eks_enable_creator_admin_permissions = true
+eks_create_cloudwatch_log_group      = true
+
+## EKS: Application Node Pool
+application_node_pool_machine_type  = "i3.large"
+application_node_pool_min_count     = 3
+application_node_pool_max_count     = 3
+application_node_pool_desired_count = 3

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -1,0 +1,102 @@
+variable "aws_region" {
+  description = "The AWS region for deploying XTDB infrastructure."
+  type        = string
+  default     = "us-east-1"
+}
+
+# S3 Storage
+variable "s3_bucket_name" {
+  description = "The globally unique name of the S3 bucket for XTDB deployment."
+  type        = string
+  validation {
+    condition     = length(var.s3_bucket_name) >= 0
+    error_message = "The S3 bucket name must be set, and globally unique."
+  }
+}
+
+variable "s3_acl" {
+  description = "The ACL for the S3 bucket."
+  type        = string
+  default     = "private"
+}
+
+# VPC
+variable "vpc_name" {
+  description = "The name of the VPC for XTDB deployment."
+  type        = string
+  default     = "xtdb-vpc"
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_availability_zones" {
+  description = "List of availability zones to use for the VPC subnets."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+}
+
+variable "vpc_public_subnets" {
+  description = "List of public subnet CIDR blocks."
+  type        = list(string)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+}
+
+# EKS Cluster
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster."
+  type        = string
+  default     = "xtdb-cluster"
+}
+
+variable "eks_cluster_version" {
+  description = "The Kubernetes version for the EKS cluster."
+  type        = string
+  default     = "1.29"
+}
+
+variable "eks_public_access" {
+  description = "Whether the EKS cluster endpoint should be publicly accessible."
+  type        = bool
+  default     = true
+}
+
+variable "eks_enable_creator_admin_permissions" {
+  description = "Enable admin permissions for the cluster creator."
+  type        = bool
+  default     = true
+}
+
+variable "eks_create_cloudwatch_log_group" {
+  description = "Whether to create a CloudWatch log group for the EKS cluster."
+  type        = bool
+  default     = true
+}
+
+# Application Node Pool
+variable "application_node_pool_machine_type" {
+  description = "Instance type for the application node pool in EKS."
+  type        = string
+  default     = "i3.large"
+}
+
+variable "application_node_pool_min_count" {
+  description = "Minimum number of nodes in the application node pool."
+  type        = number
+  default     = 2
+}
+
+variable "application_node_pool_max_count" {
+  description = "Maximum number of nodes in the application node pool."
+  type        = number
+  default     = 3
+}
+
+variable "application_node_pool_desired_count" {
+  description = "Desired number of nodes in the application node pool."
+  type        = number
+  default     = 3
+}

--- a/docs/src/content/docs/ops/aws.adoc
+++ b/docs/src/content/docs/ops/aws.adoc
@@ -12,10 +12,190 @@ In order to run an AWS based XTDB cluster, the following infrastructure is requi
 
 * An **S3 bucket** for remote storage.
 * A **Kafka cluster** for the message log.
-** Within AWS, you can use the https://aws.amazon.com/msk/[Amazon Managed Streaming for Apache Kafka (MSK)^] service.
 ** For more information on setting up Kafka for usage with XTDB, see the link:config/log/kafka[Kafka configuration^] docs.
-* IAM policies which grant XTDB permission to the S3 bucket and Kafka cluster.
+* IAM policies which grant XTDB permission to the S3 bucket
 * XTDB nodes configured to communicate with the Kafka cluster and S3 bucket.
+
+[#terraform]
+== Terraform Templates
+
+To set up a basic version of the required infrastructure, we provide a set of Terraform templates specifically designed for AWS.
+
+These can be fetched from the XTDB repository using the following command:
+
+```bash
+terraform init -from-module github.com/xtdb/xtdb.git//aws/terraform
+```
+
+=== Resources
+
+By default, running the templates will deploy the following infrastructure:
+
+* Amazon S3 Storage Bucket for remote storage.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws/latest[**terraform-aws-modules/s3-bucket**^] Terraform module.
+** Enables object ownership control and applies necessary permissions for XTDB.
+* IAM Policy for granting access to the S3 storage bucket.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest/submodules/iam-policy[**terraform-aws-modules/iam-policy**^] Terraform module.
+** Grants permissions for XTDB to read, write, and manage objects within the specified S3 bucket.
+* Virtual Private Cloud (VPC) for the XTDB EKS cluster.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest[**terraform-aws-modules/vpc**^] Terraform module.
+** Enables DNS resolution, assigns public subnets, and configures networking for the cluster.
+* Amazon Elastic Kubernetes Service (EKS) Cluster for running XTDB resources.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest[**terraform-aws-modules/eks**^] Terraform module.
+** Provisions a managed node group dedicated to XTDB workloads.
+
+=== Configuration
+
+In order to customize the deployment, we provide a number of pre-defined variables within the `terraform.tfvars` file.
+These variables can be modified to tailor the infrastructure to your specific needs.
+
+The following variables are **required** to be set:
+
+* `s3_bucket_name`: The (globally unique) name of the S3 bucket used by XTDB. 
+
+For more advanced usage, the Terraform templates themselves can be modified to suit your specific requirements.
+
+=== Outputs
+
+The Terraform templates will return several outputs:
+
+[cols="2,3", options="header"]
+|===
+| Output              | Description
+
+|`aws_region`
+|The AWS region in which the resources were created.
+
+|`eks_cluster_name`
+|The name of the EKS cluster created for the XTDB deployment.
+
+|`s3_bucket_name`
+|The name of the S3 bucket created for the XTDB cluster.
+
+|`s3_access_policy_arn`
+|The ARN of the S3 bucket created for the XTDB cluster.
+
+|`oidc_provider`
+|OpenID Connect identity provider for the EKS cluster.
+
+|`oidc_provider_arn`
+|The ARN of the OpenID Connect identity provider for the EKS cluster.
+
+|===
+
+'''
+
+[#helm]
+== `xtdb-aws` Helm Charts
+
+For setting up a production-ready XTDB cluster on AWS, we provide a **Helm** chart built specifically for AWS environments.
+
+
+=== Pre-requisites
+
+To allow the XTDB nodes to access AWS resources, a Kubernetes Service Account (KSA) must be setup and linked with an IAM role that has any necessary permissions, using link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[**IAM Roles for Service Accounts (IRSA)**^].
+
+==== Setting Up the Kubernetes Service Account:
+
+Create the Kubernetes Service Account in the target namespace:
+
+```bash
+kubectl create serviceaccount xtdb-service-account --namespace xtdb-deployment
+```
+
+==== Setting up the IAM Service Account
+
+Fetch the ARN of a policy granting access to s3 (`s3_access_policy_arn`), the OpenID Connect identity provider of the EKS cluster (`oidc_provider`) and ARN for the OIDC provider (`oidc_provider_arn`).
+
+Create a file `eks_policy_document.json` for the trust policy, replacing values as appropriate:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<oidc_provider_arn>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<oidc_provider>:aud": "sts.amazonaws.com",
+          "<oidc_provider>:sub": "system:serviceaccount:xtdb-deployment:xtdb-service-account"
+        }
+      }
+    }
+  ]
+}
+```
+
+Create the IAM role and attach the trust policy created above:
+
+```bash
+aws iam create-role --role-name xtdb-eks-role --assume-role-policy-document file://eks_policy_document.json --description "XTDB EKS Role"
+```
+
+Attach the S3 bucket role:
+
+```bash
+aws iam attach-role-policy --role-name xtdb-eks-role --policy-arn=<s3_access_policy_arn>
+```
+
+==== Annotating the Kubernetes Service Account
+
+Fetch the ARN of the IAM role:
+
+```bash
+xtdb_eks_role_arn=$(aws iam get-role --role-name xtdb-eks-role --query Role.Arn --output text)
+```
+
+Annotate the Kubernetes Service Account with the IAM role to establish the link between the two:
+
+```bash
+kubectl annotate serviceaccount xtdb-service-account --namespace xtdb-deployment eks.amazonaws.com/role-arn=$xtdb_eks_role_arn
+```
+
+=== Installation
+
+The Helm chart can be installed directly from the link:https://github.com/xtdb/xtdb/pkgs/container/helm-xtdb-aws[**Github Container Registry** releases]. 
+
+This will use the default configuration for the deployment, setting any required values as needed:  
+
+```bash
+helm install xtdb-aws oci://ghcr.io/xtdb/helm-xtdb-aws \
+  --version 2.0.0-snapshot \
+  --namespace xtdb-deployment \
+  --set xtdbConfig.serviceAccount="xtdb-service-account" \
+  --set xtdbConfig.s3Bucket=<s3_bucket> 
+```
+
+We provide a number of parameters for configuring numerous parts of the deployment, see the link:https://github.com/xtdb/xtdb/tree/main/aws/helm[`values.yaml` file] or call `helm show values`:
+
+```bash
+helm show values oci://ghcr.io/xtdb/helm-xtdb-aws \
+  --version 2.0.0-snapshot 
+```
+
+=== Resources
+
+By default, the following resources are deployed by the Helm chart:
+
+* A `ConfigMap` containing the XTDB YAML configuration.
+* A `StatefulSet` containing a configurable number of XTDB nodes, using the link:#docker-image[**xtdb-aws** docker image]
+* A `LoadBalancer` Kubernetes service to expose the XTDB cluster to the internet.
+
+=== Pulling the Chart Locally
+
+The chart can also be pulled from the **Github Container Registry**, allowing further configuration of the templates within:
+
+```bash
+helm pull oci://ghcr.io/xtdb/helm-xtdb-aws \
+  --version 2.0.0-snapshot \
+  --untar
+```
+
+'''
 
 [#docker-image]
 == `xtdb-aws` Docker Image

--- a/docs/src/content/docs/ops/guides/starting-with-aws.adoc
+++ b/docs/src/content/docs/ops/guides/starting-with-aws.adoc
@@ -2,140 +2,330 @@
 title: Setting up a cluster on AWS
 ---
 
-This guide will walk you through the process of configuring an XTDB cluster on AWS, featuring a customizable number of nodes operating on https://aws.amazon.com/ecs/[**ECS**], all accessible via a load balancer.
+This guide will walk you through the process of configuring and running an XTDB Cluster on AWS. This setup includes:
 
-We'll utilize a set of provided CloudFormation templates available in the https://github.com/xtdb/xtdb/tree/main/cloudformation[**XTDB repository**]. These will set up a cluster of XTDB nodes that use https://aws.amazon.com/s3/[**S3**] as the XTDB object store, and https://aws.amazon.com/msk/[**MSK**] hosted **Kafka** as the XTDB log.
+* Using **AWS S3** as the remote storage implementation.
+* Utilizing **Apache Kafka** as the shared message log implementation.
+* Exposing the cluster to the internet via a Postgres wire-compatible server and HTTP.
+ 
+The required AWS infrastructure is provisioned using **Terraform**, and the XTDB cluster and it's resources are deployed on link:https://aws.amazon.com/eks/[**Amazon Elastic Kubernetes Service**^] using **Helm**.
 
-While we provide numerous parameters to configure these templates, you're encouraged to edit them for more advanced use-cases or to reuse existing infrastructure where appropriate.
+Although we provide numerous parameters to configure the templates, you are encouraged to edit them, use them as a foundation for more advanced use cases, and reuse existing infrastructure when suitable. 
+These templates serve as a simple starting point for running XTDB on AWS and Kubernetes, and should be adapted to meet your specific needs, especially in production environments.
 
-The guide assumes that you are using the default templates to set everything up.
+This guide assumes that you are using the default templates.
 
-*The provided templates:*
+== Requirements 
 
-* `xtdb-vpc`: Sets up a sample VPC to be used by the other infrastructure
-* `xtdb-s3`: Sets up all S3 infrastructure & permissions that are required to be used for an XTDB Object Store
-* `xtdb-msk`: Sets up an MSK Kafka cluster for use as the XTDB log
-** Depends on `xtdb-vpc`
-* `xtdb-alb`: Sets up application load balancer and all relevant infrastructure for that to route traffic to the ECS service
-** Depends on `xtdb-vpc`
-* `xtdb-ecs`: Sets up XTDB on ECS, running on EC2 instances.
-** Depends on `xtdb-vpc`, `xtdb-s3`, `xtdb-msk` and `xtdb-alb`
+Before starting, ensure you have the following installed:
 
-== Setting up the stacks
+* The **AWS CLI** - See the link:https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[**Installation Instructions**^].
+* **Terraform** - See the link:https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli[**Installation Instructions**^].
+* **kubectl** - The Kubernetes CLI, used to interact with the AKS cluster. See the link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[**Installation Instructions**^].
+* **Helm** - The Kubernetes package manager, used to deploy numerous components to AKS. See the link:https://helm.sh/docs/intro/install/[**Installation Instructions**^].
 
-Access the **AWS CloudFormation** dashboard (or use the CLI) and follow the instructions to set up each stack in sequence.
+On AWS itself, you will need:
 
-=== Setting up the VPC
+* An AWS account and associated credentials that allow you to create resources.
 
-The `xtdb-vpc` template creates a sample VPC with networking components to be used by other infrastructure. This can be uploaded as is - no additional parameters are needed.
+=== Authenticating the AWS CLI
 
-It will **output** the following:
+Before running the Terraform templates, you need to authenticate the AWS CLI with your AWS account.
 
-* `VpcId`: ID of the created VPC.
-* `PublicSubnets`: IDs of the VPC's public subnets
-* `PrivateSubnets`: IDs of the VPC's private subnets
-* `SecurityGroupId`: ID of the VPC's security group
-
-NOTE: If you wish to group all of the resources created from all the templates under a single tag, you can apply them at the stack level when uploading the templates. This is optional, but may be useful for finding resources later.  
-
-=== Setting up the S3 resources
-
-The `xtdb-s3` template sets up infrastructure & permissions necessary to use S3 as an XTDB Object Store.
-
-It doesn't depend on `xtdb-vpc`, so you can upload both simultaneously. It requires the following **input parameter**:
-
-* `S3BucketName` - Desired name of the bucket which will contain the XTDB Object Store
-
-It will **output** the following:
-
-* `BucketName`: Created S3 bucket name (identical to `S3BucketName`)
-* `S3AccessPolicyArn`: ARN of the managed policy granting all of the relevant S3 permissions
-
-=== Setting up the MSK cluster
-
-The `xtdb-msk` template establishes an MSK Kafka cluster to be used as the XTDB log, including necessary permissions. It requires `xtdb-vpc` to be created first.
-
-It takes the following **input parameters**:
-
-* `VpcId`: ID of the VPC to host the MSK cluster on (from `xtdb-vpc`)
-* `SecurityGroupId`: ID of the security group to be used by the ECS nodes (from `xtdb-vpc`)
-* `PrivateSubnets`: List of private subnets to host the MSK brokers on, at least two (from `xtdb-vpc`)
-* `MSKClusterName`: Desired name for the MSK Kafka cluster - defaults to `xtdb-cluster-kafka`
-* `MSKVolumeSize`: The size in GiB of the EBS volume for the data drive on each broker node of the Kafka cluster - defaults to `100`
-
-It will **output** the following:
-
-* `MSKClusterArn`: ARN of the created MSK cluster 
-* `MSKClusterName`:  Name of the created MSK cluster
-* `MSKAccessPolicyArn`: ARN of the managed policy granting MSK permissions
-
-The `xtdb-msk` stack will take longer to set up - usually around thirty minutes. This is because **MSK** will need to provision and set up Kafka. In the interim, you can set up `xtdb-alb` (see <<albsetup, below>>). 
-
-Following the creation of the `xtdb-msk` stack, it's crucial to perform an additional step to enable configuration of the XTDB nodes: **retrieving the bootstrap servers from MSK**.
-
-[#bootstrap-servers]
-=== Fetching the bootstrap servers 
-
-After the `xtdb-msk` stack has been successfully created, you will need to get the list of **Kafka bootstrap servers** that the node will connect to. As these cannot be directly returned from CloudFormation itself, you will need to fetch them manually from the cluster on AWS.
-
-The steps to do so (in the AWS console) are as follows:
-
-* Go to the **MSK** dashboard in the console.
-* This should lead you to a list of **Clusters** - select whichever one has the same name as `MSKClusterName` (this defaults to `xtdb-cluster-kafka` if left unaltered)
-* You should see an overview of the created MSK cluster - at the top, there will be a **Cluster summary** - with a link to "View client information". Click on this.
-* This should lead to a list of Bootstrap Servers - there should be a copy button on the "PLAINTEXT" ones.
-** These should be in a comma separated list - there should be two of them in total.
-** The Bootstrap Server URLs should be in something similar to the following shape: `b-2.<MSKClusterName>.<ID>.c5.kafka.<Region>.amazonaws.com:9092`. 
-** Ensure they end with port `9092`, as these are the `PLAINTEXT` URLs. 
-
-[#albsetup]
-=== Setting up the load balancer
-
-The `xtdb-alb` template configures an Application Load Balancer to route traffic across the ECS service. It will require will require `xtdb-vpc` to have been created prior.
-
-It takes the following **input parameters**:
-
-- `VpcId`: ID of the VPC to host the load balancer on (from `xtdb-vpc`)
-- `SecurityGroupId`: Group ID of the security group to be used by the ECS nodes (from `xtdb-vpc`)
-- `PublicSubnets`: List of public subnets to host the load balancer on (from `xtdb-vpc`)
-
-It will **output** the following:
-
-- `TargetGroupArn`: ARN of the created target group 
-- `LoadBalancerArn`: ARN of the created Application Load Balancer
-- `LoadBalancerUrl`: The load-balanced XTDB node URL - 'http://${ECSALB.DNSName}'
-
-=== Setting up the nodes on ECS
-
-The `xtdb-ecs` template will set up our XTDB cluster on running as an ECS service, and will require all of the prior stacks to be created. 
-
-It splits it's inputs into two distinct sections - parameters/resources from other stacks, and desired ECS Configuration.
-
-* Expected **input parameters** from other resources/stacks: 
-** `SecurityGroupId`: ID of the security group to be used by the ECS nodes (from `xtdb-vpc`)
-** `PublicSubnets`: List of public subnets to host the load balancer on (from `xtdb-vpc`)
-** `TargetGroupArn`: ARN of the target group created for the nodes (from `xtdb-alb`)
-** `LoadBalancerArn`: ARN of the Application Load Balancer created for the nodes (from `xtdb-alb`)
-** `S3BucketName`: Name of the S3 bucket to use as the XTDB object store (from `xtdb-s3`)
-** `S3AccessPolicyArn`: ARN of the managed policy offering access to all the S3 permissions necessary for the object store (from `xtdb-s3`)
-** `MSKBootstrapServers`: Comma separated list containing all Kafka bootstrap server URLs from MSK (needs to be grabbed manually from the MSK cluster info, see "<<Fetching the bootstrap servers>>")
-** `MSKAccessPolicyArn`: ARN of the managed policy offering access to all the MSK permissions (from `xtdb-msk`)
-* Expected **input parameters** for the configuration of ECS: 
-** `ClusterName`: Name of the desired ECS cluster -  defaults to `xtdb-cluster`
-** `EC2InstanceType`: EC2 instance type used for ECS Service - defaults to `i3.large` (storage optimized)
-** `DesiredCapacity`: Number of EC2 instances to launch in your ECS cluster / XTDB node tasks to run - defaults to `1`
-** `ImageId:` Used to grab an 'ECS optimized' image from SSM Parameter Store (We recommend that this is left as default)  
-
-After creation - there will now be a cluster of XTDB nodes running on ECS with the desired user configuration. These will be accessible via the `LoadBalancerUrl` from `xtdb-alb`.
-
-== Accessing the node
-
-With the stacks set up in AWS, you should now be able to make calls to the nodes over HTTP using the `LoadBalancerUrl` from the Application Load Balancer. You can call to `GET` the status of one of the nodes:
+See link:https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html[**AWS CLI Sign-In Instructions**^] for more information on how to authenticate the AWS CLI - for this guide, we will use `aws sso` and profiles.
 
 ```bash
-curl $LoadBalancerUrl/status
+# Setup SSO profile
+aws configure sso
+# Authenticate with AWS SSO
+aws sso login --profile <profile_name>
 ```
 
-NOTE: As our nodes are behind an application load balancer, be aware that messages sent over HTTP will be spread across the nodes, so you may see some differing values coming back from the status as each node in the cluster processes new transactions.
+This allows you to perform necessary operations on AWS via Terraform using the User Principal on the AWS CLI.
 
-Should the above be successful, you should be ready to go with an XTDB cluster!
+[#terraform]
+== Getting started with Terraform
+
+The following assumes that you are authenticated on the AWS CLI, have Terraform installed on your machine, and are located a directory that you wish to use as the root of the Terraform configuration.
+
+First, make the following `terraform init` call:
+```
+terraform init -from-module github.com/xtdb/xtdb.git//aws/terraform
+```  
+
+This will download the Terraform files from the XTDB repository, and initialize the working directory.
+
+NOTE: For the sake of this guide, we store Terraform state locally. 
+However, to persist the state onto AWS, you will need to configure a remote backend using AWS S3. 
+This allows you to share the state file across teams, maintain versioning, and ensure consistency during deployments. 
+For more info, see the link:https://developer.hashicorp.com/terraform/language/backend/s3[**Terraform S3 backend**^] documentation.
+
+== What is being deployed on AWS?
+
+The sample Terraform directory sets up a few key components of the infrastructure required by XTDB.
+If using the default configuration, the following resources will be created:
+
+* Amazon S3 Storage Bucket for remote storage.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws/latest[**terraform-aws-modules/s3-bucket**^] Terraform module.
+** Enables object ownership control and applies necessary permissions for XTDB.
+* IAM Policy for granting access to the S3 storage bucket.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest/submodules/iam-policy[**terraform-aws-modules/iam-policy**^] Terraform module.
+** Grants permissions for XTDB to read, write, and manage objects within the specified S3 bucket.
+* Virtual Private Cloud (VPC) for the XTDB EKS cluster.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest[**terraform-aws-modules/vpc**^] Terraform module.
+** Enables DNS resolution, assigns public subnets, and configures networking for the cluster.
+* Amazon Elastic Kubernetes Service (EKS) Cluster for running XTDB resources.
+** Configured with associated resources using the link:https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest[**terraform-aws-modules/eks**^] Terraform module.
+** Provisions a managed node group dedicated to XTDB workloads.
+
+This infrastructure provides a solid foundation for deploying XTDB on AWS with Kubernetes.
+Resource sizes, IAM permissions, and networking configurations can be customized to fit your specific requirements and cost constraints.
+
+NOTE: Later within this guide we shall create an IAM role using the command line that can be assumed by a Kubernetes Service Account on the EKS cluster to access the S3 bucket. Assuming that you setup similar resources on Kubernetes, you may want to manage these using Terraform as well.
+
+== Deploying the AWS Infrastructure
+
+Before creating the Terraform resources, review and update the `terraform.tfvars` file to ensure the parameters are correctly set for your environment:
+
+* You are **required** to set a unique and valid `s3_bucket_name` for your environment.
+* You may also wish to change resource tiers, the location for the resources to be deployed on, or the VM sizes used by the EKS cluster.
+
+NOTE: In this guide, we use AWS Named Profiles to authenticate with AWS, and need to pass the profile to use our Terraform commands. Though we do this via the CLI, you can also add it directly to the terraform `provider` config or authenticate using other methods - see the link:https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration[**AWS Provider Documentation**^] for more information. 
+
+To get a full list of the resources that will be deployed by the templates, run:
+```bash
+AWS_PROFILE=<profile_name> terraform plan 
+```
+
+Finally, to create the resources, run:
+```bash
+AWS_PROFILE=<profile_name> terraform apply
+```
+
+This will create the necessary infrastructure on the AWS account.
+
+[#terraform-outputs]
+=== Fetching the Terraform Outputs
+
+The Terraform templates will generate several outputs required for setting up the XTDB nodes on the EKS cluster.
+
+To retrieve these outputs, execute the following command:
+```bash
+terraform output
+```
+
+This will return the following outputs:
+
+* `aws_region` - The AWS region in which the resources were created.
+* `eks_cluster_name` - The name of the EKS cluster created for the XTDB deployment.
+* `s3_bucket_name` - The name of the S3 bucket created for the XTDB cluster.
+* `s3_access_policy_arn` - The ARN of the S3 bucket created for the XTDB cluster.
+* `oidc_provider` - OpenID Connect identity provider for the EKS cluster.
+* `oidc_provider_arn` - The ARN of the OpenID Connect identity provider for the EKS cluster.
+
+== Deploying on Kubernetes
+
+With the infrastructure created on AWS, we can now deploy the XTDB nodes and a simple Kafka instance on the EKS cluster.
+
+Prior to deploying the Kubernetes resources, ensure that the `kubectl` CLI is installed and configured to interact with the EKS cluster. Run the following command:
+
+```bash
+aws eks --profile <profile_name> --region <region> update-kubeconfig --name <eks_cluster_name>
+```
+
+Now that `kubectl` is authenticated with the EKS cluster, you can set up the namespace for the XTDB deployment:
+
+```bash
+kubectl create namespace xtdb-deployment
+```
+
+The EKS cluster is now ready for deployment,
+
+'''
+
+=== Deploying an example Kafka 
+
+To deploy a basic set of Kafka resources within GKE, you can make use of the `bitnami/kafka` Helm chart. Run the following command:
+
+```bash
+helm install kafka oci://registry-1.docker.io/bitnamicharts/kafka \
+  --version 31.3.1 \
+  --namespace xtdb-deployment \
+  --set listeners.client.protocol=PLAINTEXT \
+  --set listeners.controller.protocol=PLAINTEXT \
+  --set controller.resourcesPreset=medium \
+  --set global.defaultStorageClass=gp2 \
+  --set controller.nodeSelector.node_pool=xtdbpool
+```
+
+This command will create:
+
+* A simple, **unauthenticated** Kafka deployment on the GKE cluster, which XTDB will use as its message log, along with its dependent infrastructure and persistent storage.
+** Using gp2 backed storage for the Persistent Volume Claims.
+* A Kubernetes service to expose the Kafka instance to the XTDB cluster.
+
+==== Considerations of the Kafka Deployment
+
+The Kafka instance set up above is for **demonstration purposes** and is **not recommended for production use**. 
+This example lacks authentication for the Kafka cluster and allows XTDB to manage Kafka topic creation and configuration itself.
+
+For production environments, consider the following:
+
+* Use a more robust Kafka deployment.
+* Pre-create the required Kafka topics.
+* Configure XTDB appropriately to interact with the production Kafka setup.
+
+Additional resources:
+
+* For further configuration options for the Helm chart, refer to the link:https://artifacthub.io/packages/helm/bitnami/kafka[**Bitnami Kafka Chart Documentation**^].
+* For detailed configuration guidance when using Kafka with XTDB, see the link:https://docs.xtdb.com/ops/config/log/kafka.html#_setup[**XTDB Kafka Setup Documentation**^].
+
+=== Verifying the Kafka Deployment
+
+After deployment, verify that the Kafka instance is running properly by checking its status and logs.
+
+To check the status of the Kafka deployment, run the following command:
+```bash
+kubectl get pods --namespace xtdb-deployment
+```
+
+To view the logs of the Kafka deployment, use the command:
+```bash
+kubectl logs -f statefulset/kafka-controller --namespace xtdb-deployment
+```
+
+By verifying the status and reviewing the logs, you can ensure the Kafka instance is correctly deployed and ready for use by XTDB.
+
+'''
+
+=== Creating an IAM Role for the XTDB nodes 
+
+To allow the XTDB nodes to access the S3 bucket created earlier, a Kubernetes Service Account (KSA) must be setup and linked with an IAM role that has the necessary permissions, using link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[**IAM Roles for Service Accounts (IRSA)**^].
+
+To set up the Kubernetes Service Account, run the following command:
+
+```bash
+kubectl create serviceaccount xtdb-service-account --namespace xtdb-deployment
+```
+
+Fetch the S3 bucket policy ARN (`s3_access_policy_arn`) and the OpenID Connect identity provider of the EKS cluster (`oidc_provider`) along with the ARN for the provider (`oidc_provider_arn`) from the Terraform outputs.
+
+Create a file `eks_policy_document.json` for the trust policy, replacing values as appropriate:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<oidc_provider_arn>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<oidc_provider>:aud": "sts.amazonaws.com",
+          "<oidc_provider>:sub": "system:serviceaccount:xtdb-deployment:xtdb-service-account"
+        }
+      }
+    }
+  ]
+}
+```
+
+Create the IAM role and attach the trust policy:
+
+```bash
+aws iam --profile <profile_name> create-role --role-name xtdb-eks-role --assume-role-policy-document file://eks_policy_document.json --description "XTDB EKS Role"
+```
+
+Now attach the S3 bucket role:
+
+```bash
+aws iam --profile <profile_name> attach-role-policy --role-name xtdb-eks-role --policy-arn=<s3_access_policy_arn>
+```
+
+Fetch the ARN of the IAM role:
+
+```bash
+xtdb_eks_role_arn=$(aws iam --profile <profile_name> get-role --role-name xtdb-eks-role --query Role.Arn --output text)
+```
+
+Finally, annotate the Kubernetes Service Account with the IAM role:
+
+```bash
+kubectl annotate serviceaccount xtdb-service-account --namespace xtdb-deployment eks.amazonaws.com/role-arn=$xtdb_eks_role_arn
+```
+
+With the XTDB service account set up, we can now deploy the XTDB cluster to the EKS cluster.
+
+'''
+
+=== Deploying the XTDB cluster
+
+In order to deploy the XTDB cluster and it's constituent parts into the AKS cluster, we provide an `xtdb-aws` Helm chart/directory.
+
+This can be found on the link:https://github.com/xtdb/xtdb/pkgs/container/helm-xtdb-aws[**XTDB Github Container Registry**^], and can be used directly with `helm` commands.
+
+With the values from the link:#terraform-outputs[Terraform outputs], you can now deploy the XTDB cluster. 
+Run the following command, substituting the values as appropriate: 
+
+```bash
+helm install xtdb-aws oci://ghcr.io/xtdb/helm-xtdb-aws \
+  --version 2.0.0-snapshot \
+  --namespace xtdb-deployment \
+  --set xtdbConfig.serviceAccount="xtdb-service-account" \
+  --set xtdbConfig.s3Bucket=<s3_bucket> 
+```
+
+The following are created by the templates:
+
+* A `ConfigMap` containing the XTDB YAML configuration.
+* A `StatefulSet` containing the XTDB nodes.
+* A `LoadBalancer` Kubernetes service to expose the XTDB cluster to the internet.
+
+To check the status of the XTDB statefulset, run:
+```bash
+kubectl get statefulset --namespace xtdb-deployment
+```
+
+To view the logs of each individual StatefulSet member, run:
+```bash
+kubectl logs -f xtdb-statefulset-n --namespace xtdb-deployment
+```
+
+==== Customizing the XTDB Deployment
+
+The above deployment uses the `xtdb-aws` chart defaults, individually setting the terraform outputs as `xtdbConfig` settings using the command line. 
+
+For more information on the available configuration options and fetching the charts locally for customization, see the link:/ops/aws#helm[`xtdb-aws` Helm documentation]
+
+'''
+
+=== Accessing the XTDB Cluster
+
+NOTE: As it will take some time for the XTDB nodes to be marked as ready (as they need to pass their initial startup checks), and AWS will need to provision a Load Balancer for the service, it may take a few minutes for the XTDB cluster to be accessible.
+
+Once the XTDB cluster is up and running, you can access it via the LoadBalancer service that was created.
+
+To get the external IP of the LoadBalancer service, run:
+```bash
+kubectl get svc xtdb-service --namespace xtdb-deployment
+```
+
+This will return the external IP of the LoadBalancer service. 
+You can use this IP and access the XTDB cluster via:
+
+* Postgres Wire Server (on port `5432`)
+* Healthz Server (on port `8080`)
+* HTTP Server (on port `3000`). 
+
+To check the status of the XTDB cluster using the HTTP server, run:
+
+```bash
+curl http://$ExternalIP:8080/healthz/alive
+
+# alternatively `/healthz/started`, `/healthz/ready`
+```
+
+If the above command succeeds, you now have a load-balanced XTDB cluster accessible over the internet.


### PR DESCRIPTION
Resolves #4137 

- Add a Terraform file setting up all of the cloud infrastructure XTDB requires and for setting up/running Kubernetes:  
  - **Amazon S3 Storage Bucket** for remote storage.  
    - Configured using [**terraform-aws-modules/s3-bucket**](https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws/latest).  
  - **IAM Policy** for granting access to the S3 storage bucket.  
    - Configured using [**terraform-aws-modules/iam-policy**](https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest/submodules/iam-policy).  
  - **Virtual Private Cloud (VPC)** for the XTDB EKS cluster.  
    - Configured using [**terraform-aws-modules/vpc**](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest).  
  - **Amazon Elastic Kubernetes Service (EKS) Cluster** for running XTDB resources.  
    - Configured using [**terraform-aws-modules/eks**](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest).  
    - Provisions a managed node group dedicated to XTDB workloads.  
  - Setting up everything else we need around those - using sensible variables to allow easy customization with `terraform.tfvars`.  
  - Setup using best practises around spreading across AZs, i3 machines with mounted NVME storage, etc.
- Add Helm config for AWS:  
  - Based on Azure Helm config.  
  - Added to Helm deploy task.  
  - Deploying all necessary config to Kubernetes.  
- Update the `AWS` docs to include notes on using both Terraform and Helm.  
- Update "Getting Started with AWS" guide to use Terraform/Helm.

Have additionally ran through the guide/docs, set this up, verified it and ran a TPCH run against it using a remote client.  
