### PR TITLE
Garbage collector component GCing old blocks.

### DIFF
--- a/core/src/main/clojure/xtdb/garbage_collector.clj
+++ b/core/src/main/clojure/xtdb/garbage_collector.clj
@@ -1,0 +1,26 @@
+(ns xtdb.garbage-collector
+  (:require [integrant.core :as ig]
+            [xtdb.node :as xtn])
+  (:import [xtdb.api Xtdb$Config GarbageCollectorConfig]
+           [xtdb.garbage_collector GarbageCollector]))
+
+(defmethod xtn/apply-config! :xtdb/garbage-collector [^Xtdb$Config config _ {:keys [enabled? blocks-to-keep approx-run-interval]}]
+  (.garbageCollector config
+                     (cond-> (GarbageCollectorConfig.)
+                       enabled? (.enabled enabled?)
+                       blocks-to-keep (.blocksToKeep blocks-to-keep)
+                       approx-run-interval (.approxRunInterval approx-run-interval))))
+
+(defmethod ig/prep-key :xtdb/garbage-collector [_ ^GarbageCollectorConfig config]
+  {:block-catalog (ig/ref :xtdb/block-catalog)
+   :enabled? (.getEnabled config)
+   :blocks-to-keep (.getBlocksToKeep config)
+   :approx-run-interval (.getApproxRunInterval config)})
+
+(defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [block-catalog enabled? blocks-to-keep approx-run-interval]}]
+  (when enabled?
+    (GarbageCollector. block-catalog blocks-to-keep approx-run-interval)))
+
+(defmethod ig/halt-key! :xtdb/garbage-collector [_ ^GarbageCollector gc]
+  (when gc
+    (.close gc)))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -4,6 +4,7 @@
             [xtdb.antlr :as antlr]
             [xtdb.api :as api]
             [xtdb.error :as err]
+            [xtdb.garbage-collector]
             [xtdb.indexer :as idx]
             [xtdb.log :as xt-log]
             [xtdb.metrics :as metrics]
@@ -268,6 +269,7 @@
          :xtdb/log (.getLog opts)
          :xtdb/buffer-pool (.getStorage opts)
          :xtdb.indexer/live-index indexer-cfg
+         :xtdb/garbage-collector (.getGarbageCollector opts)
          :xtdb/modules (.getModules opts)}
         (cond-> srv-config (assoc :xtdb.pgwire/server srv-config)
                 healthz (assoc :xtdb/healthz healthz))

--- a/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
@@ -1,0 +1,17 @@
+@file:UseSerializers(IntWithEnvVarSerde::class, DurationSerde::class)
+package xtdb.api
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.DurationSerde
+import java.time.Duration
+
+@Serializable
+data class GarbageCollectorConfig(
+    var enabled: Boolean = true,
+    var blocksToKeep: Int = 10,
+    var approxRunInterval: Duration = Duration.ofMinutes(10),
+) {
+    fun enabled(enabled: Boolean) = apply { this.enabled = enabled }
+    fun blocksToKeep(blocksToKeep: Int) = apply { this.blocksToKeep = blocksToKeep }
+    fun approxRunInterval(approxRunInterval: Duration) = apply { this.approxRunInterval = approxRunInterval }
+}

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -42,6 +42,7 @@ interface Xtdb : AutoCloseable {
         val indexer: IndexerConfig = IndexerConfig(),
         val compactor: CompactorConfig = CompactorConfig(),
         var authn: Authenticator.Factory = UserTable(),
+        var garbageCollector: GarbageCollectorConfig = GarbageCollectorConfig(),
         var nodeId: String = System.getenv("XTDB_NODE_ID")?: randomUUID().toString().takeWhile { it != '-' }
     ) {
         private val modules: MutableList<XtdbModule.Factory> = mutableListOf()
@@ -63,6 +64,12 @@ interface Xtdb : AutoCloseable {
         @JvmSynthetic
         fun healthz(configure: HealthzConfig.() -> Unit) =
             healthz(HealthzConfig().also(configure))
+
+        fun garbageCollector(garbageCollector: GarbageCollectorConfig) = apply { this.garbageCollector = garbageCollector }
+
+        @JvmSynthetic
+        fun garbageCollector(configure: GarbageCollectorConfig.() -> Unit) = 
+            garbageCollector(GarbageCollectorConfig().also(configure))
 
         fun defaultTz(defaultTz: ZoneId) = apply { this.defaultTz = defaultTz }
 

--- a/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
@@ -1,0 +1,48 @@
+package xtdb.garbage_collector
+
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import xtdb.BufferPool
+import xtdb.api.storage.ObjectStore
+import xtdb.catalog.BlockCatalog
+import xtdb.util.asPath
+import java.io.Closeable
+import java.time.Duration
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+
+private val LOGGER = LoggerFactory.getLogger(GarbageCollector::class.java)
+
+class GarbageCollector(
+    private val blockCatalog: BlockCatalog,
+    private val blocksToKeep: Int,
+    private val approxRunInterval: Duration
+) : Closeable {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    init {
+        LOGGER.info("Starting GarbageCollector with approxRunInterval: $approxRunInterval, blocksToKeep: $blocksToKeep")
+        scope.launch {
+            delay(Random.nextLong(approxRunInterval.toMillis()))
+            while (isActive) {
+                try {
+                    LOGGER.debug("Starting block garbage collection")
+                    blockCatalog.garbageCollectBlocks(blocksToKeep)
+                    LOGGER.debug("Block garbage collection completed")
+                } catch (e: Exception) {
+                    LOGGER.warn("Block garbage collection failed", e)
+                } catch (e: Throwable) {
+                    throw RuntimeException("Error encountered during Block garbage collection: ", e)
+                }
+
+                LOGGER.debug("Next GC run scheduled in ${approxRunInterval.toMillis()}ms")
+                delay(approxRunInterval.toMillis())
+            }
+        }
+    }
+
+    override fun close() {
+        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
+        LOGGER.info("GarbageCollector shut down")
+    }
+}

--- a/src/test/kotlin/xtdb/catalog/BlockCatalogTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockCatalogTest.kt
@@ -1,0 +1,106 @@
+package xtdb.catalog
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import xtdb.BufferPool
+import xtdb.api.storage.Storage
+import xtdb.block.proto.block
+import xtdb.block.proto.txKey
+import xtdb.buffer_pool.LocalBufferPool
+import xtdb.time.InstantUtil.asMicros
+import xtdb.trie.Trie.tablePath
+import xtdb.util.StringUtil.asLexHex
+import xtdb.util.asPath
+import java.nio.ByteBuffer
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BlockCatalogTest {
+    private fun writeBlock(bufferPool: BufferPool, index: Long, tableNames: List<String>, basePaths: List<Path>) {
+        val block = block {
+            blockIndex = index
+            latestCompletedTx = txKey {
+                txId = index
+                systemTime = Instant.now().asMicros
+            }
+            this.tableNames.addAll(tableNames)
+        }
+        val bytes = ByteBuffer.wrap(block.toByteArray())
+        basePaths.forEach { bufferPool.putObject(it.resolve("b${index.asLexHex}.binpb"), bytes.duplicate()) }
+    }
+
+    private fun assertBlockCount(bufferPool: BufferPool, path: Path, expected: Int) {
+        val files = bufferPool.listAllObjects(path).toList()
+        assertEquals(expected, files.size, "Expected $expected block files at $path, but got ${files.size}")
+    }
+
+    @Test
+    fun `garbageCollectBlocks deletes oldest blocks and per-table blocks`(@TempDir tempDir: Path) {
+        val bufferPool: BufferPool = LocalBufferPool(
+            Storage.localStorage(tempDir),
+            Storage.VERSION,
+            RootAllocator(),
+            SimpleMeterRegistry()
+        )
+
+        // Write dummy blocks and table blocks
+        val blocksPath = "blocks".asPath
+        val table1BlockPath = "foo".tablePath.resolve(blocksPath)
+        val table2BlockPath = "bar".tablePath.resolve(blocksPath)
+
+        // Write 10 blocks
+        (1L..10L).forEach { index ->
+            writeBlock(bufferPool, index, listOf("foo", "bar"), listOf(blocksPath, table1BlockPath, table2BlockPath))
+        }
+
+        // Validate 10 files exist for blocks and table blocks
+        assertBlockCount(bufferPool, blocksPath, 10)
+        assertBlockCount(bufferPool, table1BlockPath, 10)
+        assertBlockCount(bufferPool, table2BlockPath, 10)
+
+        // Create BlockCatalog instance
+        val catalog = BlockCatalog(bufferPool)
+
+        // Validate that the latest block is correct
+        val latestBlockIndex = catalog.currentBlockIndex
+        assertEquals(10L, latestBlockIndex)
+
+        // Validate latest completed transaction
+        val latestCompletedTx = catalog.latestCompletedTx
+        assertEquals(10L,latestCompletedTx?.txId)
+
+        // Trigger block GC
+        catalog.garbageCollectBlocks(blocksToKeep = 3)
+
+        // Validate that the oldest blocks are deleted, leaving only the latest 3 blocks
+        assertBlockCount(bufferPool, blocksPath, 3)
+        assertBlockCount(bufferPool, table1BlockPath, 3)
+        assertBlockCount(bufferPool, table2BlockPath, 3)
+
+        // Validate latest block still exists
+        val latestBlockFile = bufferPool.listAllObjects(blocksPath).toList().find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
+        assertNotNull(latestBlockFile, "Expected latest block file to exist after GC, but it was deleted")
+
+        // Attempting to delete the current block should throw an exception
+        assertThrows<IllegalStateException> {
+            catalog.garbageCollectBlocks(blocksToKeep = 0)
+        }
+
+        // Latest block should still exist - in blocks and table blocks
+        assertBlockCount(bufferPool, blocksPath, 1)
+
+        val latestBlockFileAfterGC = bufferPool.listAllObjects(blocksPath).toList().find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
+        val latestTable1BlockFileAfterGC = bufferPool.listAllObjects(table1BlockPath).toList().find { it.key == table1BlockPath.resolve("b${10L.asLexHex}.binpb") }
+        val latestTable2BlockFileAfterGC = bufferPool.listAllObjects(table2BlockPath).toList().find { it.key == table2BlockPath.resolve("b${10L.asLexHex}.binpb") }
+
+        assertNotNull(latestBlockFileAfterGC, "Expected latest block file to exist after GC, but it was deleted")
+        assertNotNull(latestTable1BlockFileAfterGC, "Expected latest table1 block file to exist after GC, but it was deleted")
+        assertNotNull(latestTable2BlockFileAfterGC, "Expected latest table2 block file to exist after GC, but it was deleted")
+    }
+}


### PR DESCRIPTION
Resolves #4307 
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Ablock-garbage-collector++

Adds a separated out configurable "garbage collector" component to XTDB, which:
- Runs a job on a schedule, with some random jitter.
- Calls down to garbage collection logic implemented within block catalog.

Within block catalog, implement functions for garbage collection all but "blocksToKeep" files:
- Deletes old block and table block files, retaining up to a configurable number of files.
- Deletion logic validates that it can NOT delete the latest block. 
- Has a set of tests against it.

In terms of feedback, interested in:
- Anything else we think that we should test here? Is there a useful test we could run against this to see the garbage collection component in operation against a node? 
- Have already moved the garbage collection logic into BlockCatalog itself - should we move anything else? Ie, should table block GC be handled by the table catalog?