### PR TITLE
Roundtripping keywords in next.jdbc

### DIFF
--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -1210,6 +1210,24 @@
                                (.get bb ba)
                                ba))}
 
+   :keyword {:typname "keyword"
+             :col-type :keyword
+             :oid 11111
+             :typsend "keywordsend"
+             :typreceive "keywordrecv"
+             :read-text (fn [_env ba] (read-utf8 ba))
+             :read-binary (fn [_env ba] (read-utf8 ba))
+             :write-text (fn [_env ^IVectorReader rdr idx]
+                           (let [bb (.getBytes rdr idx)
+                                 ba ^bytes (byte-array (.remaining bb))]
+                             (.get bb ba)
+                             ba))
+             :write-binary (fn [_env ^IVectorReader rdr idx]
+                             (let [bb (.getBytes rdr idx)
+                                   ba ^bytes (byte-array (.remaining bb))]
+                               (.get bb ba)
+                               ba))}
+
    :bytea {:typname "bytea"
            :col-type :varbinary
            :oid 17
@@ -1481,6 +1499,7 @@
    :null :text
    :regclass :regclass
    :varbinary :bytea
+   :keyword :keyword
    [:date :day] :date
    [:timestamp-local :micro] :timestamp
    [:timestamp-tz :micro] :timestamptz

--- a/jdbc/src/main/clojure/xtdb/next/jdbc.clj
+++ b/jdbc/src/main/clojure/xtdb/next/jdbc.clj
@@ -98,6 +98,9 @@
 (defmethod <-pg-obj "jsonb" [^PGobject obj]
   (JsonSerde/decode (.getValue obj)))
 
+(defmethod <-pg-obj "keyword" [^PGobject obj]
+  (keyword (.getValue obj)))
+
 (defmethod <-pg-obj :default [^PGobject obj]
   obj)
 


### PR DESCRIPTION
This adds a new oid, which is arbitrary, for keywords. Otherwise (de)serialeses keywords similar to strings. In our custom `next.jdbc` namespace we convert the string to keyword. We are hoping that drivers that are not able to deal with this type will just fall back to text.

Something like the following still doesn't work
```clj
(jdbc/execute! conn ["INSERT INTO docs (_id, foo) VALUES (1, ?)" (types/as-other :bar)])
```