### PR TITLE
Add Microsecond Precision Intervals (MDM) - 4187

### DIFF
--- a/api/src/main/clojure/xtdb/time.clj
+++ b/api/src/main/clojure/xtdb/time.clj
@@ -5,6 +5,7 @@
            [java.time.format DateTimeParseException]
            java.time.temporal.ChronoUnit
            (java.util Date)
+           (org.apache.arrow.vector PeriodDuration)
            xtdb.time.Time))
 
 (defn ->duration [d]
@@ -123,3 +124,15 @@
                               {::err/message (str "invalid timestamp: " (ex-message e))
                                :timestamp ts-str}
                               e)))))
+
+(defn alter-duration-precision ^Duration [^long precision ^Duration duration]
+  (if (= precision 0)
+    (.withNanos duration 0)
+    (.withNanos duration (let [nanos (.getNano duration)
+                               factor (Math/pow 10 (- 9 precision))]
+                           (* (Math/floor (/ nanos factor)) factor)))))
+
+(defn alter-md*-interval-precision ^PeriodDuration [^long precision ^PeriodDuration pd]
+  (PeriodDuration.
+   (.getPeriod pd)
+   (alter-duration-precision precision (.getDuration pd))))

--- a/api/src/main/kotlin/xtdb/types/IntervalMonthDayMicro.kt
+++ b/api/src/main/kotlin/xtdb/types/IntervalMonthDayMicro.kt
@@ -1,0 +1,17 @@
+package xtdb.types
+
+import java.time.Duration
+import java.time.Period
+
+data class IntervalMonthDayMicro(
+    @JvmField val period: Period,
+    @JvmField val duration: Duration
+) {
+    init {
+        require(duration.nano % 1000 == 0) { "Month Day Micro Interval only supports up to microsecond precision (6)" }
+    }
+
+    override fun toString(): String {
+        return period.toString() + duration.toString().substring(1)
+    }
+}

--- a/api/src/main/resources/data_readers.clj
+++ b/api/src/main/resources/data_readers.clj
@@ -15,6 +15,7 @@
  xt/interval-ym xtdb.serde/interval-ym-reader
  xt/interval-dt xtdb.serde/interval-dt-reader
  xt/interval-mdn xtdb.serde/interval-mdn-reader
+ xt/interval-mdm xtdb.serde/interval-mdm-reader
  xt/tstz-range xtdb.serde/tstz-range-reader
  xt/uri xtdb.serde/uri-reader
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -23,7 +23,7 @@
            (xtdb.arrow ListValueReader RelationReader ValueReader VectorPosition VectorReader)
            xtdb.arrow.ValueBox
            (xtdb.operator ProjectionSpec SelectionSpec)
-           (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
+           (xtdb.types IntervalDayTime IntervalMonthDayNano IntervalMonthDayMicro IntervalYearMonth)
            (xtdb.util StringUtil)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -393,6 +393,10 @@
 (defmethod emit-value IntervalMonthDayNano [_ code]
   `(let [imdn# ~code]
      (PeriodDuration. (.-period imdn#) (.-duration imdn#))))
+
+(defmethod emit-value IntervalMonthDayMicro [_ code]
+  `(let [imdm# ~code]
+     (PeriodDuration. (.-period imdm#) (.-duration imdm#))))
 
 (defmethod codegen-expr :literal [{:keys [literal]} _]
   (let [return-type (vw/value->col-type literal)

--- a/core/src/main/clojure/xtdb/sql/plan.clj
+++ b/core/src/main/clojure/xtdb/sql/plan.clj
@@ -22,7 +22,7 @@
            (org.apache.arrow.vector.types.pojo Field)
            [org.apache.commons.codec.binary Hex]
            (xtdb.antlr Sql$BaseTableContext Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$IntervalQualifierContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlVisitor)
-           (xtdb.types IntervalMonthDayNano)
+           (xtdb.types IntervalMonthDayMicro)
            xtdb.util.StringUtil))
 
 (defn- ->insertion-ordered-set [coll]
@@ -839,12 +839,12 @@
 (defn parse-iso-interval-literal [i-str env]
   (if-let [[_ p-str d-str] (re-matches #"P([-\dYMWD]+)?(?:T([-\dHMS\.]+)?)?" i-str)]
     (try
-      (IntervalMonthDayNano. (if p-str
-                               (Period/parse (str "P" p-str))
-                               Period/ZERO)
-                             (if d-str
-                               (Duration/parse (str "PT" d-str))
-                               Duration/ZERO))
+      (IntervalMonthDayMicro. (if p-str
+                                 (Period/parse (str "P" p-str))
+                                 Period/ZERO)
+                               (if d-str
+                                 (Duration/parse (str "PT" d-str))
+                                 Duration/ZERO))
       (catch Exception e
         (add-err! env (->CannotParseInterval i-str (.getMessage e)))))
 

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -9,7 +9,7 @@
            (java.time Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime ZonedDateTime)
            (java.util Date List Map Set UUID)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector PeriodDuration ValueVector VectorSchemaRoot)
+           (org.apache.arrow.vector ValueVector VectorSchemaRoot)
            (org.apache.arrow.vector.types.pojo Field FieldType)
            xtdb.Types
            (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalMonthDayMicro IntervalYearMonth ZonedDateTimeRange)
@@ -91,10 +91,7 @@
   (value->col-type [_] [:interval :month-day-micro])
 
   ZonedDateTimeRange
-  (value->col-type [_] :tstz-range)
-
-  PeriodDuration ;;TODO Is there any need to expose this?
-  (value->col-type [_] [:interval :month-day-micro]))
+  (value->col-type [_] :tstz-range))
 
 (extend-protocol ArrowWriteable
   (Class/forName "[B")

--- a/core/src/main/clojure/xtdb/vector/writer.clj
+++ b/core/src/main/clojure/xtdb/vector/writer.clj
@@ -12,7 +12,7 @@
            (org.apache.arrow.vector PeriodDuration ValueVector VectorSchemaRoot)
            (org.apache.arrow.vector.types.pojo Field FieldType)
            xtdb.Types
-           (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalYearMonth ZonedDateTimeRange)
+           (xtdb.types ClojureForm IntervalDayTime IntervalMonthDayNano IntervalMonthDayMicro IntervalYearMonth ZonedDateTimeRange)
            (xtdb.vector FieldVectorWriters IRelationWriter IVectorReader IVectorWriter RelationReader RelationWriter RootWriter)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -87,11 +87,14 @@
   IntervalMonthDayNano
   (value->col-type [_] [:interval :month-day-nano])
 
+  IntervalMonthDayMicro
+  (value->col-type [_] [:interval :month-day-micro])
+
   ZonedDateTimeRange
   (value->col-type [_] :tstz-range)
 
-  PeriodDuration
-  (value->col-type [_] [:interval :month-day-nano]))
+  PeriodDuration ;;TODO Is there any need to expose this?
+  (value->col-type [_] [:interval :month-day-micro]))
 
 (extend-protocol ArrowWriteable
   (Class/forName "[B")

--- a/core/src/main/kotlin/xtdb/Types.kt
+++ b/core/src/main/kotlin/xtdb/Types.kt
@@ -90,6 +90,7 @@ fun ArrowType.toLeg(): String = accept(object : ArrowTypeVisitor<String> {
         RegClassType -> "regclass"
         RegProcType -> "regproc"
         SetType -> "set"
+        IntervalMDMType -> "interval-month-day-micro"
         TsTzRangeType -> "tstz-range"
         else -> throw UnsupportedOperationException("not supported for $type")
     }
@@ -143,7 +144,8 @@ fun valueToArrowType(obj: Any?) = when (obj) {
 
     is IntervalYearMonth -> MinorType.INTERVALYEAR.type
     is IntervalDayTime -> MinorType.INTERVALDAY.type
-    is IntervalMonthDayNano, is PeriodDuration -> MinorType.INTERVALMONTHDAYNANO.type
+    is IntervalMonthDayNano -> MinorType.INTERVALMONTHDAYNANO.type
+    is IntervalMonthDayMicro , is PeriodDuration -> IntervalMDMType
 
     is ZonedDateTimeRange -> TsTzRangeType
 

--- a/core/src/main/kotlin/xtdb/Types.kt
+++ b/core/src/main/kotlin/xtdb/Types.kt
@@ -145,7 +145,7 @@ fun valueToArrowType(obj: Any?) = when (obj) {
     is IntervalYearMonth -> MinorType.INTERVALYEAR.type
     is IntervalDayTime -> MinorType.INTERVALDAY.type
     is IntervalMonthDayNano -> MinorType.INTERVALMONTHDAYNANO.type
-    is IntervalMonthDayMicro , is PeriodDuration -> IntervalMDMType
+    is IntervalMonthDayMicro -> IntervalMDMType
 
     is ZonedDateTimeRange -> TsTzRangeType
 

--- a/core/src/main/kotlin/xtdb/arrow/IntervalMonthDayMicroVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/IntervalMonthDayMicroVector.kt
@@ -1,0 +1,30 @@
+package xtdb.arrow
+
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.query.IKeyFn
+import xtdb.types.IntervalMonthDayMicro
+import xtdb.types.IntervalMonthDayNano
+import xtdb.util.Hasher
+import xtdb.vector.extensions.IntervalMDMType
+import java.nio.ByteOrder
+import java.time.Duration
+import java.time.Period
+
+class IntervalMonthDayMicroVector(override val inner: IntervalMonthDayNanoVector): ExtensionVector() {
+
+    override val type = IntervalMDMType
+
+    override fun getObject0(idx: Int, keyFn: IKeyFn<*>): IntervalMonthDayMicro {
+        val innerMDN = inner.getObject0(idx, keyFn)
+        return IntervalMonthDayMicro(innerMDN.period, innerMDN.duration)
+    }
+
+    override fun writeObject0(value: Any) {
+        if (value !is IntervalMonthDayMicro) throw InvalidWriteObjectException(fieldType, value)
+        else inner.writeObject(IntervalMonthDayNano(value.period, value.duration))
+    }
+
+    override fun hashCode0(idx: Int, hasher: Hasher) = inner.hashCode0(idx, hasher)
+
+    override fun openSlice(al: BufferAllocator) = IntervalMonthDayMicroVector(inner.openSlice(al))
+}

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -175,6 +175,7 @@ sealed class Vector : VectorReader, VectorWriter {
                     KeywordType -> KeywordVector(Utf8Vector(al, name, isNullable))
                     UuidType -> UuidVector(FixedSizeBinaryVector(al, name, isNullable, 16))
                     TransitType -> TransitVector(VarBinaryVector(al, name, isNullable))
+                    IntervalMDMType -> IntervalMonthDayMicroVector(IntervalMonthDayNanoVector(al, name, isNullable))
                     TsTzRangeType -> TsTzRangeVector(
                         FixedSizeListVector(
                             al, name, isNullable, 2,

--- a/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
+++ b/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
@@ -71,6 +71,7 @@ object VecToReader : VectorVisitor<IVectorReader, Any?> {
         is UriVector -> uriVector(v)
         is TransitVector -> transitVector(v)
         is TsTzRangeVector -> tstzRangeVector(v)
+        is IntervalMonthDayMicroVector -> intervalMdmVector(v)
 
         is SetVector -> setVector(v)
 

--- a/core/src/main/kotlin/xtdb/vector/extensions/IntervalMDMType.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/IntervalMDMType.kt
@@ -1,0 +1,20 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.IntervalUnit
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ExtensionTypeRegistry
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.arrow.IntervalMonthDayMicroVector
+
+object IntervalMDMType : XtExtensionType("xt/intervalDMMType", Interval(IntervalUnit.MONTH_DAY_NANO)) {
+    init {
+        ExtensionTypeRegistry.register(this)
+    }
+
+    override fun deserialize(serializedData: String): ArrowType = this
+
+    override fun getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator): FieldVector =
+        IntervalMonthDayMicroVector(name, allocator, fieldType)
+}

--- a/core/src/main/kotlin/xtdb/vector/extensions/IntervalMonthDayMicroVector.kt
+++ b/core/src/main/kotlin/xtdb/vector/extensions/IntervalMonthDayMicroVector.kt
@@ -1,0 +1,19 @@
+package xtdb.vector.extensions
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.IntervalMonthDayNanoVector
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.types.IntervalMonthDayMicro
+
+class IntervalMonthDayMicroVector(name: String, allocator: BufferAllocator, fieldType: FieldType) :
+    XtExtensionVector<IntervalMonthDayNanoVector>(name, allocator, fieldType, IntervalMonthDayNanoVector(name, allocator)) {
+
+    init {
+        require(fieldType.type == IntervalMDMType)
+    }
+
+    override fun getObject0(index: Int): IntervalMonthDayMicro {
+        val inner = underlyingVector.getObject(index)
+        return IntervalMonthDayMicro(inner.period, inner.duration)
+    }
+}

--- a/core/src/test/kotlin/xtdb/arrow/IntervalVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/IntervalVectorTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.types.IntervalDayTime
+import xtdb.types.IntervalMonthDayMicro
 import xtdb.types.IntervalMonthDayNano
 import java.time.Duration
 import java.time.Period
@@ -34,6 +35,19 @@ class IntervalVectorTest {
             assertEquals(2, iv.valueCount)
             assertEquals(IntervalMonthDayNano(Period.ofMonths(0), Duration.ofHours(1)), iv.getObject(0))
             assertEquals(IntervalMonthDayNano(Period.ofMonths(1), Duration.ofHours(0)), iv.getObject(1))
+        }
+    }
+
+    @Test
+    fun testIntervalMonthDayMicroReadWrite() {
+        IntervalMonthDayMicroVector(IntervalMonthDayNanoVector(allocator, "imdmv", false)).use {
+                iv ->
+            iv.writeObject(IntervalMonthDayMicro(Period.ofMonths(0), Duration.ofHours(1)))
+            iv.writeObject(IntervalMonthDayMicro(Period.ofMonths(1), Duration.ofHours(0)))
+
+            assertEquals(2, iv.valueCount)
+            assertEquals(IntervalMonthDayMicro(Period.ofMonths(0), Duration.ofHours(1)), iv.getObject(0))
+            assertEquals(IntervalMonthDayMicro(Period.ofMonths(1), Duration.ofHours(0)), iv.getObject(1))
         }
     }
 

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -1174,9 +1174,9 @@
       true '(>= (multi-field-interval "2-2" "YEAR" 2 "MONTH" 2) (single-field-interval 2 "YEAR" 2 0))
       false '(>= (single-field-interval 1 "YEAR" 2 0) (single-field-interval 2 "YEAR" 2 0))))
 
-  (t/testing "can't compare month-day-nano intervals if months > 0"
+  (t/testing "can't compare month-day-micro intervals if months > 0"
     (let [test-doc {:_id :foo,
-                    :interval (PeriodDuration. (Period/of 0 4 8) (Duration/parse "PT1H"))}]
+                    :interval (IntervalMonthDayMicro. (Period/of 0 4 8) (Duration/parse "PT1H"))}]
       (t/is (thrown-with-msg?
              RuntimeException
              #"Cannot compare month-day-micro/nano intervals when month component is non-zero."

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -203,25 +203,26 @@
 
 (t/deftest test-date-trunc-interval
   (let [test-doc {:_id :foo,
-                  :year-interval (PeriodDuration. (Period/of 1111 4 8) (Duration/parse "PT1H1M1.111111S")) 
+                  :year-interval (PeriodDuration. (Period/of 1111 4 8) (Duration/parse "PT1H1M1.111111S"))
+                  ;;TODO this shouldn't be a pd
                   :interval (PeriodDuration. (Period/of 0 4 8) (Duration/parse "PT1H1M1.111111S"))}]
 
     (letfn [(trunc [time-unit] (project1 (list 'date-trunc time-unit 'interval) test-doc))]
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1.111111S"] (trunc "MICROSECOND")))
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1.111S"] (trunc "MILLISECOND")))
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M1S"] (trunc "SECOND")))
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H1M"] (trunc "MINUTE")))
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT1H"] (trunc "HOUR")))
-      (t/is (= #xt/interval-mdn ["P4M8D" "PT0S"] (trunc "DAY")))
-      (t/is (= #xt/interval-mdn ["P4M7D" "PT0S"] (trunc "WEEK")))
-      (t/is (= #xt/interval-mdn ["P4M" "PT0S"] (trunc "MONTH")))
-      (t/is (= #xt/interval-mdn ["P3M" "PT0S"] (trunc "QUARTER"))))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT1H1M1.111111S"] (trunc "MICROSECOND")))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT1H1M1.111S"] (trunc "MILLISECOND")))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT1H1M1S"] (trunc "SECOND")))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT1H1M"] (trunc "MINUTE")))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT1H"] (trunc "HOUR")))
+      (t/is (= #xt/interval-mdm ["P4M8D" "PT0S"] (trunc "DAY")))
+      (t/is (= #xt/interval-mdm ["P4M7D" "PT0S"] (trunc "WEEK")))
+      (t/is (= #xt/interval-mdm ["P4M" "PT0S"] (trunc "MONTH")))
+      (t/is (= #xt/interval-mdm ["P3M" "PT0S"] (trunc "QUARTER"))))
     
     (letfn [(trunc [time-unit] (project1 (list 'date-trunc time-unit 'year-interval) test-doc))] 
-      (t/is (= #xt/interval-mdn ["P13332M" "PT0S"] (trunc "YEAR")))
-      (t/is (= #xt/interval-mdn ["P13320M" "PT0S"] (trunc "DECADE")))
-      (t/is (= #xt/interval-mdn ["P13200M" "PT0S"] (trunc "CENTURY")))
-      (t/is (= #xt/interval-mdn ["P12000M" "PT0S"] (trunc "MILLENNIUM"))))))
+      (t/is (= #xt/interval-mdm ["P13332M" "PT0S"] (trunc "YEAR")))
+      (t/is (= #xt/interval-mdm ["P13320M" "PT0S"] (trunc "DECADE")))
+      (t/is (= #xt/interval-mdm ["P13200M" "PT0S"] (trunc "CENTURY")))
+      (t/is (= #xt/interval-mdm ["P12000M" "PT0S"] (trunc "MILLENNIUM"))))))
 
 (t/deftest test-date-extract
   (letfn [(extract [part date-like] (project1 (list 'extract part 'date) {:date date-like}))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -14,10 +14,11 @@
   (:import (java.nio ByteBuffer)
            (java.time Duration Instant InstantSource LocalDate LocalDateTime LocalTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
-           (org.apache.arrow.vector DurationVector PeriodDuration TimeStampVector ValueVector)
+           (org.apache.arrow.vector DurationVector TimeStampVector ValueVector)
            (org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Timestamp)
            org.apache.arrow.vector.types.TimeUnit
            xtdb.arrow.RelationReader
+           (xtdb.types IntervalMonthDayMicro)
            (xtdb.util StringUtil)
            xtdb.vector.IVectorReader))
 
@@ -203,9 +204,8 @@
 
 (t/deftest test-date-trunc-interval
   (let [test-doc {:_id :foo,
-                  :year-interval (PeriodDuration. (Period/of 1111 4 8) (Duration/parse "PT1H1M1.111111S"))
-                  ;;TODO this shouldn't be a pd
-                  :interval (PeriodDuration. (Period/of 0 4 8) (Duration/parse "PT1H1M1.111111S"))}]
+                  :year-interval (IntervalMonthDayMicro. (Period/of 1111 4 8) (Duration/parse "PT1H1M1.111111S"))
+                  :interval (IntervalMonthDayMicro. (Period/of 0 4 8) (Duration/parse "PT1H1M1.111111S"))}]
 
     (letfn [(trunc [time-unit] (project1 (list 'date-trunc time-unit 'interval) test-doc))]
       (t/is (= #xt/interval-mdm ["P4M8D" "PT1H1M1.111111S"] (trunc "MICROSECOND")))
@@ -276,7 +276,7 @@
 
 (t/deftest test-interval-extract
   (letfn [(extract [part interval-val] (project1 (list 'extract part 'interval) {:interval interval-val}))]
-    (let [itvl (PeriodDuration. (Period/of 1 4 8) (Duration/parse "PT3H10M12.1S"))]
+    (let [itvl (IntervalMonthDayMicro. (Period/of 1 4 8) (Duration/parse "PT3H10M12.1S"))]
       (t/is (= 12 (extract "SECOND" itvl)))
       (t/is (= 10 (extract "MINUTE" itvl)))
       (t/is (= 3 (extract "HOUR" itvl)))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -491,34 +491,39 @@
   (t/is (= [{:duration #xt/duration "PT13M56S"}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56' MINUTE TO SECOND AS DURATION) as \"duration\"")))
 
-  (t/is (= [{:duration #xt/duration "PT13M56.123456789S"}]
+  (t/is (= [{:duration #xt/duration "PT13M56.123456S"}]
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56.123456' MINUTE TO SECOND AS DURATION) as \"duration\"")))
+  ;;
+  ;;TODO add interval(9) syntax?
+  #_(t/is (= [{:duration #xt/duration "PT13M56.123456789S"}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '13:56.123456789' MINUTE TO SECOND AS DURATION(9)) as \"duration\""))))
 
 (t/deftest test-cast-duration-to-interval
+
   (t/testing "without interval qualifier"
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT26H13M56.111111S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT26H13M56.111111S"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT122H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT122H"]}]
              (xt/q tu/*node* "SELECT CAST((TIMESTAMP '2021-10-26T14:00:00' - TIMESTAMP '2021-10-21T12:00:00') AS INTERVAL) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn  ["P0D" "PT8882H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm  ["P0D" "PT8882H"]}]
              (xt/q tu/*node* "SELECT CAST((TIMESTAMP '2021-10-26T14:00:00' - TIMESTAMP '2020-10-21T12:00:00') AS INTERVAL) as itvl"))))
 
   (t/testing "with interval qualifier"
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT0S"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL DAY) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT2H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT2H"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL DAY TO HOUR) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT2H13M"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT2H13M"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL DAY TO MINUTE) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT2H13M56.111111S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT2H13M56.111111S"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL DAY TO SECOND) as itvl")))
 
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT2H13M56.111S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT2H13M56.111S"]}]
              (xt/q tu/*node* "SELECT CAST(DURATION 'PT26H13M56.111111S' AS INTERVAL DAY TO SECOND(3)) as itvl")))))
 
 (t/deftest test-cast-interval-to-interval
@@ -528,26 +533,26 @@
   (t/is (= [{:itvl #xt/interval-ym "P12M"}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1-10' YEAR TO MONTH AS INTERVAL YEAR) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT0S"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL DAY) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT11H"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT11H"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL DAY TO HOUR) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT11H11M"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT11H11M"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL DAY TO MINUTE) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT11H11M11.111S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT11H11M11.111S"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL DAY TO SECOND) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT11H11M11S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT11H11M11S"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL DAY TO SECOND(0)) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT35H"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT35H"]}]
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1 11:11:11.111' DAY TO SECOND AS INTERVAL HOUR) as itvl"))))
 
 (t/deftest test-cast-int-to-interval
-  (t/is (= [{:itvl #xt/interval-mdn ["P3D" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P3D" "PT0S"]}]
            (xt/q tu/*node* "SELECT CAST(3 AS INTERVAL DAY) as itvl")))
 
   (t/is (= [{:itvl #xt/interval-ym "P24M"}]
@@ -559,7 +564,7 @@
          (xt/q tu/*node* "SELECT CAST(2 AS INTERVAL YEAR TO MONTH) as itvl"))))
 
 (t/deftest test-cast-string-to-interval-with-qualifier
-  (t/is (= [{:itvl #xt/interval-mdn ["P3D" "PT11H10M"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P3D" "PT11H10M"]}]
            (xt/q tu/*node* "SELECT CAST('3 11:10' AS INTERVAL DAY TO MINUTE) as itvl")))
 
   (t/is (= [{:itvl #xt/interval-ym "P24M"}]
@@ -571,22 +576,45 @@
   (t/is (thrown-with-msg?
          IllegalArgumentException
          #"Interval end field must have less significance than the start field."
-         (xt/q tu/*node* "SELECT CAST('11:10' AS INTERVAL MINUTE TO HOUR) as itvl"))))
+         (xt/q tu/*node* "SELECT CAST('11:10' AS INTERVAL MINUTE TO HOUR) as itvl")))
+
+  (t/testing "ISO with seconds precision"
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT10M10.123456S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.123456789' MINUTE TO SECOND itvl")))
+
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT10M10.1234S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.1234' MINUTE TO SECOND itvl")))
+
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT10M10.1234S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.1234' MINUTE TO SECOND(5) itvl")))
+
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT10M10.123S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.123456789' MINUTE TO SECOND(3) itvl")))
+
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT10M10.123456S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.123456789' MINUTE TO SECOND(6) itvl")))
+
+    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT10M10.123456789S"]}]
+             (xt/q tu/*node* "SELECT INTERVAL '10:10.123456789' MINUTE TO SECOND(9) itvl")))))
 
 (t/deftest test-cast-string-to-interval-without-qualifier
-  (t/is (= [{:itvl #xt/interval-mdn ["P3D" "PT11H10M"]}]
+  ;;TODO interval(9) syntax
+  (t/is (= [{:itvl #xt/interval-mdm ["P3D" "PT11H10M"]}]
            (xt/q tu/*node* "SELECT CAST('P3DT11H10M' AS INTERVAL) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P24M" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P24M" "PT0S"]}]
            (xt/q tu/*node* "SELECT CAST('P2Y' AS INTERVAL) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P22M" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P22M" "PT0S"]}]
            (xt/q tu/*node* "SELECT CAST('P1Y10M' AS INTERVAL) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P1M1D" "PT1H1M1.11111S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1M1D" "PT1H1M1.11111S"]}]
            (xt/q tu/*node* "SELECT CAST('P1M1DT1H1M1.11111S' AS INTERVAL) as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT-1H-1M"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P1M1D" "PT1H1M1.111111S"]}]
+           (xt/q tu/*node* "SELECT CAST('P1M1DT1H1M1.11111111S' AS INTERVAL) as itvl")))
+
+  (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT-1H-1M"]}]
            (xt/q tu/*node* "SELECT CAST('PT-1H-1M' AS INTERVAL) as itvl"))))
 
 (t/deftest test-cast-interval-to-string
@@ -603,10 +631,7 @@
            (xt/q tu/*node* "SELECT CAST(INTERVAL '1' DAY AS VARCHAR) as string")))
 
   (t/is (= [{:string "P1DT10H10M10S"}]
-           (xt/q tu/*node* "SELECT CAST(INTERVAL '1 10:10:10' DAY TO SECOND AS VARCHAR) as string")))
-
-  (t/is (= [{:string "P0DT10M10.111111111S"}]
-           (xt/q tu/*node* "SELECT CAST(INTERVAL '10:10.111111111' MINUTE TO SECOND(9) AS VARCHAR) as string"))))
+           (xt/q tu/*node* "SELECT CAST(INTERVAL '1 10:10:10' DAY TO SECOND AS VARCHAR) as string"))))
 
 
 (t/deftest test-timestamp-literal
@@ -651,24 +676,28 @@
 
 (t/deftest interval-literal
   (t/are [sql expected] (= expected (plan-expr-with-foo sql))
-    "INTERVAL 'P1Y'" #xt/interval-mdn ["P1Y" "PT0S"]
-    "INTERVAL 'P1Y-2M3D'" #xt/interval-mdn ["P1Y-2M3D" "PT0S"]
-    "INTERVAL 'PT5H6M12.912S'" #xt/interval-mdn ["P0D" "PT5H6M12.912S"]
-    "INTERVAL 'PT5H-6M-12.912S'" #xt/interval-mdn ["P0D" "PT4H53M47.088S"]
-    "INTERVAL 'P1Y3DT12H52S'" #xt/interval-mdn ["P1Y3D" "PT12H52S"]
-    "INTERVAL 'P1Y10M3DT12H52S'" #xt/interval-mdn ["P1Y10M3D" "PT12H52S"]))
+    "INTERVAL 'P1Y'" #xt/interval-mdm ["P1Y" "PT0S"]
+    "INTERVAL 'P1Y-2M3D'" #xt/interval-mdm ["P1Y-2M3D" "PT0S"]
+    "INTERVAL 'PT5H6M12.912S'" #xt/interval-mdm ["P0D" "PT5H6M12.912S"]
+    "INTERVAL 'PT5H-6M-12.912S'" #xt/interval-mdm ["P0D" "PT4H53M47.088S"]
+    "INTERVAL 'P1Y3DT12H52S'" #xt/interval-mdm ["P1Y3D" "PT12H52S"]
+    "INTERVAL 'P1Y10M3DT12H52S'" #xt/interval-mdm ["P1Y10M3D" "PT12H52S"])
+
+  (t/is (thrown-with-msg?
+         RuntimeException #"Month Day Micro Interval only supports up to microsecond precision \(6\)"
+         (plan-expr-with-foo "INTERVAL 'P1DT1.123456789S'"))))
 
 (t/deftest interval-literal-query
-  (t/is (= [{:itvl #xt/interval-mdn ["P12M" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P12M" "PT0S"]}]
            (xt/q tu/*node* "SELECT INTERVAL 'P1Y' as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P10M3D" "PT0S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P10M3D" "PT0S"]}]
            (xt/q tu/*node* "SELECT INTERVAL 'P1Y-2M3D' as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT5H6M12.912S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT5H6M12.912S"]}]
            (xt/q tu/*node* "SELECT INTERVAL 'PT5H6M12.912S' as itvl")))
 
-  (t/is (= [{:itvl #xt/interval-mdn ["P22M3D" "PT4H53M47.088S"]}]
+  (t/is (= [{:itvl #xt/interval-mdm ["P22M3D" "PT4H53M47.088S"]}]
            (xt/q tu/*node* "SELECT INTERVAL 'P1Y10M3DT5H-6M-12.912S' as itvl"))))
 
 (t/deftest duration-literal
@@ -775,16 +804,16 @@
          (xt/q tu/*node* "select date_trunc(hour, TIMESTAMP '2000-01-02 00:43:11+00:00', 'NotRealRegion') as \"timestamp\""))))
 
 (t/deftest test-date-trunc-with-interval-query
-  (t/is (= [{:interval #xt/interval-mdn ["P36M" "PT0S"]}]
+  (t/is (= [{:interval #xt/interval-mdm ["P36M" "PT0S"]}]
            (xt/q tu/*node* "SELECT DATE_TRUNC(YEAR, INTERVAL '3' YEAR + INTERVAL 'P3M') as \"interval\"")))
 
-  (t/is (= [{:interval #xt/interval-mdn ["P3M4D" "PT2S"]}]
+  (t/is (= [{:interval #xt/interval-mdm ["P3M4D" "PT2S"]}]
            (xt/q tu/*node* "SELECT DATE_TRUNC(SECOND, INTERVAL '3' MONTH + INTERVAL 'P4DT2S') as `interval`")))
 
-  (t/is (= [{:interval #xt/interval-mdn ["P3M4D" "PT0S"]}]
+  (t/is (= [{:interval #xt/interval-mdm ["P3M4D" "PT0S"]}]
            (xt/q tu/*node* "SELECT DATE_TRUNC(DAY, INTERVAL 'P3M' + INTERVAL '4' DAY + INTERVAL '2' SECOND) as \"interval\"")))
 
-  (t/is (= [{:interval #xt/interval-mdn ["P3M" "PT0S"]}]
+  (t/is (= [{:interval #xt/interval-mdm ["P3M" "PT0S"]}]
            (xt/q tu/*node* "SELECT DATE_TRUNC(MONTH, INTERVAL '3' MONTH + INTERVAL 'P4D' + INTERVAL '2' SECOND) as \"interval\""))))
 
 (t/deftest test-date-bin
@@ -942,33 +971,33 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
 
 (t/deftest test-age-function
   (t/testing "testing AGE with timestamps"
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT2H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT2H"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2022-05-02T01:00:00', TIMESTAMP '2022-05-01T23:00:00') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P6M" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P6M" "PT0S"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2022-11-01T00:00:00', TIMESTAMP '2022-05-01T00:00:00') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT1H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT1H"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2023-01-01T01:00:00', TIMESTAMP '2023-01-01T00:00:00') as itvl"))))
 
   (t/testing "testing AGE with timestamp with timezone"
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT1H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT1H"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2023-06-01T11:00:00+01:00[Europe/London]', TIMESTAMP '2023-06-01T11:00:00+02:00[Europe/Berlin]') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT2H"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT2H"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2023-06-01T09:00:00-05:00[America/Chicago]', TIMESTAMP '2023-06-01T12:00:00') as itvl"))))
 
   (t/testing "testing AGE with date"
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT0S"]}]
              (xt/q tu/*node* "SELECT AGE(DATE '2023-01-02', DATE '2023-01-01') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P-12M" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P-12M" "PT0S"]}]
              (xt/q tu/*node* "SELECT AGE(DATE '2023-01-01', DATE '2024-01-01') as itvl"))))
 
   (t/testing "test with mixed types"
-    (t/is (= [{:itvl #xt/interval-mdn ["P1D" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P1D" "PT0S"]}]
              (xt/q tu/*node* "SELECT AGE(DATE '2023-01-02', TIMESTAMP '2023-01-01T00:00:00') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P-6M" "PT0S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P-6M" "PT0S"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2022-05-01T00:00:00', TIMESTAMP '2022-11-01T00:00:00+00:00[Europe/London]') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT2H0.001S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT2H0.001S"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2023-07-01T12:00:30.501', TIMESTAMP '2023-07-01T12:00:30.500+02:00[Europe/Berlin]') as itvl")))
-    (t/is (= [{:itvl #xt/interval-mdn ["P0D" "PT-2H-0.001S"]}]
+    (t/is (= [{:itvl #xt/interval-mdm ["P0D" "PT-2H-0.001S"]}]
              (xt/q tu/*node* "SELECT AGE(TIMESTAMP '2023-07-01T12:00:30.499+02:00[Europe/Berlin]', TIMESTAMP '2023-07-01T12:00:30.500') as itvl")))))
 
 (t/deftest test-period-predicates

--- a/src/test/clojure/xtdb/sql/interval_test.clj
+++ b/src/test/clojure/xtdb/sql/interval_test.clj
@@ -10,20 +10,20 @@
       first :r))
 
 (t/deftest test-interval-literals
-    (t/is (= #xt/interval-ym "P36M" (q "INTERVAL '3' YEAR")))
-    (t/is (= #xt/interval-ym "P-36M" (q "INTERVAL '-3' YEAR")))
-    (t/is (= #xt/interval-ym "P3M" (q "INTERVAL '3' MONTH")))
-    (t/is (= #xt/interval-ym "P-3M" (q "INTERVAL '-3' MONTH")))
-    (t/is (= #xt/interval-ym "P40M" (q "INTERVAL '3-4' YEAR TO MONTH")))
+  (t/is (= #xt/interval-ym "P36M" (q "INTERVAL '3' YEAR")))
+  (t/is (= #xt/interval-ym "P-36M" (q "INTERVAL '-3' YEAR")))
+  (t/is (= #xt/interval-ym "P3M" (q "INTERVAL '3' MONTH")))
+  (t/is (= #xt/interval-ym "P-3M" (q "INTERVAL '-3' MONTH")))
+  (t/is (= #xt/interval-ym "P40M" (q "INTERVAL '3-4' YEAR TO MONTH")))
 
-    (t/is (= #xt/interval-mdn ["P3D" "PT4H"] (q "INTERVAL '3 4' DAY TO HOUR")))
-    (t/is (= #xt/interval-mdn ["P3D" "PT4H"] (q "INTERVAL '3 04' DAY TO HOUR")))
-    (t/is (= #xt/interval-mdn ["P3D" "PT4H20M"] (q "INTERVAL '3 04:20' DAY TO MINUTE")))
-    (t/is (= #xt/interval-mdn ["P3D" "PT4H20M34S"] (q "INTERVAL '3 04:20:34' DAY TO SECOND")))
-    (t/is (= #xt/interval-mdn ["P0D" "PT4H20M"] (q "INTERVAL '04:20' HOUR TO MINUTE")))
-    (t/is (= #xt/interval-mdn ["P0D" "PT4H20M34S"] (q "INTERVAL '04:20:34' HOUR TO SECOND")))
-    (t/is (= #xt/interval-mdn ["P0D" "PT4H20M34.245S"] (q "INTERVAL '04:20:34.245' HOUR TO SECOND")))
-  (t/is (= #xt/interval-mdn ["P0D" "PT20M34S"] (q "INTERVAL '20:34' MINUTE TO SECOND"))))
+  (t/is (= #xt/interval-mdm ["P3D" "PT4H"] (q "INTERVAL '3 4' DAY TO HOUR")))
+  (t/is (= #xt/interval-mdm ["P3D" "PT4H"] (q "INTERVAL '3 04' DAY TO HOUR")))
+  (t/is (= #xt/interval-mdm ["P3D" "PT4H20M"] (q "INTERVAL '3 04:20' DAY TO MINUTE")))
+  (t/is (= #xt/interval-mdm ["P3D" "PT4H20M34S"] (q "INTERVAL '3 04:20:34' DAY TO SECOND")))
+  (t/is (= #xt/interval-mdm ["P0D" "PT4H20M"] (q "INTERVAL '04:20' HOUR TO MINUTE")))
+  (t/is (= #xt/interval-mdm ["P0D" "PT4H20M34S"] (q "INTERVAL '04:20:34' HOUR TO SECOND")))
+  (t/is (= #xt/interval-mdm ["P0D" "PT4H20M34.245S"] (q "INTERVAL '04:20:34.245' HOUR TO SECOND")))
+  (t/is (= #xt/interval-mdm ["P0D" "PT20M34S"] (q "INTERVAL '20:34' MINUTE TO SECOND"))))
 
 (t/deftest test-interval-fns
   (t/is (= #xt/interval-ym "P-12M" (q "INTERVAL '-1' YEAR")))


### PR DESCRIPTION
Adds MonthDayMicro interval on top off mdn and uses it as the default. Also adds some, but not complete support for casting between the durations/intervals etc. of various precisions as code already existed for these and wanted to avoid removing features. That being said, I think 99.9% of people are using micro durations and intervals, so a case could be made for simplifying the logic/API here.

Commit also chooses to implicitly assume `INTERVAL` SQL literals are in `micro` rather than inferring from context. This matches current timestamp behaviour, as we map ZDT -> tstz micro, however this happens implicitly, truncating any nanos, whereas we have a specific type for MDM and so we throw during planning.

 TODO:
 
- [x] Fix MDM literals allowing nano precision.
- [x] More tests around mdn now its not the default
- [x] More testing around the various precision based casting which would cause a change in interval type
- [x] See if we can clean up the usage of PD, so its limited to internal runtime EE rep, never infer a type from it.