### PR TITLE
ability to inline XTQL in SQL using dollar-quoted strings

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -709,6 +709,7 @@ queryTerm
     | tableValueConstructor # ValuesQuery
     | recordsValueConstructor # RecordsQuery
     | '(' queryExpressionNoWith ')' # WrappedQuery
+    | 'XTQL' characterString # XtqlQuery
     | queryTerm 'INTERSECT' (ALL | DISTINCT)? queryTerm # IntersectQuery
     ;
 

--- a/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
+++ b/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
@@ -381,6 +381,7 @@ WINDOW : 'WINDOW' ;
 WITH : 'WITH' ;
 WITHOUT : 'WITHOUT' ;
 WRITE : 'WRITE' ;
+XTQL : 'XTQL' ;
 YEAR : 'YEAR' ;
 ZONE : 'ZONE' ;
 

--- a/core/src/main/clojure/xtdb/xtql/plan.clj
+++ b/core/src/main/clojure/xtdb/xtql/plan.clj
@@ -887,10 +887,13 @@
     {:ra-plan [:top {:skip offset} ra-plan]
      :provided-vars provided-vars}))
 
-(defn compile-query [query {:keys [table-info]}]
-  (let [{:keys [ra-plan]} (binding [*gensym* (util/seeded-gensym "_" 0)
-                                    *table-info* table-info]
-                            (plan-query query))]
+(defn compile-query* [query {:keys [table-info]}]
+  (binding [*gensym* (util/seeded-gensym "_" 0)
+            *table-info* table-info]
+    (plan-query query)))
+
+(defn compile-query [query opts]
+  (let [{:keys [ra-plan]} (compile-query* query opts)]
 
     (-> ra-plan
         #_(doto clojure.pprint/pprint)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -163,7 +163,7 @@ export default defineConfig({
                     ]
                 },
                 {
-                    label: 'XTQL (Clojure)',
+                    label: 'XTQL',
                     collapsed: true,
                     items: [
                         'xtql/tutorials/introducing-xtql',
@@ -188,7 +188,7 @@ export default defineConfig({
                         { label: 'Mission', link: '/intro/why-xtdb' },
                         { label: 'XTDB at a glance', link: '/intro/what-is-xtdb' },
                         { label: 'Key Concepts', link: '/concepts/key-concepts' },
-			{ label: 'How XTDB works', link: '/intro/data-model' },
+			            { label: 'How XTDB works', link: '/intro/data-model' },
                         // { label: 'Bitemporality', link: '/intro/bitemporality' }
 
                         { label: 'Community', link: '/intro/community' },

--- a/docs/src/content/docs/reference/main/sql/queries.adoc
+++ b/docs/src/content/docs/reference/main/sql/queries.adoc
@@ -66,10 +66,11 @@ const colNames = rr.Sequence("(", rr.OneOrMore("<column name>", ","), ")")
 const doc = rr.Sequence("(", rr.OneOrMore("<value>", ","), ")")
 const docs = rr.OneOrMore(doc, ",")
 const values = rr.Sequence("VALUES", docs)
+const xtql = rr.Sequence("XTQL", "<XTQL query>")
 
 const allOrDistinct = rr.Choice(0, rr.Skip(), "ALL", "DISTINCT")
 const binary = rr.Sequence("<query term>", rr.Choice(0, "UNION", "INTERSECT", "EXCEPT"), allOrDistinct, "<query term>")
-return rr.Diagram(rr.Choice(0, selectFirst, fromFirst, values, binary, rr.Sequence("(", "<query term>", ")")));
+return rr.Diagram(rr.Choice(0, selectFirst, fromFirst, values, xtql, binary, rr.Sequence("(", "<query term>", ")")));
 ----
 
 NB:
@@ -80,6 +81,10 @@ NB:
 * If you start your query with `FROM`, you may then include arbitrarily many sets of `WHERE`/`GROUP BY`/`SELECT` clauses, which will be evaluated in order.
 * Predicates can be comma-separated in XTDB, to aid with SQL generation - these are treated as conjuncts.
   There may be an arbitrary number of commas at the start, between any two predicate expressions, or at the end.
+* XTQL queries are sent within an SQL string literal - e.g. `+'(-> (from ...) ...)'+`.
+Given the possible presence of single quotes within the query, it is recommended to use dollar-delimited strings here: `XTQL &dollar;&dollar; <xtql query> &dollar;&dollar;`
++
+For more details on XTQL queries, see the link:/xtql/tutorials/introducing-xtql[XTQL documentation].
 
 === <select clause>
 [railroad]
@@ -128,13 +133,21 @@ const join = rr.Sequence("<relation>", joinType, "JOIN", "<relation>", rr.Choice
 const crossJoin = rr.Sequence("<relation>", "CROSS", "JOIN", "<relation>")
 const naturalJoin = rr.Sequence("<relation>", "NATURAL", joinType, "JOIN", "<relation>")
 
+const colNames = rr.Sequence("(", rr.OneOrMore("<column name>", ","), ")")
+const doc = rr.Sequence("(", rr.OneOrMore("<value>", ","), ")")
+const docs = rr.OneOrMore(doc, ",")
+const values = rr.Sequence("VALUES", docs)
+
+const xtql = rr.Sequence("XTQL", "<XTQL query>")
 const subquery = rr.Sequence("(", "<query>", ")")
 const lateral = rr.Sequence("LATERAL", subquery)
 const unnest = rr.Sequence("UNNEST", "(", "<value>", ")", rr.Optional(rr.Sequence("WITH", "ORDINALITY"), "skip"))
-const subqs = rr.Sequence(rr.Choice(0, subquery, lateral, unnest), tableAlias)
+const subqs = rr.Sequence(rr.Choice(0, values, xtql, subquery, lateral, unnest), tableAlias)
 
 return rr.Diagram(rr.Choice(0, wrapped, base, join, crossJoin, naturalJoin, subqs))
 ----
+
+* See link:#_query_term[<query term>] for details on XTQL queries.
 
 === <temporal filter>
 [railroad]
@@ -198,7 +211,7 @@ return rr.Diagram(rr.Choice(0, objectBraceConstructor, objectFnConstructor))
 === <literal>
 [railroad]
 ----
-const stringLiteral = rr.Choice(0, rr.Sequence("'", "<SQL-style string>", "'"), rr.Sequence("E'", "<C-style string>", "'"))
+const stringLiteral = rr.Choice(0, rr.Sequence("'", "<SQL-style string>", "'"), rr.Sequence('$$', '<string>', '$$'), rr.Sequence("E'", "<C-style string>", "'"))
 
 const dateLiteral = rr.Sequence("DATE", "'", "<ISO8601 date literal>", "'")
 const timeLiteral = rr.Sequence("TIME", "'", "<ISO8601 time literal>", "'")

--- a/docs/src/content/docs/xtql/tutorials/introducing-xtql.adoc
+++ b/docs/src/content/docs/xtql/tutorials/introducing-xtql.adoc
@@ -5,15 +5,41 @@ title: Introducing XTQL
 :test: ../src/test/clojure/xtdb/docs/xtql_walkthrough_test.clj
 :example: ../src/test/resources/docs/xtql_tutorial_examples.yaml
 
-In Clojure, XTDB is queryable using two query languages: **SQL** and **XTQL**.
+XTDB is queryable using two query languages: **SQL** and **XTQL**.
 
-XTQL is our new, data-oriented, composable query language, inspired by the strong theoretical bases of both **Datalog** and **relational algebra**.
-These two combine to create a joyful, productive, interactive development experience, with the ability to build queries iteratively, testing and debugging smaller parts in isolation.
+XTQL is our new, data-oriented, composable query language:
 
+* It is inspired by the strong theoretical bases of both **Datalog** and **relational algebra**.
+  These two combine to create a joyful, productive, interactive development experience, with the ability to build queries iteratively, testing and debugging smaller parts in isolation.
 * It is designed to be highly amenable to dynamic query generation - we believe that our industry has spent more than enough time trying to generate SQL strings (not to mention the concomitant https://owasp.org/www-community/attacks/SQL_Injection[security vulnerabilities^]).
-* It can be used for both link:#operators_and_relations[queries] and link:#dml[transactions].
 
-Let's start with XTQL queries:
+== Querying XTQL
+
+XTQL can either be queried within an SQL query, or via the Clojure API.
+
+To query XTQL within a SQL query, you can either execute it:
+
+* as a top-level query (like SQL's `VALUES`): `XTQL &dollar;&dollar; <query> &dollar;&dollar;`:
++
+[source,sql]
+----
+XTQL $$
+  (-> (from :users [first-name last-name])
+      ...)
+$$
+----
+* or within a wider SQL query:
++
+[source,sql]
+----
+SELECT ...
+FROM (XTQL $$
+  (-> (from :users [first-name last-name])
+      ...)
+$$) u
+ORDER BY u.last_name DESC, u.first_name DESC
+LIMIT 10
+----
 
 [#operators_and_relations]
 == 'Operators' and 'relations'


### PR DESCRIPTION
This PR adds the ability to query XTQL inlined within SQL.

* Grammar is `XTQL 'XTQL string'` - but most likely to be used with dollar-quoted strings (as is common in Postgres for things like `CREATE FUNCTION (...) AS $$ [SQL] $$` to avoid needing to escape quotes.
* Works as a standalone query: `XTQL $$ (-> (from ...) (aggregate ...) ...) $$`
* Also works as a FROM/JOIN relation: `FROM (XTQL $$ ... $$) foo SELECT ...`
* I'd imagine this'll be most often used from Clojure with a helper (which we may want to consider adding to `xt.next.jdbc`, but also see seancorfield/honeysql#572.

  ```clojure
  (defn xtql [q] 
    (format "XTQL $$ %s $$" (pr-str q)
  ```