### PR TITLE
4141 deprecate status endpoint

### DIFF
--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -18,11 +18,7 @@
   (status [node] [node opts]))
 
 (def http-routes
-  [["/status" {:name :status
-               :summary "Status"
-               :description "Get status information from the node"}]
-
-   ["/tx" {:name :tx
+  [["/tx" {:name :tx
            :summary "Transaction"
            :description "Submits a transaction to the cluster"}]
 

--- a/cloudformation/xtdb_alb.yml
+++ b/cloudformation/xtdb_alb.yml
@@ -31,12 +31,12 @@ Resources:
     DependsOn: ECSALB
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPath: /status
+      HealthCheckPath: /healthz/alive
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       Name: ECSTargetGroup
-      Port: 3000
+      Port: 8080
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId: !Ref VpcId

--- a/docs/src/content/docs/intro/installation-via-docker.adoc
+++ b/docs/src/content/docs/intro/installation-via-docker.adoc
@@ -26,15 +26,13 @@ You can start a 'standalone' (i.e. non-production, non-distributed) XTDB server 
 docker run -it --pull=always \
   -p 5432:5432 \
   -p 8080:8080 \
-  -p 3000:3000 \
   ghcr.io/xtdb/xtdb
 
 # 5432: Postgres wire-compatible server (primary API)
 # 8080: Monitoring/healthz HTTP endpoints
-# 3000: HTTP query/tx API
 ----
 
-This command starts a Postgres wire-compatible endpoint on port 5432 and an HTTP server available at http://localhost:3000
+This command starts a Postgres wire-compatible endpoint on port 5432.
 
 By default your data will only be stored transiently using a local directory within the Docker container, but you can attach a host volume to preserve your data across container restarts, e.g. by adding `-v /tmp/xtdb-data-dir:/var/lib/xtdb`.
 

--- a/http-server/src/main/clojure/xtdb/server.clj
+++ b/http-server/src/main/clojure/xtdb/server.clj
@@ -88,24 +88,13 @@
 
 (s/def :xtdb.server.tx/opts (s/nilable (s/keys :opt-un [::system-time ::default-tz ::key-fn ::explain?])))
 
-(defn- json-status-encoder []
-  (reify
-    mf/EncodeToBytes
-    (encode-to-bytes [_ data _charset]
-      (let [{:keys [^TransactionKey latest-completed-tx latest-submitted-tx-id]} data]
-        (json/write-value-as-bytes {"latestCompletedTx" (when latest-completed-tx
-                                                          {"txId" (.getTxId latest-completed-tx)
-                                                           "systemTime" (.getSystemTime latest-completed-tx)})
-                                    "latestSubmittedTxId" (when-not (neg? latest-submitted-tx-id)
-                                                            latest-submitted-tx-id)})))
-    mf/EncodeToOutputStream))
-
-(defmethod route-handler :status [_]
-  {:muuntaja (m/create (-> muuntaja-opts
-                           (assoc-in [:formats "application/json" :encoder] (json-status-encoder))))
-
-   :post {:handler (fn [{:keys [node] :as _req}]
-                     {:status 200, :body (xtp/status node)})}})
+(defmethod route-handler ::default [_]
+  {:get {:handler (fn [_req]
+                    {:status 404
+                     :body {:error "Not found"}})}
+   :post {:handler (fn [_req]
+                     {:status 404
+                      :body {:error "Not found"}})}})
 
 (def ^:private json-tx-encoder
   (reify

--- a/http-server/src/main/resources/openapi.yaml
+++ b/http-server/src/main/resources/openapi.yaml
@@ -138,14 +138,6 @@ components:
         queryOpts:
           $ref: '#/components/schemas/QueryOpts'
 
-    Status:
-      type: object
-      properties:
-        latestCompletedTx:
-          $ref: '#/components/schemas/TransactionKey'
-        latestSubmittedTx:
-          $ref: '#/components/schemas/TransactionKey'
-
     TransactionKey:
       type: object
       properties:
@@ -381,23 +373,6 @@ components:
         '@value': "2020-01-01T12:34:56.789[Europe/Paris]"
 
 paths:
-  /status:
-    post:
-      summary: Status
-      description: Get status information from the node
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthOpts'
-        required: false
-      responses:
-        '200':
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /tx:
     post:
       summary: Transaction


### PR DESCRIPTION
I've removed reference to the status endpoint from protocols and the openapi spec as well as reference to the http server from the docs. However, I haven't changed the docker image so it still starts the http server, I can do this as well if needed.