### PR TITLE
old IVectorWriter now extends new VectorWriter

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1746,7 +1746,8 @@
                              (into {} (map (juxt types/field->col-type (fn [_] (gensym 'out-writer))))))]
         {:writer-bindings (into [out-writer-sym `(vw/->writer ~out-vec-sym)]
                                 (mapcat (fn [[value-type writer-sym]]
-                                          [writer-sym `(.legWriter ~out-writer-sym ~(types/->arrow-type value-type))]))
+                                          [writer-sym `(.vectorFor ~out-writer-sym
+                                                                   ~(types/arrow-type->leg (types/->arrow-type value-type)))]))
                                 writer-syms)
 
          :write-value-out! (fn [value-type code]

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -524,16 +524,16 @@
 
     (.logPut live-table (util/->iid user) system-time-µs Long/MAX_VALUE
              (fn write-doc! []
-               (doto (.structKeyWriter doc-writer "_id" (FieldType/notNullable #xt.arrow/type :utf8))
+               (doto (.vectorFor doc-writer "_id" (FieldType/notNullable #xt.arrow/type :utf8))
                  (.writeObject user))
 
-               (doto (.structKeyWriter doc-writer "username" (FieldType/notNullable #xt.arrow/type :utf8))
+               (doto (.vectorFor doc-writer "username" (FieldType/notNullable #xt.arrow/type :utf8))
                  (.writeObject user))
 
-               (doto (.structKeyWriter doc-writer "usesuper" (FieldType/notNullable #xt.arrow/type :bool))
+               (doto (.vectorFor doc-writer "usesuper" (FieldType/notNullable #xt.arrow/type :bool))
                  (.writeObject false))
 
-               (doto (.structKeyWriter doc-writer "passwd" (FieldType/nullable #xt.arrow/type :utf8))
+               (doto (.vectorFor doc-writer "passwd" (FieldType/nullable #xt.arrow/type :utf8))
                  (.writeObject (authn/encrypt-pw password)))
 
                (.endStruct doc-writer)))))
@@ -614,16 +614,16 @@
 
     (.logPut live-table (util/->iid tx-id) system-time-µs Long/MAX_VALUE
              (fn write-doc! []
-               (doto (.structKeyWriter doc-writer "_id" (FieldType/notNullable #xt.arrow/type :i64))
+               (doto (.vectorFor doc-writer "_id" (FieldType/notNullable #xt.arrow/type :i64))
                  (.writeLong tx-id))
 
-               (doto (.structKeyWriter doc-writer "system_time" (FieldType/notNullable (types/->arrow-type types/temporal-col-type)))
+               (doto (.vectorFor doc-writer "system_time" (FieldType/notNullable (types/->arrow-type types/temporal-col-type)))
                  (.writeLong system-time-µs))
 
-               (doto (.structKeyWriter doc-writer "committed" (FieldType/notNullable #xt.arrow/type :bool))
+               (doto (.vectorFor doc-writer "committed" (FieldType/notNullable #xt.arrow/type :bool))
                  (.writeBoolean (nil? t)))
 
-               (let [e-wtr (.structKeyWriter doc-writer "error" (FieldType/nullable #xt.arrow/type :transit))]
+               (let [e-wtr (.vectorFor doc-writer "error" (FieldType/nullable #xt.arrow/type :transit))]
                  (if (or (nil? t) (= t abort-exn))
                    (.writeNull e-wtr)
                    (try

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -49,15 +49,12 @@
                           (.tryAdvance dep-cursor
                                        (reify Consumer
                                          (accept [_ dep-rel]
-                                           (let [vp (VectorPosition/build)
-                                                 match-vec (.vectorForOrNull ^RelationReader dep-rel "_expr")
-                                                 match-rdr (.valueReader match-vec vp)]
+                                           (let [match-vec (.vectorForOrNull ^RelationReader dep-rel "_expr")]
                                              (dotimes [idx (.getValueCount match-vec)]
-                                               (.setPosition vp idx)
-                                               (if (.isNull match-rdr)
+                                               (if (.isNull match-vec idx)
                                                  (aset !match 0 (max (aget !match 0) 0))
                                                  (aset !match 0 (max (aget !match 0)
-                                                                     (if (.readBoolean match-rdr) 1 -1)))))))))))
+                                                                     (if (.getBoolean match-vec idx) 1 -1)))))))))))
               (let [match (aget !match 0)]
                 (if (zero? match)
                   (.writeNull out-writer)

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -211,7 +211,7 @@
 
                                   ~(continue (fn [acc-type acc-code]
                                                `(do
-                                                  (.setPosition (.writerPosition ~acc-writer-sym) ~group-idx-sym)
+                                                  (.setValueCount ~acc-writer-sym ~group-idx-sym)
                                                   ~(expr/write-value-code acc-type acc-writer-sym acc-code))))))))
                          #_(doto clojure.pprint/pprint) ;; <<no-commit>>
                          eval)}))
@@ -527,7 +527,7 @@
       (set! (.out-vec this) out-vec)
 
       (let [list-writer (vw/->writer out-vec)
-            el-writer (.listElementWriter list-writer)
+            el-writer (.getListElements list-writer)
             row-copier (.rowCopier (vw/vec-wtr->rdr acc-col) el-writer)]
         (doseq [^IntStream$Builder isb group-idxmaps]
           (.forEach (.build isb)

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -26,7 +26,7 @@
 
 ;;;; fields
 
-(defn arrow-type->leg [^ArrowType arrow-type]
+(defn arrow-type->leg ^String [^ArrowType arrow-type]
   (Types/toLeg arrow-type))
 
 (defprotocol FromArrowType

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -208,8 +208,7 @@
   (vr/vec->reader (.getVector (doto w (.syncValueCount)))))
 
 (defn rel-wtr->rdr ^xtdb.vector.RelationReader [^xtdb.vector.IRelationWriter w]
-  (vr/rel-reader (map vec-wtr->rdr (vals w))
-                 (.getPosition (.writerPosition w))))
+  (vr/rel-reader (map vec-wtr->rdr (vals w)) (.getRowCount w)))
 
 (defn append-vec [^IVectorWriter vec-writer, ^IVectorReader in-col]
   (let [row-copier (.rowCopier in-col vec-writer)]
@@ -220,5 +219,4 @@
   (doseq [^IVectorReader src-col src-rel]
     (append-vec (.colWriter dest-rel (.getName src-col)) src-col))
 
-  (let [wp (.writerPosition dest-rel)]
-    (.setPosition wp (+ (.getPosition wp) (.getRowCount src-rel)))))
+  (.setRowCount dest-rel (+ (.getRowCount dest-rel) (.getRowCount src-rel))))

--- a/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
@@ -55,9 +55,7 @@ class FixedSizeListVector(
 
     override val listElements get() = elVector
 
-    override fun elementWriter() = elVector
-
-    override fun elementWriter(fieldType: FieldType): VectorWriter =
+    override fun getListElements(fieldType: FieldType): VectorWriter =
         when {
             elVector.field.fieldType == fieldType -> elVector
 

--- a/core/src/main/kotlin/xtdb/arrow/ListVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ListVector.kt
@@ -74,9 +74,8 @@ class ListVector(
     }
 
     override val listElements get() = elVector
-    override fun elementWriter() = elVector
 
-    override fun elementWriter(fieldType: FieldType): VectorWriter =
+    override fun getListElements(fieldType: FieldType): VectorWriter =
         when {
             elVector.field.fieldType == fieldType -> elVector
 

--- a/core/src/main/kotlin/xtdb/arrow/MapVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MapVector.kt
@@ -67,9 +67,9 @@ class MapVector(private val listVector: ListVector, private val keysSorted: Bool
 
     override fun writeObject0(value: Any) = when (value) {
         is Map<*, *> -> {
-            val elWriter = listVector.elementWriter()
-            val keyWriter = elWriter.mapKeyWriter()
-            val valueWriter = elWriter.mapValueWriter()
+            val elWriter = listVector.listElements
+            val keyWriter = elWriter.mapKeys
+            val valueWriter = elWriter.mapValues
 
             value.forEach { k, v ->
                 keyWriter.writeObject(k)
@@ -84,17 +84,14 @@ class MapVector(private val listVector: ListVector, private val keysSorted: Bool
     }
 
     override val listElements get() = listVector.listElements
-    override fun elementWriter() = listVector.elementWriter()
-    override fun elementWriter(fieldType: FieldType) = listVector.elementWriter(fieldType)
+    override fun getListElements(fieldType: FieldType) = listVector.getListElements(fieldType)
 
     override fun endList() = listVector.endList()
 
     override val mapKeys get() = listElements.mapKeys
+    override fun getMapKeys(fieldType: FieldType) = listElements.getMapKeys(fieldType)
     override val mapValues get() = listElements.mapValues
-    override fun mapKeyWriter() = elementWriter().mapKeyWriter()
-    override fun mapKeyWriter(fieldType: FieldType) = elementWriter().mapKeyWriter(fieldType)
-    override fun mapValueWriter() = elementWriter().mapValueWriter()
-    override fun mapValueWriter(fieldType: FieldType) = elementWriter().mapValueWriter(fieldType)
+    override fun getMapValues(fieldType: FieldType) = listElements.getMapValues(fieldType)
 
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) =
         listVector.unloadPage(nodes, buffers)

--- a/core/src/main/kotlin/xtdb/arrow/StructVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/StructVector.kt
@@ -44,9 +44,9 @@ class StructVector(
 
     override fun vectorForOrNull(name: String) = childWriters[name]
 
-    override fun keyWriter(name: String) = childWriters[name] ?: error("missing child vector: $name")
+    override fun vectorFor(name: String) = childWriters[name] ?: error("missing child vector: $name")
 
-    override fun keyWriter(name: String, fieldType: FieldType) =
+    override fun vectorFor(name: String, fieldType: FieldType) =
         childWriters.compute(name) { _, v ->
             if (v == null) {
                 fromField(allocator, Field(name, fieldType, emptyList())).also { newVec ->
@@ -69,12 +69,8 @@ class StructVector(
         }
     }
 
-    override val mapKeys: VectorReader
-        get() = childWriters.sequencedValues().firstOrNull() ?: TODO("auto-creation")
-    override val mapValues: VectorReader
-        get() = childWriters.sequencedValues().lastOrNull() ?: TODO("auto-creation")
-    override fun mapKeyWriter(): VectorWriter = childWriters.sequencedValues().firstOrNull() ?: TODO("auto-creation")
-    override fun mapValueWriter(): VectorWriter = childWriters.sequencedValues().lastOrNull() ?: TODO("auto-creation")
+    override val mapKeys get() = childWriters.sequencedValues().firstOrNull() ?: TODO("auto-creation")
+    override val mapValues get() = childWriters.sequencedValues().lastOrNull() ?: TODO("auto-creation")
 
     override fun getObject0(idx: Int, keyFn: IKeyFn<*>): Any =
         childWriters.sequencedEntrySet()
@@ -93,7 +89,7 @@ class StructVector(
             value.forEach {
                 val key = keyString(it.key)
                 val obj = it.value
-                val childWriter = childWriters[key] ?: keyWriter(key, obj.toFieldType())
+                val childWriter = childWriters[key] ?: vectorFor(key, obj.toFieldType())
 
                 if (childWriter.valueCount != this.valueCount)
                     throw xtdb.IllegalArgumentException(

--- a/core/src/main/kotlin/xtdb/arrow/TsTzRangeVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/TsTzRangeVector.kt
@@ -22,7 +22,7 @@ class TsTzRangeVector(override val inner: FixedSizeListVector) : ExtensionVector
 
     override fun writeObject0(value: Any) = when (value) {
         is ZonedDateTimeRange -> {
-            inner.elementWriter(FieldType.notNullable(Timestamp(MICROSECOND, "UTC"))).let {
+            inner.getListElements(FieldType.notNullable(Timestamp(MICROSECOND, "UTC"))).let {
                 it.writeObject(value.from)
                 if (value.to != null) it.writeObject(value.to) else it.writeLong(Long.MAX_VALUE)
             }

--- a/core/src/main/kotlin/xtdb/arrow/ValueWriter.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ValueWriter.kt
@@ -4,14 +4,15 @@ import java.nio.ByteBuffer
 
 interface ValueWriter {
     fun writeNull()
-    fun writeBoolean(v: Boolean)
-    fun writeByte(v: Byte)
-    fun writeShort(v: Short)
-    fun writeInt(v: Int)
-    fun writeLong(v: Long)
-    fun writeFloat(v: Float)
-    fun writeDouble(v: Double)
-    fun writeBytes(v: ByteBuffer)
+
+    fun writeBoolean(v: Boolean): Unit = unsupported("writeBoolean")
+    fun writeByte(v: Byte): Unit = unsupported("writeByte")
+    fun writeShort(v: Short): Unit = unsupported("writeShort")
+    fun writeInt(v: Int): Unit = unsupported("writeInt")
+    fun writeLong(v: Long): Unit = unsupported("writeLong")
+    fun writeFloat(v: Float): Unit = unsupported("writeFloat")
+    fun writeDouble(v: Double): Unit = unsupported("writeDouble")
+    fun writeBytes(v: ByteBuffer): Unit = unsupported("writeBytes")
     fun writeObject(obj: Any?)
 
     fun legWriter(leg: String): ValueWriter

--- a/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
@@ -51,7 +51,15 @@ interface VectorReader : ILookup, AutoCloseable {
     val keyNames: Set<String>? get() = null
     val legNames: Set<String>? get() = null
 
+    /**
+     * @return an existing vector, or null if a vector doesn't exist with the given name
+     */
     fun vectorForOrNull(name: String): VectorReader? = unsupported("vectorFor")
+
+    /**
+     * @return an existing vector
+     * @throws IllegalStateException if the vector doesn't exist
+     */
     fun vectorFor(name: String) = vectorForOrNull(name) ?: error("missing vector: $name")
 
     /**

--- a/core/src/main/kotlin/xtdb/vector/SingletonListReader.kt
+++ b/core/src/main/kotlin/xtdb/vector/SingletonListReader.kt
@@ -28,7 +28,7 @@ class SingletonListReader(override val name: String, private val elReader: IVect
     override fun copyTo(vector: ValueVector) = TODO("Not yet implemented")
 
     override fun rowCopier(writer: IVectorWriter): RowCopier {
-        val elCopier = elReader.rowCopier(writer.listElementWriter(elReader.field.fieldType))
+        val elCopier = elReader.rowCopier(writer.getListElements(elReader.field.fieldType))
 
         return RowCopier { idx ->
             check(idx == 0)

--- a/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
@@ -30,8 +30,8 @@ class DenseUnionVectorTest {
                 Utf8Vector(allocator, "utf8", true)
             )
         ).use { duv ->
-            val i32Leg = duv.legWriter("i32")
-            val utf8Leg = duv.legWriter("utf8")
+            val i32Leg = duv.vectorFor("i32")
+            val utf8Leg = duv.vectorFor("utf8")
 
             i32Leg.writeInt(12)
             utf8Leg.writeObject("hello")

--- a/core/src/test/kotlin/xtdb/arrow/MultiVectorReaderTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/MultiVectorReaderTest.kt
@@ -160,8 +160,8 @@ class MultiVectorReaderTest {
                 )
 
                 Vector.fromField(alloc, duvField).use { duvVec ->
-                    duvVec.legWriter("i32").writeInt(2)
-                    duvVec.legWriter("utf8").writeObject("fifth")
+                    duvVec.vectorFor("i32").writeInt(2)
+                    duvVec.vectorFor("utf8").writeObject("fifth")
 
                     val indirectRdr = MultiVectorReader(
                         listOf(intVec, stringVec, duvVec),
@@ -201,12 +201,12 @@ class MultiVectorReaderTest {
 
         Vector.fromField(alloc, duvField).use { duv1 ->
             Vector.fromField(alloc, duvField).use { duv2 ->
-                duv1.legWriter("i32").writeInt(0)
-                duv2.legWriter("utf8").writeObject("first")
-                duv1.legWriter("null").writeNull()
-                duv2.legWriter("i32").writeInt(3)
-                duv1.legWriter("utf8").writeObject("fourth")
-                duv2.legWriter("null").writeNull()
+                duv1.vectorFor("i32").writeInt(0)
+                duv2.vectorFor("utf8").writeObject("first")
+                duv1.vectorFor("null").writeNull()
+                duv2.vectorFor("i32").writeInt(3)
+                duv1.vectorFor("utf8").writeObject("fourth")
+                duv2.vectorFor("null").writeNull()
 
                 val indirectRdr = MultiVectorReader(
                     listOf(duv1, duv2),
@@ -243,7 +243,7 @@ class MultiVectorReaderTest {
         )
 
         Vector.fromField(alloc, duvField).use { duvVec1 ->
-            duvVec1.legWriter("i32").run { writeInt(0); writeInt(1) }
+            duvVec1.vectorFor("i32").run { writeInt(0); writeInt(1) }
 
             val indirectRdr = MultiVectorReader(
                 listOf(duvVec1),

--- a/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
@@ -157,8 +157,8 @@ class RelationTest {
             )
         )
 
-        val i32Leg = duv.legWriter("i32")
-        val utf8Leg = duv.legWriter("utf8")
+        val i32Leg = duv.vectorFor("i32")
+        val utf8Leg = duv.vectorFor("utf8")
 
         i32Leg.writeInt(12)
         utf8Leg.writeObject("hello")

--- a/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
@@ -55,8 +55,8 @@ class StructVectorTest {
         )
 
         StructVector(allocator, "struct", false, children).use { structVec ->
-            val i32Writer = structVec.keyWriter("i32")
-            val utf8Writer = structVec.keyWriter("utf8")
+            val i32Writer = structVec.vectorFor("i32")
+            val utf8Writer = structVec.vectorFor("utf8")
 
             i32Writer.writeInt(4)
             utf8Writer.writeObject("Hello")
@@ -83,12 +83,12 @@ class StructVectorTest {
     @Test
     fun createsMissingVectors() {
         StructVector(allocator, "struct", false).use { structVec ->
-            val i32Writer = structVec.keyWriter("i32", 4.toFieldType())
+            val i32Writer = structVec.vectorFor("i32", 4.toFieldType())
 
             i32Writer.writeInt(4)
             structVec.endStruct()
 
-            val utf8Writer = structVec.keyWriter("utf8", "foo".toFieldType())
+            val utf8Writer = structVec.vectorFor("utf8", "foo".toFieldType())
 
             i32Writer.writeInt(8)
             utf8Writer.writeObject("Hello")
@@ -204,9 +204,9 @@ class StructVectorTest {
             )))
 
         StructVector(allocator, "struct", false, children).use { structVec ->
-            val i32Writer = structVec.keyWriter("i32")
-            val duvWriter = structVec.keyWriter("duv")
-            val nestedUtf8Writer = duvWriter.legWriter("utf8")
+            val i32Writer = structVec.vectorFor("i32")
+            val duvWriter = structVec.vectorFor("duv")
+            val nestedUtf8Writer = duvWriter.vectorFor("utf8")
             i32Writer.writeInt(1)
             nestedUtf8Writer.writeObject("one")
             structVec.endStruct()

--- a/core/src/test/kotlin/xtdb/vector/DenseUnionVectorWriterTest.kt
+++ b/core/src/test/kotlin/xtdb/vector/DenseUnionVectorWriterTest.kt
@@ -31,7 +31,7 @@ class DenseUnionVectorWriterTest {
             // first we add the not-nullable field
             UNION_FIELD_TYPE.createNewSingleVector("src", al, null).use { srcVec ->
                 val srcWriter = writerFor(srcVec)
-                val f64Writer = srcWriter.legWriter("f64", FieldType.notNullable(MinorType.FLOAT8.type))
+                val f64Writer = srcWriter.vectorFor("f64", FieldType.notNullable(MinorType.FLOAT8.type))
                 f64Writer.writeDouble(12.3)
 
                 destWriter.rowCopier(srcVec).copyRow(0)
@@ -40,7 +40,7 @@ class DenseUnionVectorWriterTest {
             // then we simulate a nullable field coming in
             UNION_FIELD_TYPE.createNewSingleVector("src", al, null).use { srcVec ->
                 val srcWriter = writerFor(srcVec)
-                val f64Writer = srcWriter.legWriter("f64", FieldType.nullable(MinorType.FLOAT8.type))
+                val f64Writer = srcWriter.vectorFor("f64", FieldType.nullable(MinorType.FLOAT8.type))
                 f64Writer.writeNull()
                 f64Writer.writeDouble(18.9)
 

--- a/core/src/test/kotlin/xtdb/vector/StructVectorWriterTest.kt
+++ b/core/src/test/kotlin/xtdb/vector/StructVectorWriterTest.kt
@@ -116,12 +116,12 @@ class StructVectorWriterTest {
         StructVector.empty("src", al).use { srcVec ->
             val structWriter = writerFor(srcVec)
 
-            val nullWriter = structWriter.structKeyWriter("a", FieldType.nullable(MinorType.BIGINT.type))
+            val nullWriter = structWriter.vectorFor("a", FieldType.nullable(MinorType.BIGINT.type))
 
             assertEquals(structField, structWriter.field)
             assertEquals(aField, nullWriter.field)
 
-            val nnWriter = structWriter.structKeyWriter("a", FieldType.notNullable(MinorType.BIGINT.type))
+            val nnWriter = structWriter.vectorFor("a", FieldType.notNullable(MinorType.BIGINT.type))
 
             assertEquals(structField, structWriter.field)
             assertEquals(aField, nnWriter.field)

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -383,14 +383,14 @@
 
 (defn open-arrow-hash-trie-rel ^xtdb.arrow.Relation [^BufferAllocator al, paths]
   (util/with-close-on-catch [meta-rel (Relation. al (Trie/getMetaRelSchema))]
-    (let [nodes-wtr (.get meta-rel "nodes")
-          nil-wtr (.legWriter nodes-wtr "nil")
-          iid-branch-wtr (.legWriter nodes-wtr "branch-iid")
-          iid-branch-el-wtr (.elementWriter iid-branch-wtr)
+    (let [nodes-wtr (.vectorFor meta-rel "nodes")
+          nil-wtr (.vectorFor nodes-wtr "nil")
+          iid-branch-wtr (.vectorFor nodes-wtr "branch-iid")
+          iid-branch-el-wtr (.getListElements iid-branch-wtr)
 
-          data-wtr (.legWriter nodes-wtr "leaf")
-          data-page-idx-wtr (.keyWriter data-wtr "data-page-idx")
-          metadata-wtr (.keyWriter data-wtr "columns")]
+          data-wtr (.vectorFor nodes-wtr "leaf")
+          data-page-idx-wtr (.vectorFor data-wtr "data-page-idx")
+          metadata-wtr (.vectorFor data-wtr "columns")]
       (letfn [(write-paths [paths]
                 (cond
                   (nil? paths) (.writeNull nil-wtr)

--- a/src/test/clojure/xtdb/vector/reader_test.clj
+++ b/src/test/clojure/xtdb/vector/reader_test.clj
@@ -147,11 +147,11 @@
               rel-wtr3 (vw/->rel-writer tu/*allocator*)]
     (-> rel-wtr1
         (.colWriter "my-column" (FieldType/notNullable #xt.arrow/type :union))
-        (.legWriter "foo" (FieldType/notNullable #xt.arrow/type :i64))
+        (.vectorFor "foo" (FieldType/notNullable #xt.arrow/type :i64))
         (.writeLong 42))
     (-> rel-wtr2
         (.colWriter "my-column" (FieldType/notNullable #xt.arrow/type :union))
-        (.legWriter "foo" (FieldType/notNullable #xt.arrow/type :f64))
+        (.vectorFor "foo" (FieldType/notNullable #xt.arrow/type :f64))
         (.writeDouble 42.0))
     (t/is (thrown-with-msg?
            RuntimeException #"Field type mismatch"
@@ -191,9 +191,9 @@
               list-vec (ListVector/empty "my-list" tu/*allocator*)]
     (let [duv-wrt (vw/->writer duv)
           list-wrt (vw/->writer list-vec)
-          duv-list-wrt (.legWriter duv-wrt "list" (FieldType/notNullable #xt.arrow/type :list))]
+          duv-list-wrt (.vectorFor duv-wrt "list" (FieldType/notNullable #xt.arrow/type :list))]
       (doto (-> duv-list-wrt
-                (.listElementWriter (FieldType/notNullable #xt.arrow/type :i64)))
+                (.getListElements (FieldType/notNullable #xt.arrow/type :i64)))
         (.writeLong 42)
         (.writeLong 43))
 
@@ -218,10 +218,10 @@
               struct-vec (StructVector/empty "my-struct" tu/*allocator*)]
     (let [duv-wrt (vw/->writer duv)
           struct-wrt (vw/->writer struct-vec)
-          duv-struct-wrt (.legWriter duv-wrt "struct" (FieldType/notNullable #xt.arrow/type :struct))]
-      (-> (.structKeyWriter duv-struct-wrt "foo" (FieldType/notNullable #xt.arrow/type :i64))
+          duv-struct-wrt (.vectorFor duv-wrt "struct" (FieldType/notNullable #xt.arrow/type :struct))]
+      (-> (.vectorFor duv-struct-wrt "foo" (FieldType/notNullable #xt.arrow/type :i64))
           (.writeLong 42))
-      (-> (.structKeyWriter duv-struct-wrt "bar" (FieldType/notNullable #xt.arrow/type :utf8))
+      (-> (.vectorFor duv-struct-wrt "bar" (FieldType/notNullable #xt.arrow/type :utf8))
           (.writeObject "forty-two"))
       (.endStruct duv-struct-wrt)
       (let [copier (.rowCopier struct-wrt duv)]
@@ -250,9 +250,9 @@
   (t/testing "structs"
     (with-open [rel-wtr1 (vw/->rel-writer tu/*allocator*)]
       (let [my-column-wtr1 (.colWriter rel-wtr1 "my_column" (FieldType/notNullable #xt.arrow/type :struct))]
-        (-> (.structKeyWriter my-column-wtr1 "long_name" (FieldType/notNullable #xt.arrow/type :i64))
+        (-> (.vectorFor my-column-wtr1 "long_name" (FieldType/notNullable #xt.arrow/type :i64))
             (.writeLong 42))
-        (-> (.structKeyWriter my-column-wtr1 "short_name" (FieldType/notNullable #xt.arrow/type :utf8))
+        (-> (.vectorFor my-column-wtr1 "short_name" (FieldType/notNullable #xt.arrow/type :utf8))
             (.writeObject "forty-two"))
         (.endStruct my-column-wtr1)
         (.endRow rel-wtr1))


### PR DESCRIPTION
similar lines to #4291 and #4292, but for VectorWriters

* both method names and behaviour made consistent:
  * `vectorForOrNull(String)` and `vectorFor(String)` will never create vectors; `vectorFor(String, FieldType)` will create one with the given type if it doesn't exist - i.e. pass a union-type or null-type to `vectorFor` if you don't know the type ahead-of-time.