### PR TITLE
Use temporal file metadata

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -244,7 +244,8 @@
                                                                                                                 col-names)
                                                                                          :page-metadata page-metadata})))
                                                                               (-> (cat/trie-state trie-catalog table-name)
-                                                                                  (cat/current-tries)))
+                                                                                  (cat/current-tries)
+                                                                                  (cat/filter-tries temporal-bounds)))
 
                                                                   live-table-wm (conj (-> (trie/->Segment (.getLiveTrie live-table-wm))
                                                                                           (assoc :memory-rel (.getLiveRelation live-table-wm))))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -254,7 +254,7 @@
                                                                                               (assoc :memory-rel memory-rel)))))]
                                                    (->> (HashTrieKt/toMergePlan segments (->path-pred iid-arrow-buf))
                                                         (into [] (keep (fn [^MergePlanTask mpt]
-                                                                         (when-let [leaves (trie/->merge-task
+                                                                         (when-let [leaves (trie/filter-meta-objects
                                                                                             (for [^MergePlanNode mpn (.getMpNodes mpt)
                                                                                                   :let [{:keys [data-file-path page-metadata page-idx-pred trie memory-rel]} (.getSegment mpn)
                                                                                                         node (.getNode mpn)]]

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -8,8 +8,7 @@
            (xtdb.log.proto TrieDetails TrieMetadata)
            xtdb.operator.scan.MergePlanPage
            (xtdb.trie ISegment MemoryHashTrie Trie Trie$Key)
-           (xtdb.util TemporalBounds TemporalDimension)
-           (xtdb.util Temporal)))
+           (xtdb.util Temporal TemporalBounds TemporalDimension)))
 
 (defn ->trie-details ^TrieDetails
   ([table-name, trie-key, ^long data-file-size] (->trie-details table-name trie-key data-file-size nil))

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -6,7 +6,7 @@
            java.time.LocalDate
            (java.util ArrayList)
            (xtdb.log.proto TrieDetails TrieMetadata)
-           xtdb.operator.scan.MergePlanPage
+           (xtdb.operator.scan Metadata)
            (xtdb.trie ISegment MemoryHashTrie Trie Trie$Key)
            (xtdb.util Temporal TemporalBounds TemporalDimension)))
 
@@ -62,47 +62,47 @@
         (.setPageLimit page-limit))
       (.build)))
 
-(defn ->merge-task
-  ([mp-pages] (->merge-task mp-pages (TemporalBounds.)))
-  ([mp-pages ^TemporalBounds query-bounds]
+(defn filter-meta-objects
+  ([meta-objects] (filter-meta-objects meta-objects (TemporalBounds.)))
+  ([meta-objects ^TemporalBounds query-bounds]
    (let [leaves (ArrayList.)]
-     (loop [[^MergePlanPage mp-page & more-mp-pages] mp-pages
+     (loop [[^Metadata meta-obj & more-meta-objs] meta-objects
             smallest-valid-from Long/MAX_VALUE
             largest-valid-to Long/MIN_VALUE
             smallest-system-from Long/MAX_VALUE
-            non-taken-pages []]
-       (if mp-page
-         (let [page-temp-meta (.getTemporalMetadata mp-page)
-               take-node? (and (Temporal/intersects page-temp-meta query-bounds)
-                               (.testMetadata mp-page))]
+            non-taken-meta-objects []]
+       (if meta-obj
+         (let [temporal-metadata (.getTemporalMetadata meta-obj)
+               take-node? (and (Temporal/intersects temporal-metadata query-bounds)
+                               (.testMetadata meta-obj))]
 
            (if take-node?
              (do
-               (.add leaves mp-page)
-               (recur more-mp-pages
-                      (min smallest-valid-from (.getMinValidFrom page-temp-meta))
-                      (max largest-valid-to (.getMaxValidTo page-temp-meta))
-                      (min smallest-system-from (.getMinSystemFrom page-temp-meta))
-                      non-taken-pages))
+               (.add leaves meta-obj)
+               (recur more-meta-objs
+                      (min smallest-valid-from (.getMinValidFrom temporal-metadata))
+                      (max largest-valid-to (.getMaxValidTo temporal-metadata))
+                      (min smallest-system-from (.getMinSystemFrom temporal-metadata))
+                      non-taken-meta-objects))
 
-             (recur more-mp-pages
+             (recur more-meta-objs
                     smallest-valid-from
                     largest-valid-to
                     smallest-system-from
-                    (cond-> non-taken-pages
-                      (Temporal/intersectsSystemTime page-temp-meta query-bounds)
-                      (conj mp-page)))))
+                    (cond-> non-taken-meta-objects
+                      (Temporal/intersectsSystemTime temporal-metadata query-bounds)
+                      (conj meta-obj)))))
 
          (when (seq leaves)
            (let [valid-time (TemporalDimension. smallest-valid-from largest-valid-to)]
-             (loop [[^MergePlanPage page & more-pages] non-taken-pages]
-               (when page
-                 (let [page-temp-meta (.getTemporalMetadata page)
-                       page-largest-system-from (.getMaxSystemFrom page-temp-meta)]
-                   (when (and (<= smallest-system-from page-largest-system-from)
-                              (.intersects (TemporalDimension. (.getMinValidFrom page-temp-meta)
-                                                               (.getMaxValidTo page-temp-meta))
+             (loop [[^Metadata meta-obj & meta-objects] non-taken-meta-objects]
+               (when meta-obj
+                 (let [temporal-metadata (.getTemporalMetadata meta-obj)
+                       obj-largest-system-from (.getMaxSystemFrom temporal-metadata)]
+                   (when (and (<= smallest-system-from obj-largest-system-from)
+                              (.intersects (TemporalDimension. (.getMinValidFrom temporal-metadata)
+                                                               (.getMaxValidTo temporal-metadata))
                                            valid-time))
-                     (.add leaves page))
-                   (recur more-pages)))))
+                     (.add leaves meta-obj))
+                   (recur meta-objects)))))
            (vec leaves)))))))

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -5,13 +5,14 @@
             [xtdb.trie :as trie]
             [xtdb.util :as util])
   (:import [java.nio ByteBuffer]
+           [java.time LocalDate ZoneOffset]
            [java.util ArrayList Map]
            [java.util.concurrent ConcurrentHashMap]
-           [java.time LocalDate ZoneId]
            org.roaringbitmap.buffer.ImmutableRoaringBitmap
            (xtdb BufferPool)
            xtdb.catalog.BlockCatalog
            (xtdb.log.proto TemporalMetadata TrieDetails TrieMetadata)
+           xtdb.operator.scan.Metadata
            (xtdb.util Temporal TemporalBounds TemporalDimension)))
 
 ;; table-tries data structure
@@ -211,61 +212,19 @@
        ;; the sort is needed as the table blocks need the current tries to be in the total order for restart
        (sort-by (juxt :level :block-idx #(or (:recency %) LocalDate/MAX)))))
 
-(defn- recency->micros [^LocalDate recency]
-  (time/instant->micros (time/->instant recency {:default-tz (ZoneId/of "UTC")})))
-
-(defn filter-tries*
-  ([tries] (filter-tries* tries (TemporalBounds.)))
-  ([tries ^TemporalBounds query-bounds]
-   (let [min-query-recency (min (.getLower (.getValidTime query-bounds)) (.getLower (.getSystemTime query-bounds)))
-         leaves (ArrayList.)]
-     (loop [[{:keys [^long recency ^TemporalMetadata temporal-metadata] :as trie} & more-tries] tries
-            smallest-valid-from Long/MAX_VALUE
-            largest-valid-to Long/MIN_VALUE
-            smallest-system-from Long/MAX_VALUE
-            non-taken-pages []]
-       (if trie
-         ;; the recency of a trie is exclusive, no row in that file has a recency equal to it
-         (let [larger-recency? (or (nil? recency) (< min-query-recency recency))
-               take-node? (and larger-recency? (Temporal/intersects temporal-metadata query-bounds))]
-
-           (if take-node?
-             (do
-               (.add leaves trie)
-               (recur more-tries
-                      (min smallest-valid-from (.getMinValidFrom temporal-metadata))
-                      (max largest-valid-to (.getMaxValidTo temporal-metadata))
-                      ;; we could potentially lower bound this by query-system-from
-                      (min smallest-system-from (.getMinSystemFrom temporal-metadata))
-                      non-taken-pages))
-
-             (recur more-tries
-                    smallest-valid-from
-                    largest-valid-to
-                    smallest-system-from
-                    (cond-> non-taken-pages
-                      (and larger-recency? (Temporal/intersectsSystemTime temporal-metadata query-bounds))
-                      (conj trie)))))
-
-         (when (seq leaves)
-           (let [valid-time (TemporalDimension. smallest-valid-from largest-valid-to)]
-             (loop [[{:keys [^TemporalMetadata temporal-metadata] :as trie} & more-tries] non-taken-pages]
-               (when trie
-                 (let [trie-largest-system-from (.getMaxSystemFrom temporal-metadata)]
-                   (when (and (<= smallest-system-from trie-largest-system-from)
-                              (.intersects (TemporalDimension. (.getMinValidFrom temporal-metadata)
-                                                               (.getMaxValidTo temporal-metadata))
-                                           valid-time))
-                     (.add leaves trie))
-                   (recur more-tries)))))
-           (vec leaves)))))))
+(defrecord CatalogEntry [^LocalDate recency ^TrieMetadata trie-metadata ^TemporalBounds query-bounds]
+  Metadata
+  (testMetadata [_]
+    (let [min-query-recency (min (.getLower (.getValidTime query-bounds)) (.getLower (.getSystemTime query-bounds)))]
+      (if-let [^long recency (and recency (time/instant->micros (time/->instant recency {:default-tz ZoneOffset/UTC})))]
+        ;; the recency of a trie is exclusive, no row in that file has a recency equal to it
+        (< min-query-recency recency)
+        true)))
+  (getTemporalMetadata [_] (.getTemporalMetadata trie-metadata)))
 
 (defn filter-tries [tries query-bounds]
-  (-> (map (fn [trie] (-> trie
-                          (assoc :temporal-metadata (.getTemporalMetadata ^TrieMetadata (:trie-metadata trie)))
-                          (update :recency #(and % (recency->micros %)))))
-           tries)
-      (filter-tries* query-bounds)))
+  (-> (map (comp map->CatalogEntry #(assoc % :query-bounds query-bounds)) tries)
+      (trie/filter-meta-objects query-bounds)))
 
 (defn <-trie-metadata [^TrieMetadata trie-metadata]
   (when (and trie-metadata (.hasTemporalMetadata trie-metadata))

--- a/core/src/main/kotlin/xtdb/operator/scan/MergePlanPage.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/MergePlanPage.kt
@@ -21,10 +21,13 @@ private val UNBOUND_TEMPORAL_METADATA =
         .setMaxSystemFrom(MAX_LONG)
         .build()
 
-interface MergePlanPage {
-    fun loadPage(rootCache: RootCache): RelationReader
+interface Metadata {
     fun testMetadata(): Boolean
     val temporalMetadata: TemporalMetadata
+}
+
+interface MergePlanPage  : Metadata {
+    fun loadPage(rootCache: RootCache): RelationReader
 
     class Arrow(
         private val bp: BufferPool,

--- a/core/src/main/kotlin/xtdb/operator/scan/MergePlanPage.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/MergePlanPage.kt
@@ -5,6 +5,7 @@ import xtdb.BufferPool
 import xtdb.log.proto.TemporalMetadata
 import xtdb.metadata.PageMetadata
 import xtdb.trie.MemoryHashTrie
+import xtdb.util.TemporalBounds
 import xtdb.vector.RelationReader
 import java.nio.file.Path
 import java.util.function.IntPredicate
@@ -26,7 +27,7 @@ interface Metadata {
     val temporalMetadata: TemporalMetadata
 }
 
-interface MergePlanPage  : Metadata {
+interface MergePlanPage : Metadata {
     fun loadPage(rootCache: RootCache): RelationReader
 
     class Arrow(

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -2,9 +2,11 @@
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
             [xtdb.test-util :as tu]
+            [xtdb.time :as time]
+            [xtdb.trie :as trie]
             [xtdb.trie-catalog :as cat]
-            [xtdb.util :as util]
-            [xtdb.trie :as trie]))
+            [xtdb.util :as util])
+  (:import [java.time LocalDate]))
 
 (defn- apply-msgs [& trie-keys]
   (-> trie-keys
@@ -38,6 +40,106 @@
       (t/is (false? (stale? l1 "l01-r20190101-b02")))
       (t/is (false? (stale? l1 "l01-rc-b01")))
       (t/is (false? (stale? l1 "l01-rc-b02"))))))
+
+
+(defn apply-filter-msgs [& trie-keys]
+  (map (fn [[trie-key recency temporal-metadata]]
+         {:trie-key trie-key
+          :recency recency
+          :temporal-metadata (apply tu/->temporal-metadata temporal-metadata)})
+       trie-keys))
+
+(defn- filter-tries [trie-keys query-bounds]
+  (-> (apply apply-filter-msgs trie-keys)
+      (cat/filter-tries* query-bounds)
+      (->> (into #{} (map :trie-key)))))
+
+(t/deftest test-filter-tries
+  (let [current-time 20200101]
+    (t/testing "recency filtering (temporal metadata always overlaps the query)"
+      (let [query-bounds (tu/->temporal-bounds current-time (inc current-time))]
+        (t/is (empty? (filter-tries [] query-bounds)))
+
+
+        (t/is (= #{"l0-current-block-02" "l0-current-block-01" "l0-current-block-00"}
+                 (filter-tries [["l0-current-block-00" nil [20200101 Long/MAX_VALUE]]
+                                ["l0-current-block-01" nil [20200101 Long/MAX_VALUE]]
+                                ["l0-current-block-02" nil [20200101 Long/MAX_VALUE]]]
+                               query-bounds)))
+
+        (t/is (= #{"l01-current-block-00" "l01-current-block-01"}
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2019-block-01" 20190101 [20200101 Long/MAX_VALUE]]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2020-block-01" 20200101 [20200101 Long/MAX_VALUE]]]
+                               query-bounds))
+              "older recency files get filtered (even at boundary)")
+
+        (t/is (= #{"l01-current-block-00" "l01-current-block-01" "l01-recency-2022-block-01"}
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2022-block-01" 20220101 [20200101 Long/MAX_VALUE] ]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]]
+                               query-bounds))
+              "newer recency files get taken"))
+
+      (let [all-st-query (tu/->temporal-bounds current-time (inc current-time) Long/MIN_VALUE Long/MAX_VALUE)
+            all-vt-query (tu/->temporal-bounds Long/MIN_VALUE Long/MAX_VALUE current-time (inc current-time))
+            st-range-query (tu/->temporal-bounds current-time (inc current-time) current-time Long/MAX_VALUE)
+            vt-range-query (tu/->temporal-bounds current-time Long/MAX_VALUE current-time (inc current-time))]
+
+        (t/is (= #{"l01-current-block-00" "l01-recency-2019-block-01" "l01-current-block-01" "l01-recency-2021-block-01"}
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2019-block-01" 20190101 [20200101 Long/MAX_VALUE]]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2021-block-01" 20210101 [20200101 Long/MAX_VALUE]]]
+                               all-st-query)
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2019-block-01" 20190101 [20200101 Long/MAX_VALUE]]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2021-block-01" 20210101 [20200101 Long/MAX_VALUE]]]
+                               all-vt-query))
+              "all system-time or valid-time means bringing in older recency pages")
+
+        (t/is (= #{"l01-current-block-00" "l01-current-block-01" "l01-recency-2021-block-01"}
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2019-block-01" 20190101 [20200101 Long/MAX_VALUE]]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2021-block-01" 20210101 [20200101 Long/MAX_VALUE]]]
+                               st-range-query)
+                 (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2019-block-01" 20190101 [20200101 Long/MAX_VALUE]]
+                                ["l01-current-block-01"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l01-recency-2021-block-01" 20210101 [20200101 Long/MAX_VALUE]]]
+                               vt-range-query))
+              "system-time range or valid-time range can filter certain pages")))
+
+    (t/testing "filtering via temporal metadata"
+      (let [query-bounds (tu/->temporal-bounds current-time Long/MAX_VALUE)]
+
+        (t/is (= #{"l0-current-block-00" "l0-current-block-01"}
+                 (filter-tries [["l0-recency-2021-block-00" 20210101 [20180101 20190101]]
+                                ["l0-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
+                                ["l0-recency-2021-block-01" 20210101 [20190101 20200101]]
+                                ["l0-current-block-01"      nil [20200101 Long/MAX_VALUE]]]
+                               query-bounds))
+              "recency doesn't filter, temporal metadata does filter"))
+
+      (let [query-bounds (tu/->temporal-bounds current-time 20210101)]
+
+        (t/is (= #{"l0-current-block-01" "l0-current-block-02"}
+                 (filter-tries [["l0-current-block-00" nil [20100101 20190101]]
+                                ["l0-current-block-01" nil [20190101 20250101]]
+                                ["l0-current-block-02" nil [20220101 Long/MAX_VALUE]]
+                                ["l0-current-block-03" nil [20250101 Long/MAX_VALUE]]]
+                               query-bounds))
+              "recency doesn't filter, temporal metadata does filter, files that can bound items in the query files set need to get taken")
+
+        (t/is (= #{"l0-current-block-01"}
+                 (filter-tries [["l0-current-block-00" nil [20100101 20190101 20100101]]
+                                ["l0-current-block-01" nil [20190101 20250101 20200101]]
+                                ["l0-current-block-02" nil [20220101 Long/MAX_VALUE 20190101]]]
+                               query-bounds))
+              "recency doesn't filter, temporal metadata does filter, if valid-time bounding files come earlier in system time they don't need to get taken")))))
 
 (t/deftest test-l0-l1-tries
   (t/is (= #{} (curr-tries)))

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -64,6 +64,14 @@
         (cat/filter-tries query-bounds)
         (->> (into #{} (map :trie-key))))))
 
+(t/deftest earilier-recency-files-can-effect-splitting-in-later-buckets-4097
+  (let [query-bounds (tu/->temporal-bounds 20220101 20220102)]
+    (t/is (= #{"l0-recency-2019-block-00" "l0-current-block-00"}
+             (filter-tries [["l0-recency-2019-block-00" nil [20190101 20210101]]
+                            ["l0-current-block-00" nil [20200101 Long/MAX_VALUE 20190101]]]
+                           query-bounds))
+          "earlier pages that contain data with later system time need to be taken")))
+
 (t/deftest test-filter-tries
   (let [current-time 20200101]
     (t/testing "recency filtering (temporal metadata always overlaps the query)"

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -121,7 +121,7 @@
   (let [[system-from1 system-from2] [20200101 20200103]
         [valid-from1 valid-from2] [20200101 20200103]
         [valid-to1 valid-to2] [20200105 20200104]]
-    (t/is (= [1 0] (->> (trie/->merge-task
+    (t/is (= [1 0] (->> (trie/filter-meta-objects
                          [(->mock-merge-plan-page 0 false valid-from1 valid-to1 system-from1)
                           (->mock-merge-plan-page 1 true  valid-from2 valid-to2 system-from2)])
                         (map :page)))
@@ -146,41 +146,41 @@
 
       (t/testing "No constraints on query bounds"
 
-        (t/is (= #{1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 vt3 sf1 (dec sf2))
-                                               (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
-                                              (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 vt3 sf1 (dec sf2))
+                                                      (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
+                                                     (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                            ->pages))
               "Take page 1. Page 0 system from strictly before page 1.")
-        (t/is (= #{0 1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 (inc vt1) sf1 sf2)
-                                                 (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
-                                                (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{0 1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 (inc vt1) sf1 sf2)
+                                                        (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
+                                                       (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 0 system from overlaps.")
 
-        (t/is (= #{1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 vt1 sf1 (inc sf2))
-                                               (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
-                                              (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 vt1 sf1 (inc sf2))
+                                                      (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
+                                                     (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                            ->pages))
               "Take page 1. Page 0 valid-time strictly before page 1.")
 
-        (t/is (= #{0 1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 (inc vt1) sf1 (inc sf2))
-                                                 (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
-                                                (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{0 1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 (inc vt1) sf1 (inc sf2))
+                                                        (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
+                                                       (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 0 valid-time overlpas."))
 
 
       (t/testing "Tighter constraints on query bounds"
         ;; TODO could we filter page 0 in the two assertions below?
-        (t/is (= #{0 1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 vt2 sf1 sf2)
-                                                 (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
-                                                (tu/->temporal-bounds vt0 Long/MAX_VALUE (inc sf2) Long/MAX_VALUE))
+        (t/is (= #{0 1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 vt2 sf1 sf2)
+                                                        (->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)]
+                                                       (tu/->temporal-bounds vt0 Long/MAX_VALUE (inc sf2) Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 0 system from overlaps. Query system-time bounds don't touch page 0")
 
-        (t/is (= #{0 1} (->> (trie/->merge-task [(->mock-merge-plan-page 0 false vt0 vt1 sf1 (inc sf2))
-                                                 (->mock-merge-plan-page 1 true (dec vt1) vt2 sf2 sf2)]
-                                                (tu/->temporal-bounds (inc vt1) Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{0 1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 false vt0 vt1 sf1 (inc sf2))
+                                                        (->mock-merge-plan-page 1 true (dec vt1) vt2 sf2 sf2)]
+                                                       (tu/->temporal-bounds (inc vt1) Long/MAX_VALUE sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 0 valid-time overlpas. Query valid-time bounds don't touch page 0")))
 
@@ -188,44 +188,44 @@
 
       (t/testing "No constraints on query bounds"
 
-        (t/is (= #{1} (->> (trie/->merge-task [(->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)
-                                               (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
-                                              (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 1 true vt1 vt2 sf2 sf2)
+                                                      (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
+                                                     (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                            ->pages))
               "Take page 1. Page 2 doesn't overlap in valid-time")
 
-        (t/is (= #{1 2} (->> (trie/->merge-task [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
-                                                 (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
-                                                (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{1 2} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
+                                                        (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
+                                                       (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 2 overlaps in valid-time")
 
-        (t/is (= #{1 2} (->> (trie/->merge-task [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
-                                                 (->mock-merge-plan-page 2 false vt2 (inc vt3) sf3 sf3)]
-                                                (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
+        (t/is (= #{1 2} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
+                                                        (->mock-merge-plan-page 2 false vt2 (inc vt3) sf3 sf3)]
+                                                       (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 2 can bound page 1 and we can't filter newer pages (no constraints on query system-time)."))
 
 
       (t/testing "Constraints on query bounds"
         ;; TODO can 2 be filtered here?
-        (t/is (= #{1 2} (->> (trie/->merge-task [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
-                                                 (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
-                                                (tu/->temporal-bounds vt1 (dec vt2) sf1 Long/MAX_VALUE))
+        (t/is (= #{1 2} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf2)
+                                                        (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)]
+                                                       (tu/->temporal-bounds vt1 (dec vt2) sf1 Long/MAX_VALUE))
                              ->pages))
               "Take page 1. Page 2 overlaps in valid-time")
 
 
-        (t/is (= #{1} (->> (trie/->merge-task [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf3)
-                                               (->mock-merge-plan-page 2 false vt2 (inc vt3) sf3 sf3)]
-                                              (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 sf3))
+        (t/is (= #{1} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 1 true vt1 (inc vt2) sf2 sf3)
+                                                      (->mock-merge-plan-page 2 false vt2 (inc vt3) sf3 sf3)]
+                                                     (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 sf3))
                            ->pages))
               "Take page 1. Page 2 can bound page 1 and we can filter newer pages because of query system-time constraints.")))
 
 
-    (t/is (= #{0 1 2} (->> (trie/->merge-task [(->mock-merge-plan-page 0 true vt0 Long/MAX_VALUE sf1 sf1)
-                                               (->mock-merge-plan-page 1 false vt1 vt2 sf2 sf2)
-                                               (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)])
+    (t/is (= #{0 1 2} (->> (trie/filter-meta-objects [(->mock-merge-plan-page 0 true vt0 Long/MAX_VALUE sf1 sf1)
+                                                      (->mock-merge-plan-page 1 false vt1 vt2 sf2 sf2)
+                                                      (->mock-merge-plan-page 2 false vt2 vt3 sf3 sf3)])
                            ->pages))
           "All pages pages need to be taken if later pages bound valid-time")))
 
@@ -235,7 +235,7 @@
                             #inst "2021-01-01" #inst "2022-01-01" #inst "2023-01-01"])]
 
     (letfn [(query-bounds+temporal-page-metadata->pages [temporal-page-metadata query-bounds]
-              (->> (trie/->merge-task
+              (->> (trie/filter-meta-objects
                     (for [[page min-vf max-vt] temporal-page-metadata]
                       (->mock-merge-plan-page page min-vf max-vt))
                     query-bounds)

--- a/src/test/clojure/xtdb/trie_test.clj
+++ b/src/test/clojure/xtdb/trie_test.clj
@@ -117,16 +117,6 @@
 
 (def ^:private inst->micros (comp time/instant->micros time/->instant))
 
-(deftest earilier-recency-buckets-can-effect-splitting-in-later-buckets-4097
-  (let [[system-from1 system-from2] [20200101 20200103]
-        [valid-from1 valid-from2] [20200101 20200103]
-        [valid-to1 valid-to2] [20200105 20200104]]
-    (t/is (= [1 0] (->> (trie/filter-meta-objects
-                         [(->mock-merge-plan-page 0 false valid-from1 valid-to1 system-from1)
-                          (->mock-merge-plan-page 1 true  valid-from2 valid-to2 system-from2)])
-                        (map :page)))
-          "earlier pages that contain data with later system time need to be taken")))
-
 (deftest test-to-merge-task
   (let [[sf1 sf2 sf3] [20200 20210 20220]
         [vt0 vt1 vt2 vt3] [20200 20210 20220 20230]


### PR DESCRIPTION
~With #4281 the change of using metadata for filtering files becomes a breeze. We rename `->merge-task` to `filter-meta-objects` which means it should works for anything that implements `PMetadta` (pages + files for now).~

I have first added a function `filter-tries` to the trie-catalog which takes the tries as well as the query bounds and using the metadata + recency calculates which tries are relevant for the query.

In a second pass I have consolidated `->merge-task` (page level) and `filter-tries` (file level) into a single function (`filter-meta-objects`) as the logic is identical. The only difference is that trie filtering also makes use of recency which then becomes an extra step in `filter-tries`.

TODO:
- [x] The big todo is currently in `trie_test.clj`. There are quite a few tests that mainly test the logic around which pages to take while we were still having recency in the tries. ~Should this be moved to end to end tests with appropriate data ingestion (things going into historical as well as current) + compaction + range scans~ or should this remain ~higher~ lower level test on the trie_catalog?

Decision:
- Try to remove all recency logic testing from `trie_test.clj` (keep the correct IID resolving)
- Add appropriate tests for `filter-meta-objects` to trie_catalog
- Actually use `recency` in `filter-meta-objects` on file level