### PR TITLE
setting per-tx variables - tz and watermark

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -902,13 +902,14 @@ transactionMode
 txTzOption : ('TIMEZONE' | 'TIME' 'ZONE') '='? tz=expr ;
 
 readOnlyTxOption
-    : 'SNAPSHOT_TIME' ('=')? dateTimeLiteral # SnapshotTimeTxOption
-    | 'CLOCK_TIME' ('=')? dateTimeLiteral # ClockTimeTxOption
+    : 'SNAPSHOT_TIME' '='? dateTimeLiteral # SnapshotTimeTxOption
+    | 'CLOCK_TIME' '='? dateTimeLiteral # ClockTimeTxOption
+    | 'WATERMARK' '='? watermarkTx=expr # WatermarkTxOption
     | txTzOption # TxTzOption0
     ;
 
 readWriteTxOption
-    : 'SYSTEM_TIME' ('=')? dateTimeLiteral # SystemTimeTxOption
+    : 'SYSTEM_TIME' '='? dateTimeLiteral # SystemTimeTxOption
     | txTzOption # TxTzOption1
     ;
 

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -899,13 +899,17 @@ transactionMode
     | 'READ' 'WRITE' ('WITH' '(' readWriteTxOption? (',' readWriteTxOption?)* ')')? # ReadWriteTransaction
     ;
 
+txTzOption : ('TIMEZONE' | 'TIME' 'ZONE') '='? tz=expr ;
+
 readOnlyTxOption
     : 'SNAPSHOT_TIME' ('=')? dateTimeLiteral # SnapshotTimeTxOption
     | 'CLOCK_TIME' ('=')? dateTimeLiteral # ClockTimeTxOption
+    | txTzOption # TxTzOption0
     ;
 
 readWriteTxOption
     : 'SYSTEM_TIME' ('=')? dateTimeLiteral # SystemTimeTxOption
+    | txTzOption # TxTzOption1
     ;
 
 levelOfIsolation


### PR DESCRIPTION
for #4424 

e.g. 

```sql
BEGIN READ ONLY WITH (
  WATERMARK = 3,
  TIME ZONE = 'America/New_York'
);
```

This sets the watermark and time zone for the duration of the transaction, resetting to the connection default on commit/rollback.