### PR TITLE
add `xt.live_tables` and `xt.live_columns` tables for debugging

### DIFF
--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -38,6 +38,8 @@
 
       (liveTable [_ table-name] (.get wms table-name))
 
+      (getLiveTables [_] (keys wms))
+
       AutoCloseable
       (close [_] (util/close wms)))))
 
@@ -126,6 +128,7 @@
             (reify LiveIndex$Watermark
               (getAllColumnFields [_] (update-vals wms #(.getColumnFields ^LiveTable$Watermark %)))
               (liveTable [_ table-name] (.get wms table-name))
+              (getLiveTables [_] (keys wms))
 
               AutoCloseable
               (close [_] (util/close wms)))))

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -3,7 +3,6 @@ package xtdb.indexer
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log.Message
-import xtdb.api.log.Log.Record
 import java.time.Instant
 
 interface LiveIndex : Watermark.Source, AutoCloseable {
@@ -11,6 +10,7 @@ interface LiveIndex : Watermark.Source, AutoCloseable {
     interface Watermark : AutoCloseable {
         val allColumnFields: Map<String, Map<String, Field>>
         fun liveTable(tableName: String): LiveTable.Watermark
+        val liveTables: Iterable<String>
     }
 
     interface Tx : AutoCloseable {
@@ -25,6 +25,7 @@ interface LiveIndex : Watermark.Source, AutoCloseable {
     val latestCompletedBlockTx: TransactionKey?
 
     fun liveTable(name: String): LiveTable
+    val liveTables: Iterable<String>
 
     // N.B. LiveIndex.Watermark and xtdb.indexer.Watermark are different classes
     // there used to be quite a lot of difference between them


### PR DESCRIPTION
Just shows the types present in the live tables, as a debugging aid

* `xt.live_tables` :: schema_name, table_name, row_count
* `xt.live_columns` :: schema_name, table_name, col_name, col_type