### PR TITLE
Defaulting to `start-of-time` for explicit NULL from in VALID_TIME and SYSTEM_TIME filters

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -47,25 +47,25 @@
 
 (s/def ::temporal-filter-value
   (s/or :now #{:now '(current-timestamp)}
-        :literal (some-fn util-date? temporal?)
+        :literal (some-fn util-date? temporal? nil?)
         :param simple-symbol?))
 
 (defmethod temporal-filter-spec :at [_]
   (s/tuple #{:at} ::temporal-filter-value))
 
 (defmethod temporal-filter-spec :in [_]
-  (s/tuple #{:in} (s/nilable ::temporal-filter-value) (s/nilable ::temporal-filter-value)))
+  (s/tuple #{:in} ::temporal-filter-value ::temporal-filter-value))
 
 (defmethod temporal-filter-spec :from [_]
-  (s/and (s/tuple #{:from} (s/nilable ::temporal-filter-value))
+  (s/and (s/tuple #{:from} ::temporal-filter-value)
          (s/conformer (fn [x] [:in (second x) nil]) identity)))
 
 (defmethod temporal-filter-spec :to [_]
-  (s/and (s/tuple #{:to} (s/nilable ::temporal-filter-value))
+  (s/and (s/tuple #{:to} ::temporal-filter-value)
          (s/conformer (fn [x] [:in nil (second x)]) identity)))
 
 (defmethod temporal-filter-spec :between [_]
-  (s/tuple #{:between} (s/nilable ::temporal-filter-value) (s/nilable ::temporal-filter-value)))
+  (s/tuple #{:between} ::temporal-filter-value ::temporal-filter-value))
 
 (s/def ::temporal-filter
   (s/multi-spec temporal-filter-spec (fn retag [_] (throw (UnsupportedOperationException.)))))

--- a/src/test/clojure/xtdb/xtql/plan_test.clj
+++ b/src/test/clojure/xtdb/xtql/plan_test.clj
@@ -1332,7 +1332,7 @@
                       '(from :docs {:bind [{:xt/id id
                                             :xt/valid-from vt-from
                                             :xt/valid-to vt-to}]
-                                    :for-valid-time (in nil #inst "2040")})
+                                    :for-valid-time (in :now #inst "2040")})
                       {:current-time (time/->instant #inst "2023")})))))
 
 (t/deftest test-temporal-opts-from-and-to
@@ -1376,7 +1376,10 @@
                  :vt-to #xt/zoned-date-time "2050-01-01T00:00Z[UTC]"}
                 {:id :matthew,
                  :vt-from #xt/zoned-date-time "2020-01-02T00:00Z[UTC]",
-                 :vt-to #xt/zoned-date-time "2040-01-01T00:00Z[UTC]"}]
+                 :vt-to #xt/zoned-date-time "2040-01-01T00:00Z[UTC]"}
+                {:id :matthew,
+                 :vt-from #xt/zdt "2015-01-01T00:00Z[UTC]",
+                 :vt-to #xt/zdt "2020-01-02T00:00Z[UTC]"}]
                (q '(from :docs {:bind [{:xt/id id
                                         :xt/valid-from vt-from
                                         :xt/valid-to vt-to}]


### PR DESCRIPTION
This means a `FROM table FOR VALID_TIME/SYSTEM_TIME FROM NULL to NULL` now means a table scan for all of time. 