### PR TITLE
Mention that `FLAG` is a supported parameter for `LIKE_REGEX`

### DIFF
--- a/docs/src/content/docs/reference/main/stdlib/string.adoc
+++ b/docs/src/content/docs/reference/main/stdlib/string.adoc
@@ -19,7 +19,7 @@ Notes:
 * `_`: matches any single character
 * `%`: matches 0-n characters
 --
-`str [NOT] LIKE_REGEX regex`:: Returns true iff the `str` matches (/ doesn't match) the `regex`.
+`str [NOT] LIKE_REGEX regex [FLAG flags]`:: Returns true iff the `str` matches (/ doesn't match) the `regex`.
 +
 See link:#regexes[Regular expressions in XTDB] for more details.
 


### PR DESCRIPTION
Was pleasantly surprised to see that this was [already implemented](https://github.com/xtdb/xtdb/blob/90e0d5c9eb804717b946da3c7c98a033e938a4f8/src/test/clojure/xtdb/sql/expr_test.clj#L60) :)