### PR TITLE
Add list expressions, use within emit-table-cols.

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1825,7 +1825,7 @@
        :write-value-out! (fn [value-type code]
                            (write-value-code value-type out-writer-sym code))})))
 
-(defn- wrap-zone-id-cache-buster [f]
+(defn wrap-zone-id-cache-buster [f]
   (fn [expr opts]
     (f expr (assoc opts :zone-id *default-tz*))))
 

--- a/core/src/main/clojure/xtdb/expression/list.clj
+++ b/core/src/main/clojure/xtdb/expression/list.clj
@@ -1,0 +1,27 @@
+(ns xtdb.expression.list
+  (:require [xtdb.expression :as expr]
+            [xtdb.types :as types]
+            [xtdb.util :as util])
+  (:import (clojure.lang IPersistentMap)
+           (xtdb.arrow ListExpression RelationReader ListValueReader)))
+
+(def vec-writer-sym (gensym 'vec_writer))
+
+(def compile-list-expr
+  (-> (fn [expr opts]
+        (let [expr (expr/prepare-expr expr)
+              {:keys [return-type continue] :as emitted-expr} (expr/codegen-expr expr opts)
+              field (types/unnest-field (types/col-type->field return-type))]
+          {:field field
+           :->list-expr (eval `(fn [~(-> expr/schema-sym (expr/with-tag IPersistentMap))
+                                    ~(-> expr/args-sym (expr/with-tag RelationReader))]
+                                 (let [~@(expr/batch-bindings emitted-expr)
+                                       ^ListValueReader lvr# ~(continue (fn [_t c]
+                                                                          c))]
+                                   (reify ListExpression
+                                     (getSize [_#] (.size lvr#))
+                                     (writeTo [_# ~vec-writer-sym start# len#]
+                                       (dotimes [~expr/idx-sym len#]
+                                         (.writeValue ~vec-writer-sym (.nth lvr# (+ start# ~expr/idx-sym)))))))))}))
+      (util/lru-memoize) ; <<no-commit>>
+      expr/wrap-zone-id-cache-buster))

--- a/core/src/main/kotlin/xtdb/arrow/ListExpression.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ListExpression.kt
@@ -1,0 +1,9 @@
+package xtdb.arrow
+
+import xtdb.vector.IVectorWriter
+import org.apache.arrow.vector.types.pojo.Field
+
+interface ListExpression {
+    val size: Int
+    fun writeTo(vecWriter: IVectorWriter, start: Int, len: Int)
+}

--- a/src/test/clojure/xtdb/expression/list_test.clj
+++ b/src/test/clojure/xtdb/expression/list_test.clj
@@ -1,0 +1,84 @@
+(ns xtdb.expression.list-test
+  (:require [clojure.test :as t]
+            [xtdb.error :as err]
+            [xtdb.expression :as expr]
+            [xtdb.expression.list :as list-expr]
+            [xtdb.types :as types]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
+  (:import (org.apache.arrow.vector.types.pojo Field)
+           (xtdb.arrow ListExpression)))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(t/deftest compile-list-expr-test
+  (letfn [(run-test [form opts]
+            (let [expr (expr/form->expr form opts)
+                  {:keys [->list-expr ^Field field]} (list-expr/compile-list-expr expr {})
+                  ^ListExpression res (->list-expr {} {})]
+              {:field field
+               :size (some-> res (.getSize))
+               :value (when res
+                        (util/with-open [out-vec (.createVector field tu/*allocator*)]
+                          (let [out-vec-writer (vw/->writer out-vec)]
+                            (.writeTo res out-vec-writer 0 (.getSize res))
+                            (vec (.toList (vw/vec-wtr->rdr out-vec-writer))))))}))]
+    (t/is (= {:field (types/col-type->field "i64" :i64)
+              :size 10
+              :value [1 2 3 4 5 6 7 8 9 10]}
+             (run-test '(generate_series 1 11 1) {}))
+          "happy case with generate_series")
+    
+    (t/is (= {:field (types/col-type->field "null" :null)
+              :size nil
+              :value nil}
+             (run-test '(get_field 1) {}))
+          "expr that returns nil")
+
+    (t/is (= {:field (types/col-type->field "null" :null)
+              :size nil
+              :value nil}
+             (run-test '(+ 1 1) {}))
+          "expr that doesn't return a list")
+
+    (t/is (= {:field (types/col-type->field "null" :null)
+              :size nil
+              :value nil}
+             (run-test '(if true (+ 1 1) [1 2]) {}))
+          "expr that might return a list (and doesn't)")
+    
+    ;; FIXME: Unnest returns the wrong type when something _might_ return a list 
+    #_(t/is (= {:field (types/col-type->field "i64" :i64)
+              :size 2
+              :value [1 2]}
+             (run-test '(if false (+ 1 1) [1 2]) {}))
+          "expr that might return a list (and does)")))
+
+(t/deftest testing-write-to
+  (let [expr (expr/form->expr '[1 2 3 4 5 6 7 8 9 10] {})
+        {:keys [->list-expr ^Field field]} (list-expr/compile-list-expr expr {})
+        ^ListExpression list-expr (->list-expr {} {})
+        run-write-test (fn [start count]
+                         (util/with-open [out-vec (.createVector field tu/*allocator*)]
+                           (let [out-vec-writer (vw/->writer out-vec)]
+                             (.writeTo list-expr out-vec-writer start count)
+                             (vec (.toList (vw/vec-wtr->rdr out-vec-writer))))))]
+
+    (t/is (= [1 2 3 4 5 6 7 8 9 10]
+             (run-write-test 0 (.getSize list-expr)))
+          "writeTo - all values from start")
+
+    (t/is (= [1 2 3 4 5]
+             (run-write-test 0 5))
+          "writeTo - half values from start")
+
+    (t/is (= [6 7 8 9 10]
+             (run-write-test 5 5))
+          "writeTo - half values from halfway")
+
+    (t/is (thrown-with-msg?
+           IllegalArgumentException
+           #"No matching clause: 10"
+           (run-write-test 0 15))
+          "writeTo - more values than size")))


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aimplement-list-expr++

Adds in the `ListExpression` interface, alongside `xtdb.expression.list`, and makes use of this with emit-col-table. Simplifies how we handle lists within there, and acts as an incremental/equivalence change which should make reasoning around batching generate-series simpler.
