### PR TITLE
XT JDBC driver also takes care of encoding Clojure-idiomatic values

### DIFF
--- a/api/src/main/kotlin/xtdb/util/Transit.kt
+++ b/api/src/main/kotlin/xtdb/util/Transit.kt
@@ -10,3 +10,6 @@ internal enum class TransitFormat(fmt: String) {
 
 internal fun readTransit(bs: ByteArray, fmt: TransitFormat) =
     requiringResolve("xtdb.serde/read-transit").invoke(bs, fmt.key)
+
+internal fun writeTransit(obj: Any, fmt: TransitFormat) =
+    requiringResolve("xtdb.serde/write-transit").invoke(obj, fmt.key) as ByteArray

--- a/modules/kafka-connect/src/main/clojure/xtdb/kafka/connect.clj
+++ b/modules/kafka-connect/src/main/clojure/xtdb/kafka/connect.clj
@@ -122,7 +122,7 @@
                   valid-from (get doc (keyword (.getValidFromField conf)))
                   valid-to (get doc (keyword (.getValidToField conf)))]
               [(format "INSERT INTO %s RECORDS ?" table)
-               (xt-jdbc/->pg-obj (assoc doc :_id id, :_valid_from valid-from, :_valid_to valid-to))])
+               (assoc doc :_id id, :_valid_from valid-from, :_valid_to valid-to)])
 
             (= "record_key" (.getIdMode conf))
             (let [id (find-record-key-eid conf record)]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1621,10 +1621,10 @@
 (t/deftest test-combines-dml
   (with-open [conn (jdbc-conn)]
     (jdbc/with-transaction [tx conn]
-      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" (xt-jdbc/->pg-obj {:xt/id 1, :a "one"})])
-      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" (xt-jdbc/->pg-obj {:xt/id 2, :a "two"})])
+      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" {:xt/id 1, :a "one"}])
+      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" {:xt/id 2, :a "two"}])
       (jdbc/execute! tx ["INSERT INTO foo RECORDS {_id: ?, a: ?}" 3, "three"])
-      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" (xt-jdbc/->pg-obj {:xt/id 4, :a "four"})])
+      (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" {:xt/id 4, :a "four"}])
 
       ;; HACK.
       (t/is (= [[:sql "INSERT INTO foo RECORDS $1"
@@ -1911,7 +1911,7 @@ ORDER BY t.oid DESC LIMIT 1"
                            "transit" nil true])))))
 
   (with-open [conn (jdbc-conn {"prepareThreshold" -1})]
-    (jdbc/execute! conn ["INSERT INTO foo (_id, v) VALUES (1, ?)" (xt-jdbc/->pg-obj {:a 1, :b 2})])
+    (jdbc/execute! conn ["INSERT INTO foo (_id, v) VALUES (1, ?)" {:a 1, :b 2}])
 
     (with-open [stmt (.prepareStatement conn "SELECT v FROM foo")
                 rs (.executeQuery stmt)]
@@ -1926,12 +1926,10 @@ ORDER BY t.oid DESC LIMIT 1"
 
     (t/testing "qualified names"
       (jdbc/execute! conn ["INSERT INTO users RECORDS ?"
-                           (xt-jdbc/->pg-obj {:xt/id "jms",
-                                              :user/first-name "James"})])
+                           {:xt/id "jms", :user/first-name "James"}])
 
       (jdbc/execute! conn ["INSERT INTO users RECORDS ?"
-                           (xt-jdbc/->pg-obj {:_id "jdt",
-                                              :user$first_name "Jeremy"})])
+                           {:_id "jdt", :user$first_name "Jeremy"}])
 
       (t/is (= #{{:_id "jdt", :user$first_name "Jeremy"}
                  {:_id "jms", :user$first_name "James"}}
@@ -2298,10 +2296,10 @@ ORDER BY t.oid DESC LIMIT 1"
   (with-open [conn (jdbc-conn)
               ps (jdbc/prepare conn ["INSERT INTO foo RECORDS ?, ?"])]
     (jdbc/execute-batch! ps
-                         [[(xt-jdbc/->pg-obj {:xt/id 1, :v 1})
-                           (xt-jdbc/->pg-obj {:xt/id 2, :v 1})]
-                          [(xt-jdbc/->pg-obj {:xt/id 1, :v 2})
-                           (xt-jdbc/->pg-obj {:xt/id 3, :v 1})]])))
+                         [[{:xt/id 1, :v 1}
+                           {:xt/id 2, :v 1}]
+                          [{:xt/id 1, :v 2}
+                           {:xt/id 3, :v 1}]])))
 
 (t/deftest test-multiple-tzs-3723
   (with-open [conn (jdbc-conn)]
@@ -2727,10 +2725,9 @@ ORDER BY 1,2;")
                     (every? #(compare-decimals-with-scale (:data (first %)) (:data (second %))))))
             "correct scale"))))
 
-
 (deftest keyword-roundtripping-4237
   (with-open [conn (jdbc-conn)]
-    (jdbc/execute! conn ["INSERT INTO docs RECORDS ?" (xt-jdbc/->pg-obj {:xt/id 1, :foo :bar})])
+    (jdbc/execute! conn ["INSERT INTO docs RECORDS ?" {:xt/id 1, :foo :bar}])
 
     (with-open [ps (jdbc/prepare conn ["FROM docs"])]
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2521,15 +2521,11 @@ UNION ALL
            (xt/q tu/*node* "SELECT STR('hello, ', NULL, 42.0, ' at ', DATE '2020-01-01') str"))))
 
 (t/deftest insert-with-transit-param-3907
-  (letfn [(->serialised-records [records]
-            (map xt-jdbc/->pg-obj records))
-
-          (jdbc-insert-txn [table records]
+  (letfn [(jdbc-insert-txn [table records]
             (let [total (count records)
                   into-table (partial str "INSERT INTO " table " RECORDS ")
-                  args (interpose ", " (repeat total "?"))
-                  pg-objects (->serialised-records records)]
-              (into [(apply into-table args)] pg-objects)))
+                  args (interpose ", " (repeat total "?"))]
+              (into [(apply into-table args)] records)))
 
           (jdbc-insert-records [conn table records]
             (jdbc/execute! conn (jdbc-insert-txn table records) {:builder-fn xt-jdbc/builder-fn}))]


### PR DESCRIPTION
no need for `->pg-obj` now - just:

```clojure
(jdbc/execute! node ["INSERT INTO foo RECORDS ?" {:xt/id "foo", :bar "bar"}])
```

breaking change because I've taken `->pg-obj` out of the public API