### PR TITLE
HTTP server -> labs in prep for 2.0.0

### DIFF
--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
+ext {
+    set("labs", true)
+}
+
 publishing {
     publications.create("maven", MavenPublication::class) {
         pom {


### PR DESCRIPTION
We're not ruling out further breaking changes in the HTTP server, so best that this is marked as a labs project before 2.x

Recommendation is to use the primary Postgres-compatible API.