### PR TITLE
Change default explicit `NULL` behaviour for `PORTION OF VALID_TIME` for DML operations

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -830,9 +830,13 @@ dmlStatementValidTimeExtents
 
 patchStatement
   : PATCH INTO tableName
-    ('FOR' ('PORTION' 'OF')? 'VALID_TIME' 'FROM' validFrom=staticExpr ('TO' validTo=staticExpr)?)?
-    patchSource
-  ;
+    patchStatementValidTimeExtents?
+    patchSource;
+
+// could become dmlStatementValidTimeExtents
+patchStatementValidTimeExtents
+: 'FOR' ('PORTION' 'OF')? 'VALID_TIME' 'FROM' from=staticExpr ('TO' to=staticExpr)? # PatchStatementValidTimePortion
+;
 
 patchSource
   : recordsValueConstructor # PatchRecords

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -62,6 +62,7 @@
 (defn form->expr [form {:keys [col-types param-types locals] :as env}]
   (cond
     (symbol? form) (cond
+                     (= 'xtdb/start-of-time form) {:op :literal, :literal time/start-of-time}
                      (= 'xtdb/end-of-time form) {:op :literal, :literal time/end-of-time}
                      (= 'xtdb/postgres-server-version form) {:op :literal, :literal (str "PostgreSQL " postgres-server-version)}
                      (= 'xtdb/xtdb-server-version form) {:op :literal, :literal (str "XTDB @ " (xtdb-server-version))}

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2438,7 +2438,7 @@ ORDER BY t.oid DESC LIMIT 1"
 
           (t/testing "parse error doesn't halt ingestion"
             (t/is (thrown-with-msg? PSQLException
-                                    #"internal error conforming query plan"
+                                    #"ERROR: internal error conforming query plan"
                                     (q conn ["PATCH INTO bar FOR VALID_TIME FROM '2020-01-05' TO DATE '2020-01-07' RECORDS {_id: 1, tmp: 'hi!'}"])))
 
             (t/is (= expected

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2978,10 +2978,9 @@ FROM dates"))))
 (t/deftest inconsistent-patch-behaviour-4448
   (xt/execute-tx tu/*node* [[:sql "INSERT INTO users RECORDS {_id: ?, _valid_from: ?, _valid_to: ?}" [1 #inst "2010" #inst "2040"]]])
 
-  (xt/execute-tx tu/*node* [[:sql "PATCH INTO users FOR PORTION OF VALID_TIME FROM NULL TO ? RECORDS {_id: 1, foo: 3}" [#inst "2015"]]])
+  (xt/execute-tx tu/*node* [[:sql "PATCH INTO users FOR PORTION OF VALID_TIME FROM ? TO ? RECORDS {_id: 1, foo: 3}" [#inst "2020" #inst "2015"]]])
 
   (t/is (= [{:committed false,
              :error
-             #xt/runtime-err [:xtdb.indexer/invalid-valid-times "Runtime error: 'xtdb.indexer/invalid-valid-times'"
-                              {:valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to #xt/instant "2015-01-01T00:00:00Z"}]}]
+             #xt/runtime-err [:xtdb.indexer/invalid-valid-times "Runtime error: 'xtdb.indexer/invalid-valid-times'" {:valid-from #xt/instant "2020-01-01T00:00:00Z", :valid-to #xt/instant "2015-01-01T00:00:00Z"}]}]
            (xt/q tu/*node* '(from :xt/txs [{:xt/id 1} committed error])))))

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-as-of.edn
@@ -4,5 +4,5 @@
   foo.1
   [:scan
    {:table public/foo,
-    :for-system-time [:at #xt/date-time "2999-01-01T00:00"]}
+    :for-system-time [:at #xt/ldt "2999-01-01T00:00"]}
    [bar]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
@@ -16,7 +16,5 @@
       [:scan
        {:table public/z,
         :for-system-time
-        [:in
-         #xt/date "3001-01-01"
-         #xt/zoned-date-time "3002-01-01T00:00Z"]}
+        [:in #xt/date "3001-01-01" #xt/zdt "3002-01-01T00:00Z"]}
        [z]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
@@ -10,7 +10,5 @@
     [:scan
      {:table public/t1,
       :for-system-time
-      [:between
-       #xt/date "3001-01-01"
-       #xt/zoned-date-time "3002-01-01T00:00Z"]}
+      [:between #xt/date "3001-01-01" #xt/zdt "3002-01-01T00:00Z"]}
      []]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b.edn
@@ -5,7 +5,5 @@
   [:scan
    {:table public/foo,
     :for-system-time
-    [:in
-     #xt/date "2999-01-01"
-     #xt/zoned-date-time "3000-01-01T00:00Z"]}
+    [:in #xt/date "2999-01-01" #xt/zdt "3000-01-01T00:00Z"]}
    [bar]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -3,7 +3,11 @@
  [:project
   [_iid
    {_valid_from
-    (greatest _valid_from (cast ?_0 [:timestamp-tz :micro "UTC"]))}
+    (greatest
+     _valid_from
+     (cast
+      (coalesce ?_0 xtdb/start-of-time)
+      [:timestamp-tz :micro "UTC"]))}
    {_valid_to
     (least
      (coalesce _valid_to xtdb/end-of-time)

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-contains-with-period-literal.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-contains-with-period-literal.edn
@@ -10,11 +10,8 @@
    [:scan
     {:table public/foo}
     [name
-     {_valid_from
-      (<= _valid_from #xt/zoned-date-time "2000-01-01T00:00Z")}
+     {_valid_from (<= _valid_from #xt/zdt "2000-01-01T00:00Z")}
      {_valid_to
       (>=
        (coalesce _valid_to xtdb/end-of-time)
-       (coalesce
-        #xt/zoned-date-time "2001-01-01T00:00Z"
-        xtdb/end-of-time))}]]]]]
+       (coalesce #xt/zdt "2001-01-01T00:00Z" xtdb/end-of-time))}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-infix-overlaps.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-infix-overlaps.edn
@@ -13,10 +13,8 @@
      {_valid_from
       (<
        _valid_from
-       (coalesce
-        #xt/zoned-date-time "2001-01-01T00:00Z"
-        xtdb/end-of-time))}
+       (coalesce #xt/zdt "2001-01-01T00:00Z" xtdb/end-of-time))}
      {_valid_to
       (>
        (coalesce _valid_to xtdb/end-of-time)
-       #xt/zoned-date-time "2000-01-01T00:00Z")}]]]]]
+       #xt/zdt "2000-01-01T00:00Z")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -5,7 +5,9 @@
    {_valid_from
     (greatest
      _valid_from
-     (cast #xt/date "2020-05-01" [:timestamp-tz :micro "UTC"]))}
+     (cast
+      (coalesce #xt/date "2020-05-01" xtdb/start-of-time)
+      [:timestamp-tz :micro "UTC"]))}
    {_valid_to _valid_to}]
   [:project
    [{_iid u.1/_iid}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -5,7 +5,9 @@
    {_valid_from
     (greatest
      _valid_from
-     (cast #xt/date "2021-07-01" [:timestamp-tz :micro "UTC"]))}
+     (cast
+      (coalesce #xt/date "2021-07-01" xtdb/start-of-time)
+      [:timestamp-tz :micro "UTC"]))}
    {_valid_to _valid_to}
    first_name
    id

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
@@ -5,9 +5,7 @@
   [:scan
    {:table public/t1,
     :for-valid-time
-    [:between
-     #xt/zoned-date-time "3001-01-01T00:00Z"
-     #xt/date "3000-01-01"],
+    [:between #xt/zdt "3001-01-01T00:00Z" #xt/date "3000-01-01"],
     :for-system-time
     [:between #xt/date "2000-01-01" #xt/date "2001-01-01"]}
    []]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-as-of.edn
@@ -4,5 +4,5 @@
   foo.1
   [:scan
    {:table public/foo,
-    :for-valid-time [:at #xt/date-time "2999-01-01T00:00"]}
+    :for-valid-time [:at #xt/ldt "2999-01-01T00:00"]}
    [bar]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
@@ -5,7 +5,5 @@
   [:scan
    {:table public/t1,
     :for-valid-time
-    [:between
-     #xt/zoned-date-time "3000-01-01T00:00Z"
-     #xt/date "3001-01-01"]}
+    [:between #xt/zdt "3000-01-01T00:00Z" #xt/date "3001-01-01"]}
    []]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-from-to.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-from-to.edn
@@ -5,7 +5,5 @@
   [:scan
    {:table public/foo,
     :for-valid-time
-    [:in
-     #xt/date "2999-01-01"
-     #xt/zoned-date-time "3000-01-01T00:00Z"]}
+    [:in #xt/date "2999-01-01" #xt/zdt "3000-01-01T00:00Z"]}
    [bar]]]]


### PR DESCRIPTION
Any `PORTION OF VALID_FROM FROM NULL TO NULL` for DML operations now defaults to `start-of-time` to `end-of-time`. Not specifying `PORTION OF...` results in the default behaviour of `now` to `end-of-time`.

Todo:
- [x] Deal with `start-of-time` overflow.