### PR TITLE
fix stack-overflow in the trie-catalog

### DIFF
--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -317,3 +317,11 @@
   ;; (in practice, we always submit L1C after L1H - but this keeps the invariant definition simpler to understand)
   (t/is (= #{"l01-r20200101-b01" "l01-r20200102-b01" "l01-rc-b01"}
            (curr-tries ["l01-r20200101-b01" 5] ["l01-rc-b01" 15] ["l01-r20200102-b01" 5]))))
+
+(t/deftest stack-overflow-exception-creating-tries-4377
+  (t/is (= #{"l01-rc-b3270f"}
+           (apply curr-tries
+                  (concat (for [n (range 10000)]
+                            [(str "l00-rc-b" (util/->lex-hex-string n)) 1])
+                          (for [n (range 10000)]
+                            [(str "l01-rc-b" (util/->lex-hex-string n)) 1]))))))


### PR DESCRIPTION
test case: 10k L0s, followed by 10k L1s. not likely to happen under normal circumstances because the compactor mostly stays up to date - this was observed after b7 migration.

each L1 was updating the L0 trie list by calling `supersede-by-block-idx`, which was creating a map-while thunk none of these thunks were ever being realised, until `current-tries` the `seq` call in map-while then needed to evaluate this chain of calls to determine whether the sequence contained any elements, which is what caused the SOE.

we now evaluate map-while semi-eagerly (until the function returns nil) so that these are not stacked atop each other.