### PR TITLE
add `SET datestyle = 'iso8601'`, and XT JDBC driver now round-trips ZDTs in the correct TZ (#4424)

### DIFF
--- a/api/src/main/kotlin/xtdb/jdbc/Driver.kt
+++ b/api/src/main/kotlin/xtdb/jdbc/Driver.kt
@@ -20,7 +20,8 @@ class Driver : org.postgresql.Driver() {
         (super.connect(url.asPgUrl, info) as? PgConnection)?.let(::XtConnection)
             ?.also { conn ->
                 conn.createStatement().use { stmt ->
-                    stmt.execute("SET FALLBACK_OUTPUT_FORMAT = 'transit'")
+                    stmt.execute("SET fallback_output_format = 'transit'")
+                    stmt.execute("SET datestyle = 'iso8601'")
                 }
             }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -294,14 +294,19 @@ dependencies {
 
     api(libs.next.jdbc)
     testImplementation(libs.honeysql)
-    api("org.postgresql", "postgresql", "42.7.3")
     api(libs.integrant)
     api(project(":xtdb-core"))
+
+    api(libs.pgjdbc)
+    testImplementation(libs.exposed.core)
+    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.exposed.java.time)
 
     implementation(libs.junit.jupiter.api)
 
     testImplementation(libs.clojure.`data`.csv)
     testImplementation(libs.clojure.tools.cli)
+
 
     devImplementation("integrant", "repl", "0.3.2")
     devImplementation("com.azure", "azure-identity", "1.9.0")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ antlr="4.13.2"
 arrow="18.2.0"
 arrow-adbc="0.17.0"
 clojure="1.12.0"
+exposed="0.61.0"
 kotlin-coroutines = "1.10.2"
 junit = "5.8.1"
 netty="4.2.0.Final"
@@ -53,6 +54,9 @@ junit-jupiter-api={ group="org.junit.jupiter", name="junit-jupiter-api", version
 junit-jupiter-engine={ group="org.junit.jupiter", name="junit-jupiter-engine", version.ref="junit" }
 
 pgjdbc={ group="org.postgresql", name="postgresql", version="42.7.5" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
 
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }

--- a/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
+++ b/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
@@ -1,0 +1,63 @@
+package xtdb.jdbc
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import xtdb.api.Xtdb
+import xtdb.test.NodeResolver
+import xtdb.time.asInstant
+import xtdb.time.asOffsetDateTime
+import xtdb.time.asZonedDateTime
+import java.sql.Timestamp
+import java.time.OffsetDateTime
+
+@ExtendWith(NodeResolver::class)
+class XtConnectionTest {
+
+    private fun Transaction.execForOne(sql: String) = exec(sql) { it.next(); it.getObject(1) }
+
+    private fun <T> Transaction.execForOne(sql: String, c: Class<T>) =
+        exec(sql) { it.next(); it.getObject(1, c) }
+
+    private fun Transaction.execForOneTimestamp(sql: String) = exec(sql) { it.next(); it.getTimestamp(1) }
+
+    @Test
+    fun testDateStyle(node: Xtdb) {
+        transaction(Database.connect(node)) {
+            assertEquals(
+                "2020-01-01Z".asZonedDateTime(),
+                execForOne("SELECT TIMESTAMP '2020-01-01Z' ts")
+            )
+
+            assertEquals(
+                "2020-01-01T00:00:00Z".asOffsetDateTime(),
+                execForOne("SELECT TIMESTAMP '2020-01-01Z' ts", OffsetDateTime::class.java)
+            )
+
+            assertEquals(
+                Timestamp.from("2020-01-01Z".asInstant()),
+                execForOneTimestamp("SELECT TIMESTAMP '2020-01-01Z' ts")
+            )
+
+            exec("SET datestyle = 'iso8601'")
+            assertEquals(
+                "2020-05-01+01:00[Europe/London]".asZonedDateTime(),
+                execForOne("SELECT TIMESTAMP '2020-05-01+01:00[Europe/London]' ts")
+            )
+
+            assertEquals(
+                "2020-05-01-08:00".asZonedDateTime(),
+                execForOne("SELECT TIMESTAMP '2020-05-01-08:00' ts")
+            )
+
+            exec("SET datestyle = 'iso'")
+            assertEquals(
+                "2020-05-01-08:00".asZonedDateTime(),
+                execForOne("SELECT TIMESTAMP '2020-05-01-08:00' ts")
+            )
+        }
+    }
+}


### PR DESCRIPTION
(#4424)

The XTDB JDBC driver now returns ZDTs by default for anything that advertises itself as a timestamptz (default PGJDBC behaviour is to return a j.sql.Timestamp).

Behind the scenes, this adds support for `SET datestyle` (a [Postgres option](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT)). We add a slight hack here:

* Postgres says that 'ISO' is 'ISO 8601, SQL standard', which is a contradiction; it also has 'SQL'.
* PGJDBC throws a wobbly if you try to set the datestyle to anything that doesn't _begin with_ 'ISO' (yes, you can probably see where this is going)
* So we set the date-style on any XTDB JDBC driver connections to 'ISO8601' - this keeps the underlying PGJDBC connection happy, but also gives us something to distinguish on the backend.