### PR TITLE
XTQL → positional params, `fn`/`#()`, #3969

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -176,7 +176,7 @@
   (prepare-xtql [this query query-opts]
     (let [{:keys [snapshot-time ^long after-tx-id tx-timeout] :as query-opts} (-> query-opts (with-query-opts-defaults this))
           ast (cond
-                (sequential? query) (xtql/parse-query query)
+                (sequential? query) (xtql/parse-query query nil)
                 (instance? XtqlQuery query) query
                 :else (throw (err/illegal-arg :xtdb/unsupported-query-type
                                               {::err/message (format "Unsupported XTQL query type: %s" (type query))})))]

--- a/docs/src/content/docs/reference/main/xtql/queries.adoc
+++ b/docs/src/content/docs/reference/main/xtql/queries.adoc
@@ -6,7 +6,6 @@ XTQL queries consist of composable operators, optionally combined with a pipelin
 
 == Operators
 
-
 * link:#_source_operators[Source operators] are valid at the start of a pipeline, or in isolation.
 * link:#_tail_operators[Tail operators] transform data in a pipeline - they aren't valid as the first operator, because they don't source data, but can appear anywhere else in the pipeline.
 
@@ -28,6 +27,17 @@ Pipelines are optional - queries with just a source operator (i.e. no tails) can
 [source,clojure]
 ----
 (from ...)
+----
+
+[source]
+----
+Query :: (fn [Param*] Pipeline) | Pipeline
+Param :: Symbol
+
+Pipeline :: (-> Source Tail*) | Source
+Source :: From | Rel | Unify
+Tail :: Aggregate | Limit | Offset | OrderBy | Return
+        | Where | With | Without | Unnest
 ----
 
 === Source operators
@@ -213,19 +223,12 @@ These binding specs act as both 'join conditions' (if the logic variables are re
 * The 'join' operator performs an inner, or required, join with the sub-query - if a row from the outer query doesn't match, it won't be returned
 * The 'left-join' operator performs an outer, or optional, join with the sub-query - if a row from the outer query matches, it'll be returned; if it doesn't, it will still be returned, but with null values in the sub-query columns.
 
-Parameters in the sub-query can be fulfilled with the `:args` option - see the link:#_argument_specs[argument specs] section for more details.
+Parameters in the sub-query can be fulfilled by passing a vector of arguments or, if the symbols all match, the arguments may be omitted - see the link:#_argument_specs[argument specs] section for more details.
 
 [source]
 ----
-Join :: (join Query JoinOpts)
-LeftJoin :: (left-join Query JoinOpts)
-
-JoinOpts :: [BindSpec+]
-          | {; required
-             :bind [BindSpec+]
-
-             ; optional
-             :args [ArgSpec+]}
+Join :: (join Subquery [BindSpec+])
+LeftJoin :: (left-join Subquery [BindSpec+])
 ----
 
 [source,clojure]
@@ -360,8 +363,8 @@ Expr :: <defined separately>
 (rel [{:a 1, :b 2}, {:a 3, :b 4}] [a b])
 
 ;; from a parameter
-(xt/q node '(rel $t [a b])
-      {:args {:t [{:a 1, :b 2}, {:a 3, :b 4}]}})
+(xt/q node ['#(rel % [a b])
+            [{:a 1, :b 2}, {:a 3, :b 4}]])
 
 ;; from a value in another document
 ;; assume we have a document {:xt/id <id>, :my-nested-rel [{:a 1, :b 2}, ...]}
@@ -560,8 +563,6 @@ The columns in the returned row will be nested into a map in the outer expressio
   The rows will be nested into an array of maps in the outer expression.
 * The arguments to sub-queries are referred to as parameters in the inner query; no other variables from the outer scope are available in the inner query.
 
-* In Clojure parameter symbols must be prefixed by a `$`; other variables must not start with a `$`.
-
 [source]
 ----
 Expr :: number | "string" | true | false | nil | ObjectExpr
@@ -577,43 +578,33 @@ VectorExpr :: [Expr*]
 MapExpr :: {MapKey Expr, ...}
 MapKey :: keyword
 
-ParamExpr :: '$' symbol
+ParamExpr :: symbol
 VariableExpr :: symbol
 GetFieldExpr :: (. Expr symbol)
 CallExpr :: (symbol Expr*)
 
-SubQueryExpr :: (q Query
-                   {; optional
-                    :args ArgSpec})
-
-ExistsExpr :: (exists Query
-                      {; optional
-                       :args ArgSpec})
-
-PullExpr :: (pull Query
-                  {; optional
-                   :args ArgSpec})
-
-PullManyExpr :: (pull* Query
-                       {; optional
-                        :args ArgSpec})
+SubqueryExpr :: (q Subquery)
+ExistsExpr :: (exists Subquery)
+PullExpr :: (pull Subquery)
+PullManyExpr :: (pull* Subquery)
 ----
 
 The following example retrieves a post together with their author and comments:
 
 [source,clojure]
 ----
-(-> (from :posts [{:xt/id $post-id} post-content author-id])
-    (with {:author (pull (from :authors [{:xt/id $author-id} first-name last-name])
-                         {:args [author-id]})
+(fn [post-id]
+  (-> (from :posts [{:xt/id post-id} post-content author-id])
+      (with {:author (pull (from :authors [{:xt/id author-id} first-name last-name])
+                           {:args [author-id]})
 
-           :comments (pull* (-> (from :comments [{:post-id $post-id} comment posted-at])
-                                (order-by posted-at)
-                                (limit 2)
-                                (return comment))
-                            {:args [{:post-id $post-id}]})})
+             :comments (pull* (-> (from :comments [{:post-id post-id} comment posted-at])
+                                  (order-by posted-at)
+                                  (limit 2)
+                                  (return comment))
+                              {:args [{:post-id post-id}]})})
 
-    (return post-content author comments))
+      (return post-content author comments)))
 
 ;; =>
 
@@ -656,7 +647,13 @@ Expr :: <defined separately>
 [source,clojure]
 ----
 (from :users [{:username "james"} first-name last-name])
-(from :users [{:username $username} first-name last-name])
+
+;; a query that takes one parameter, that we name `username`
+(fn [username]
+  (from :users [{:username username} first-name last-name]))
+
+;; using Clojure's `#()` syntax
+#(from :users [{:username %} first-name last-name])
 
 ;; i.e. `SELECT first_name, last_name FROM users WHERE username = 'james'`
 ;;      `SELECT first_name, last_name FROM users WHERE username = ?`
@@ -666,19 +663,16 @@ Expr :: <defined separately>
 
 Within unify operators, these output names (`first-name`, `last-name` etc.) create 'logic variables' which, if they are re-used within the same unify operator, will add a 'join condition' - see the link:#_unify[unify] operator for more details.
 
-== Argument specs
+== Arguments
 
-Argument specs are used to fulfil parameters in a sub-query (exists, pull, pull-many) or join (and left-join).
+Arguments are used to pass values into a query, both for the query itself and for sub-queries.
+By using parameters, we can create reusable queries that can be re-executed with different values.
 
 Where link:#_binding_specs[bindings] specify how to join the *output* of the sub-query/join to the outer query, arguments specify the *inputs* to the sub-query/join from the outer query.
 
-This is commonly used in 'pull' queries and all other link:#_subqueries[Subqueries]:
-
 [source]
 ----
-ArgSpec :: ArgVariable | {Parameter Expr, ...}
-ArgVariable :: symbol
-Parameter :: keyword
+Subquery :: [ Query Expr* ] | Query
 Expr :: <defined separately>
 ----
 
@@ -686,11 +680,22 @@ Expr :: <defined separately>
 ----
 ;; find the most recent 5 posts and, for each, their most recent 3 comments
 
-;; in this query, the `post-id` argument fulfils the `$post-id` parameter in the sub-query
 (-> (from :posts [{:xt/id post-id} ...])
-    (with {:comments (pull* (-> (from :comments [{:post-id $post-id} comment commented-at])
-                                (limit 3))
-                            {:args [post-id]})}))
+    (with {:comments (pull* [(fn [post-id]
+                               (-> (from :comments [{:post-id post-id} comment commented-at])
+                                   (limit 3)))
+
+                             post-id])}))
+
+;; in this query, the `post-id` argument is referenced as `post-id` in the sub-query
+
+;; given the variable has the same name in the outer and inner query,
+;; we can omit the application vector
+
+(-> (from :posts [{:xt/id post-id} ...])
+    (with {:comments (pull* (fn [post-id]
+                              (-> (from :comments [{:post-id post-id} comment commented-at])
+                                  (limit 3))))}))
 ----
 
 As well as 'pull', this is quite commonly used in left joins, because we don't want to filter out rows that don't match (which would happen if the `<>` here was in the outer unify).
@@ -701,14 +706,25 @@ Instead, we want to preserve them, albeit without values for the columns in the 
 ----
 ;; find everybody and, for those who have them, their siblings
 
-;; in this query, the `person` argument fulfils the `$person` parameter in the sub-query;
-;; `sibling` and `parent` (in `bind`) are joined on the way out.
+(-> (unify (from :people [{:xt/id person, :parent parent}])
+           (left-join [(fn [person]
+                         (-> (from :people [{:xt/id sibling, :parent parent}])
+                             (where (<> person sibling))))
+                        person]
+                      [sibling parent]))
+    (return person sibling))
+
+;; in this query, the `person` argument is referenced as `person` in the sub-query;
+;; `sibling` and `parent` are joined on the way out.
+
+;; again, given the variable has the same name in the outer and inner query,
+;; we can omit the application vector
 
 (-> (unify (from :people [{:xt/id person, :parent parent}])
-           (left-join (-> (from :people [{:xt/id sibling, :parent parent}])
-                          (where (<> $person sibling)))
-                      {:args [person]
-                       :bind [sibling parent]}))
+           (left-join (fn [person]
+                        (-> (from :people [{:xt/id sibling, :parent parent}])
+                            (where (<> person sibling))))
+                      [sibling parent]))
     (return person sibling))
 ----
 
@@ -722,13 +738,10 @@ requires that the node has indexed _at least_ the specified transaction.
   This is so that, by default, transactions submitted to a client are guaranteed to be visible to any later query to that same client.
 * If submitting transactions and queries to different clients (e.g. via a non-sticky load-balancer), it is the user's responsibility to pass the transaction token returned from `submit-tx` as the `after-tx-id` for subsequent queries to guarantee this same read-after-write consistency level.
 * If the requested transaction hasn't been indexed, the XTDB client will wait (see `tx-timeout`) before evaluating the query.
-`args`::
-a map of arguments to pass to the query. Parameters are prefixed with `$` in the query itself:
 +
 [source,clojure]
 ----
-(xt/q node '(from :users [{:username $username}])
-      {:args {:username "james"}})
+(xt/q node ['#(from :users [{:username %}]) "james"])
 ----
 `snapshot-time`:: specifies the latest system-time that'll be visible to the query.
 +

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -161,10 +161,6 @@
   (xt/submit-tx *node* devs)
 
   (t/is (= #{{:name "James"} {:name "Matt"}}
-           (set (xt/q *node* "SELECT u.name FROM users u WHERE u.name IN (?, ?)"
-                      {:args ["James" "Matt"]}))))
-
-  (t/is (= #{{:name "James"} {:name "Matt"}}
            (set (xt/q *node* ["SELECT u.name FROM users u WHERE u.name IN (?, ?)"
                               "James" "Matt"])))))
 
@@ -375,7 +371,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id :petr :name "Petr"}]])
 
   (t/is (= [{:name "Petr"}]
-           (xt/q tu/*node* '(from :docs [{:xt/id $petr} name]) {:args {:petr :petr}}))))
+           (xt/q tu/*node* ['#(from :docs [{:xt/id %} name]) :petr]))))
 
 (t/deftest test-close-node-multiple-times
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id :petr :name "Petr"}]])
@@ -468,10 +464,10 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
  [name age _valid_from _valid_to]
  [:scan
   {:table public/people, :for-valid-time nil, :for-system-time nil}
-  [{_id (= _id ?pid)} name age _valid_from _valid_to]]]
+  [{_id (= _id ?_0)} name age _valid_from _valid_to]]]
 "}]
            (xt/q tu/*node*
-                 '(from :people [{:xt/id $pid} name age xt/valid-from xt/valid-to])
+                 ['#(from :people [{:xt/id %} name age xt/valid-from xt/valid-to])]
                  {:explain? true})))
 
   (t/is (= '[{:plan

--- a/src/test/clojure/xtdb/bench/auctionmark_test.clj
+++ b/src/test/clojure/xtdb/bench/auctionmark_test.clj
@@ -181,14 +181,14 @@
 
       (am/proc-new-comment worker)
 
-      (t/is (= [{:comment-id comment-id}]
-               (xt/q *node* '(from :item-comment [{:xt/id comment-id} response])
-                     {:args {:comment-id comment-id}})))
+      (t/is (= [{}]
+               (xt/q *node* ['#(from :item-comment [{:xt/id %} response])
+                             comment-id])))
 
       (am/proc-new-comment-response worker)
 
-      (t/is (true? (-> (xt/q *node* '(from :item-comment [{:xt/id comment-id} response])
-                             {:args {:comment-id comment-id}})
+      (t/is (true? (-> (xt/q *node* ['#(from :item-comment [{:xt/id %} response])
+                                     comment-id])
                        first
                        (contains? :response)))))))
 

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -26,8 +26,7 @@
                   ["claire", "Claire", #inst "2019"]]])
 
   (t/is (= [{:name "Dave"}]
-           (xt/q tu/*node* "SELECT users.name FROM users WHERE users._id = ?"
-                 {:args ["dave"]}))
+           (xt/q tu/*node* ["SELECT users.name FROM users WHERE users._id = ?" "dave"]))
         "#310"))
 
 (deftest test-bloom-filter-for-num-types-2133

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -399,16 +399,13 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
     (t/is (= [{:committed? false}]
              (xt/q tu/*node*
-                   '(from :xt/txs [{:xt/id $tx-id, :committed committed?}])
-                   {:args {:tx-id 1}})))
+                   ['#(from :xt/txs [{:xt/id %, :committed committed?}]) 1])))
 
     (t/is (thrown-with-msg?
            RuntimeException
            #"Assert failed"
 
-           (throw (-> (xt/q tu/*node*
-                            '(from :xt/txs [{:xt/id $tx-id, :error err}])
-                            {:args {:tx-id 3}})
+           (throw (-> (xt/q tu/*node* ['#(from :xt/txs [{:xt/id %, :error err}]) 3])
                       first
                       :err))))))
 
@@ -426,8 +423,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
     (t/is (= [{:committed? false}]
              (xt/q tu/*node*
-                   '(from :xt/txs [{:xt/id $tx-id, :committed committed?}])
-                   {:args {:tx-id 0}})))))
+                   ['#(from :xt/txs [{:xt/id %, :committed committed?}]) 0])))))
 
 (t/deftest test-nulling-valid-time-columns-2504
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO docs (_id, _valid_from, _valid_to) VALUES (1, NULL, ?), (2, ?, NULL), (3, NULL, NULL)"

--- a/src/test/clojure/xtdb/operator/group_by_test.clj
+++ b/src/test/clojure/xtdb/operator/group_by_test.clj
@@ -491,21 +491,21 @@
               {:id 2 :a 3}]]
 
     (t/is (= [{:id 1, :a 1} {:id 2, :a 5}]
-             (xt/q tu/*node* '(-> (rel $data [id a])
-                                  (aggregate id {:a (sum a)}))
-                   {:args {:data data}}))
+             (xt/q tu/*node* ['#(-> (rel % [id a])
+                                    (aggregate id {:a (sum a)}))
+                              data]))
           "no default provided")
 
     (t/is (= [{:id 1, :a 3} {:id 2, :a 5}]
-             (xt/q tu/*node* '(-> (rel $data [id a])
-                                  (with {:a (coalesce a 2)})
-                                  (aggregate id {:a (sum a)}))
-                   {:args {:data data}}))
+             (xt/q tu/*node* ['#(-> (rel % [id a])
+                                    (with {:a (coalesce a 2)})
+                                    (aggregate id {:a (sum a)}))
+                              data]))
           "default provided with `coalesce`")
 
     (t/is (= [{:id 1, :a 6} {:id 2, :a 5}]
-             (xt/q tu/*node* '(-> (rel $data [id a])
-                                  (with {:a (if a a 5)})
-                                  (aggregate id {:a (sum a)}))
-                   {:args {:data data}}))
+             (xt/q tu/*node* ['#(-> (rel % [id a])
+                                    (with {:a (if a a 5)})
+                                    (aggregate id {:a (sum a)}))
+                              data]))
           "default provided with `if` (which mentions `absent` values)")))

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -231,22 +231,24 @@
   (t/is (= [{:intersection
              #xt/tstz-range [#xt/zoned-date-time "2021-01-01T00:00Z"
                              #xt/zoned-date-time "2022-01-01T00:00Z"]}]
-           (xt/q tu/*node* "SELECT PERIOD(?, ?) * PERIOD(?, ?) AS intersection"
-                 {:args [(time/->zdt #inst "2020-01-01")
-                         (time/->zdt #inst "2022-01-01")
-                         (time/->zdt #inst "2021-01-01")
-                         (time/->zdt #inst "2023-01-01")]})))
+           (xt/q tu/*node* ["SELECT PERIOD(?, ?) * PERIOD(?, ?) AS intersection"
+
+                            (time/->zdt #inst "2020-01-01")
+                            (time/->zdt #inst "2022-01-01")
+                            (time/->zdt #inst "2021-01-01")
+                            (time/->zdt #inst "2023-01-01")])))
 
   (t/is (= [{:variadic
              #xt/tstz-range [#xt/zoned-date-time "2022-01-01T00:00Z"
                              #xt/zoned-date-time "2024-01-01T00:00Z"]}]
-           (xt/q tu/*node* "SELECT PERIOD(?, ?) * PERIOD(?, ?) * PERIOD(?, ?) AS variadic"
-                 {:args [(time/->zdt #inst "2020-01-01")
-                         (time/->zdt #inst "2024-01-01")
-                         (time/->zdt #inst "2021-01-01")
-                         (time/->zdt #inst "2025-01-01")
-                         (time/->zdt #inst "2022-01-01")
-                         (time/->zdt #inst "2026-01-01")]}))
+           (xt/q tu/*node* ["SELECT PERIOD(?, ?) * PERIOD(?, ?) * PERIOD(?, ?) AS variadic"
+
+                            (time/->zdt #inst "2020-01-01")
+                            (time/->zdt #inst "2024-01-01")
+                            (time/->zdt #inst "2021-01-01")
+                            (time/->zdt #inst "2025-01-01")
+                            (time/->zdt #inst "2022-01-01")
+                            (time/->zdt #inst "2026-01-01")]))
         "variadic")
 
   (xt/submit-tx tu/*node* [[:put-docs :foo {:xt/id 1}]])
@@ -263,9 +265,9 @@
            (xt/q tu/*node* "SELECT _id, _valid_time FROM bar FOR ALL VALID_TIME")))
 
   (t/is (= [{:xt/id 1,
-            :intersection
-            #xt/tstz-range [#xt/zoned-date-time "2020-01-02T00:00:00Z"
-                            #xt/zoned-date-time "2020-01-03T00:00:00Z"]}]
+             :intersection
+             #xt/tstz-range [#xt/zoned-date-time "2020-01-02T00:00:00Z"
+                             #xt/zoned-date-time "2020-01-03T00:00:00Z"]}]
            (xt/q tu/*node* "SETTING DEFAULT VALID_TIME ALL
                             SELECT _id, foo._valid_time * bar._valid_time AS intersection
                             FROM foo JOIN bar USING (_id)

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2862,8 +2862,8 @@ UNION ALL
   (t/is (= [{:mdm #xt/interval "P1DT1.123456S",
              :mdn [#xt/interval "P1DT1.123456789S"],
              :mdm-literal #xt/interval "P1DT1.123456S"}]
-           (xt/q tu/*node* "SELECT ? mdm, ? mdn, INTERVAL 'P1DT1.123456S' mdm_literal"
-                 {:args [#xt/interval "P1DT1.123456S" [#xt/interval "P1DT1.123456789S"]]}))))
+           (xt/q tu/*node* ["SELECT ? mdm, ? mdn, INTERVAL 'P1DT1.123456S' mdm_literal"
+                            #xt/interval "P1DT1.123456S" [#xt/interval "P1DT1.123456789S"]]))))
 
 (defn- compare-decimals [^BigDecimal d1 ^BigDecimal d2]
   (and (= (.scale d1) (.scale d2))

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -113,9 +113,8 @@
 (defn test-xtql-query [n expected-res]
   (let [q (inc n)]
     (when (contains? *xtql-qs* q)
-      (let [query @(nth tpch-xtql/queries n)
-            {::tpch-xtql/keys [args]} (meta query)]
-        (t/is (is-equal? expected-res (xt/q *node* query {:args args, :key-fn :snake-case-keyword}))
+      (let [query+args @(nth tpch-xtql/queries n)]
+        (t/is (is-equal? expected-res (xt/q *node* query+args {:key-fn :snake-case-keyword}))
               (format "Q%02d" (inc n)))))))
 
 (t/deftest test-001-xtql


### PR DESCRIPTION
resolves #3969 - see that card for the motivation.

XTQL parameters are now positional at the top-level, and within subqueries:

```clojure
;; before:
(xt/q node (-> (from :foo [{:xt/id $foo-id}]) ...) {:args {:foo 1}})

;; now:

(xt/q node ['(fn [foo-id]
               (-> (from :foo [{:xt/id foo-id}]))) 
            1])

;; or, using Clojure's `#()` syntax (which pretty much Just Works™ given the example before)

(xt/q node ['#(-> (from :foo [{:xt/id %}]) ...) 1]
```

* in `xt/q` and friends, we now submit args in next.jdbc style (rather than `:args` in the option map):

  ```clojure
  (xt/q node ['(fn [arg1 arg2] ...) arg1-value arg2-value])
  ```

  This was already supported for SQL (but the user could choose to send via `:args`) - it's now required for both SQL and XTQL.
* In sub-queries and joins/left-joins, we follow a similar pattern:

  ```clojure
  (xt/q node (-> (from ...)
                 (where (exists? [(fn [a]
                                    (from ...))
                                  a]))))
  ```
* In a sub-query where all the variables match the param names, the vector application can be elided
  ```clojure
  (xt/q node (-> (from ...)
                 (where (exists? (fn [a]
                                   (from ...))))))
  ```