### PR TITLE
Logs shouldn't use latestProcessedMsgId - pass in and use an offset.

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -59,9 +59,9 @@ class InMemoryLog(private val instantSource: InstantSource) : Log {
             res.await()
         }
 
-    override fun subscribe(subscriber: Subscriber): Subscription {
+    override fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
         val job = scope.launch(SupervisorJob()) {
-            var latestCompletedOffset = subscriber.latestProcessedMsgId
+            var latestCompletedOffset = latestProcessedOffset
 
             val ch = Channel<Record>(100)
 

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -198,8 +198,8 @@ class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
             onCommit.await().logOffset
         }
 
-    override fun subscribe(subscriber: Subscriber): Subscription {
-        var latestCompletedOffset = subscriber.latestProcessedMsgId
+    override fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
+        var latestCompletedOffset = latestProcessedOffset
 
         val ch = Channel<Record>(100)
 
@@ -212,7 +212,7 @@ class LocalLog(rootPath: Path, private val instantSource: InstantSource) : Log {
 
                         runInterruptible {
                             FileChannel.open(logFilePath).use { ch ->
-                                val latestCompleted = subscriber.latestProcessedMsgId
+                                val latestCompleted = latestCompletedOffset
                                 if (latestCompleted >= 0) {
                                     ch.position(latestCompleted)
                                     ch.readMessage()

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -107,7 +107,7 @@ interface Log : AutoCloseable {
 
     fun appendMessage(message: Message): CompletableFuture<LogOffset>
 
-    fun subscribe(subscriber: Subscriber): Subscription
+    fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription
 
     @FunctionalInterface
     fun interface Subscription : AutoCloseable

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -98,7 +98,8 @@ class LogProcessor(
 
     private val flusher = Flusher(flushTimeout, liveIndex)
 
-    private val subscription = log.subscribe(this)
+    private val latestProcessedOffset = latestProcessedMsgId
+    private val subscription = log.subscribe(this, latestProcessedOffset)
 
     override fun processRecords(records: List<Log.Record>) = runBlocking {
         flusher.checkBlockTimeout(liveIndex)?.let { flushMsg ->

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaLog.kt
@@ -143,12 +143,12 @@ class KafkaLog internal constructor(
                 .also { offset -> latestSubmittedOffset0.updateAndGet { it.coerceAtLeast(offset) } }
         }
 
-    override fun subscribe(subscriber: Subscriber): Subscription {
+    override fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
         val job = scope.launch {
             kafkaConfigMap.openConsumer().use { c ->
                 TopicPartition(topic, 0).also { tp ->
                     c.assign(listOf(tp))
-                    c.seek(tp, subscriber.latestProcessedMsgId + 1)
+                    c.seek(tp, latestProcessedOffset + 1)
                 }
 
                 runInterruptible(Dispatchers.IO) {

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogTest.kt
@@ -59,7 +59,7 @@ class KafkaLogTest {
         KafkaLog.kafka(container.bootstrapServers, "test-topic")
             .pollDuration(Duration.ofMillis(100))
             .openLog().use { log ->
-                log.subscribe(subscriber).use { _ ->
+                log.subscribe(subscriber, 0).use { _ ->
                     val txPayload = ByteBuffer.allocate(9).put(-1).putLong(42).flip()
                     log.appendMessage(Message.Tx(txPayload)).await()
 


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions?query=branch%3Alogs-should-use-offsets++

Following our prior changes to replace numerous usages of the offset outside of the log with MsgId - somewhat of the opposite, where Log similarly shouldn't be depending on the LogProcessor/Processed Message Id. Instead - pass in an offset on subscribe, and update that as we go.