### PR TITLE
Replace usages of "offset" outside of the log - introduce "messageId"

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -819,7 +819,7 @@
                     ^Timer tx-timer
                     ^Counter tx-error-counter]
   IIndexer
-  (indexTx [this tx-id msg-ts tx-root]
+  (indexTx [this msg-id msg-ts tx-root]
     (let [lc-tx (.getLatestCompletedTx live-idx)
           default-system-time (or (when-let [lc-sys-time (some-> lc-tx (.getSystemTime))]
                                     (when-not (neg? (compare lc-sys-time msg-ts))
@@ -832,10 +832,10 @@
 
       (if (and system-time lc-tx
                (neg? (compare system-time (.getSystemTime lc-tx))))
-        (let [tx-key (serde/->TxKey tx-id default-system-time)
+        (let [tx-key (serde/->TxKey msg-id default-system-time)
               err (err/illegal-arg :invalid-system-time
                                    {::err/message "specified system-time older than current tx"
-                                    :tx-key (serde/->TxKey tx-id system-time)
+                                    :tx-key (serde/->TxKey msg-id system-time)
                                     :latest-completed-tx (.getLatestCompletedTx live-idx)})]
           (log/warnf "specified system-time '%s' older than current tx '%s'"
                      (pr-str system-time)
@@ -847,10 +847,10 @@
             (add-tx-row! live-idx-tx tx-key err)
             (.commit live-idx-tx))
 
-          (serde/->tx-aborted tx-id default-system-time err))
+          (serde/->tx-aborted msg-id default-system-time err))
 
         (let [system-time (or system-time default-system-time)
-              tx-key (serde/->TxKey tx-id system-time)]
+              tx-key (serde/->TxKey msg-id system-time)]
           (util/with-open [live-idx-tx (.startTx live-idx tx-key)]
             (if (nil? tx-root)
               (do
@@ -859,7 +859,7 @@
                   (add-tx-row! live-idx-tx tx-key skipped-exn)
                   (.commit live-idx-tx))
 
-                (serde/->tx-aborted tx-id system-time skipped-exn))
+                (serde/->tx-aborted msg-id system-time skipped-exn))
 
               (let [^DenseUnionVector tx-ops-vec (-> ^ListVector (.getVector tx-root "tx-ops")
                                                      (.getDataVector))
@@ -918,14 +918,14 @@
                           (add-tx-row! live-idx-tx tx-key e)
                           (.commit live-idx-tx))
 
-                        (serde/->tx-aborted tx-id system-time
+                        (serde/->tx-aborted msg-id system-time
                                             (when-not (= e abort-exn)
                                               e)))
 
                       (do
                         (add-tx-row! live-idx-tx tx-key nil)
                         (.commit live-idx-tx)
-                        (serde/->tx-committed tx-id system-time))))))))))))
+                        (serde/->tx-committed msg-id system-time))))))))))))
 
   Closeable
   (close [_]

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -212,15 +212,14 @@
         (defonce -log-skip-txs-once
           (log/info "All XTDB_SKIP_TXS have been skipped and block has been finished - it is safe to remove the XTDB_SKIP_TXS environment variable.")))))
 
-  (forceFlush [this record msg]
+  (forceFlush [this msg msg-id msg-timestamp]
     (let [expected-last-block-tx-id (.getExpectedBlockTxId msg)
           latest-block-tx-id (some-> latest-completed-block-tx (.getTxId))]
       (when (= (or latest-block-tx-id -1) expected-last-block-tx-id)
         (.finishBlock this)))
 
     (set! (.latest-completed-tx this)
-          (serde/->TxKey (.getLogOffset record)
-                         (.getLogTimestamp record))))
+          (serde/->TxKey msg-id msg-timestamp)))
 
   AutoCloseable
   (close [_]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -148,7 +148,7 @@
 
   xtp/PStatus
   (latest-completed-tx [_] (.getLatestCompletedTx live-idx))
-  (latest-submitted-tx-id [_] (.getLatestSubmittedOffset log))
+  (latest-submitted-tx-id [_] (.getLatestSubmittedMsgId log-processor))
   (status [this]
     {:latest-completed-tx (.getLatestCompletedTx live-idx)
      :latest-submitted-tx-id (xtp/latest-submitted-tx-id this)})

--- a/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
@@ -5,7 +5,7 @@ package xtdb.api
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
-import xtdb.api.log.LogOffset
+import xtdb.api.log.MessageId
 import java.time.Duration
 
 @Serializable
@@ -14,16 +14,16 @@ data class IndexerConfig(
     var pageLimit: Long = 1024L,
     var rowsPerBlock: Long = 102400L,
     var flushDuration: Duration = Duration.ofHours(4),
-    var skipTxs: List<LogOffset> = System.getenv("XTDB_SKIP_TXS")?.let(::parseSkipTxsEnv).orEmpty()
+    var skipTxs: List<MessageId> = System.getenv("XTDB_SKIP_TXS")?.let(::parseSkipTxsEnv).orEmpty()
 ) {
     fun logLimit(logLimit: Long) = apply { this.logLimit = logLimit }
     fun pageLimit(pageLimit: Long) = apply { this.pageLimit = pageLimit }
     fun rowsPerBlock(rowsPerBlock: Long) = apply { this.rowsPerBlock = rowsPerBlock }
     fun flushDuration(flushDuration: Duration) = apply { this.flushDuration = flushDuration }
-    fun skipTxs(skipTxs: List<LogOffset>) = apply { this.skipTxs = skipTxs.sorted() }
+    fun skipTxs(skipTxs: List<MessageId>) = apply { this.skipTxs = skipTxs.sorted() }
 
     companion object {
-        private fun parseSkipTxsEnv(skipTxs: String): List<LogOffset> =
+        private fun parseSkipTxsEnv(skipTxs: String): List<MessageId> =
             skipTxs.split(",").map { it.trim().toLong() }.sorted()
     }
 }

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -61,7 +61,7 @@ class InMemoryLog(private val instantSource: InstantSource) : Log {
 
     override fun subscribe(subscriber: Subscriber): Subscription {
         val job = scope.launch(SupervisorJob()) {
-            var latestCompletedOffset = subscriber.latestCompletedOffset
+            var latestCompletedOffset = subscriber.latestProcessedMsgId
 
             val ch = Channel<Record>(100)
 

--- a/core/src/main/kotlin/xtdb/api/log/IngestionStoppedException.kt
+++ b/core/src/main/kotlin/xtdb/api/log/IngestionStoppedException.kt
@@ -1,4 +1,4 @@
 package xtdb.api.log
 
-class IngestionStoppedException(val logOffset: LogOffset, cause: Throwable) :
+class IngestionStoppedException(val msgId: MessageId, cause: Throwable) :
     IllegalStateException("Ingestion stopped: ${cause.message}", cause)

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -199,7 +199,7 @@ class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
         }
 
     override fun subscribe(subscriber: Subscriber): Subscription {
-        var latestCompletedOffset = subscriber.latestCompletedOffset
+        var latestCompletedOffset = subscriber.latestProcessedMsgId
 
         val ch = Channel<Record>(100)
 
@@ -212,7 +212,7 @@ class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
 
                         runInterruptible {
                             FileChannel.open(logFilePath).use { ch ->
-                                val latestCompleted = subscriber.latestCompletedOffset
+                                val latestCompleted = subscriber.latestProcessedMsgId
                                 if (latestCompleted >= 0) {
                                     ch.position(latestCompleted)
                                     ch.readMessage()

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -13,6 +13,7 @@ import java.time.Instant
 import java.util.concurrent.CompletableFuture
 
 typealias LogOffset = Long
+typealias MessageId = Long
 
 interface Log : AutoCloseable {
     companion object {
@@ -118,7 +119,8 @@ interface Log : AutoCloseable {
     )
 
     interface Subscriber {
-        val latestCompletedOffset: LogOffset
+        val latestProcessedMsgId: MessageId
+        val latestSubmittedMsgId: MessageId
         fun processRecords(records: List<Record>)
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/IIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/IIndexer.kt
@@ -2,9 +2,9 @@ package xtdb.indexer
 
 import org.apache.arrow.vector.VectorSchemaRoot
 import xtdb.api.TransactionResult
-import xtdb.api.log.LogOffset
+import xtdb.api.log.MessageId
 import java.time.Instant
 
 interface IIndexer {
-    fun indexTx(msgOffset: LogOffset, msgTimestamp: Instant, txRoot: VectorSchemaRoot?): TransactionResult
+    fun indexTx(msgId: MessageId, msgTimestamp: Instant, txRoot: VectorSchemaRoot?): TransactionResult
 }

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -4,6 +4,7 @@ import org.apache.arrow.vector.types.pojo.Field
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log.Message
 import xtdb.api.log.Log.Record
+import java.time.Instant
 
 interface LiveIndex : Watermark.Source, AutoCloseable {
 
@@ -34,5 +35,5 @@ interface LiveIndex : Watermark.Source, AutoCloseable {
 
     fun finishBlock()
 
-    fun forceFlush(record: Record, msg: Message.FlushBlock)
+    fun forceFlush(msg: Message.FlushBlock, msgId: Long, msgTimestamp: Instant)
 }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
@@ -148,7 +148,7 @@ class KafkaLog internal constructor(
             kafkaConfigMap.openConsumer().use { c ->
                 TopicPartition(topic, 0).also { tp ->
                     c.assign(listOf(tp))
-                    c.seek(tp, subscriber.latestCompletedOffset + 1)
+                    c.seek(tp, subscriber.latestProcessedMsgId + 1)
                 }
 
                 runInterruptible(Dispatchers.IO) {

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogTest.kt
@@ -45,7 +45,7 @@ class KafkaLogTest {
 
         val subscriber = mockk<Subscriber> {
             every { processRecords(capture(msgs)) } returns Unit
-            every { latestCompletedOffset } returns -1
+            every { latestProcessedMsgId } returns -1
         }
 
         fun trieDetails(key: String, size: Long) =

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -17,9 +17,9 @@
         (t/testing "started endpoint"
           (let [resp (clj-http/get (->healthz-url port "started"))]
             (t/is (= 200 (:status resp)))
-            (t/is (= {"X-XTDB-Target-Offset" "-1", "X-XTDB-Current-Offset" "-1"}
+            (t/is (= {"X-XTDB-Target-Message-Id" "-1", "X-XTDB-Current-Message-Id" "-1"}
                      (-> (:headers resp)
-                         (select-keys ["X-XTDB-Target-Offset" "X-XTDB-Current-Offset"]))))
+                         (select-keys ["X-XTDB-Target-Message-Id" "X-XTDB-Current-Message-Id"]))))
             (t/is (= "Started." (:body resp)))))
 
         (t/testing "alive endpoint"
@@ -54,15 +54,15 @@
 
                 (case (long (:status resp))
                   503 (do
-                        (t/is (= {"X-XTDB-Target-Offset" "2097"}
+                        (t/is (= {"X-XTDB-Target-Message-Id" "2097"}
                                  (-> (:headers resp)
-                                     (select-keys ["X-XTDB-Target-Offset"]))))
+                                     (select-keys ["X-XTDB-Target-Message-Id"]))))
                         (Thread/sleep 250)
                         (recur))
                   200 (do
-                        (t/is (= {"X-XTDB-Target-Offset" "2097", "X-XTDB-Current-Offset" "2097"}
+                        (t/is (= {"X-XTDB-Target-Message-Id" "2097", "X-XTDB-Current-Message-Id" "2097"}
                                  (-> (:headers resp)
-                                     (select-keys ["X-XTDB-Target-Offset" "X-XTDB-Current-Offset"]))))
+                                     (select-keys ["X-XTDB-Target-Message-Id" "X-XTDB-Current-Message-Id"]))))
                         (t/is (= "Started." (:body resp)))))))))))))
 
 (t/deftest test-indexer-error


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions?query=branch%3Aoffset-to-msg-id+

This is an equivalence change to aid in the epoch/empty log changes, but essentially is entirely focused on removing the idea of "offset" outside of the Log, and instead using "messageIds" (which more generally is what the system is talking in terms of)