### PR TITLE
Bitemporal resolution for events in the same transaction when compacting L0 -> L1

### DIFF
--- a/core/src/main/kotlin/xtdb/bitemporal/PolygonCalculator.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/PolygonCalculator.kt
@@ -16,6 +16,8 @@ class PolygonCalculator(private val temporalBounds: TemporalBounds? = null) {
     private val ceiling = Ceiling()
     private val polygon = Polygon()
 
+    fun reset() = ceiling.reset()
+
     fun calculate(erp: EventRowPointer): Polygon? {
         if (skipIidPtr == erp.getIidPointer(currentIidPtr)) return null
 

--- a/core/src/main/kotlin/xtdb/trie/DataRel.kt
+++ b/core/src/main/kotlin/xtdb/trie/DataRel.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.BufferPool
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
+import xtdb.compactor.resolveSameSystemTimeEvents
 import xtdb.trie.Trie.dataFilePath
 import xtdb.util.closeAll
 import java.nio.file.Path
@@ -24,8 +25,9 @@ interface DataRel<L> : AutoCloseable {
             mutableListOf<Arrow>().also { res ->
                 try {
                     trieKeys.forEach { trieKey ->
+                        val parsedKey = Trie.parseKey(trieKey)
                         val dataFile = tableName.dataFilePath(trieKey)
-                        res.add(Arrow(al, bp, dataFile, bp.getFooter(dataFile).schema))
+                        res.add(Arrow(al, bp, dataFile, bp.getFooter(dataFile).schema, parsedKey.level))
                     }
                 } catch (e: Throwable) {
                     res.closeAll()
@@ -39,14 +41,24 @@ interface DataRel<L> : AutoCloseable {
 
     class Arrow(
         private val al: BufferAllocator, private val bp: BufferPool,
-        private val dataFile: Path, override val schema: Schema
+        private val dataFile: Path, override val schema: Schema, private val level: Long
     ) : DataRel<ArrowHashTrie.Leaf> {
 
         private val relsToClose = mutableListOf<Relation>()
 
         override fun loadPage(leaf: ArrowHashTrie.Leaf): RelationReader =
             bp.getRecordBatch(dataFile, leaf.dataPageIndex).use { rb ->
-                Relation.fromRecordBatch(al, schema, rb).also { relsToClose.add(it) }
+                Relation.fromRecordBatch(al, schema, rb).let { standardRel ->
+                    if (level == 0L) {
+                        resolveSameSystemTimeEvents(al, standardRel).also {
+                            standardRel.close()
+                            relsToClose.add(it)
+                        }
+                    } else {
+                        relsToClose.add(standardRel)
+                        standardRel
+                    }
+                }
             }
 
         override fun close() {

--- a/src/test/resources/xtdb/tpch/results-sf-001.edn
+++ b/src/test/resources/xtdb/tpch/results-sf-001.edn
@@ -127,32 +127,32 @@
   {:nation "IRAQ", :o_year 1992, :sum_profit 29098.2557}
   {:nation "KENYA", :o_year 1998, :sum_profit 33148.3345}
   {:nation "KENYA", :o_year 1997, :sum_profit 54355.016500000005}
-  {:nation "KENYA", :o_year 1996, :sum_profit 48581.83179999999}
-  {:nation "KENYA", :o_year 1995, :sum_profit 76990.8225}
-  {:nation "KENYA", :o_year 1994, :sum_profit 96344.8077}
-  {:nation "KENYA", :o_year 1993, :sum_profit 102229.2056}
-  {:nation "KENYA", :o_year 1992, :sum_profit 117628.157}
-  {:nation "MOROCCO", :o_year 1998, :sum_profit 33230.57119999999}
-  {:nation "MOROCCO", :o_year 1997, :sum_profit 23551.318999999996}
-  {:nation "MOROCCO", :o_year 1996, :sum_profit 36267.44679999999}
-  {:nation "MOROCCO", :o_year 1995, :sum_profit 61891.08599999999}
-  {:nation "MOROCCO", :o_year 1994, :sum_profit 40765.0484}
-  {:nation "MOROCCO", :o_year 1993, :sum_profit 53336.78869999999}
-  {:nation "MOROCCO", :o_year 1992, :sum_profit 59010.90879999999}
-  {:nation "PERU", :o_year 1998, :sum_profit 44157.15479999999}
-  {:nation "PERU", :o_year 1997, :sum_profit 53030.599700000006}
-  {:nation "PERU", :o_year 1996, :sum_profit 19218.720899999997}
-  {:nation "PERU", :o_year 1995, :sum_profit 77680.12879999998}
+  {:nation "KENYA", :o_year 1996, :sum_profit 43794.411799999994}
+  {:nation "KENYA", :o_year 1995, :sum_profit 69156.86249999999}
+  {:nation "KENYA", :o_year 1994, :sum_profit 88510.8477}
+  {:nation "KENYA", :o_year 1993, :sum_profit 95483.2956}
+  {:nation "KENYA", :o_year 1992, :sum_profit 93473.447}
+  {:nation "MOROCCO", :o_year 1998, :sum_profit 80034.8312}
+  {:nation "MOROCCO", :o_year 1997, :sum_profit 48218.42899999999}
+  {:nation "MOROCCO", :o_year 1996, :sum_profit 111533.75679999999}
+  {:nation "MOROCCO", :o_year 1995, :sum_profit 190286.55599999998}
+  {:nation "MOROCCO", :o_year 1994, :sum_profit 120458.78839999999}
+  {:nation "MOROCCO", :o_year 1993, :sum_profit 121013.21870000001}
+  {:nation "MOROCCO", :o_year 1992, :sum_profit 170329.1488}
+  {:nation "PERU", :o_year 1998, :sum_profit 58330.754799999995}
+  {:nation "PERU", :o_year 1997, :sum_profit 54422.6497}
+  {:nation "PERU", :o_year 1996, :sum_profit 22129.370899999998}
+  {:nation "PERU", :o_year 1995, :sum_profit 94384.7288}
   {:nation "PERU", :o_year 1994, :sum_profit 55023.0632}
-  {:nation "PERU", :o_year 1993, :sum_profit 78976.0271}
-  {:nation "PERU", :o_year 1992, :sum_profit 54368.2184}
-  {:nation "UNITED KINGDOM", :o_year 1998, :sum_profit 40248.77600000001}
-  {:nation "UNITED KINGDOM", :o_year 1997, :sum_profit 14478.572199999993}
-  {:nation "UNITED KINGDOM", :o_year 1996, :sum_profit 42889.01}
-  {:nation "UNITED KINGDOM", :o_year 1995, :sum_profit 33265.249599999996}
-  {:nation "UNITED KINGDOM", :o_year 1994, :sum_profit 14068.781999999992}
-  {:nation "UNITED KINGDOM", :o_year 1993, :sum_profit 36729.326000000015}
-  {:nation "UNITED KINGDOM", :o_year 1992, :sum_profit 14954.960400000005}
+  {:nation "PERU", :o_year 1993, :sum_profit 87328.32710000001}
+  {:nation "PERU", :o_year 1992, :sum_profit 59177.11840000001}
+  {:nation "UNITED KINGDOM", :o_year 1998, :sum_profit 62507.256}
+  {:nation "UNITED KINGDOM", :o_year 1997, :sum_profit 52221.212199999994}
+  {:nation "UNITED KINGDOM", :o_year 1996, :sum_profit 114503.24999999999}
+  {:nation "UNITED KINGDOM", :o_year 1995, :sum_profit 147460.92960000003}
+  {:nation "UNITED KINGDOM", :o_year 1994, :sum_profit 70682.74199999998}
+  {:nation "UNITED KINGDOM", :o_year 1993, :sum_profit 192054.806}
+  {:nation "UNITED KINGDOM", :o_year 1992, :sum_profit 29955.240400000006}
   {:nation "UNITED STATES", :o_year 1998, :sum_profit 32847.96}
   {:nation "UNITED STATES", :o_year 1997, :sum_profit 30849.5}
   {:nation "UNITED STATES", :o_year 1996, :sum_profit 56125.46000000001}
@@ -160,6 +160,7 @@
   {:nation "UNITED STATES", :o_year 1994, :sum_profit 31671.2}
   {:nation "UNITED STATES", :o_year 1993, :sum_profit 55057.469}
   {:nation "UNITED STATES", :o_year 1992, :sum_profit 51970.23}]
+
 
  ;; Q10
  [{:c_custkey "custkey_121"


### PR DESCRIPTION
As per #4303, to guarantee we always do the same resolution for events in the same transaction, we need to do the bi-temporal resolution of these events when they get potentially moved to different files (different recencies). 

In L0 events sit in a certain order in the same file and that order (later events in the tx come earlier in the bitemporal resolution) determines the bitemporal resolution. When events get moved to higher levels the order is no longer guaranteed as events with the same system time get moved to different files. To keep that order across all levels we do bi-temporal resolution for events in the same transaction when they move from L0 to L1. This means that we might have more events then were originally in the transaction in L1. The increase in events should only happen when there are overlapping valid times for the same entity id in the same transaction. We are doing this extra bitemporal resolution when we are loading a page from L0.

This PR also updates TPCH 0.001 results as in 0.001 there are some overwrites in the SF 0.001 transactions. We were previously storing the "wrong" result which can be verified on main by comparing non compacted TPCH 0.001 against compacted TPCH 0.001.