### PR TITLE
Re-implment implicit truncating of nano intervals to micro precision in pgwire

### DIFF
--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2047,7 +2047,11 @@ ORDER BY t.oid DESC LIMIT 1"
              (jdbc/execute! conn ["SELECT INTERVAL 'P12MT0S' AS i"])))
 
     (t/is (= [{:i (PGInterval. "P-22MT0S")}]
-             (jdbc/execute! conn ["SELECT INTERVAL 'P-22MT0S' AS i"])))))
+             (jdbc/execute! conn ["SELECT INTERVAL 'P-22MT0S' AS i"])))
+
+    (t/testing "mdn implicitly truncated and returned with micro precision"
+      (t/is (= [{:i (PGInterval. "PT10M10.123456S")}]
+               (jdbc/execute! conn ["SELECT INTERVAL '10:10.123456789' MINUTE TO SECOND(9) i"]))))))
 
 (deftest test-playground
   (with-open [srv (pgwire/open-playground)]


### PR DESCRIPTION
Ensures any existing MDN can still be returned via pgwire, which was the case prior https://github.com/xtdb/xtdb/pull/4310.

May eventually be handling as its own custom type as along with other nano types. See: https://github.com/xtdb/xtdb/issues/4327