### PR TITLE
XTQL queries through SQL can optionally specify `?`s so that PGJDBC knows the param count

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -704,9 +704,11 @@ queryTerm
     | tableValueConstructor # ValuesQuery
     | recordsValueConstructor # RecordsQuery
     | '(' queryExpressionNoWith ')' # WrappedQuery
-    | 'XTQL' characterString # XtqlQuery
+    | 'XTQL' ( xtqlQuery=characterString | '(' xtqlQuery=characterString xtqlParams ')' ) # XtqlQuery
     | queryTerm 'INTERSECT' (ALL | DISTINCT)? queryTerm # IntersectQuery
     ;
+
+xtqlParams : ( ',' parameterSpecification )* ;
 
 queryTail
     : whereClause # WhereTail

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2485,7 +2485,7 @@
                                           [(str tbl) (into #{} (map str) cols)]))))
 
           {:keys [ra-plan]} (-> (edn/read-string {:readers *data-readers*}
-                                                 (.accept (.characterString ctx) string-literal-visitor))
+                                                 (.accept (.xtqlQuery ctx) string-literal-visitor))
                                 (xtql/parse-query {:!param-count (:!param-count env)})
                                 (xtql.plan/compile-query* {:table-info table-info}))]
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2956,7 +2956,13 @@ FROM dates"))))
     (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
              (xt/q tu/*node* [(format "FROM (XTQL $$ %s $$) t SELECT *, ? AS x"
                                       (pr-str '#(from :bar [{:xt/id %} *])))
-                              2 "x"])))))
+                              2 "x"])))
+
+    (with-open [conn (jdbc/get-connection tu/*node*)]
+      (t/is (= {:xt/id 2, :y "baz"}
+               (jdbc/execute-one! conn [(format "XTQL ($$ %s $$, ?)" (pr-str '#(from :bar [{:xt/id %} *]))) 2]
+                                  {:builder-fn xt-jdbc/builder-fn}))
+            "XTQL params through PGJDBC"))))
 
 (t/deftest use-parent-left-scope-in-nested-join-table-4131
   (t/is (=plan-file


### PR DESCRIPTION
eugh.

So PGJDBC tries to parse the SQL query before it's sent to determine how many parameters the query's got - safe to say, it doesn't recognise XTQL params (in the `fn`, but mainly because it's within a `$$` string).

This PR allows users to optionally send `XTQL ($$ <query> $$, ?, ?, ?)` (which we don't check) to appease the transport.

Any other suggestions welcome!