### PR TITLE
breaking change: xt/execute-tx throws on transaction failure

### DIFF
--- a/api/src/main/kotlin/xtdb/IllegalArgumentException.kt
+++ b/api/src/main/kotlin/xtdb/IllegalArgumentException.kt
@@ -4,6 +4,7 @@ import clojure.lang.IExceptionInfo
 import clojure.lang.IPersistentMap
 import clojure.lang.Keyword
 import clojure.lang.PersistentHashMap
+import clojure.lang.Util
 
 private val ERROR_KEY: Keyword = Keyword.intern("xtdb.error", "error-key")
 
@@ -21,6 +22,25 @@ data class IllegalArgumentException(
     override fun getData(): IPersistentMap =
         (data as? IPersistentMap ?: PersistentHashMap.create(data)).assoc(ERROR_KEY, key)
 
+    // exclude `cause`
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IllegalArgumentException) return false
+
+        if (key != other.key) return false
+        if (message != other.message) return false
+        if (!Util.equiv(data, other.data)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = key?.hashCode() ?: 0
+        result = 31 * result + (message?.hashCode() ?: 0)
+        result = 31 * result + Util.hash(data)
+        return result
+    }
+
     /**
      * @suppress
      */
@@ -35,4 +55,6 @@ data class IllegalArgumentException(
         fun create(key: Keyword?, data: Map<*, *>, cause: Throwable? = null) =
             IllegalArgumentException(key, data = data, cause = cause)
     }
+
+
 }

--- a/api/src/main/kotlin/xtdb/RuntimeException.kt
+++ b/api/src/main/kotlin/xtdb/RuntimeException.kt
@@ -4,6 +4,7 @@ import clojure.lang.IExceptionInfo
 import clojure.lang.IPersistentMap
 import clojure.lang.Keyword
 import clojure.lang.PersistentHashMap
+import clojure.lang.Util
 
 private val ERROR_KEY: Keyword = Keyword.intern("xtdb.error", "error-key")
 
@@ -21,4 +22,22 @@ data class RuntimeException(
     override fun getData(): IPersistentMap =
         (data as? IPersistentMap ?: PersistentHashMap.create(data)).assoc(ERROR_KEY, key)
 
+    // exclude `cause`
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RuntimeException) return false
+
+        if (key != other.key) return false
+        if (message != other.message) return false
+        if (!Util.equiv(data, other.data)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = key?.hashCode() ?: 0
+        result = 31 * result + (message?.hashCode() ?: 0)
+        result = 31 * result + Util.hash(data)
+        return result
+    }
 }

--- a/docs/src/content/docs/guides/clojure-sql-cookbook.adoc
+++ b/docs/src/content/docs/guides/clojure-sql-cookbook.adoc
@@ -28,7 +28,7 @@ SQL transactions are submitted through `xtdb.api/execute-tx` and `xtdb.api/submi
 ** `opts` (map):
 *** `:default-tz` (`java.time.ZoneRegion`): time zone to be used by default in functions where no explicit override is provided.
     Defaults to the current TZ of the server JVM.
-* `(xt/execute-tx <node> <tx-ops> <opts>?)` : additionally awaits for the transaction to be processed, and returns `{:committed? true|false, :error err}` alongside the transaction key.
+* `(xt/execute-tx <node> <tx-ops> <opts>?)` : additionally awaits for the transaction to be processed, and throws if the transaction fails (either through error, or assertion failure).
 
 SQL transaction operations are of the form `[:sql "<sql query>"]`.
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -4,7 +4,6 @@
             [clojure.test :as t]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
-            [next.jdbc.prepare :as jdbc.prep]
             [xtdb.api :as xt]
             [xtdb.client :as xtc]
             [xtdb.indexer :as idx]
@@ -26,7 +25,6 @@
            (java.nio.channels Channels)
            (java.nio.file Files Path)
            java.nio.file.attribute.FileAttribute
-           (java.sql PreparedStatement Types)
            (java.time Duration Instant InstantSource LocalTime Period YearMonth ZoneId ZoneOffset)
            (java.time.temporal ChronoUnit)
            (java.util LinkedList)

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -167,9 +167,9 @@
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (start-kafka-node local-disk-cache (random-uuid))]
       (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
-        (t/is (true? (:committed? (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]
-                                                       [:put-docs :bar {:xt/id "bar2"}]
-                                                       [:put-docs :bar {:xt/id "bar3"}]]))))
+        (t/is (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]
+                                   [:put-docs :bar {:xt/id "bar2"}]
+                                   [:put-docs :bar {:xt/id "bar3"}]]))
 
         (tu/finish-block! node)
 

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -651,8 +651,12 @@
       (t/testing test-name
         (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
           (xt/execute-tx node [[:put-docs :docs
-                                {:xt/id 1, :version 1 :xt/valid-from vf1 :xt/valid-to vt1}
-                                {:xt/id 1, :version 2 :xt/valid-from vf2 :xt/valid-to vt2}]])
+                                (cond-> {:xt/id 1, :version 1}
+                                  vf1 (assoc :xt/valid-from vf1)
+                                  vt1 (assoc :xt/valid-to vt1))
+                                (cond-> {:xt/id 1, :version 2}
+                                  vf2 (assoc :xt/valid-from vf2)
+                                  vt2 (assoc :xt/valid-to vt2))]])
 
           (let [res-before-compaction (xt/q node q)]
             (tu/finish-block! node)

--- a/src/test/clojure/xtdb/docs/xtql_walkthrough_test.clj
+++ b/src/test/clojure/xtdb/docs/xtql_walkthrough_test.clj
@@ -325,9 +325,9 @@
 (deftest DML-Delete-additional-unify-clauses-sql
   (xt/submit-tx tu/*node* (concat posts comments))
 
-  (t/is (:committed? (xt/execute-tx tu/*node*
-                                    [[:sql (sql-example "DML-Delete-additional-unify-clauses-sql")
-                                      ["ivan"]]])))
+  (t/is (xt/execute-tx tu/*node*
+                       [[:sql (sql-example "DML-Delete-additional-unify-clauses-sql")
+                         ["ivan"]]]))
 
   (t/is (empty? (xt/q tu/*node*
                       ['(fn [author]
@@ -355,8 +355,8 @@
                           (from :promotions {:bind [promotion-type]
                                              :for-valid-time (from #inst "2023-12-26")}))))))
 
-  (t/is (:committed? (xt/execute-tx tu/*node*
-                                    [[:sql (sql-example "DML-Delete-bitemporal-sql")]])))
+  (t/is (xt/execute-tx tu/*node*
+                       [[:sql (sql-example "DML-Delete-bitemporal-sql")]]))
 
   (t/is (= #{{:promotion-type "general"}}
            (set
@@ -385,9 +385,9 @@
   (t/is (= [{:version 1}]
            (xt/q tu/*node* '(from :documents [version]))))
 
-  (t/is (:committed? (xt/execute-tx tu/*node*
-                                    [[:sql (sql-example "DML-Update-sql")
-                                      ["doc-id"]]])))
+  (t/is (xt/execute-tx tu/*node*
+                       [[:sql (sql-example "DML-Update-sql")
+                         ["doc-id"]]]))
 
   (t/is (= [{:version 2}]
            (xt/q tu/*node* '(from :documents [version])))))

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -115,8 +115,10 @@
       (util/with-open [node (tu/->local-node {:node-dir node-dir})]
         (let [^BufferPool bp (tu/component node :xtdb/buffer-pool)]
 
-          (let [{:keys [tx-id]} (last (for [tx-ops txs] (xt/execute-tx node tx-ops)))]
-            (tu/then-await-tx tx-id node (Duration/ofSeconds 2)))
+          (doseq [tx-ops txs]
+            (try
+              (xt/execute-tx node tx-ops)
+              (catch xtdb.RuntimeException _)))
 
           (tu/finish-block! node)
 

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -1,18 +1,10 @@
 (ns ^:kafka xtdb.kafka-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
-            [xtdb.log :as log]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
-  (:import [java.nio ByteBuffer]
-           [java.time Duration]
-           [java.util Map]
-           [org.apache.kafka.clients.admin AdminClient NewTopic]
-           [org.apache.kafka.clients.consumer ConsumerRecord KafkaConsumer]
-           [org.apache.kafka.clients.producer KafkaProducer ProducerRecord]
-           [org.apache.kafka.common TopicPartition]
-           org.apache.kafka.common.KafkaException
+  (:import org.apache.kafka.common.KafkaException
            org.testcontainers.containers.GenericContainer
            org.testcontainers.kafka.ConfluentKafkaContainer
            org.testcontainers.utility.DockerImageName
@@ -50,7 +42,7 @@
   (let [test-uuid (random-uuid)]
     (with-open [node (xtn/start-node {:log [:kafka {:bootstrap-servers *bootstrap-servers*
                                                     :topic (str "xtdb.kafka-test." test-uuid)}]})]
-      (t/is (true? (:committed? (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))
+      (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))
 
       (t/is (= [{:xt/id :foo}]
                (tu/query-ra '[:scan {:table public/xt_docs} [_id]]
@@ -80,7 +72,7 @@
                                         :storage [:remote {:object-store [:in-memory {}]
                                                            :local-disk-cache path}]})]
         (t/testing "Send a transaction"
-          (t/is (= true (:committed? (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))))
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))
 
       (t/testing "should be no 'xtdb-tx-subscription' threads remaining"
         (let [all-threads (.keySet (Thread/getAllStackTraces))


### PR DESCRIPTION
This is to bring it in line with how JDBC behaves (#4424)

Now, execute-tx will:
* return a tx-key (n.b. no `:committed?`) on commit
* throw on rollback/error