### PR TITLE
Add capability to restart node from storage when you have an empty/stale log topic

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -29,7 +29,8 @@
            (xtdb.api.query XtqlQuery)
            [xtdb.api.tx TxOp]
            (xtdb.indexer IIndexer LiveIndex LogProcessor)
-           (xtdb.query IQuerySource PreparedQuery)))
+           (xtdb.query IQuerySource PreparedQuery)
+           (xtdb.util TxIdUtil)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -100,8 +101,9 @@
 
   xtp/PNode
   (submit-tx [this tx-ops opts]
-    (try
-      @(xt-log/submit-tx& this (->TxOps tx-ops) opts)
+    (try 
+      (let [offset @(xt-log/submit-tx& this (->TxOps tx-ops) opts)]
+        (TxIdUtil/offsetToTxId (.getEpoch log) offset)) 
       (catch ExecutionException e
         (throw (ex-cause e)))
       (catch IllegalArgumentException e

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -15,14 +15,18 @@ import java.time.temporal.ChronoUnit.MICROS
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-class InMemoryLog(private val instantSource: InstantSource) : Log {
+class InMemoryLog(private val instantSource: InstantSource, override val epoch: Int) : Log {
 
     @SerialName("!InMemory")
     @Serializable
-    data class Factory(@Transient var instantSource: InstantSource = InstantSource.system()) : Log.Factory {
+    data class Factory(
+        @Transient var instantSource: InstantSource = InstantSource.system(),
+        var epoch: Int = 0
+    ) : Log.Factory {
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
+        fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
-        override fun openLog() = InMemoryLog(instantSource)
+        override fun openLog() = InMemoryLog(instantSource, epoch)
     }
 
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -33,7 +33,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
 import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
 
-class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
+class LocalLog(rootPath: Path, private val instantSource: InstantSource, override val epoch: Int) : Log {
     companion object {
         private val Path.logFilePath get() = resolve("LOG")
 
@@ -268,11 +268,13 @@ class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
     data class Factory @JvmOverloads constructor(
         val path: Path,
         @Transient var instantSource: InstantSource = InstantSource.system(),
+        var epoch: Int = 0
     ) : Log.Factory {
 
         @Suppress("unused")
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
+        fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
-        override fun openLog() = LocalLog(path, instantSource)
+        override fun openLog() = LocalLog(path, instantSource, epoch)
     }
 }

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -105,6 +105,8 @@ interface Log : AutoCloseable {
      */
     val latestSubmittedOffset: LogOffset
 
+    val epoch: Int
+
     fun appendMessage(message: Message): CompletableFuture<LogOffset>
 
     fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription

--- a/core/src/main/kotlin/xtdb/util/TxIdUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/TxIdUtil.kt
@@ -1,0 +1,20 @@
+package xtdb.util
+
+object TxIdUtil {
+    private const val EPOCH_LIMIT = 1L shl 16
+    private const val OFFSET_LIMIT = 1L shl 48
+    private const val OFFSET_MASK = OFFSET_LIMIT - 1
+
+    @JvmStatic
+    fun offsetToTxId(epoch: Int, offset: Long): Long {
+        require(epoch < EPOCH_LIMIT) { "Epoch value ($epoch) exceeds the limit ($EPOCH_LIMIT)" }
+        require(offset < OFFSET_LIMIT) { "Offset value ($offset) exceeds the limit ($OFFSET_LIMIT)" }
+        return (epoch.toLong() shl 48) + offset
+    }
+
+    @JvmStatic
+    fun txIdToEpoch(txId: Long): Int = (txId shr 48).toInt()
+
+    @JvmStatic
+    fun txIdToOffset(txId: Long): Long = txId and OFFSET_MASK
+}

--- a/core/src/test/kotlin/xtdb/util/TxIdUtilTest.kt
+++ b/core/src/test/kotlin/xtdb/util/TxIdUtilTest.kt
@@ -1,0 +1,29 @@
+package xtdb.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TxIdUtilTest {
+    @Test
+    fun testRoundTripZeroEpoch() {
+        val epoch = 0
+        val offset = 123L
+        val txId = TxIdUtil.offsetToTxId(epoch, offset)
+
+        // Check that the txId is equal to the offset when epoch is 0
+        assertEquals(offset, txId)
+
+        assertEquals(epoch, TxIdUtil.txIdToEpoch(txId))
+        assertEquals(offset, TxIdUtil.txIdToOffset(txId))
+    }
+
+    @Test
+    fun testRoundTripNonZeroEpoch() {
+        val epoch = 3
+        val offset = 123L
+        val txId = TxIdUtil.offsetToTxId(epoch, offset)
+
+        assertEquals(epoch, TxIdUtil.txIdToEpoch(txId))
+        assertEquals(offset, TxIdUtil.txIdToOffset(txId))
+    }
+}

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -151,6 +151,13 @@ export default defineConfig({
                         { label: 'AWS', link: '/ops/aws' },
                         { label: 'Azure', link: '/ops/azure' },
                         { label: 'Google Cloud', link: '/ops/google-cloud' },
+                        { 
+                            label: 'Backup and Restore',
+                            items: [
+                                { label: 'Overview', link: '/ops/backup-and-restore/overview' },
+                                { label: 'Out of Sync Log & Intact Storage', link: '/ops/backup-and-restore/out-of-sync-log' },
+                            ]
+                        },
                         { label: 'Troubleshooting', link: '/ops/troubleshooting' },
 
                     ]

--- a/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.adoc
+++ b/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.adoc
@@ -1,0 +1,64 @@
+---
+title: Scenario - Out of Sync Log & Intact Storage
+---
+
+If the transaction log is unexpectedly out of sync — for example, due to topic deletion, rotation, or truncation — but the indexed storage still exists, XTDB will refuse to start.  
+This is a safety mechanism designed to prevent divergence between the transaction log and the object store.
+
+You may encounter an error such as:
+
+> "*Node failed to start due to an invalid transaction log state (epoch=0, offset=200) that does not correspond with the latest indexed transaction (epoch=0 and offset=289).*"
+
+or:
+
+> "*Node failed to start due to an invalid transaction log state (the log is empty) that does not correspond with the latest indexed transaction (epoch=0 and offset=289).*"
+
+== What Is Preserved
+
+If storage remains intact, all previously indexed data is still available:
+
+* Full queryable state up to the last successfully indexed transaction
+
+== What Is Lost
+
+Any recently submitted transactions that were not indexed — whether due to being lost, truncated, or deleted from the log — are **unrecoverable** unless they were separately backed up.
+
+== Recovery Strategy: Using Epochs
+
+XTDB provides a mechanism called an `epoch` to reset the transaction log tracking and allow recovery.
+
+For full details about epochs, see link:/ops/config/log#epochs[Epochs].
+
+=== Recovery Steps
+
+. *Shut down all XTDB nodes* +
+Before making any changes, ensure all cluster nodes are stopped to avoid inconsistencies.
+
+. *Determine the current epoch value* +
+Refer to the startup error message for the current epoch — typically `0` for a fresh installation.
+
+. *Choose a new `epoch` value* +
+Select an integer greater than the previous epoch — usually `epoch + 1`.
+
+. *(Optional) Prepare a clean log state* +
+If the log backend is not already empty, you need to create a new topic / directory for the log. 
+Ensure the log backend (e.g., Kafka, local disk) is writable and correctly initialized before restarting.
+
+. *Update the node configuration* +
+Set the new `epoch` value in your node’s log configuration. 
+See link:/ops/config/log#epoch-configuration[Epoch Configuration].
+
+. *Restart all nodes together* +
+Once all configurations are updated, restart the cluster nodes at the same time.
+XTDB will skip offset validation and begin writing to the log under the new epoch.
+
+. *(Optional) Re-submit any lost transactions* +
+If you are aware of any missing transactions, manually reissue them or restore them via your application’s recovery layer.
+
+== Notes & Warnings
+
+* Beginning a new epoch will make the recovery of unindexed transactions from any previous epoch nearly impossible. 
+** Therefore, it is recommended to _only_ increment the epoch after you are confident that the original log is irrecoverable and you understand the potential consequences.
+* Always take a backup of storage before making epoch changes.
+* The new epoch marks a clean slate for the log but does *not* delete any existing storage files.
+* All nodes must use the same epoch value. Mismatched epochs will cause startup failures.

--- a/docs/src/content/docs/ops/backup-and-restore/overview.adoc
+++ b/docs/src/content/docs/ops/backup-and-restore/overview.adoc
@@ -1,0 +1,57 @@
+---
+title: Backup and Restore
+---
+
+This document provides a high-level overview of XTDB’s stateful architecture and outlines what data is stored where, what typical backups include, and how to think about restoring XTDB in different failure scenarios.
+
+== Overview of Stateful Components
+
+XTDB consists of two primary stateful components:
+
+=== Log
+
+The log contains the record of all submitted transactions and inter-node messages.
+
+* The log is structured as a totally ordered, append-only sequence of entries.
+* Each transaction is recorded immutably and assigned a durable log offset.
+* The log guarantees ACID-compliant, serial execution of all writes across the cluster.
+
+From a backup perspective, the log is the source of truth for all changes made to the database. 
+Losing log entries that have not yet been indexed into storage risks permanent data loss.
+
+For more information on the available implementations of the transaction log, see the link:/ops/config/log[Log] docs.
+
+=== Storage Module
+
+The storage module contains the database’s state: tables, indexes, and supporting metadata.
+
+* Storage consists of immutable, append-only files.
+* Each file represents a snapshot of the database’s state at a specific point in the transaction log.
+
+From a backup perspective, storage files can be treated as **immutable snapshots** aligned with specific log offsets, making them well-suited to incremental or full backup strategies.
+
+For more information on available storage backends and configuration, see the link:/ops/config/storage[Storage Module] docs.
+
+== What Data Is at Risk?
+
+[cols="1,3", options="header"]
+|===
+| Component | Risk if Lost
+
+| Log
+| All transactions on the log since the last indexed offset would be lost.
+
+| Storage Module
+| Without a backup or infinite retention on the log, all indexed data would be lost.
+
+| XTDB compute nodes
+| Only transient, in-memory cache state would be lost. 
+All critical data is durably recorded in the log and storage module. 
+Compute nodes can be restarted or replaced without risking data loss.
+|===
+
+== Failure and Recovery Scenarios
+
+The following are common failure scenarios and links to detailed guidance for each:
+
+* link:out-of-sync-log[**Transaction log is out of sync, but storage is intact.**]

--- a/docs/src/content/docs/ops/config/log.adoc
+++ b/docs/src/content/docs/ops/config/log.adoc
@@ -55,3 +55,45 @@ A multi-node persistent log implementation that uses a remote service to store t
 We currently offer the following remote log implementations, available in their own modules:
 
 * link:log/kafka[Kafka]: a log implementation that uses a Apache Kafka topic to store the log.
+
+[#epochs]
+== Epochs
+
+An *epoch* is a manually assigned, monotonically increasing integer used to identify the generation of the log in XTDB:
+
+* Epochs allow a cluster to safely reset its log state following partial log loss, corruption, or intentional recovery operations, without requiring full reindexing of storage data.
+* If not explicitly configured, nodes assume `epoch = 0`.
+
+[#epoch-configuration]
+=== Configuration
+
+To configure an epoch, specify the `epoch` field inside the node's log configuration:
+
+[source,yaml]
+----
+log: !<LogType>
+  epoch: <new-epoch>
+----
+
+Where:
+
+* `<LogType>` is the chosen log implementation (e.g., `!Kafka`, `!Local`).
+* `<new-epoch>` is a positive integer greater than the previous epoch.
+
+All nodes within the same cluster **must** use an identical epoch value at startup.
+
+[#epoch-change-process]
+==== Bumping an Epoch
+
+WARNING: Beginning a new epoch will make the recovery of unindexed transactions from any previous epoch nearly impossible. 
+Therefore, it is recommended to only increment the epoch after you are confident that the original log is irrecoverable and you understand the potential consequences.
+
+When applying a new epoch:
+
+* Shut down all XTDB nodes to prevent divergence.
+* Update each node's configuration with the new `epoch` value.
+* (Optional) Prepare a clean log backend if required (e.g., create a new Kafka topic or clear the local log directory).
+* Restart all nodes simultaneously with the updated configuration.
+
+Once restarted, nodes will begin writing to the new log generation, and prior log history will be disregarded.
+

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -10,10 +10,12 @@
   [^Xtdb$Config config _ {:keys [bootstrap-servers
                                  topic create-topic?
                                  poll-duration
-                                 properties-map properties-file]}]
+                                 properties-map properties-file
+                                 epoch]}]
   (doto config
     (.setLog (cond-> (KafkaLog/kafka bootstrap-servers topic)
                create-topic? (.autoCreateTopic create-topic?)
                poll-duration (.pollDuration (time/->duration poll-duration))
                properties-map (.propertiesMap properties-map)
-               properties-file (.propertiesFile (util/->path properties-file))))))
+               properties-file (.propertiesFile (util/->path properties-file))
+               epoch (.epoch epoch)))))

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
@@ -109,6 +109,7 @@ class KafkaLog internal constructor(
     private val kafkaConfigMap: KafkaConfigMap,
     private val topic: String,
     private val pollDuration: Duration,
+    override val epoch: Int
 ) : Log {
 
     private val producer = kafkaConfigMap.openProducer()
@@ -225,15 +226,15 @@ class KafkaLog internal constructor(
         var autoCreateTopic: Boolean = true,
         var pollDuration: Duration = Duration.ofSeconds(1),
         var propertiesMap: Map<String, String> = emptyMap(),
-        var propertiesFile: Path? = null
+        var propertiesFile: Path? = null,
+        var epoch: Int = 0
     ) : Log.Factory {
 
         fun autoCreateTopic(autoCreateTopic: Boolean) = apply { this.autoCreateTopic = autoCreateTopic }
-
         fun pollDuration(pollDuration: Duration) = apply { this.pollDuration = pollDuration }
-
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
         fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
+        fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
         private val Path.asPropertiesMap: Map<String, String>
             get() =
@@ -253,7 +254,7 @@ class KafkaLog internal constructor(
                 admin.ensureTopicExists(topic, autoCreateTopic)
             }
 
-            return KafkaLog(configMap, topic, pollDuration)
+            return KafkaLog(configMap, topic, pollDuration, epoch)
         }
     }
 

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -5,7 +5,14 @@
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
-  (:import org.apache.kafka.common.KafkaException
+  (:import [java.nio ByteBuffer]
+           [java.time Duration]
+           [java.util Map]
+           [org.apache.kafka.clients.admin AdminClient NewTopic]
+           [org.apache.kafka.clients.consumer ConsumerRecord KafkaConsumer]
+           [org.apache.kafka.clients.producer KafkaProducer ProducerRecord]
+           [org.apache.kafka.common TopicPartition]
+           org.apache.kafka.common.KafkaException
            org.testcontainers.containers.GenericContainer
            org.testcontainers.kafka.ConfluentKafkaContainer
            org.testcontainers.utility.DockerImageName
@@ -89,3 +96,168 @@
                                                          :bootstrap-servers "nonresolvable:9092"
                                                          :create-topic? false
                                                          :some-secret "foobar"}]}))))
+
+(t/deftest ^:integration test-kafka-topic-cleared
+  (let [original-topic (str "xtdb.kafka-test." (random-uuid))
+        empty-topic (str "xtdb.kafka-test." (random-uuid))]
+    (util/with-tmp-dirs #{local-disk-path}
+      ;; Node with storage and log topic 
+      (with-open [node (xtn/start-node {:log [:kafka {:topic original-topic
+                                                      :bootstrap-servers *bootstrap-servers*
+                                                      :create-topic? true
+                                                      :poll-duration "PT2S"
+                                                      :properties-map {}
+                                                      :properties-file nil}]
+                                        :storage [:local {:path local-disk-path}]})]
+        ;; Submit a few transactions
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
+        (t/is (= (set [{:xt/id :foo} {:xt/id :bar}])
+                 (set (xt/q node "SELECT _id FROM xt_docs"))))
+        ;; Finish the block
+        (t/is (nil? (tu/finish-block! node)))
+
+        ;; Submit a few more transactions
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :willbe}]])
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :lost}]])
+        (t/is (= (set [{:xt/id :foo} 
+                       {:xt/id :bar}
+                       {:xt/id :willbe}
+                       {:xt/id :lost}])
+                 (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+      ;; Node with intact storage and (now) empty topic
+      (t/is
+       (thrown-with-msg?
+        IllegalStateException
+        #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
+        (xtn/start-node {:log [:kafka {:topic empty-topic
+                                       :bootstrap-servers *bootstrap-servers*
+                                       :create-topic? true
+                                       :poll-duration "PT2S"
+                                       :properties-map {}
+                                       :properties-file nil}]
+                         :storage [:local {:path local-disk-path}]})))
+
+      ;; Node with intact storage and topic 2 (ie, empty topic) along with setting log offset
+      (with-open [node (xtn/start-node {:log [:kafka {:topic empty-topic
+                                                      :bootstrap-servers *bootstrap-servers*
+                                                      :create-topic? true
+                                                      :poll-duration "PT2S"
+                                                      :properties-map {}
+                                                      :properties-file nil
+                                                      :epoch 1}]
+                                        :storage [:local {:path local-disk-path}]})]
+        (t/testing "can query previous indexed values, unindexed values will be lost"
+          (t/is (= (set [{:xt/id :foo} {:xt/id :bar}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+        (t/testing "can index/query new transactions"
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new}]]))
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new2}]])) 
+          (t/is (= (set [{:xt/id :foo}
+                         {:xt/id :bar}
+                         {:xt/id :new}
+                         {:xt/id :new2}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+        (t/testing "can finish the block"
+          (t/is (nil? (tu/finish-block! node)))))
+
+      (with-open [node (xtn/start-node {:log [:kafka {:topic empty-topic
+                                                      :bootstrap-servers *bootstrap-servers*
+                                                      :create-topic? true
+                                                      :poll-duration "PT2S"
+                                                      :properties-map {}
+                                                      :properties-file nil
+                                                      :epoch 1}]
+                                        :storage [:local {:path local-disk-path}]})]
+        (t/testing "can query all previously indexed values, including those after new epoch started"
+          (t/is (= (set [{:xt/id :foo} 
+                         {:xt/id :bar} 
+                         {:xt/id :new} 
+                         {:xt/id :new2} ])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+        (t/testing "can continue to index/query new transactions"
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new3}]]))
+          (t/is (= (set [{:xt/id :foo}
+                         {:xt/id :bar} 
+                         {:xt/id :new}
+                         {:xt/id :new2}
+                         {:xt/id :new3}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))))))
+
+  (t/deftest ^:integration test-stale-log-recovery
+    (let [original-topic (str "xtdb.kafka-test." (random-uuid))
+          stale-topic (str "xtdb.kafka-test." (random-uuid))
+          empty-topic (str "xtdb.kafka-test." (random-uuid))]
+
+      (util/with-tmp-dirs #{local-disk-path}
+        ;; Start a node, write a few transactions to the original topic
+        (with-open [node (xtn/start-node {:log [:kafka {:topic original-topic
+                                                        :bootstrap-servers *bootstrap-servers*
+                                                        :create-topic? true
+                                                        :poll-duration "PT2S"}]
+                                          :storage [:local {:path local-disk-path}]})]
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :baz}]])
+          (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz}])
+                   (set (xt/q node "SELECT _id FROM xt_docs"))))
+
+          ;; Finish the block
+          (t/is (nil? (tu/finish-block! node)))
+
+          ;; Submit a few more transactions
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :willbelost}]])
+          (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz} {:xt/id :willbelost}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+        ;; Setup a "stale log":
+        ;; - Start a node with a new topic and memory storage.
+        ;; - Submit two txes to it.
+        (with-open [node (xtn/start-node {:log [:kafka {:topic stale-topic
+                                                        :bootstrap-servers *bootstrap-servers*
+                                                        :create-topic? true
+                                                        :poll-duration "PT2S"}]
+                                          :storage [:in-memory {}]})]
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]]))
+
+        ;; Attempt to restart the node with intact storage and the stale topic + original epoch
+        (t/is
+         (thrown-with-msg?
+          IllegalStateException
+          #"Node failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest indexed transaction \(epoch=0 and offset=2\)"
+          (xtn/start-node {:log [:kafka {:topic stale-topic
+                                         :bootstrap-servers *bootstrap-servers*
+                                         :create-topic? false
+                                         :poll-duration "PT2S"}]
+                           :storage [:local {:path local-disk-path}]})))
+
+        ;; Attempt to restart the node with intact storage, a new topic + new epoch
+        (with-open [node (xtn/start-node {:log [:kafka {:topic empty-topic
+                                                        :bootstrap-servers *bootstrap-servers*
+                                                        :create-topic? true
+                                                        :poll-duration "PT2S"
+                                                        :properties-map {}
+                                                        :properties-file nil
+                                                        :epoch 1}]
+                                          :storage [:local {:path local-disk-path}]})]
+          (t/testing "can query previous indexed values, unindexed values will be lost"
+            (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz}])
+                     (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+          (t/testing "can index/query new transactions"
+            (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new}]]))
+            (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new2}]]))
+            (t/is (= (set [{:xt/id :foo}
+                           {:xt/id :bar}
+                           {:xt/id :baz}
+                           {:xt/id :new}
+                           {:xt/id :new2}])
+                     (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+          (t/testing "can finish the block"
+            (t/is (nil? (tu/finish-block! node))))))))


### PR DESCRIPTION
Resolves #3928 and #4248
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Arestart-node-empty-log-topic++

### Summary

Stores an epoch value into the message id, which allows us to have a "version" of the offsets, and start reading from the start of the log when we need to (ie, the log component is now pointed at any empty log) and a new currentEpoch has been set. 
- Of the 64bit message ID, we use:
  - The first 16 bits to represent the epoch (giving us a potential 65536 epochs)  
  - The remaining 48 bits represent the offset (allowing us a total of 2^48-1 offsets per epoch).
- Since the first epoch is 0, messageId remains as it is, assuming nobody has more than 2^48-1 offsets currently (ie, those first 16 bits will always be zero currently)

When an out of sync log with intact storage is detected, we log an error at the point of starting up log and prevent the node from starting, providing a chunk of this information to the user within the error itself. This handles:
- Empty log -  (ie, current epoch is the same as last written epoch, and last submitted offset is -1/empty)
- Stale log - (ie, current epoch is the same as last written epoch, and last submitted offset is earlier than latest completed one)

This PR also starts our "backup and restore" docs section, with the following:
- An overview document explaining what data is stored where, impact of losing said data and linking out to specific recovery scenarios.
- A document explaining the recovery process for an out of sync log.
