### PR TITLE
Support decimals in pgwire and the EE.

### DIFF
--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -470,7 +470,7 @@
     (->field col-name (.getType minor-type) (or nullable? (= col-type :null)))))
 
 (defmethod col-type->field* :decimal [col-name nullable? [_ precision scale bit-width]]
-  (->field col-name (ArrowType$Decimal/createDecimal precision scale bit-width) nullable?))
+  (->field col-name (ArrowType$Decimal/createDecimal precision scale (int bit-width)) nullable?))
 
 (defmethod col-type->field-name :decimal [[type-head precision scale bit-width :as v]]
   (str (name type-head) "-" precision "-" scale "-" bit-width))

--- a/core/src/main/kotlin/xtdb/Types.kt
+++ b/core/src/main/kotlin/xtdb/Types.kt
@@ -4,7 +4,6 @@ package xtdb
 
 import clojure.lang.Keyword
 import com.github.benmanes.caffeine.cache.Caffeine
-import org.apache.arrow.vector.PeriodDuration
 import org.apache.arrow.vector.types.DateUnit
 import org.apache.arrow.vector.types.DateUnit.DAY
 import org.apache.arrow.vector.types.FloatingPointPrecision
@@ -20,7 +19,6 @@ import org.apache.arrow.vector.types.pojo.FieldType
 import xtdb.types.*
 import xtdb.vector.extensions.*
 import java.math.BigDecimal
-import java.math.BigInteger
 import java.net.URI
 import java.nio.ByteBuffer
 import java.time.*
@@ -118,7 +116,7 @@ fun valueToArrowType(obj: Any?) = when (obj) {
             // Java Arrow only supports 128 and 256 bit widths
             in 0..32 -> 32
             in 33..64 -> 64
-            else -> throw IllegalArgumentException("unsupported precision: ${obj.precision()}")
+            else -> throw IllegalArgumentException.createNoKey("Unsupported precision: ${obj.precision()}", emptyMap<String, String>())
         }
         ArrowType.Decimal(precision, obj.scale(), precision * 4)
     }

--- a/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
+++ b/core/src/main/kotlin/xtdb/vector/FieldVectorWriters.kt
@@ -212,14 +212,14 @@ private class TimeNanoVectorWriter(override val vector: TimeNanoVector) : TimeVe
     override fun writeLong(v: Long) = vector.setSafe(valueCount++, v)
 }
 
-private val DECIMAL_ERROR_KEY = Keyword.intern("xtdb.error", "decimal-error")
+val DECIMAL_ERROR_KEY = Keyword.intern("xtdb.error", "decimal-error")
 
 private class DecimalVectorWriter(override val vector: DecimalVector) : ScalarVectorWriter(vector) {
     override fun writeObject0(obj: Any) {
         if (obj !is BigDecimal) throw InvalidWriteObjectException(field.fieldType, obj)
         try {
-            vector.setSafe(valueCount++, obj.setScale(vector.scale))
-        } catch (e: ArithmeticException) {
+            vector.setSafe(valueCount++, obj)
+        } catch (e: UnsupportedOperationException) {
             throw RuntimeException(DECIMAL_ERROR_KEY, e.message, emptyMap<Keyword, Any>(), e)
         }
     }
@@ -231,8 +231,8 @@ private class Decimal256VectorWriter(override val vector: Decimal256Vector) : Sc
     override fun writeObject0(obj: Any) {
         if (obj !is BigDecimal) throw InvalidWriteObjectException(field.fieldType, obj)
         try {
-            vector.setSafe(valueCount++, obj.setScale(vector.scale))
-        } catch (e: ArithmeticException) {
+            vector.setSafe(valueCount++, obj)
+        } catch (e: UnsupportedOperationException) {
             throw RuntimeException(DECIMAL_ERROR_KEY, e.message, emptyMap<Keyword, Any>(), e)
         }
     }

--- a/core/src/test/kotlin/xtdb/arrow/DecimalVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DecimalVectorTest.kt
@@ -64,4 +64,22 @@ class DecimalVectorTest {
             assertEquals(listOf(BigDecimal("0.01"), BigDecimal("24580955505371094.01")), dec.toList())
         }
     }
+
+    @Test
+    fun `test negative scales`() {
+        DecimalVector(
+            allocator, "dec",
+            true, ArrowType.Decimal(32, -2, 128)
+        ).use { dec ->
+
+            dec.writeObject(BigDecimal("1E+2"))
+            dec.writeObject(BigDecimal("2E+2"))
+
+            assertEquals(2, dec.valueCount)
+            assertEquals(-2, (dec.getObject(0) as BigDecimal).scale())
+            assertEquals(listOf(BigDecimal("1E+2"), BigDecimal("2E+2")), dec.toList())
+        }
+    }
+
+
 }

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -8,6 +8,7 @@
             [next.jdbc.optional :as jdbc.optional]
             [next.jdbc.prepare :as jdbc.prep]
             [next.jdbc.result-set :as jdbc.rs]
+            [xtdb.api :as xt]
             [xtdb.client :as xtc]
             [xtdb.indexer :as idx]
             [xtdb.indexer.live-index :as li]
@@ -15,6 +16,7 @@
             [xtdb.logical-plan :as lp]
             [xtdb.next.jdbc :as xt-jdbc]
             [xtdb.node :as xtn]
+            [xtdb.node.impl :as node.impl]
             [xtdb.protocols :as xtp]
             [xtdb.query :as q]
             [xtdb.serde :as serde]
@@ -541,3 +543,11 @@
   (let [name (str (.getFileName path))]
     (when-let [idx (str/last-index-of name ".")]
       (subs name (inc idx)))))
+
+(defn q-sql
+  "Like xtdb.api/q, but also returns the result type."
+  ([node query] (q-sql node query {}))
+  ([node query opts]
+   (let [^PreparedQuery prepared-q (xtp/prepare-sql node query opts)]
+     {:res (xt/q node query opts)
+      :res-type (mapv (juxt #(.getName ^Field %) types/field->col-type) (.columnFields prepared-q))})))


### PR DESCRIPTION
I took the least invasive route to add support. This mainly means:
- The EE is working on standard Java big decimals. The EE now deals specially with the following operations:
   - Unless otherwise specified the precision is 32 if both operands have a precision less than or equal to 32, otherwise a precision of 64 is used.
   - `+` - scale = max of the two operands
   - `-` - scale = max of the two operands
   - `*` - scale = the sum of two operands
   - `/` - scale = `max(6, s1 + s2 + 1)`
        - Decimal devision might create infinite decimal expansion in the result. So we can only try to do something reasonable. Multiple databases like SQL Server and AWS Kinesis Data Analytics use `MAX (6, s1 + p2 +1)`. As we don't have the precision of the divisor at hand, this is not an option. We do something similar but only take the scales into account. We always set a minimum scale of 6 for devision.
        - The standard says:
        If the operator is division and the approximate mathematical result of the operation represented with the precision and scale of the result data type loses one or more leading significant digits after rounding or truncating if necessary, then an exception condition is raised: data exception — numeric value out of range. The choice of whether to round or truncate is implementation-defined.
        - DuckDB actually goes to floats in this case.
   - We use the standard clojure operands like `<`, `<=` etc... and by extension `greatest` and `least` for decimals. 
       - This means an operation on columns with multiple decimal legs (union) will also return a union for the latter ones (`greatest` and `least`).  
   - Operations between a decimal type and a non decimal type follow the standard widening hierarchy mechanics. 
- A Cast like `::DECIMAL(5,2)` gets honoured on disk.
- A Cast like `::DECIMAL(5)` gets honoured on disk with a scale of 0.
- A Cast like `::DECIMAL` gets defaulted to `[:decimal 64 9 256]` (this differs from the spec and likely postgres)
     - The exception to this is if the value you are casting from is already a decimal. In that case the `::DECIMAL` cast is a no-op.
     - The main reason for this quirck is so that a cast (which is actually a type annotation) in the following `["INSERT INTO table RECORDS {_id: 1, data: ?::decimal}" 1.111111111111M]` does not override the scale getting passed in via pgwire.
- There is one kind of "bad case" in the EE for decimal operations. If you add two large decimals at the edges of 32 precision types, you might create a decimal that needs a 64 precision vector. In this case the EE will throw although we support 64 precision in general. 
   
Todo:
- [x] Cleanup the throws to idiomatic EE errors