### PR TITLE
Sending j.u.Dates as timestamp-tz over pgwire

### DIFF
--- a/api/src/main/kotlin/xtdb/jdbc/XtConnection.kt
+++ b/api/src/main/kotlin/xtdb/jdbc/XtConnection.kt
@@ -94,6 +94,10 @@ internal class XtConnection(private val conn: PgConnection) : BaseConnection by 
 
     internal inner class XtCallableStatement(private val inner: CallableStatement) : CallableStatement by inner
 
+    companion object {
+        private val UTC_CAL = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    }
+
     internal inner class XtPreparedStatement(private val inner: PreparedStatement) : PreparedStatement by inner {
         override fun getResultSet() = inner.resultSet?.let { XtResultSet(it) }
 
@@ -143,6 +147,10 @@ internal class XtConnection(private val conn: PgConnection) : BaseConnection by 
                 it.value = toString()
             }
 
+        override fun setTimestamp(parameterIndex: Int, x: Timestamp?) {
+            setTimestamp(parameterIndex, x, UTC_CAL)
+        }
+
         override fun setObject(parameterIndex: Int, x: Any?) {
             when (x) {
                 is Map<*, *>, is List<*>, is Set<*>, is Keyword, is URI ->
@@ -152,7 +160,7 @@ internal class XtConnection(private val conn: PgConnection) : BaseConnection by 
                 is Instant -> setObject(parameterIndex, x.atZone(ZoneOffset.UTC))
                 is ZonedDateTimeRange -> inner.setObject(parameterIndex, x.asPgObject)
                 is Interval -> inner.setObject(parameterIndex, x.asPgObject)
-                is Date -> setObject(parameterIndex, x.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime())
+                is Date -> setObject(parameterIndex, x.toInstant())
                 is LocalDateTime -> setIsoTimestamp(parameterIndex, x)
 
                 else -> inner.setObject(parameterIndex, x)

--- a/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
+++ b/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
@@ -13,6 +13,9 @@ import xtdb.time.asOffsetDateTime
 import xtdb.time.asZonedDateTime
 import java.sql.Timestamp
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+import kotlin.test.assertTrue
 
 @ExtendWith(NodeResolver::class)
 class XtConnectionTest {
@@ -58,6 +61,28 @@ class XtConnectionTest {
                 "2020-05-01-08:00".asZonedDateTime(),
                 execForOne("SELECT TIMESTAMP '2020-05-01-08:00' ts")
             )
+        }
+    }
+
+    @Test
+    fun `test j-u-Date is UTC`(node: Xtdb) {
+        val now = Date()
+        node.getConnection().use { conn ->
+            conn.prepareStatement("INSERT INTO foo (_id, dt) VALUES (?, ?)").use { stmt ->
+                stmt.setObject(1, "setObject")
+                stmt.setObject(2, now)
+                stmt.execute()
+            }
+
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT dt FROM foo").use { res ->
+                    assertTrue(res.next())
+                    assertEquals(
+                        now.toInstant().atZone(ZoneOffset.UTC),
+                        res.getObject(1)
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This has always been a weird one in JDBC.

* `j.u.Date` is effectively an Instant in the JVM - i.e. it's stored as milliseconds since the UTC epoch. For some reason, when JDBC was created, it was sent over the wire as a local date time.
* JDBC connections are implicitly opened in the local time zone of the client JVM - we preserve this where possible, for compatibility reasons.
* Impact of these two is that, when a `j.u.Date` is roundtripped from a client JVM not set to UTC, it returns a different timestamp.
* In practice, most clients do set themselves to UTC to avoid this - but as a tool author, we obviously cannot rely on this.

In this PR, we change `setObject` within the XTDB JDBC driver to send `j.u.Date` as we do `j.t.Instant` - i.e. a timestamp-with-tz.