### PR TITLE
Add expressions in temporal filters

### DIFF
--- a/api/src/main/clojure/xtdb/time.clj
+++ b/api/src/main/clojure/xtdb/time.clj
@@ -117,6 +117,8 @@
 (def ^java.time.Instant start-of-time
   (micros->instant Long/MIN_VALUE))
 
+(def ^long start-of-time-as-micros Long/MIN_VALUE)
+
 (defn max-tx [l r]
   (if (or (nil? l)
           (and r (neg? (compare l r))))

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -577,17 +577,10 @@ queryValidTimePeriodSpecification
    ;
 
 tableTimePeriodSpecification
-    : 'AS' 'OF' periodSpecificationExpr # TableAsOf
+    : 'AS' 'OF' at=expr # TableAsOf
     | 'ALL' # TableAllTime
-    | 'BETWEEN' periodSpecificationExpr 'AND' periodSpecificationExpr # TableBetween
-    | 'FROM' periodSpecificationExpr 'TO' periodSpecificationExpr # TableFromTo
-    ;
-
-// replace usages of this with dateTimeExpr when possible - #3306
-periodSpecificationExpr
-    : literal #PeriodSpecLiteral
-    | parameterSpecification #PeriodSpecParam
-    | ('NOW' | 'CURRENT_TIMESTAMP') #PeriodSpecNow
+    | 'BETWEEN' from=expr 'AND' to=expr # TableBetween
+    | 'FROM' from=expr 'TO' to=expr # TableFromTo
     ;
 
 tableOrQueryName : tableName ;

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -48,7 +48,8 @@
 (s/def ::temporal-filter-value
   (s/or :now #{:now '(current-timestamp)}
         :literal (some-fn util-date? temporal? nil?)
-        :param simple-symbol?))
+        :param simple-symbol?
+        :expr ::expression))
 
 (defmethod temporal-filter-spec :at [_]
   (s/tuple #{:at} ::temporal-filter-value))

--- a/core/src/main/clojure/xtdb/xtql/plan.clj
+++ b/core/src/main/clojure/xtdb/xtql/plan.clj
@@ -364,13 +364,13 @@
     ;;TODO could be better to have its own error, to make it clear you can't
     ;;ref logic vars in temporal opts
     (required-vars-available? (.getAt this) #{})
-    [:at (plan-expr (.getAt this))])
+    [:at (or (plan-expr (.getAt this)) :now)])
 
   TemporalFilter$In
   (plan-temporal-filter [this]
     (required-vars-available? (.getFrom this) #{})
     (required-vars-available? (.getTo this) #{})
-    [:in (plan-expr (.getFrom this)) (plan-expr (.getTo this))])
+    [:in (or (plan-expr (.getFrom this)) 'xtdb/start-of-time) (plan-expr (.getTo this))])
 
   nil
   (plan-temporal-filter [_this]

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -528,3 +528,9 @@
    (let [^PreparedQuery prepared-q (xtp/prepare-sql node query opts)]
      {:res (xt/q node query opts)
       :res-type (mapv (juxt #(.getName ^Field %) types/field->col-type) (.columnFields prepared-q))})))
+
+(defn temporal-bounds->data [^TemporalBounds bounds]
+  (let [vt (.getValidTime bounds)
+        st (.getSystemTime bounds)]
+    {:valid-time [(.getLower vt) (.getUpper vt)]
+     :system-time [(.getLower st) (.getUpper st)]}))

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as t :refer [deftest]]
             [xtdb.api :as xt]
             [xtdb.compactor :as c]
+            [xtdb.expression :as expr]
             [xtdb.node :as xtn]
             [xtdb.operator.scan :as scan]
             xtdb.query
@@ -11,7 +12,8 @@
             [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector.writer :as vw])
-  (:import java.util.Date
+  (:import [java.time InstantSource]
+           java.util.Date
            (java.util.function IntPredicate)
            (xtdb.compactor RecencyPartition)
            xtdb.vector.RelationReader))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2197,7 +2197,7 @@ ORDER BY t.oid DESC LIMIT 1"
 
           (t/testing "parse error doesn't halt ingestion"
             (t/is (thrown-with-msg? PSQLException
-                                    #"ERROR: internal error conforming query plan"
+                                    #"internal error conforming query plan"
                                     (q conn ["PATCH INTO bar FOR VALID_TIME FROM '2020-01-05' TO DATE '2020-01-07' RECORDS {_id: 1, tmp: 'hi!'}"])))
 
             (t/is (= expected

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -215,11 +215,11 @@
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (_id) VALUES (2)"]])
   (xt/submit-tx tu/*node* [[:sql "DELETE FROM xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? WHERE xt_docs._id = 2"
                             [#inst "2011"]]])
-  ;; TODO what do we want to do about NULL here? atm it works like 'start of time'
   (t/is (= #{{:tx-id 0, :committed? false}
              {:tx-id 1, :committed? true}
              {:tx-id 2, :committed? true}}
            (set (xt/q tu/*node* '(from :xt/txs [{:xt/id tx-id, :committed committed?}])))))
+
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO xt_docs (_id) VALUES (3)"]])
   (xt/submit-tx tu/*node* [[:sql "UPDATE xt_docs FOR PORTION OF VALID_TIME FROM NULL TO ? SET foo = 'bar' WHERE xt_docs._id = 3"
                             [#inst "2011"]]])

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
@@ -4,6 +4,6 @@
   f.1
   [:scan
    {:table public/foo,
-    :for-valid-time [:at :now],
-    :for-system-time [:at :now]}
+    :for-valid-time [:at (current-timestamp)],
+    :for-system-time [:at (current-timestamp)]}
    [bar]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
@@ -6,4 +6,6 @@
    [{bar foo.1/bar}]
    [:rename
     foo.1
-    [:scan {:table public/foo, :for-valid-time [:at :now]} [bar]]]]]]
+    [:scan
+     {:table public/foo, :for-valid-time [:at (current-timestamp)]}
+     [bar]]]]]]


### PR DESCRIPTION
Simply adds an extra EE call at runtime (before any values are scanned from disk) to evaluate the expression. No column references are allowed see #3447. Literals and params are "evaluated" without a call to the expression engine.

Todo:
- [x] Dealing with overflowing `start-of-time` and `end-of-time`.