### PR TITLE
[pgwire] including ex-cause in the detail part of the ErrorResponse

### DIFF
--- a/api/src/main/clojure/xtdb/serde.clj
+++ b/api/src/main/clojure/xtdb/serde.clj
@@ -296,9 +296,11 @@
   (transit/write-handler-map transit-write-handlers))
 
 (defn read-transit
-  ([bytes] (read-transit bytes nil))
-  ([bytes fmt]
-   (with-open [bais (ByteArrayInputStream. bytes)]
+  ([bytes-or-str] (read-transit bytes-or-str nil))
+  ([bytes-or-str fmt]
+   (with-open [bais (ByteArrayInputStream. (cond
+                                             (bytes? bytes-or-str) bytes-or-str
+                                             (string? bytes-or-str) (-> ^String bytes-or-str (.getBytes StandardCharsets/UTF_8))))]
      (transit/read (transit/reader bais (or fmt :msgpack) {:handlers transit-read-handler-map})))))
 
 (defn transit-seq [rdr]
@@ -333,3 +335,4 @@
                                                                   k)))))))
                    (write-transit :json)
                    (String. StandardCharsets/UTF_8)))))
+


### PR DESCRIPTION
This PR includes the exception cause in pgwire's ErrorResponse message so that it can potentially be re-constructed on the client side, and (for those who don't care about that) it gives a structured error message that they can parse.

* If the user has set 'fallback_output_format' = transit, this is encoded in transit format; otherwise, it uses JSON.