### PR TITLE
Add grace period configuration to garbage collector

### DIFF
--- a/core/src/main/clojure/xtdb/garbage_collector.clj
+++ b/core/src/main/clojure/xtdb/garbage_collector.clj
@@ -4,22 +4,25 @@
   (:import [xtdb.api Xtdb$Config GarbageCollectorConfig]
            [xtdb.garbage_collector GarbageCollector]))
 
-(defmethod xtn/apply-config! :xtdb/garbage-collector [^Xtdb$Config config _ {:keys [enabled? blocks-to-keep approx-run-interval]}]
+(defmethod xtn/apply-config! :xtdb/garbage-collector [^Xtdb$Config config _ {:keys [enabled? blocks-to-keep
+                                                                                    grace-period approx-run-interval]}]
   (.garbageCollector config
                      (cond-> (GarbageCollectorConfig.)
                        enabled? (.enabled enabled?)
                        blocks-to-keep (.blocksToKeep blocks-to-keep)
+                       grace-period (.gracePeriod grace-period)
                        approx-run-interval (.approxRunInterval approx-run-interval))))
 
 (defmethod ig/prep-key :xtdb/garbage-collector [_ ^GarbageCollectorConfig config]
   {:block-catalog (ig/ref :xtdb/block-catalog)
    :enabled? (.getEnabled config)
    :blocks-to-keep (.getBlocksToKeep config)
+   :grace-period (.getGracePeriod config)
    :approx-run-interval (.getApproxRunInterval config)})
 
-(defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [block-catalog enabled? blocks-to-keep approx-run-interval]}]
+(defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [block-catalog enabled? blocks-to-keep grace-period approx-run-interval]}]
   (when enabled?
-    (GarbageCollector. block-catalog blocks-to-keep approx-run-interval)))
+    (GarbageCollector. block-catalog blocks-to-keep grace-period approx-run-interval)))
 
 (defmethod ig/halt-key! :xtdb/garbage-collector [_ ^GarbageCollector gc]
   (when gc

--- a/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
@@ -9,6 +9,7 @@ import java.time.Duration
 data class GarbageCollectorConfig(
     var enabled: Boolean = true,
     var blocksToKeep: Int = 10,
+    var gracePeriod: Duration = Duration.ofHours (6),
     var approxRunInterval: Duration = Duration.ofMinutes(10),
 ) {
     fun enabled(enabled: Boolean) = apply { this.enabled = enabled }

--- a/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
@@ -16,6 +16,7 @@ private val LOGGER = LoggerFactory.getLogger(GarbageCollector::class.java)
 class GarbageCollector(
     private val blockCatalog: BlockCatalog,
     private val blocksToKeep: Int,
+    private val gracePeriod: Duration,
     private val approxRunInterval: Duration
 ) : Closeable {
     private val scope = CoroutineScope(Dispatchers.IO)
@@ -27,7 +28,7 @@ class GarbageCollector(
             while (isActive) {
                 try {
                     LOGGER.debug("Starting block garbage collection")
-                    blockCatalog.garbageCollectBlocks(blocksToKeep)
+                    blockCatalog.garbageCollectBlocks(blocksToKeep, gracePeriod)
                     LOGGER.debug("Block garbage collection completed")
                 } catch (e: Exception) {
                     LOGGER.warn("Block garbage collection failed", e)

--- a/src/test/kotlin/xtdb/ClockUtil.kt
+++ b/src/test/kotlin/xtdb/ClockUtil.kt
@@ -1,0 +1,26 @@
+package xtdb
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class ClockUtil {
+    companion object {
+        fun createClock(step: Duration, initialTime: Instant = Instant.now()): Clock {
+            return object : Clock() {
+                private var currentTime = initialTime
+
+                override fun instant(): Instant {
+                    val result = currentTime
+                    currentTime = currentTime.plus(step)
+                    return result
+                }
+
+                override fun getZone(): ZoneId = ZoneId.systemDefault()
+
+                override fun withZone(zone: ZoneId?): Clock = this
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add gracePeriod parameter to GarbageCollectorConfig with 6-hour default
- Update garbage collection logic to respect grace period when deleting blocks. Meaning we either keep 10 blocks or more if there are more in the gracePeriod.
- Prevent deletion of blocks newer than the grace period cutoff
- Add ClockUtil test utility for time-based testing

Part of #4512.