### PR TITLE
Using idiomatic XTDB (and also Clojure) in Auctionmark

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -182,7 +182,6 @@
   (^TransactionKey [node, tx-ops tx-opts]
    (xtp/execute-tx node (vec tx-ops) tx-opts)))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn status
   "Returns the status of this node as a map,
   including details of both the latest submitted and completed tx
@@ -194,7 +193,6 @@
   ([node] (xtp/status node))
   ([node opts] (xtp/status node opts)))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro template
   "This macro quotes the given query, but additionally allows you to use Clojure's unquote (`~`) and unquote-splicing (`~@`) forms within the quoted form.
 

--- a/cloud-benchmark/src/main/clojure/xtdb/run_auctionmark/main.clj
+++ b/cloud-benchmark/src/main/clojure/xtdb/run_auctionmark/main.clj
@@ -5,7 +5,7 @@
             [clojure.stacktrace :as st]
             [clojure.tools.logging :as log]
             [xtdb.bench :as b]
-            [xtdb.bench.auctionmark :as am]
+            xtdb.bench.auctionmark
             [xtdb.node :as xtn]
             [xtdb.util :as util])
   (:import [clojure.lang ExceptionInfo]))
@@ -60,9 +60,9 @@
 
 (defn run-load-phase-only [node]
   (let [am-config {:seed 0
-                   :scale-factor scale-factor}
-        load-phase-bench (am/load-phase-only am-config)
-        load-phase-fn (b/compile-benchmark load-phase-bench)]
+                   :scale-factor scale-factor
+                   :only-load? true}
+        load-phase-fn (b/compile-benchmark (b/->benchmark :auctionmark am-config))]
     (log/info "Running Load Phase with the following config... \n" am-config)
     (try
       (binding [b/*registry* (util/component node :xtdb.metrics/registry)]

--- a/modules/bench/src/main/clojure/xtdb/bench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench.clj
@@ -14,12 +14,11 @@
   (:import (com.google.common.collect MinMaxPriorityQueue)
            (io.micrometer.core.instrument Timer)
            (java.lang.management ManagementFactory)
-           (java.time Clock Duration Instant InstantSource)
+           (java.time Clock Duration InstantSource)
            java.time.Duration
            (java.util Comparator Random)
-           (java.util.concurrent ConcurrentHashMap Executors TimeUnit)
+           (java.util.concurrent Executors TimeUnit)
            (java.util.concurrent.atomic AtomicLong)
-           (java.util.function Function)
            (oshi SystemInfo)))
 
 (defn wrap-in-catch [f]
@@ -30,40 +29,31 @@
         (log/error t (str "Error while executing " f))
         (throw t)))))
 
-(defrecord Worker [node random domain-state clock bench-id jvm-id])
+(defrecord Worker [node random clock bench-id jvm-id])
 
-(defn current-timestamp ^Instant [worker]
+(defn current-timestamp ^java.time.Instant [worker]
   (.instant ^Clock (:clock worker)))
 
-(defn counter ^AtomicLong [worker domain]
-  (.computeIfAbsent ^ConcurrentHashMap (:domain-state worker) domain (reify Function (apply [_ _] (AtomicLong.)))))
-
-(defn rng ^Random [worker] (:random worker))
+(defn rng ^java.util.Random [worker] (:random worker))
 
 (defn current-timestamp-ms ^long [worker] (.millis ^Clock (:clock worker)))
 
-(defn increment [worker domain] (domain (.getAndIncrement (counter worker domain))))
+(defn sample-gaussian ^long [worker ^AtomicLong !counter]
+  (let [v (.get !counter)]
+    (-> (long (.nextGaussian (rng worker) (* v 0.5) (/ v 6.0)))
+        (max 0)
+        (min (dec v)))))
 
-(defn set-domain [worker domain cnt] (.getAndAdd (counter worker domain) cnt))
+(defn sample-flat ^long [worker, ^AtomicLong !counter]
+  (let [v (.get !counter)]
+    (when (pos? v)
+      (.nextLong (rng worker) v))))
 
-(defn- nat-or-nil [n] (when (nat-int? n) n))
+(defn inc-count! [^AtomicLong !counter]
+  (.getAndIncrement !counter))
 
-(defn sample-gaussian [worker domain]
-  (let [random (rng worker)
-        long-counter (counter worker domain)]
-    ;; not a real gaussian, we cut of some bits at the tails
-    (some-> (min (dec (.get long-counter)) (max 0 (Math/round (* (.get long-counter) 0.5 (+ 1.0 (.nextGaussian random))))))
-            long
-            nat-or-nil
-            domain)))
-
-(defn sample-flat [worker domain]
-  (let [random (rng worker)
-        long-counter (counter worker domain)]
-    (some-> (min (dec (.get long-counter)) (Math/round (* (.get long-counter) (.nextDouble random))))
-            long
-            nat-or-nil
-            domain)))
+(defn set-count! [^AtomicLong !counter, ^long v]
+  (.set !counter (inc v)))
 
 (defn weighted-sample-fn
   "Aliased random sampler:
@@ -157,10 +147,12 @@
 
 (defn wrap-stage [f {:keys [stage]}]
   (fn instrumented-stage [worker]
+    (log/info "Starting stage:" stage)
     (let [start-ms (System/currentTimeMillis)]
       (f worker)
       (log-report worker {:stage stage,
-                          :time-taken-ms (- (System/currentTimeMillis) start-ms)}))))
+                          :time-taken-ms (- (System/currentTimeMillis) start-ms)})
+      (log/info "Done stage:" stage))))
 
 (defn wrap-transaction [f {:keys [transaction labels]}]
   (let [timer-delay (delay
@@ -206,7 +198,7 @@
                     sleep (if (pos? think-ms) #(Thread/sleep think-ms) (constantly nil))
                     f (compile-task pooled-task)
 
-                    executor (Executors/newFixedThreadPool thread-count (util/->prefix-thread-factory "core2-benchmark"))
+                    executor (Executors/newFixedThreadPool thread-count (util/->prefix-thread-factory "xtdb-benchmark"))
 
                     thread-loop (fn run-pool-thread-loop [worker]
                                   (loop [wait-until (+ (current-timestamp-ms worker) (.toMillis duration))]
@@ -236,7 +228,7 @@
         :concurrently (let [{:keys [^Duration duration, ^Duration join-wait, thread-tasks]} task
                             thread-task-fns (mapv compile-task thread-tasks)
 
-                            executor (Executors/newFixedThreadPool (count thread-tasks) (util/->prefix-thread-factory "core2-benchmark"))
+                            executor (Executors/newFixedThreadPool (count thread-tasks) (util/->prefix-thread-factory "xtdb-benchmark"))
 
                             start-thread (fn [root-worker _i f]
                                            (let [bindings (get-thread-bindings)
@@ -281,10 +273,7 @@
 (defn compile-benchmark [{:keys [title seed ->state], :or {seed 0}, :as benchmark}]
   (let [fns (mapv compile-task (:tasks benchmark))]
     (fn run-benchmark [node]
-      (let [clock (Clock/systemUTC)
-            domain-state (ConcurrentHashMap.)
-            root-random (Random. seed)
-            worker (into (->Worker node root-random domain-state clock (random-uuid) (System/getProperty "user.name"))
+      (let [worker (into (->Worker node (Random. seed) (Clock/systemUTC) (random-uuid) (System/getProperty "user.name"))
                          (cond
                            (vector? ->state) (apply (first ->state) (rest ->state))
                            (fn? ->state) (->state)))

--- a/modules/bench/src/main/clojure/xtdb/bench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench.clj
@@ -255,7 +255,7 @@
                               (throw (ex-info "Task threads did not stop within join-wait" {:task task, :executor executor}))))))
 
         :pick-weighted (let [{:keys [choices]} task
-                             sample-fn (weighted-sample-fn (mapv (fn [[task weight]] [(compile-task task) weight]) choices))]
+                             sample-fn (weighted-sample-fn (mapv (fn [[weight task]] [(compile-task task) weight]) choices))]
                          (if (empty? choices)
                            (constantly nil)
                            (fn run-pick-weighted [worker]

--- a/modules/bench/src/main/clojure/xtdb/bench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench.clj
@@ -30,7 +30,7 @@
         (log/error t (str "Error while executing " f))
         (throw t)))))
 
-(defrecord Worker [sut random domain-state custom-state clock bench-id jvm-id])
+(defrecord Worker [node random domain-state custom-state clock bench-id jvm-id])
 
 (defn current-timestamp ^Instant [worker]
   (.instant ^Clock (:clock worker)))
@@ -280,12 +280,12 @@
 
 (defn compile-benchmark [{:keys [title seed], :or {seed 0}, :as benchmark}]
   (let [fns (mapv compile-task (:tasks benchmark))]
-    (fn run-benchmark [sut]
+    (fn run-benchmark [node]
       (let [clock (Clock/systemUTC)
             domain-state (ConcurrentHashMap.)
             custom-state (ConcurrentHashMap.)
             root-random (Random. seed)
-            worker (->Worker sut root-random domain-state custom-state clock (random-uuid) (System/getProperty "user.name"))
+            worker (->Worker node root-random domain-state custom-state clock (random-uuid) (System/getProperty "user.name"))
             start-ms (System/currentTimeMillis)]
         (doseq [f fns]
           (f worker))
@@ -311,7 +311,7 @@
    (let [doc-seq (remove nil? (repeatedly (long n) (partial f worker)))
          partition-count 512]
      (doseq [batch (partition-all partition-count doc-seq)]
-       (xt/submit-tx (:sut worker) [(into [:put-docs table] batch)])))))
+       (xt/submit-tx (:node worker) [(into [:put-docs table] batch)])))))
 
 (defmulti cli-flags identity
   :default ::default)

--- a/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
@@ -684,24 +684,22 @@
                                       :thread-count threads
                                       :think Duration/ZERO
                                       :pooled-task {:t :pick-weighted
-                                                    :choices [[{:t :call, :transaction :new-user, :f (b/wrap-in-catch proc-new-user)} 5.0]
-                                                              [{:t :call, :transaction :new-item, :f (b/wrap-in-catch proc-new-item)} 10.0]
-                                                              [{:t :call, :transaction :new-bid,  :f (b/wrap-in-catch proc-new-bid)}  18.0]
-                                                              [{:t :call, :transaction :new-comment,
-                                                                :f (b/wrap-in-catch proc-new-comment)}  2.0]
-                                                              [{:t :call, :transaction :new-comment-response,
-                                                                :f (b/wrap-in-catch proc-new-comment-response)}  1.0]
-                                                              [{:t :call, :transaction :new-purchase,
-                                                                :f (b/wrap-in-catch proc-new-purchase)}  2.0]
-                                                              [{:t :call, :transaction :new-feedback,
-                                                                :f (b/wrap-in-catch proc-new-feedback)}  3.0]
-                                                              [{:t :call, :transaction :get-item, :f (b/wrap-in-catch proc-get-item)} 45.0]
-                                                              [{:t :call, :transaction :update-item,
-                                                                :f (b/wrap-in-catch proc-update-item)} 2.0]
-                                                              [{:t :call, :transaction :get-comment,
-                                                                :f (b/wrap-in-catch proc-get-comment)} 2.0]
-                                                              [{:t :call, :transaction :get-user-info,
-                                                                :f (b/wrap-in-catch proc-get-user-info)} 10.0]]}}
+                                                    :choices [[5.0 {:t :call, :transaction :new-user, :f (b/wrap-in-catch proc-new-user)}]
+                                                              [10.0 {:t :call, :transaction :new-item, :f (b/wrap-in-catch proc-new-item)}]
+                                                              [18.0 {:t :call, :transaction :new-bid, :f (b/wrap-in-catch proc-new-bid)}]
+                                                              [2.0 {:t :call, :transaction :new-comment, :f (b/wrap-in-catch proc-new-comment)}]
+                                                              [1.0 {:t :call, :transaction :new-comment-response, :f (b/wrap-in-catch proc-new-comment-response)}]
+                                                              [2.0 {:t :call, :transaction :new-purchase,
+                                                                    :f (b/wrap-in-catch proc-new-purchase)}]
+                                                              [3.0 {:t :call, :transaction :new-feedback,
+                                                                    :f (b/wrap-in-catch proc-new-feedback)}]
+                                                              [45.0 {:t :call, :transaction :get-item, :f (b/wrap-in-catch proc-get-item)}]
+                                                              [2.0 {:t :call, :transaction :update-item,
+                                                                    :f (b/wrap-in-catch proc-update-item)}]
+                                                              [2.0 {:t :call, :transaction :get-comment,
+                                                                    :f (b/wrap-in-catch proc-get-comment)}]
+                                                              [10.0 {:t :call, :transaction :get-user-info,
+                                                                     :f (b/wrap-in-catch proc-get-user-info)}]]}}
                                      {:t :freq-job
                                       :duration duration
                                       :freq (Duration/ofMillis (* 0.2 (.toMillis duration)))

--- a/modules/bench/src/main/clojure/xtdb/bench/products.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/products.clj
@@ -58,21 +58,21 @@
                              [{:t :do
                                :stage :submit-docs
                                :tasks [{:t :call
-                                        :f (fn [{:keys [sut]}]
+                                        :f (fn [{:keys [node]}]
                                              (with-open [is (-> products-file
                                                                 io/input-stream
                                                                 (GZIPInputStream.))]
-                                               (store-documents! sut (cond->> (transit-seq (transit/reader is :msgpack))
-                                                                       limit (take limit)))))}]}])
+                                               (store-documents! node (cond->> (transit-seq (transit/reader is :msgpack))
+                                                                        limit (take limit)))))}]}])
 
                            [{:t :call, :stage :sync
-                             :f (fn [{:keys [sut]}]
-                                  (b/sync-node sut (Duration/ofHours 5)))}
+                             :f (fn [{:keys [node]}]
+                                  (b/sync-node node (Duration/ofHours 5)))}
 
                             {:t :call, :stage :finish-block
-                             :f (fn [{:keys [sut]}]
-                                  (b/finish-block! sut))}
+                             :f (fn [{:keys [node]}]
+                                  (b/finish-block! node))}
 
                             {:t :call, :stage :compact
-                             :f (fn [{:keys [sut]}]
-                                  (b/compact! sut))}])}]})
+                             :f (fn [{:keys [node]}]
+                                  (b/compact! node))}])}]})

--- a/modules/bench/src/main/clojure/xtdb/bench/test_benchmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/test_benchmark.clj
@@ -17,12 +17,12 @@
                        :job-task {:t :call,
                                   :transaction :insert-documents,
                                   :f (bench/wrap-in-catch
-                                      (fn [{:keys [sut] :as worker}]
-                                        (xt/submit-tx sut [(->>
-                                                            (fn [] {:xt/id (rand-int 1000000)
-                                                                    :foo (bench/random-str worker)})
-                                                            (repeatedly 10)
-                                                            (into [:put-docs :docs]))])))}}
+                                      (fn [{:keys [node] :as worker}]
+                                        (xt/submit-tx node [(->>
+                                                             (fn [] {:xt/id (rand-int 1000000)
+                                                                     :foo (bench/random-str worker)})
+                                                             (repeatedly 10)
+                                                             (into [:put-docs :docs]))])))}}
 
                       {:t :freq-job
                        :duration duration
@@ -30,5 +30,5 @@
                        :job-task {:t :call,
                                   :transaction :query-documents,
                                   :f (bench/wrap-in-catch
-                                      (fn [{:keys [sut]}]
-                                        (xt/q sut '(from :docs [xt/id foo]))))}}]}]}))
+                                      (fn [{:keys [node]}]
+                                        (xt/q node '(from :docs [xt/id foo]))))}}]}]}))

--- a/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
@@ -14,9 +14,9 @@
         {::tpch-ra/keys [args]} (meta q)]
     {:t :do, :stage stage-name
      :tasks [{:t :call
-              :f (fn [{:keys [sut]}]
+              :f (fn [{:keys [node]}]
                    (try
-                     (count (tu/query-ra q {:node sut, :args args}))
+                     (count (tu/query-ra q {:node node, :args args}))
                      (catch Exception e
                        (.printStackTrace e))))}]}))
 
@@ -53,17 +53,17 @@
             :tasks (concat (when-not no-load?
                              [{:t :call
                                :stage :submit-docs
-                               :f (fn [{:keys [sut]}] (tpch/submit-docs! sut scale-factor))}])
+                               :f (fn [{:keys [node]}] (tpch/submit-docs! node scale-factor))}])
 
                            [{:t :do
                              :stage :sync
-                             :tasks [{:t :call :f (fn [{:keys [sut]}] (b/sync-node sut (Duration/ofHours 5)))}]}
+                             :tasks [{:t :call :f (fn [{:keys [node]}] (b/sync-node node (Duration/ofHours 5)))}]}
                             {:t :do
                              :stage :finish-block
-                             :tasks [{:t :call :f (fn [{:keys [sut]}] (b/finish-block! sut))}]}
+                             :tasks [{:t :call :f (fn [{:keys [node]}] (b/finish-block! node))}]}
                             {:t :do
                              :stage :compact
-                             :tasks [{:t :call :f (fn [{:keys [sut]}] (b/compact! sut))}]}])}
+                             :tasks [{:t :call :f (fn [{:keys [node]}] (b/compact! node))}]}])}
 
            (queries-stage :cold-queries)
 

--- a/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
@@ -31,16 +31,16 @@
 
                     {:t :call
                      :stage :submit-docs
-                     :f (fn [{:keys [sut custom-state]}]
-                          (tsd/submit-ts-devices sut {:device-info-file (get custom-state :device-info-file)
+                     :f (fn [{:keys [node custom-state]}]
+                          (tsd/submit-ts-devices node {:device-info-file (get custom-state :device-info-file)
                                                       :readings-file (get custom-state :readings-file)}))}
                     {:t :call
                      :stage :sync
-                     :f (fn [{:keys [sut]}] (b/sync-node sut (Duration/ofHours 5)))}
+                     :f (fn [{:keys [node]}] (b/sync-node node (Duration/ofHours 5)))}
 
                     {:t :call
                      :stage :finish-block
-                     :f (fn [{:keys [sut]}] (b/finish-block! sut))}]}]})
+                     :f (fn [{:keys [node]}] (b/finish-block! node))}]}]})
 
 ;; not intended to be run as a test - more for ease of REPL dev
 (t/deftest ^:benchmark run-ts-devices

--- a/src/test/clojure/xtdb/bench/auctionmark_test.clj
+++ b/src/test/clojure/xtdb/bench/auctionmark_test.clj
@@ -213,7 +213,7 @@
 
         (t/is (= [{:ic_id ic_id}]
                  (xt/q *node* '(from :item-comment [ic_id])
-                       {:after-tx-id (am/get-last-tx-id worker), :key-fn :snake-case-keyword})))
+                       {:key-fn :snake-case-keyword})))
 
         (t/is (false? (-> (xt/q *node* '(from :item-comment [{:xt/id "ic_0"} ic_response])
                                 {:key-fn :snake-case-keyword})
@@ -317,16 +317,12 @@
         (am/proc-new-feedback worker)
 
         ;; user 0 is a seller
-        (let [[user-results item-results feedback-results] (am/get-user-info *node* (am/user-id 0) true true true
-                                                                             (am/get-last-tx-id worker))]
-
+        (let [[user-results _item-results _feedback-results] (am/get-user-info *node* (am/user-id 0) {:seller-items? true, :buyer-items? true, :feedback? true})]
           (t/is (= 1 (count user-results)))
           #_(t/is (= 1 (count item-results)))
           #_(t/is (= 1 (count feedback-results))))
 
         ;; user 1 is a buyer
-        (let [[user-results item-results _] (am/get-user-info *node* (am/user-id 1) false true true
-                                                              (am/get-last-tx-id worker))]
-
+        (let [[user-results _item-results _feedback] (am/get-user-info *node* (am/user-id 1) {:seller-items? false, :buyer-items? true, :feedback? true})]
           (t/is (= 1 (count user-results)))
           #_(t/is (= 1 (count item-results))))))))

--- a/src/test/clojure/xtdb/bench/auctionmark_test.clj
+++ b/src/test/clojure/xtdb/bench/auctionmark_test.clj
@@ -5,22 +5,22 @@
             [xtdb.bench.auctionmark :as am]
             [xtdb.test-util :as tu :refer [*node*]])
   (:import (java.time Clock)
-           (java.util Random UUID)
-           (java.util.concurrent ConcurrentHashMap)))
+           (java.util Random UUID)))
 
 (t/use-fixtures :each tu/with-node)
 
 (defn- ->worker [node]
-  (into (b/->Worker node (Random. 112) (ConcurrentHashMap.) (Clock/systemUTC) (random-uuid) (System/getProperty "user.name"))
+  (into (b/->Worker node (Random. 112) (Clock/systemUTC) (random-uuid) (System/getProperty "user.name"))
         (am/->initial-state)))
 
 (deftest generate-user-test
   (let [worker (->worker *node*)]
+    (b/generate worker :region am/generate-region 1)
     (b/generate worker :user am/generate-user 1)
 
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :user [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/user-id 0) (b/sample-flat worker am/user-id)))))
+    (t/is (= 0 (am/random-id worker :users)))))
 
 (deftest generate-categories-test
   (let [worker (->worker *node*)]
@@ -28,7 +28,7 @@
 
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :category [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/category-id 0) (b/sample-flat worker am/category-id)))))
+    (t/is (= 0 (am/random-id worker :categories)))))
 
 (deftest generate-region-test
   (let [worker (->worker *node*)]
@@ -36,7 +36,7 @@
 
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :region [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/region-id 0) (b/sample-flat worker am/region-id)))))
+    (t/is (= 0 (am/random-id worker :regions)))))
 
 (deftest generate-global-attribute-group-test
   (let [worker (->worker *node*)]
@@ -45,7 +45,7 @@
 
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :gag [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/gag-id 0) (b/sample-flat worker am/gag-id)))))
+    (t/is (= 0 (am/random-id worker :gags)))))
 
 (deftest generate-global-attribute-value-test
   (let [worker (->worker *node*)]
@@ -55,189 +55,169 @@
 
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :gav [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/gav-id 0) (b/sample-flat worker am/gav-id)))))
+    (t/is (= 0 (am/random-id worker :gavs)))))
 
 (deftest generate-user-attributes-test
   (let [worker (->worker *node*)]
+    (b/generate worker :region am/generate-region 1)
     (b/generate worker :user am/generate-user 1)
     (b/generate worker :user-attribute am/generate-user-attributes 1)
     (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :user-attribute [])
                                                     (aggregate {:count-id (row-count)}))))))
-    (t/is (= (am/user-attribute-id 0) (b/sample-flat worker am/user-attribute-id)))))
+    (t/is (= 0 (am/random-id worker :user-attributes)))))
 
 (deftest generate-item-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
+      (b/generate worker :region am/generate-region 1)
       (b/generate worker :user am/generate-user 1)
       (b/generate worker :category am/generate-category 1)
       (b/generate worker :item am/generate-item 1)
 
       (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :item [])
                                                       (aggregate {:count-id (row-count)}))))))
-      (t/is (= (UUID. (.getMostSignificantBits ^UUID (am/user-id 0)) (am/item-id 0))
-               (:i_id (am/random-item worker {:status :open}))))
-      (t/is (= (am/user-id 0) (:i_u_id (am/random-item worker {:status :open}))))
+      (t/is (= (UUID. (am/uuid->msb (am/->user-id 0)) 0)
+               (:item-id (am/random-item worker {:status :open}))))
+      (t/is (= (am/->user-id 0) (:seller-id (am/random-item worker {:status :open}))))
 
       (t/testing "item update"
-        (let [{old-description :i-description} (first (xt/q *node* '(from :item [i-description])))
+        (let [{old-description :description} (first (xt/q *node* '(from :item [description])))
               _ (am/proc-update-item worker)
-              {new-description :i-description} (first (xt/q *node* '(from :item [i-description])))]
+              {new-description :description} (first (xt/q *node* '(from :item [description])))]
           (t/is (not= old-description new-description)))))))
 
 (deftest proc-get-item-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
+      (b/generate worker :region am/generate-region 1)
       (b/generate worker :user am/generate-user 1)
       (b/generate worker :category am/generate-category 1)
       (b/generate worker :item am/generate-item 1)
-      ;; to wait for indexing
-      (Thread/sleep 10)
-      (t/is (not (nil? (-> (am/proc-get-item worker) first :i_id)))))))
+      (b/sync-node *node*)
+      (t/is (some? (first (am/proc-get-item worker)))))))
 
 (deftest proc-new-user-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
+      (b/generate worker :region am/generate-region 1)
       (b/generate worker :category am/generate-category 1)
       (am/proc-new-user worker)
 
       (t/is (= {:count-id 1} (first (xt/q *node* '(-> (from :user [])
                                                       (aggregate {:count-id (row-count)}))))))
-      (t/is (= (am/user-id 0) (b/sample-flat worker am/user-id))))))
+      (t/is (= 0 (am/random-id worker :users))))))
 
 (deftest proc-new-bid-test
   (with-redefs [am/sample-status (constantly :open)]
-    (letfn [(number-bids []
-              (-> (xt/q *node* '(from :item [i_num_bids])
-                        {:key-fn :snake-case-keyword})
-                  first :i_num_bids))]
+    (let [worker (->worker *node*)]
+      (t/testing "new bid"
+        (b/generate worker :region am/generate-region 1)
+        (b/generate worker :user am/generate-user 2)
+        (b/generate worker :category am/generate-category 1)
+        (b/generate worker :item am/generate-item 1)
 
-      (let [worker (->worker *node*)]
-        (t/testing "new bid"
-          (b/generate worker :user am/generate-user 2)
-          (b/generate worker :category am/generate-category 1)
-          (b/generate worker :item am/generate-item 1)
+        (am/proc-new-bid worker)
 
+        ;; there exists a bid
+        (t/is (= {:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000000"
+                  :item-id #uuid "d526fcdf-9b10-329b-0000-000000000000"
+                  :bidder-id #uuid "d33def0e-b493-3f91-b88e-b4e784adaf05"}
+                 (first (xt/q *node* '(from :item-bid [xt/id item-id bidder-id])))))
+        ;; new max bid
+        (t/is (= {:item-id #uuid "d526fcdf-9b10-329b-0000-000000000000"
+                  :max-bid-id #uuid "d526fcdf-9b10-329b-0000-000000000000"}
+                 (first (xt/q *node* '(from :item-max-bid [{:xt/id item-id} max-bid-id]))))))
+
+      (t/testing "new bid but does not exceed max"
+        (with-redefs [am/random-price (constantly Double/MIN_VALUE)]
+          (b/generate worker :user am/generate-user 1)
           (am/proc-new-bid worker)
 
-          ;; item has a new bid
-          ;; (t/is (= nil (am/generate-new-bid-params worker)))
-          (t/is (= 1 (number-bids)))
-          ;; there exists a bid
-          (t/is (= {:ib_id #uuid "d33def0e-b493-3f91-0000-000000000000",
-                    :ib_i_id #uuid "d33def0e-b493-3f91-0000-000000000000",
-                    :ib_buyer_id #uuid "d526fcdf-9b10-329b-9482-0f729dbb25f4"}
-                   (first (xt/q *node* '(from :item-bid [ib_id ib_i_id ib_buyer_id])
-                                {:key-fn :snake-case-keyword}))))
-          ;; new max bid
-          (t/is (= {:imb_i_id #uuid "d33def0e-b493-3f91-0000-000000000000",
-                    :imb #uuid "d33def0e-b493-3f91-d33d-ef0eb4933f91"}
-                   (first (xt/q *node*
-                                '(from :item-max-bid [{:xt/id imb}, imb_i_id])
-                                {:key-fn :snake-case-keyword})))))
+          ;; winning bid remains the same
+          (t/is (= {:item-id #uuid "d526fcdf-9b10-329b-0000-000000000000"
+                    :max-bid-id #uuid "d526fcdf-9b10-329b-0000-000000000000"}
+                   (first (xt/q *node* '(from :item-max-bid [{:xt/id item-id} max-bid-id])))))))
 
-        (t/testing "new bid but does not exceed max"
-          (with-redefs [am/random-price (constantly Double/MIN_VALUE)]
-            (b/generate worker :user am/generate-user 1)
-            (am/proc-new-bid worker)
+      (t/testing "new exceeds max bid"
+        (with-redefs [am/random-price (constantly Double/MAX_VALUE)]
+          ;; (b/generate worker :user am/generate-user 1)
+          (am/proc-new-bid worker)
 
-            ;; new bid
-            (t/is (= 2 (number-bids)))
-
-            ;; winning bid remains the same
-            (t/is (= {:imb #uuid "d33def0e-b493-3f91-d33d-ef0eb4933f91",
-                      :imb_ib_id #uuid "d33def0e-b493-3f91-0000-000000000000"}
-                     (first (xt/q *node* '(from :item-max-bid [{:xt/id imb} imb_ib_id])
-                                  {:key-fn :snake-case-keyword}))))))
-
-        (t/testing "new exceeds max bid"
-          (with-redefs [am/random-price (constantly Double/MAX_VALUE)]
-            ;; (b/generate worker :user am/generate-user 1)
-            (am/proc-new-bid worker)
-
-            ;; new bid
-            (t/is (= 3 (number-bids)))
-
-
-            ;; winning bid gets superseded
-            (t/is (= {:imb #uuid "d33def0e-b493-3f91-d33d-ef0eb4933f91",
-                      :imb_ib_id #uuid "d33def0e-b493-3f91-0000-000000000002"}
-                     (first (xt/q *node* '(from :item-max-bid [{:xt/id imb} imb_ib_id])
-                                  {:key-fn :snake-case-keyword}))))))))))
+          ;; winning bid gets superseded
+          (t/is (= {:item-id #uuid "d526fcdf-9b10-329b-0000-000000000000",
+                    :max-bid-id #uuid "d526fcdf-9b10-329b-0000-000000000002"}
+                   (first (xt/q *node* '(from :item-max-bid [{:xt/id item-id} max-bid-id]))))))))))
 
 (deftest proc-new-item-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
-      (t/testing "new item"
-        (b/generate worker :user am/generate-user 1)
-        (b/generate worker :category am/generate-category 10)
-        (b/generate worker :gag am/generate-global-attribute-group 10)
-        (b/generate worker :gav am/generate-global-attribute-value 100)
-        (am/proc-new-item worker)
+      (b/generate worker :region am/generate-region 1)
+      (b/generate worker :user am/generate-user 1)
+      (b/generate worker :category am/generate-category 10)
+      (b/generate worker :gag am/generate-global-attribute-group 10)
+      (b/generate worker :gav am/generate-global-attribute-value 100)
+      (am/proc-new-item worker)
 
-        ;; new item
-        (let [{:keys [i_id i_u_id]} (first (xt/q *node* '(from :item [i_id i_u_id])
-                                                 {:key-fn :snake-case-keyword}))]
-          (t/is (= (UUID. (.getMostSignificantBits ^UUID (am/user-id 0)) (am/item-id 0))
-                   i_id))
-          (t/is (= (am/user-id 0) i_u_id)))
-        (t/is (< (- (:u_balance (first (xt/q *node* '(from :user [u_balance])
-                                             {:key-fn :snake-case-keyword})))
-                    (double -1.0))
-                 0.0001))))))
+      ;; new item
+      (let [{:keys [item-id seller-id]} (first (xt/q *node* '(from :item [{:xt/id item-id} seller-id])))]
+        (t/is (= (UUID. (am/uuid->msb (am/->user-id 0)) 0)
+                 item-id))
+        (t/is (= (am/->user-id 0) seller-id)))
+
+      (t/is (< (- (:balance (first (xt/q *node* '(from :user [balance]))))
+                  (double -1.0))
+               0.0001)))))
 
 (deftest proc-new-comment-and-response-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)
-          ic_id #uuid "d526fcdf-9b10-329b-0000-000000000000"]
-      (t/testing "new comment"
-        (b/generate worker :user am/generate-user 1)
-        (b/generate worker :category am/generate-category 10)
-        (b/generate worker :gag am/generate-global-attribute-group 10)
-        (b/generate worker :gav am/generate-global-attribute-value 100)
-        (b/generate worker :item am/generate-item 1)
+          comment-id #uuid "d526fcdf-9b10-329b-0000-000000000000"]
+      (b/generate worker :region am/generate-region 1)
+      (b/generate worker :user am/generate-user 1)
+      (b/generate worker :category am/generate-category 10)
+      (b/generate worker :gag am/generate-global-attribute-group 10)
+      (b/generate worker :gav am/generate-global-attribute-value 100)
+      (b/generate worker :item am/generate-item 1)
 
-        (am/proc-new-comment worker)
+      (am/proc-new-comment worker)
 
-        (t/is (= [{:ic_id ic_id}]
-                 (xt/q *node* '(from :item-comment [ic_id])
-                       {:key-fn :snake-case-keyword})))
+      (t/is (= [{:comment-id comment-id}]
+               (xt/q *node* '(from :item-comment [{:xt/id comment-id} response])
+                     {:args {:comment-id comment-id}})))
 
-        (t/is (false? (-> (xt/q *node* '(from :item-comment [{:xt/id "ic_0"} ic_response])
-                                {:key-fn :snake-case-keyword})
-                          first
-                          (contains? :ic_response))))
+      (am/proc-new-comment-response worker)
 
-        (am/proc-new-comment-response worker)
-
-        (t/is (true? (-> (xt/q *node* (list 'from :item-comment [{:xt/id ic_id} 'ic_response])
-                               {:key-fn :snake-case-keyword})
-                         first
-                         (contains? :ic_response))))))))
+      (t/is (true? (-> (xt/q *node* '(from :item-comment [{:xt/id comment-id} response])
+                             {:args {:comment-id comment-id}})
+                       first
+                       (contains? :response)))))))
 
 (deftest proc-new-purchase-test
   (with-redefs [am/sample-status (constantly :waiting-for-purchase)]
     (let [worker (->worker *node*)]
       (t/testing "new purchase"
+        (b/generate worker :region am/generate-region 1)
         (b/generate worker :user am/generate-user 1)
         (b/generate worker :category am/generate-category 10)
         (b/generate worker :gag am/generate-global-attribute-group 10)
         (b/generate worker :gav am/generate-global-attribute-value 100)
         (b/generate worker :item am/generate-item 1)
 
-        (t/is (= [{:i-status :waiting-for-purchase}]
-                 (xt/q *node* '(from :item [i_status]))))
+        (t/is (= [{:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000000", :status :waiting-for-purchase}]
+                 (xt/q *node* '(from :item [xt/id status]))))
         (am/proc-new-purchase worker)
 
-        (t/is (= [{:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000000"}]
-                 (xt/q *node* '(from :item-purchase [xt/id]))))
+        (t/is (= [{:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000000", :status :closed}]
+                 (xt/q *node* '(from :item [xt/id status]))))
 
-        (t/is (= [{:i-status :closed}]
-                 (xt/q *node* '(from :item [i_status]))))))))
+        (t/is (= [{:status :closed}]
+                 (xt/q *node* '(from :item [status]))))))))
 
 (deftest proc-new-feedback-test
   (with-redefs [am/sample-status (constantly :closed)]
     (let [worker (->worker *node*)]
       (t/testing "new feedback"
+        (b/generate worker :region am/generate-region 1)
         (b/generate worker :user am/generate-user 1)
         (b/generate worker :category am/generate-category 10)
         (b/generate worker :gag am/generate-global-attribute-group 10)
@@ -252,6 +232,7 @@
 (deftest proc-check-winning-bids-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
+      (b/generate worker :region am/generate-region 1)
       (b/generate worker :user am/generate-user 2)
       (b/generate worker :category am/generate-category 10)
       (b/generate worker :gag am/generate-global-attribute-group 10)
@@ -262,13 +243,16 @@
       (am/proc-check-winning-bids worker)
 
       ;; works as we use a pseudorandom generator
-      (t/is (= [{:xt/id #uuid "d33def0e-b493-3f91-0000-000000000000"}] (xt/q *node* '(from :item [{:i_status :closed} xt/id]))))
-      (t/is (= [{:xt/id #uuid "d33def0e-b493-3f91-0000-000000000001"}] (xt/q *node* '(from :item [{:i_status :waiting-for-purchase} xt/id])))))))
+      (t/is (= [{:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000000"}]
+               (xt/q *node* '(from :item [{:status :closed} xt/id]))))
+      (t/is (= [{:xt/id #uuid "d526fcdf-9b10-329b-0000-000000000001"}]
+               (xt/q *node* '(from :item [{:status :waiting-for-purchase} xt/id])))))))
 
 (deftest proc-get-item-comment-test
   (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
       (t/testing "non-answered-comments"
+        (b/generate worker :region am/generate-region 1)
         (b/generate worker :user am/generate-user 1)
         (b/generate worker :category am/generate-category 10)
         (b/generate worker :gag am/generate-global-attribute-group 10)
@@ -280,8 +264,7 @@
                  (map :xt/id (am/proc-get-comment worker))))))))
 
 (deftest proc-get-user-info
-  (with-redefs [am/sample-status (constantly :open)
-                b/random-bool (constantly true)]
+  (with-redefs [am/sample-status (constantly :open)]
     (let [worker (->worker *node*)]
       (t/testing "non-answered-comments"
         (b/generate worker :region am/generate-region 1)
@@ -293,18 +276,18 @@
 
         (am/proc-new-bid worker)
         (am/proc-check-winning-bids worker)
-        (am/index-item-status-groups worker)
+        (am/index-item-status-groups! worker)
         (am/proc-new-purchase worker)
-        (am/index-item-status-groups worker)
+        (am/index-item-status-groups! worker)
         (am/proc-new-feedback worker)
 
         ;; user 0 is a seller
-        (let [[user-results _item-results _feedback-results] (am/get-user-info *node* (am/user-id 0) {:seller-items? true, :buyer-items? true, :feedback? true})]
+        (let [[user-results _item-results _feedback-results] (am/get-user-info *node* (am/->user-id 0) {:seller-items? true, :buyer-items? true, :feedback? true})]
           (t/is (= 1 (count user-results)))
           #_(t/is (= 1 (count item-results)))
           #_(t/is (= 1 (count feedback-results))))
 
         ;; user 1 is a buyer
-        (let [[user-results _item-results _feedback] (am/get-user-info *node* (am/user-id 1) {:seller-items? false, :buyer-items? true, :feedback? true})]
+        (let [[user-results _item-results _feedback] (am/get-user-info *node* (am/->user-id 1) {:seller-items? false, :buyer-items? true, :feedback? true})]
           (t/is (= 1 (count user-results)))
           #_(t/is (= 1 (count item-results))))))))


### PR DESCRIPTION
This PR iterates on our Auctiomark benchmark to write it as an XTDB user would do. Mainly:

* Sane column names (no more `ib_i_b_u_id` et al :sweat_smile:). I've also distinguished between the different `user_id`s, so we now have `buyer-id`, `seller-id`, `bidder-id`, etc. And kebab-case, because it's written in Clojure.
* Removing `item_purchase` in favour of a nullable field on the `item` table
* Inlined `item_images` in favour of a nested list on `item`.
* Using item-id as the PK on the item-max-bid table given they have a 0..1 relationship, saves creating more surrogate keys than we need
* Drop table prefixes in queries (previously these were required in XT SQL)
* Drop table prefixes in column names (e.g. `users.u_this, users.u_that`)
* Needless let-bound names that were then just put into a map (with a suitably named keyword key)
* Remove `custom-state` and `domain-state` in the bench worker, in favour of the individual benchmarks managing their own state (as opposed to trying to prematurely generalise).
* `sut` -> `node` throughout bench.
* a couple of mischievous `core2` references :laughing: 

Strictly speaking this means we aren't comparable with other databases that use this benchmark, but tbh we haven't been doing that anyway - in practice, we're using it more as a regression/optimisation test between XTDB versions.