### PR TITLE
Change EE pd-scale to def to fix return type hint - Fixes #4252

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -996,10 +996,12 @@
   {:return-type interval-type
    :->call-code (fn [[i]] `(pd-neg ~i))})
 
-(defn pd-scale ^PeriodDuration [^PeriodDuration pd ^long factor]
-  (let [p (.getPeriod pd)
-        d (.getDuration pd)]
-    (PeriodDuration. (.multipliedBy p factor) (.multipliedBy d factor))))
+;;HACK https://clojure.atlassian.net/browse/CLJ-2817
+(def ^PeriodDuration pd-scale
+  (fn ^PeriodDuration [^PeriodDuration pd ^long factor]
+    (let [p (.getPeriod pd)
+          d (.getDuration pd)]
+      (PeriodDuration. (.multipliedBy p factor) (.multipliedBy d factor)))))
 
 (defmethod expr/codegen-call [:* :interval :int] [{[l-type _] :arg-types}]
   {:return-type l-type

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -1683,6 +1683,23 @@
                         {:i #xt/interval-mdn ["P0D" "PT15M"]
                          :src #inst "2020-01-01T00:20:10Z"}))))
 
+(deftest test-date-bin-with-origin
+  (t/is (= #xt/zoned-date-time "2024-03-06T12:00Z"
+           (et/project1
+            '(date-bin stride src origin)
+            {:stride #xt/interval-mdn ["P0D" "PT3H"]
+             :src #xt/zoned-date-time "2024-03-06T14:23:45Z"
+             :origin #xt/zoned-date-time "2000-01-01T00:00:00Z"}))))
+
+(deftest test-pd-scale-type-hinting-4252
+  ;;pd accessors in ts +/- interval causes reflection if pd-scale return
+  ;;type not hinted
+  (t/is (= #xt/zoned-date-time "2020-01-03T06:00Z"
+           (et/project1
+            '(+ #xt/zoned-date-time "2020-01-01T00:00:00Z"
+                (* #xt/interval-mdn ["P1D" "PT3H"] 2))
+            {}))))
+
 (deftest test-range-bins
   (let [base (time/->zdt #inst "2020-01-01")]
     (letfn [(f [start end]


### PR DESCRIPTION
See: https://clojure.atlassian.net/browse/CLJ-2817

Significant performance increase for queries that heavily depend on `pd-scale` (via `bin_date`).