### PR TITLE
Add batched list operator, use for generate_series.

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -184,6 +184,14 @@
     (mapv symbol (if (map? table)
                    (keys table)
                    (keys (first table))))
+            
+    [:list explicit-column-names _]
+    (vec explicit-column-names)
+    
+    [:list list]
+    (mapv symbol (if (map? list)
+                   (keys list)
+                   (keys (first list))))
 
     [:scan _scan-opts columns]
     (mapv ->projected-column columns)

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -1,0 +1,62 @@
+(ns xtdb.operator.list
+  (:require [clojure.spec.alpha :as s]
+            [xtdb.expression :as expr]
+            [xtdb.expression.list :as expr-list]
+            [xtdb.logical-plan :as lp]
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr]
+            [xtdb.vector.writer :as vw])
+  (:import (org.apache.arrow.vector.types.pojo Field)
+           (org.apache.arrow.memory BufferAllocator)
+           (xtdb ICursor)
+           (xtdb.arrow ListExpression)
+           (xtdb.vector RelationReader)))
+
+(defmethod lp/ra-expr :list [_]
+  (s/cat :op #{:list}
+         :explicit-col-names (s/? (s/coll-of ::lp/column :kind vector?))
+         :list (s/map-of ::lp/column any?, :count 1)))
+
+
+(defn- restrict-cols [fields {:keys [explicit-col-names]}]
+  (cond-> fields
+    explicit-col-names (-> (->> (merge (zipmap explicit-col-names (repeat types/null-field))))
+                           (select-keys explicit-col-names))))
+
+(def ^:dynamic *batch-size* 1024)
+
+(deftype ListCursor [^BufferAllocator allocator
+                     ^ListExpression list-expr
+                     ^Field field
+                     ^long batch-size
+                     ^:unsynchronized-mutable ^long current-pos]
+  ICursor
+  (tryAdvance [_ consumer]
+    (boolean
+     (when (and list-expr (< current-pos (.getSize list-expr)))
+       (let [start current-pos
+             end (min (.getSize list-expr) (+ current-pos batch-size))]
+         (set! current-pos end)
+         (util/with-open [out-vec (.createVector field allocator)]
+           (let [out-vec-writer (vw/->writer out-vec)]
+             (.writeTo list-expr out-vec-writer start (- end start))
+             (.accept consumer (vr/rel-reader [(vw/vec-wtr->rdr out-vec-writer)]))
+             true))))))
+
+  (close [_] nil))
+
+(defmethod lp/emit-expr :list
+  [{:keys [list] :as list-expr}
+   {:keys [param-fields schema] :as opts}]
+  (let [[out-col v] (first list)
+        param-types (update-vals param-fields types/field->col-type)
+        input-types (assoc opts :param-types param-types)
+        expr (expr/form->expr v input-types) 
+        {:keys [field ->list-expr]} (expr-list/compile-list-expr expr input-types)
+        named-field (types/field-with-name field (str out-col))
+        fields {(symbol (.getName named-field)) named-field}]
+    {:fields (restrict-cols fields list-expr)
+     :->cursor (fn [{:keys [allocator ^RelationReader args]}]
+                 (ListCursor. allocator (->list-expr schema args) named-field
+                              *batch-size* 0))}))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -16,6 +16,7 @@
             xtdb.operator.csv
             xtdb.operator.group-by
             xtdb.operator.join
+            xtdb.operator.list
             xtdb.operator.order-by
             xtdb.operator.patch
             xtdb.operator.project

--- a/src/test/clojure/xtdb/operator/list_test.clj
+++ b/src/test/clojure/xtdb/operator/list_test.clj
@@ -1,0 +1,59 @@
+(ns xtdb.operator.list-test
+  (:require [clojure.test :as t]
+            [xtdb.operator.list :as ol]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-allocator tu/with-node)
+
+(t/deftest test-generate-series
+  (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5}]
+           (tu/query-ra [:list '{a (generate_series 1 6 1)}])))
+
+  (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5}]
+           (tu/query-ra [:top {:limit 5}
+                         [:list '{a (generate_series 1 2000000000 1)}]]))
+        "large generate_series with limit")
+
+  (t/is (= [{:a 1000000001}
+            {:a 1000000002}
+            {:a 1000000003}
+            {:a 1000000004}
+            {:a 1000000005}]
+           (tu/query-ra [:top {:skip 1000000000
+                               :limit 5}
+                         [:list '{a (generate_series 1 2000000000 1)}]]))
+        "large generate_series with skip + limit")
+
+  (t/is (= [{:a 2} {:a 3} {:a 4}]
+           (tu/query-ra [:list '{a (generate_series ?start ?stop ?step)}]
+                        {:args {:start 2 :stop 5 :step 1}}))
+        "generate_series with parameterised start, stop, step"))
+
+(t/deftest test-batch-boundaries
+  (binding [ol/*batch-size* 3]
+    (t/is (= [[{:a 1} {:a 2}]]
+             (tu/query-ra [:list '{a (generate_series 1 3 1)}]
+                          {:preserve-pages? true}))
+          "Should handle size smaller than a single batch")
+
+    (t/is (= [[{:a 1} {:a 2} {:a 3}]]
+             (tu/query-ra [:list '{a (generate_series 1 4 1)}]
+                          {:preserve-pages? true}))
+          "Should handle size of a single full batch")
+
+    (t/is (= [[{:a 1} {:a 2} {:a 3}]
+              [{:a 4} {:a 5} {:a 6}]]
+             (tu/query-ra [:list '{a (generate_series 1 7 1)}]
+                          {:preserve-pages? true}))
+          "Should yield two full batches")
+
+    (t/is (= [[{:a 1} {:a 2} {:a 3}]
+              [{:a 4} {:a 5}]]
+             (tu/query-ra [:list '{a (generate_series 1 6 1)}]
+                          {:preserve-pages? true}))
+          "Should yield one full batch and one partial batch")
+
+    (t/is (= []
+             (tu/query-ra [:list '{a (generate_series 1 1 1)}]
+                          {:preserve-pages? true}))
+          "Should yield no pages with empty list")))


### PR DESCRIPTION
Resolves #4412 

Github action runs here: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Abatched-list-operator

Adds in a batched list operator into XTDB, using it from the SQL planner to handle generate_series. Adds a set of tests around the behavior of this. 


### Note on GENERATE_SERIES for Timestamps

This would still an issue for timestamps, as we evaluate generate_series for those eagerly, for example:

```
;; Would generate 3.6 billion timestamps (3600 seconds × 1,000,000)
  (t/is (= [{:ts #xt/date-time "2020-01-01T00:00:00.000Z"}
            {:ts #xt/date-time "2020-01-01T00:00:00.001Z"}
            {:ts #xt/date-time "2020-01-01T00:00:00.002Z"}
            {:ts #xt/date-time "2020-01-01T00:00:00.003Z"}
            {:ts #xt/date-time "2020-01-01T00:00:00.004Z"}]
           (xt/q tu/*node* "SELECT ts FROM generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 01:00:00', INTERVAL 'PT0.000001S') AS t(ts) LIMIT 5"))
        "timestamp generate_series with microsecond interval and LIMIT should not blow memory")
```

Will still throw an OoM - within ts_series itself.

### Note on #4387 

I wrote the following test against generate_series on main based on the issue, getting it to reliably throw an out of memory against a 6GB Heap by upping the sizes of GENERATE_SERIES:
```
(t/deftest test-oom-on-left-joined-generate-series-4387
  (t/is (= [{:xt/id 1 :rn 1}]
           (xt/q tu/*node* "WITH systemCTE AS (SELECT system._id AS _id, ROW_NUMBER() OVER (PARTITION BY system._id) AS rn FROM GENERATE_SERIES(1,100000) AS system(_id)) SELECT system.* FROM systemCTE AS system LEFT JOIN systemCTE AS load2 USING (_id) LEFT JOIN GENERATE_SERIES(1,100000) AS gen(t) ON TRUE LIMIT 1;"))))
```

Following this change - this _still_ throws an OoM, so not certain these changes would necessarily fixed the observed memory leak. 
