### PR TITLE
Add support for round-tripping decimals

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -627,6 +627,7 @@
     (nil? obj) nil
     (boolean? obj) obj
     (int? obj) obj
+    (decimal? obj) obj
 
     ;; I am allowing string pass through for now but be aware data.json escapes unicode and that may not be
     ;; what we want at some point (e.g pass plain utf8 unless prompted as a param).

--- a/core/src/main/java/xtdb/vector/ValueVectorReader.java
+++ b/core/src/main/java/xtdb/vector/ValueVectorReader.java
@@ -7,6 +7,7 @@ import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.DurationVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.IntVector;
@@ -40,6 +41,7 @@ import xtdb.vector.extensions.TransitVector;
 import xtdb.vector.extensions.TsTzRangeVector;
 import xtdb.vector.extensions.UuidVector;
 
+import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -440,6 +442,32 @@ public class ValueVectorReader implements IVectorReader {
             @Override
             public int hashCode0(int idx, Hasher hasher) {
                 return hasher.hash(v.get(idx));
+            }
+        };
+    }
+
+    public static IVectorReader decimalVector(DecimalVector v) {
+        return new ValueVectorReader(v) {
+            @Override
+            public BigDecimal getObject(int idx) {
+                return v.getObject(idx);
+            }
+            @Override
+            public int hashCode0(int idx, Hasher hasher) {
+                return hasher.hash(v.getObject(idx).doubleValue());
+            }
+        };
+    }
+
+    public static IVectorReader decimal256Vector(Decimal256Vector v) {
+        return new ValueVectorReader(v) {
+            @Override
+            public BigDecimal getObject(int idx) {
+                return v.getObject(idx);
+            }
+            @Override
+            public int hashCode0(int idx, Hasher hasher) {
+                return hasher.hash(v.getObject(idx).doubleValue());
             }
         };
     }

--- a/core/src/main/kotlin/xtdb/arrow/Buffers.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Buffers.kt
@@ -5,6 +5,8 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.util.ArrowBufPointer
 import org.apache.arrow.memory.util.hash.ArrowBufHasher
 import org.apache.arrow.vector.BitVectorHelper
+import org.apache.arrow.vector.util.DecimalUtility
+import java.math.BigDecimal
 import java.nio.ByteBuffer
 import kotlin.math.max
 
@@ -125,6 +127,15 @@ internal class ExtensibleBuffer(private val allocator: BufferAllocator, private 
         buf.setBytes(writerIndex, src.buf, start, len)
         buf.writerIndex(writerIndex + len)
     }
+
+    fun writeBigDecimal(value: BigDecimal, byteWidth: Int) {
+        ensureWritable(byteWidth.toLong())
+        DecimalUtility.writeBigDecimalToArrowBuf(value, buf, (buf.writerIndex() / byteWidth).toInt(), byteWidth)
+        buf.writerIndex(buf.writerIndex() + byteWidth)
+    }
+
+    fun readBigDecimal(idx: Int, scale: Int, byteWidth: Int) =
+        DecimalUtility.getBigDecimalFromArrowBuf(buf, idx, scale, byteWidth)
 
     fun getPointer(idx: Int, len: Int, reuse: ArrowBufPointer? = null) =
         (reuse ?: ArrowBufPointer()).apply { set(this@ExtensibleBuffer.buf, idx.toLong(), len.toLong()) }

--- a/core/src/main/kotlin/xtdb/arrow/DecimalVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DecimalVector.kt
@@ -1,0 +1,53 @@
+package xtdb.arrow
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ArrowType.Decimal
+import xtdb.api.query.IKeyFn
+import xtdb.api.query.IKeyFn.KeyFn.KEBAB_CASE_KEYWORD
+import xtdb.arrow.metadata.MetadataFlavour
+import xtdb.util.Hasher
+import java.math.BigDecimal
+
+class DecimalVector private constructor(
+    override var name: String, override var nullable: Boolean, override var valueCount: Int,
+    override val validityBuffer: ExtensibleBuffer, override val dataBuffer: ExtensibleBuffer,
+    private val decimalType : Decimal
+) : FixedWidthVector(), MetadataFlavour.Number {
+
+    private val BIT_WIDTHS = setOf(32, 64, 128, 256)
+    val precision = decimalType.precision
+    val scale = decimalType.scale
+    val bitWidth = decimalType.bitWidth
+
+    init {
+       require(bitWidth in BIT_WIDTHS) { "Invalid bit width for DecimalVector: $bitWidth" }
+    }
+
+    constructor(al: BufferAllocator, name: String, nullable: Boolean, decimalType: Decimal)
+            : this(name, nullable, 0, ExtensibleBuffer(al), ExtensibleBuffer(al), decimalType)
+
+    override val byteWidth = (bitWidth / 8)
+
+    override val type: ArrowType = Decimal(precision, scale, bitWidth)
+
+    override fun getObject0(idx: Int, keyFn: IKeyFn<*>) : BigDecimal =
+       dataBuffer.readBigDecimal(idx, scale, byteWidth)
+
+    override fun writeObject0(value: Any) {
+        if (value is BigDecimal) {
+            if (value.precision() > precision || value.scale() != scale) {
+                throw InvalidWriteObjectException(fieldType, value)
+            }
+            dataBuffer.writeBigDecimal(value, byteWidth)
+            writeNotNull()
+        } else throw InvalidWriteObjectException(fieldType, value)
+    }
+
+    override fun getMetaDouble(idx: Int): Double = getObject0(idx, KEBAB_CASE_KEYWORD).toDouble()
+
+    override fun hashCode0(idx: Int, hasher: Hasher) = hasher.hash(getObject0(idx, KEBAB_CASE_KEYWORD).toDouble())
+
+    override fun openSlice(al: BufferAllocator) =
+        DecimalVector(name, nullable, valueCount, validityBuffer.openSlice(al), dataBuffer.openSlice(al), decimalType)
+}

--- a/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
@@ -37,7 +37,7 @@ sealed class FixedWidthVector : Vector() {
         writeUndefined()
     }
 
-    private fun writeNotNull() = validityBuffer.writeBit(valueCount++, 1)
+    protected fun writeNotNull() = validityBuffer.writeBit(valueCount++, 1)
 
     protected fun getByte0(idx: Int) =
         if (NULL_CHECKS && isNull(idx)) throw NullPointerException("null at index $idx")

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -130,7 +130,7 @@ sealed class Vector : VectorReader, VectorWriter {
                     DOUBLE -> DoubleVector(al, name, isNullable)
                 }
 
-                override fun visit(type: Decimal) = TODO("Not yet implemented")
+                override fun visit(type: Decimal) = DecimalVector(al, name, isNullable, type)
 
                 override fun visit(type: Utf8) = Utf8Vector(al, name, isNullable)
                 override fun visit(type: Utf8View) = TODO("Not yet implemented")

--- a/core/src/main/kotlin/xtdb/pg/codec/NumericBin.kt
+++ b/core/src/main/kotlin/xtdb/pg/codec/NumericBin.kt
@@ -1,0 +1,116 @@
+/**
+ * This file contains code originally released under the Unlicense by [igrishaev/pg2].
+ * Original source: https://github.com/igrishaev/pg2/blob/ad5b1f5dbb7b32f32788101bda66b7a7b1e79020/pg-core/src/java/org/pg/codec/NumericBin.java
+ *
+ * The Unlicense places the original work in the public domain without restrictions.
+ * This version is now distributed under  MPL-2.0 license.
+ */
+@file:JvmName("NumericBin")
+package xtdb.pg.codec
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import java.nio.ByteBuffer
+import java.util.ArrayList
+
+private const val DECIMAL_DIGITS = 4
+private val TEN_THOUSAND = BigInteger("10000")
+
+private const val NUMERIC_POS = 0x0000
+private const val NUMERIC_NEG = 0x4000
+
+fun encode(value: BigDecimal): ByteBuffer {
+    // Number of fractional digits:
+    val fractionDigits = value.scale()
+
+    // Number of Fraction Groups:
+    val fractionGroups = if (fractionDigits > 0) (fractionDigits + 3) / 4 else 0
+
+    val digits = digits(value)
+
+    val bbLen = 8 + (2 * digits.size)
+    val bb = ByteBuffer.allocate(bbLen)
+
+    bb.putShort(digits.size.toShort())
+    bb.putShort((digits.size - fractionGroups - 1).toShort())
+    bb.putShort((if (value.signum() == 1) NUMERIC_POS else NUMERIC_NEG).toShort())
+    bb.putShort(Math.max(fractionDigits, 0).toShort())
+
+    for (pos in digits.indices.reversed()) {
+        val valueToWrite = digits[pos]
+        bb.putShort(valueToWrite.toShort())
+    }
+
+    return bb
+}
+
+fun decode(bb: ByteBuffer): BigDecimal {
+    val digitsNum = bb.short
+
+    if (digitsNum == 0.toShort()) {
+        return BigDecimal.ZERO
+    }
+
+    val weight = bb.short
+    val sign = bb.short
+    val scale = bb.short
+
+    val exp = (weight - digitsNum + 1) * DECIMAL_DIGITS
+
+    var num = BigInteger.ZERO
+
+    for (i in 0 until digitsNum) {
+        val base = TEN_THOUSAND.pow((digitsNum - i - 1).toInt())
+        val digit = BigInteger.valueOf(bb.short.toLong())
+        num = num.add(base.multiply(digit))
+    }
+
+    if (sign.toInt() != NUMERIC_POS) {
+        num = num.negate()
+    }
+
+    return BigDecimal(num)
+        .scaleByPowerOfTen(exp)
+        .setScale(scale.toInt(), RoundingMode.DOWN)
+}
+
+// Inspired by implementation here:
+// https://github.com/PgBulkInsert/PgBulkInsert/blob/master/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/BigDecimalValueHandler.java
+private fun digits(value: BigDecimal): List<Int> {
+    var unscaledValue = value.unscaledValue()
+
+    if (value.signum() == -1) {
+        unscaledValue = unscaledValue.negate()
+    }
+
+    val digits = ArrayList<Int>()
+
+    if (value.scale() > 0) {
+        // The scale needs to be a multiple of 4:
+        val scaleRemainder = value.scale() % 4
+
+        // Scale the first value:
+        if (scaleRemainder != 0) {
+            val result = unscaledValue.divideAndRemainder(BigInteger.TEN.pow(scaleRemainder))
+            val digit = result[1].toInt() * Math.pow(10.0, (DECIMAL_DIGITS - scaleRemainder).toDouble()).toInt()
+            digits.add(digit)
+            unscaledValue = result[0]
+        }
+
+        while (unscaledValue != BigInteger.ZERO) {
+            val result = unscaledValue.divideAndRemainder(TEN_THOUSAND)
+            digits.add(result[1].toInt())
+            unscaledValue = result[0]
+        }
+    } else {
+        var originalValue = unscaledValue.multiply(BigInteger.TEN.pow(Math.abs(value.scale())))
+        while (originalValue != BigInteger.ZERO) {
+            val result = originalValue.divideAndRemainder(TEN_THOUSAND)
+            digits.add(result[1].toInt())
+            originalValue = result[0]
+        }
+    }
+
+    return digits
+}

--- a/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
+++ b/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
@@ -214,13 +214,10 @@ private class TimeNanoVectorWriter(override val vector: TimeNanoVector) : TimeVe
 private val DECIMAL_ERROR_KEY = Keyword.intern("xtdb.error", "decimal-error")
 
 private class DecimalVectorWriter(override val vector: DecimalVector) : ScalarVectorWriter(vector) {
-    @Throws(RuntimeException::class)
     override fun writeObject0(obj: Any) {
         if (obj !is BigDecimal) throw InvalidWriteObjectException(field.fieldType, obj)
         try {
             vector.setSafe(valueCount++, obj.setScale(vector.scale))
-        } catch (e: Exception) {
-            throw RuntimeException(DECIMAL_ERROR_KEY, e.message, emptyMap<Keyword, Any>(), e)
         } catch (e: ArithmeticException) {
             throw RuntimeException(DECIMAL_ERROR_KEY, e.message, emptyMap<Keyword, Any>(), e)
         }

--- a/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
+++ b/core/src/main/kotlin/xtdb/vector/ValueVectorReaders.kt
@@ -16,6 +16,9 @@ object VecToReader : VectorVisitor<IVectorReader, Any?> {
         is Float4Vector -> float4Vector(v)
         is Float8Vector -> float8Vector(v)
 
+        is DecimalVector -> decimalVector(v)
+        is Decimal256Vector -> decimal256Vector(v)
+
         is DateDayVector -> dateDayVector(v)
         is DateMilliVector -> dateMilliVector(v)
 

--- a/core/src/test/kotlin/xtdb/arrow/DecimalVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DecimalVectorTest.kt
@@ -1,0 +1,67 @@
+package xtdb.arrow
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+
+class DecimalVectorTest {
+    private lateinit var allocator: BufferAllocator
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    @Test
+    fun `test DecimalVector`() {
+        DecimalVector(
+            allocator, "dec",
+            true, ArrowType.Decimal(5, 2, 32)
+        ).use { dec ->
+
+            dec.writeObject(BigDecimal("123.45"))
+            dec.writeObject(BigDecimal("789.01"))
+            dec.writeNull()
+
+            assertEquals(3, dec.valueCount)
+            assertEquals(listOf(BigDecimal("123.45"), BigDecimal("789.01"), null), dec.toList())
+
+
+            // precision error
+            assertThrows<InvalidWriteObjectException> {
+                dec.writeObject(BigDecimal("1234567890.01"))
+            }
+
+            // scale error
+            assertThrows<InvalidWriteObjectException> {
+                dec.writeObject(BigDecimal("12.345"))
+            }
+        }
+    }
+
+    @Test
+    fun `test different precisions`() {
+        DecimalVector(
+            allocator, "dec",
+            true, ArrowType.Decimal(32, 2, 128)
+        ).use { dec ->
+
+            dec.writeObject(BigDecimal("0.01"))
+            dec.writeObject(BigDecimal("24580955505371094.01"))
+
+            assertEquals(2, dec.valueCount)
+            assertEquals(listOf(BigDecimal("0.01"), BigDecimal("24580955505371094.01")), dec.toList())
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
@@ -1,6 +1,5 @@
 package xtdb.arrow
 
-import com.google.protobuf.struct
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.SequencedMap
 
 class DenseUnionVectorTest {
     private lateinit var allocator: BufferAllocator

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1351,27 +1351,26 @@
                                           (tu/open-vec "y" [y])])]
               (-> (run-projection rel (list f 'x 'y))
                   (update :res first))))]
-
     ;; standard ops
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '+ (bigdec 1.0) (bigdec 1.0))))
-    (t/is (= {:res 0.0M, :res-type :decimal}
+    (t/is (= {:res 0.0M, :res-type [:decimal 32 1 128]}
              (run-test '- (bigdec 1.0) (bigdec 1.0))))
-    (t/is (= {:res 0.5M, :res-type :decimal}
+    (t/is (= {:res 0.5M, :res-type [:decimal 32 1 128]}
              (run-test '/ (bigdec 1.0) (bigdec 2.0))))
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '* (bigdec 1.0) (bigdec 2.0))))
     (t/is (= {:res false, :res-type :bool}
              (run-test '> (bigdec 1.0) (bigdec 2.0))))
 
     ;; LUB
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '* (byte 1) (bigdec 2.0))))
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '* (short 1) (bigdec 2.0))))
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '* (int 1) (bigdec 2.0))))
-    (t/is (= {:res 2.0M, :res-type :decimal}
+    (t/is (= {:res 2.0M, :res-type [:decimal 32 1 128]}
              (run-test '* (bigdec 2.0) (int 1))))
     (t/is (= {:res true, :res-type :bool}
              (run-test '< (int 1) (bigdec 2.0))))
@@ -1388,16 +1387,22 @@
              (run-test 'log (double 2.0) (bigdec 8.0))))
 
     ;; least + greatest
-    (t/is (= {:res 2.0, :res-type [:union #{:f64 :decimal}]}
-             (run-test 'least (bigdec 3.0) (double 2.0))))
-    (t/is (= {:res 3.0, :res-type [:union #{:f64 :decimal}]}
-             (run-test 'greatest (double 3.0) (bigdec 2.0))))
 
+    (t/is (= {:res 2.0, :res-type [:union #{:f64 [:decimal 32 1 128]}]}
+             (run-test 'least (bigdec 3.0) (double 2.0))))
+    (t/is (= {:res 3.0, :res-type [:union #{:f64 [:decimal 32 1 128]}]}
+             (run-test 'greatest (double 3.0) (bigdec 2.0))))
 
     ;; TODO decide on behaviour
     ;; out of fixed precision range
+    ;; FIXME see #4331, this is not correct
+    (t/is (= {:res 2E+128M, :res-type [:decimal 32 -128 128]}
+             (run-test '+ (bigdec 1E+128M) (bigdec 1E+128M))))
+
+    ;; rounding necessary
     (t/is (thrown? RuntimeException
-                   (run-test '+ (bigdec 1E+19M) (bigdec 1E+19M))))
+                   (run-test '+ (bigdec 1E+1M) (bigdec 1E+64M))))
+
     ;; overflow
     (t/is (thrown? RuntimeException
                    (run-test '+ (bigdec 1E+35M) (bigdec 1E-35M))))

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -443,7 +443,15 @@
               :typnotnull false,
               :typname "_text",
               :typnamespace 2125819141,
-              :typbasetype 0}}
+              :typbasetype 0}
+             {:typtypmod -1,
+              :typnotnull false,
+              :typtype "b",
+              :typbasetype 0,
+              :typnamespace 2125819141,
+              :typname "numeric",
+              :typowner 1376455703,
+              :oid 1700}}
            (set (tu/query-ra '[:scan {:table pg_catalog/pg_type}
                                [oid typname typnamespace typowner typtype typbasetype typnotnull typtypmod]]
                              {:node tu/*node*})))))

--- a/src/test/clojure/xtdb/vector/arrow_generative_test.clj
+++ b/src/test/clojure/xtdb/vector/arrow_generative_test.clj
@@ -29,7 +29,7 @@
                                        #xt.arrow/type :i64
                                        ;; #xt.arrow/type :f32
                                        #xt.arrow/type :f64
-                                       #xt.arrow/type :decimal
+                                       #xt.arrow/type [:decimal 32 1 128]
                                        #xt.arrow/type :utf8
                                        #xt.arrow/type :varbinary
                                        #xt.arrow/type :keyword
@@ -104,7 +104,7 @@
                   #xt.arrow/type :i64 i62-gen
                   ;; #xt.arrow/type :f32 (throw (UnsupportedOperationException.))
                   #xt.arrow/type :f64 (gen/double* {:NaN? false})
-                  #xt.arrow/type :decimal decimal-gen
+                  #xt.arrow/type [:decimal 32 1 128] decimal-gen
                   #xt.arrow/type :utf8 gen/string
                   #xt.arrow/type :varbinary (gen/let [bs gen/bytes] (ByteBuffer/wrap bs))
                   #xt.arrow/type :keyword (gen/one-of [gen/keyword gen/keyword-ns])


### PR DESCRIPTION
This adds support for decimal round-tripping. We now support `[:decimal #{32 64} scale #{128 256}]`. Where the first value is the precision and the last the bit-width. If not specified by the user we default to one of the two and only using  the larger when needed. This also adds the `xtdb.arrow.DecimalVector` implementation.  