### PR TITLE
Fix: EXPLAIN now works for pgwire queries with parameters

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -293,7 +293,8 @@
 
                                :else (throw (err/illegal-arg :unknown-query-type {:query query, :type (type query)})))]
                     (if (:explain? query-opts)
-                      [:table [{:plan (with-out-str (pp/pprint plan))}]]
+                      (with-meta [:table [{:plan (with-out-str (pp/pprint plan))}]]
+                                 (-> (meta plan) (select-keys [:param-count :warnings])))
                       plan))))))
 
       AutoCloseable

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2619,6 +2619,11 @@ ORDER BY 1,2;")
            (t/is (nil? more-rows))
            (t/is (= expected-plan (read-string plan)))))))))
 
+(t/deftest test-explain-query-with-params
+  (with-open [conn (pg-conn {})]
+    (let [[{:keys [plan]}] (pg/execute conn "EXPLAIN SELECT $1" {:params [""]})]
+      (t/is (some? plan)))))
+
 (t/deftest test-ro-server-4043
   (with-open [node (xtn/start-node {:server {:read-only-port 0, :port 0}})]
     (binding [*port* (.getServerPort node)]


### PR DESCRIPTION
The issue is that the query plan metadata is lost when the printed query plan is inserted into the EXPLAIN plan.

I have preserved the relevant metadata for accepting query parameters at the pgwire BIND step, and I'm also including warnings. Other metadata, such as `:ordered-outer-projection`, is not preserved, as it doesn't apply to the EXPLAIN results.

Alternatively, I guess we could have ignored BIND parameters for an EXPLAIN query, but I think it's better to preserve the usual behavior, for doing the same checks as with the bare query.

Is this a good approach? Should I include a test?

