### PR TITLE
MemoryCache and DiskCache becoming separate top-level components

### DIFF
--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -64,7 +64,9 @@ xtdbConfig:
       objectStore: !S3
         bucket: !Env AWS_S3_BUCKET
         prefix: xtdb-object-store
-      localDiskCache: /var/lib/xtdb/buffers/disk-cache
+
+    diskCache:
+      path: /var/lib/xtdb/buffers/disk-cache
 
     healthz:
       host: '*'

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -69,7 +69,9 @@ xtdbConfig:
         container: !Env AZURE_STORAGE_CONTAINER
         prefix: "xtdb-object-store"
         userManagedIdentityClientId: !Env AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
-      localDiskCache: /var/lib/xtdb/buffers/disk-cache
+
+    diskCache:
+      path: /var/lib/xtdb/buffers/disk-cache
 
     healthz:
       host: '*'

--- a/cloud-benchmark/aws/aws-config.yaml
+++ b/cloud-benchmark/aws/aws-config.yaml
@@ -10,7 +10,9 @@ storage: !Remote
   objectStore: !S3
     bucket: !Env XTDB_S3_BUCKET
     prefix: "xtdb-object-store"
-  localDiskCache: /var/lib/xtdb/buffers
+
+diskCache:
+  path: /var/lib/xtdb/buffers
 
 modules:
   - !CloudWatch

--- a/cloud-benchmark/azure/kubernetes/xtdb-config.yaml
+++ b/cloud-benchmark/azure/kubernetes/xtdb-config.yaml
@@ -44,8 +44,10 @@ data:
         container: !Env XTDB_AZURE_STORAGE_CONTAINER
         prefix: "xtdb-object-store"
         userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
-      localDiskCache: /var/lib/xtdb/buffers/
-      maxDiskCachePercentage: 75
+
+    diskCache:
+      path: /var/lib/xtdb/buffers/
+      maxSizeRatio: 0.75
 
     modules:
       - !AzureMonitor

--- a/cloud-benchmark/google-cloud/google-cloud-config.yaml
+++ b/cloud-benchmark/google-cloud/google-cloud-config.yaml
@@ -10,4 +10,6 @@ storage: !Remote
     projectId: !Env XTDB_GCP_PROJECT_ID
     bucket: !Env XTDB_GCP_BUCKET
     prefix: !Env XTDB_GCP_BUCKET_PREFIX
-  localDiskCache: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH
+
+diskCache:
+  path: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH

--- a/core/src/main/clojure/xtdb/cache.clj
+++ b/core/src/main/clojure/xtdb/cache.clj
@@ -1,0 +1,37 @@
+(ns xtdb.cache
+  (:require [integrant.core :as ig]
+            [xtdb.node :as xtn]
+            [xtdb.util :as util])
+  (:import xtdb.api.Xtdb$Config
+           (xtdb.cache DiskCache$Factory MemoryCache$Factory)))
+
+(defmethod xtn/apply-config! ::memory [^Xtdb$Config config _ {:keys [max-cache-bytes max-cache-ratio]}]
+  (cond-> (.getMemoryCache config)
+    max-cache-bytes (.maxSizeBytes max-cache-bytes)
+    max-cache-ratio (.maxSizeRatio max-cache-ratio)))
+
+(defmethod ig/prep-key ::memory [_ factory]
+  {:allocator (ig/ref :xtdb/allocator)
+   :factory factory
+   :metrics-registry (ig/ref :xtdb.metrics/registry)})
+
+(defmethod ig/init-key ::memory [_ {:keys [allocator ^MemoryCache$Factory factory metrics-registry]}]
+  (.open factory allocator metrics-registry))
+
+(defmethod ig/halt-key! ::memory [_ ^MemoryCache$Factory memory-cache]
+  (util/close memory-cache))
+
+(defmethod xtn/apply-config! ::disk [^Xtdb$Config config _ {:keys [path max-cache-bytes max-cache-ratio]}]
+  (.diskCache config
+              (cond-> (DiskCache$Factory. (util/->path path))
+                max-cache-bytes (.maxSizeBytes max-cache-bytes)
+                max-cache-ratio (.maxSizeRatio max-cache-ratio))))
+
+(defmethod ig/prep-key ::disk [_ factory]
+  {:factory factory
+   :metrics-registry (ig/ref :xtdb.metrics/registry)})
+
+(defmethod ig/init-key ::disk [_ {:keys [^DiskCache$Factory factory metrics-registry]}]
+  (some-> factory (.build metrics-registry)))
+
+(defmethod ig/halt-key! ::disk [_ ^DiskCache$Factory _disk-cache])

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -33,6 +33,12 @@
 (defmethod apply-config! :log [config _ opts]
   (apply-config! config :xtdb/log opts))
 
+(defmethod apply-config! :memory-cache [config _ opts]
+  (apply-config! config :xtdb.cache/memory opts))
+
+(defmethod apply-config! :disk-cache [config _ opts]
+  (apply-config! config :xtdb.cache/disk opts))
+
 (defmethod apply-config! :storage [config _ opts]
   (apply-config! config :xtdb.buffer-pool/storage opts))
 

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -265,6 +265,8 @@
          :xtdb/authn {:authn-factory (.getAuthn opts)}
          :xtdb/log (.getLog opts)
          :xtdb/buffer-pool (.getStorage opts)
+         :xtdb.cache/memory (.getMemoryCache opts)
+         :xtdb.cache/disk (.getDiskCache opts)
          :xtdb.indexer/live-index indexer-cfg
          :xtdb/garbage-collector (.getGarbageCollector opts)
          :xtdb/modules (.getModules opts)}

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -13,6 +13,8 @@ import xtdb.api.metrics.HealthzConfig
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.inMemoryStorage
+import xtdb.cache.DiskCache
+import xtdb.cache.MemoryCache
 import xtdb.util.requiringResolve
 import java.nio.file.Files
 import java.nio.file.Path
@@ -37,6 +39,8 @@ interface Xtdb : DataSource, AutoCloseable {
         var server: ServerConfig? = ServerConfig(),
         var log: Log.Factory = inMemoryLog,
         var storage: Storage.Factory = inMemoryStorage(),
+        val memoryCache: MemoryCache.Factory = MemoryCache.Factory(),
+        var diskCache: DiskCache.Factory? = null,
         var healthz: HealthzConfig? = null,
         var defaultTz: ZoneId = ZoneOffset.UTC,
         val indexer: IndexerConfig = IndexerConfig(),
@@ -49,6 +53,8 @@ interface Xtdb : DataSource, AutoCloseable {
 
         fun log(log: Log.Factory) = apply { this.log = log }
         fun storage(storage: Storage.Factory) = apply { this.storage = storage }
+
+        fun diskCache(diskCache: DiskCache.Factory?) = apply { this.diskCache = diskCache }
 
         @JvmSynthetic
         fun server(configure: ServerConfig.() -> Unit) = apply { (server ?: ServerConfig()).configure() }

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -5,7 +5,6 @@ package xtdb.api.storage
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -13,13 +12,15 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowFooter
 import xtdb.BufferPool
 import xtdb.api.PathWithEnvVarSerde
-import xtdb.api.Xtdb
 import xtdb.buffer_pool.LocalBufferPool
 import xtdb.buffer_pool.MemoryBufferPool
 import xtdb.buffer_pool.RemoteBufferPool
+import xtdb.cache.DiskCache
+import xtdb.cache.MemoryCache
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.closeOnCatch
 import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 typealias StorageVersion = Int
 
@@ -41,8 +42,8 @@ object Storage {
     @Serializable
     sealed interface Factory {
         fun open(
-            allocator: BufferAllocator,
-            meterRegistry: MeterRegistry = SimpleMeterRegistry(),
+            allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
+            meterRegistry: MeterRegistry? = null,
             storageVersion: StorageVersion = VERSION
         ): BufferPool
     }
@@ -57,8 +58,10 @@ object Storage {
     @Serializable
     @SerialName("!InMemory")
     data object InMemoryStorageFactory : Factory {
-        override fun open(allocator: BufferAllocator, meterRegistry: MeterRegistry, storageVersion: StorageVersion) =
-            MemoryBufferPool(allocator, meterRegistry)
+        override fun open(
+            allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+        ): BufferPool = MemoryBufferPool(allocator, meterRegistry)
     }
 
     @JvmStatic
@@ -70,10 +73,7 @@ object Storage {
      * Example usage, as part of a node config:
      * ```kotlin
      * Xtdb.openNode {
-     *    localStorage(path = Paths.get("test-path")) {
-     *        maxCacheEntries = 1024,
-     *        maxCacheBytes = 536870912
-     *    },
+     *    localStorage(path = Paths.get("test-path")),
      *    ...
      * }
      * ```
@@ -82,87 +82,49 @@ object Storage {
      */
     @Serializable
     @SerialName("!Local")
-    data class LocalStorageFactory(
-        val path: Path,
-        var maxCacheEntries: Long = 1024,
-        var maxCacheBytes: Long? = null,
-    ) : Factory {
+    data class LocalStorageFactory(val path: Path) : Factory {
 
-        fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
-        fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
+        override fun open(
+            allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+        ): BufferPool {
+            val diskStore = path.resolve(storageRoot(storageVersion)).also { it.createDirectories() }
 
-        override fun open(allocator: BufferAllocator, meterRegistry: MeterRegistry, storageVersion: StorageVersion) =
-            LocalBufferPool(this, storageVersion, allocator, meterRegistry)
+            return LocalBufferPool(allocator, memoryCache, meterRegistry, diskStore)
+        }
     }
 
     @JvmStatic
     fun localStorage(path: Path) = LocalStorageFactory(path)
 
-    @JvmSynthetic
-    fun Xtdb.Config.localStorage(path: Path, configure: LocalStorageFactory.() -> Unit) =
-        storage(LocalStorageFactory(path).also(configure))
-
     /**
      * Implementation for the storage module that persists data remotely within a specified [objectStore],
-     * while maintaining a local cache of the working set cache under the [localDiskCache] directory.
      *
      * Any implementer of [ObjectStore.Factory] can be used as the [objectStore]. We currently offer:
      * * AWS S3 (under **xtdb-aws**)
      * * Azure Blob Storage (under **xtdb-azure**)
      * * Google Cloud Storage (under **xtdb-google-cloud**)
      *
-     * Example usage, as part of a node config:
-     * ```kotlin
-     * Xtdb.openNode {
-     *    remoteStorage(
-     *       objectStore = objStoreImpl(...) { ... },
-     *       localDiskCache = Paths.get("test-path")
-     *    ) {
-     *       maxCacheEntries = 1024,
-     *       maxCacheBytes = 536870912,
-     *       maxDiskCachePercentage = 75,
-     *       maxDiskCacheBytes = 10737418240
-     *    },
-     *    ...
-     * }
-     * ```
-     *
      * @property objectStore configuration of the object store to use for remote storage.
-     * @property localDiskCache local directory to store the working-set cache in.
      */
     @Serializable
     @SerialName("!Remote")
-    data class RemoteStorageFactory(
-        val objectStore: ObjectStore.Factory,
-        val localDiskCache: Path,
-        var maxCacheEntries: Long = 1024,
-        var maxCacheBytes: Long? = null,
-        var maxDiskCachePercentage: Long = 75,
-        var maxDiskCacheBytes: Long? = null
-    ) : Factory {
+    data class RemoteStorageFactory(val objectStore: ObjectStore.Factory) : Factory {
 
-        fun maxCacheEntries(maxCacheEntries: Long) = apply { this.maxCacheEntries = maxCacheEntries }
-        fun maxCacheBytes(maxCacheBytes: Long) = apply { this.maxCacheBytes = maxCacheBytes }
-        fun maxDiskCachePercentage(maxDiskCachePercentage: Long) =
-            apply { this.maxDiskCachePercentage = maxDiskCachePercentage }
+        override fun open(
+            allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+        ): BufferPool {
+            requireNotNull(diskCache) { "diskCache is required for remote storage" }
 
-        fun maxDiskCacheBytes(maxDiskCacheBytes: Long) = apply { this.maxDiskCacheBytes = maxDiskCacheBytes }
-
-        override fun open(allocator: BufferAllocator, meterRegistry: MeterRegistry, storageVersion: StorageVersion) =
-            objectStore.openObjectStore(storageRoot(storageVersion)).closeOnCatch { objectStore ->
-                RemoteBufferPool(this, allocator, objectStore, meterRegistry)
+            return objectStore.openObjectStore(storageRoot(storageVersion)).closeOnCatch { objectStore ->
+                RemoteBufferPool(allocator, objectStore, memoryCache, diskCache, meterRegistry)
             }
+        }
     }
 
     @JvmStatic
-    fun remoteStorage(objectStore: ObjectStore.Factory, localDiskCachePath: Path) =
-        RemoteStorageFactory(objectStore, localDiskCache = localDiskCachePath)
-
-    @JvmSynthetic
-    fun Xtdb.Config.remoteStorage(
-        objectStore: ObjectStore.Factory,
-        localDiskCachePath: Path,
-        configure: RemoteStorageFactory.() -> Unit,
-    ) = storage(RemoteStorageFactory(objectStore, localDiskCache = localDiskCachePath).also(configure))
+    fun remoteStorage(objectStore: ObjectStore.Factory) =
+        RemoteStorageFactory(objectStore)
 }
 

--- a/core/src/main/kotlin/xtdb/buffer_pool/MemoryBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/buffer_pool/MemoryBufferPool.kt
@@ -23,7 +23,7 @@ import java.nio.channels.Channels.newChannel
 import java.nio.file.Path
 import java.util.*
 
-class MemoryBufferPool(
+internal class MemoryBufferPool(
     allocator: BufferAllocator,
     meterRegistry: MeterRegistry? = null
 ) : BufferPool, IEvictBufferTest {

--- a/core/src/main/kotlin/xtdb/cache/DiskCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/DiskCache.kt
@@ -1,9 +1,13 @@
+@file:UseSerializers(PathWithEnvVarSerde::class)
 package xtdb.cache
 
 import com.github.benmanes.caffeine.cache.RemovalCause
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import org.slf4j.LoggerFactory
+import xtdb.api.PathWithEnvVarSerde
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE
@@ -17,22 +21,28 @@ import kotlin.math.max
 
 private val LOGGER = LoggerFactory.getLogger(DiskCache::class.java)
 
-class DiskCache(
-    val rootPath: Path,
+class DiskCache internal constructor(val rootPath: Path, val maxSizeBytes: Long) {
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    val maxSizeBytes: Long
-) {
+    @Serializable
+    data class Factory
+    @JvmOverloads constructor(
+        val path: Path,
+        var maxSizeBytes: Long? = null,
+        var maxSizeRatio: Double = 0.75,
+    ) {
+        fun maxSizeBytes(maxSizeBytes: Long?) = apply { this.maxSizeBytes = maxSizeBytes }
+        fun maxSizeRatio(maxSizeRatio: Double) = apply { this.maxSizeRatio = maxSizeRatio }
+
+        fun build(meterRegistry: MeterRegistry? = null) =
+            DiskCache(
+                path.also { it.createDirectories() },
+                maxSizeBytes ?: (Files.getFileStore(path).totalSpace * maxSizeRatio).toLong()
+            ).also { meterRegistry?.registerDiskCache(it) }
+    }
+
     val pinningCache = PinningCache<Path, Entry>(maxSizeBytes)
 
     val stats get() = pinningCache.stats
-
-    fun MeterRegistry.registerDiskCache(meterName: String) {
-        pinningCache.registerMetrics(meterName, this)
-
-        Gauge.builder("$meterName.maxSizeBytes", this) { maxSizeBytes.toDouble() }
-            .baseUnit("bytes").register(this)
-    }
 
     inner class Entry(
         inner: PinningCache.IEntry<Path>,
@@ -42,7 +52,7 @@ class DiskCache(
 
         override fun onEvict(k: Path, reason: RemovalCause) {
             path.deleteIfExists()
-            LOGGER.trace("Evicted $k due to $reason")
+            LOGGER.trace("Evicted {} due to {}", k, reason)
             super.onEvict(k, reason)
         }
 
@@ -103,5 +113,18 @@ class DiskCache(
                 tmpFile.moveTo(diskCachePath.createParentDirectories(), ATOMIC_MOVE, REPLACE_EXISTING)
                 completedFuture(Entry(pinningCache.Entry(diskCachePath.fileSize()), k, diskCachePath))
             }
+    }
+
+    companion object {
+        @JvmStatic
+        fun factory(path: Path) = Factory(path)
+
+        fun MeterRegistry.registerDiskCache(cache: DiskCache) {
+            cache.pinningCache.registerMetrics("disk-cache", this)
+
+            Gauge.builder("disk-cache.maxSizeBytes", cache) { it.maxSizeBytes.toDouble() }
+                .baseUnit("bytes").register(this)
+        }
+
     }
 }

--- a/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
+++ b/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
@@ -1,9 +1,52 @@
 package xtdb.multipart
 
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
 import xtdb.api.storage.ObjectStore
+import xtdb.buffer_pool.RemoteBufferPool
+import xtdb.util.logger
+import xtdb.util.warn
+import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 
 interface SupportsMultipart<Part> : ObjectStore {
     fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<Part>>
+
+    companion object {
+
+        private const val MAX_CONCURRENT_PART_UPLOADS = 4
+
+        private val LOGGER = RemoteBufferPool::class.logger
+
+        private val multipartUploadDispatcher =
+            IO.limitedParallelism(MAX_CONCURRENT_PART_UPLOADS, "upload-multipart")
+
+        @JvmStatic
+        fun <P> SupportsMultipart<P>.uploadMultipartBuffers(key: Path, nioBuffers: List<ByteBuffer>): Unit = runBlocking {
+            val upload = startMultipart(key).await()
+
+            try {
+                val waitingParts = nioBuffers.mapIndexed { idx, it ->
+                    async(multipartUploadDispatcher) {
+                        upload.uploadPart(idx, it).await()
+                    }
+                }
+
+                upload.complete(waitingParts.awaitAll()).await()
+            } catch (e: Throwable) {
+                try {
+                    LOGGER.warn("Error caught in uploadMultipartBuffers - aborting multipart upload of $key")
+                    upload.abort().get()
+                } catch (abortError: Throwable) {
+                    LOGGER.warn(abortError, "Throwable caught when aborting uploadMultipartBuffers")
+                    e.addSuppressed(abortError)
+                }
+                throw e
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/xtdb/buffer_pool/LocalBufferPoolTest.kt
+++ b/core/src/test/kotlin/xtdb/buffer_pool/LocalBufferPoolTest.kt
@@ -5,29 +5,31 @@ import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import xtdb.BufferPool
-import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.localStorage
-import xtdb.api.storage.Storage.storageRoot
+import xtdb.cache.MemoryCache
 import java.nio.file.Files.createTempDirectory
 
 class LocalBufferPoolTest : BufferPoolTest() {
-    override fun bufferPool(): BufferPool = localBufferPool
-
     private lateinit var allocator: BufferAllocator
-    private lateinit var localBufferPool: LocalBufferPool
+    private lateinit var memoryCache: MemoryCache
+    private lateinit var localBufferPool: BufferPool
+
+    override fun bufferPool(): BufferPool = localBufferPool
 
     @BeforeEach
     fun setUp() {
         allocator = RootAllocator()
+        memoryCache = MemoryCache.Factory().open(allocator)
 
-        localBufferPool = LocalBufferPool(
-            localStorage(createTempDirectory("local-buffer-pool-test")), Storage.VERSION, allocator
-        )
+        localBufferPool =
+            localStorage(createTempDirectory("local-buffer-pool-test"))
+                .open(allocator, memoryCache, null)
     }
 
     @AfterEach
     fun tearDown() {
         localBufferPool.close()
+        memoryCache.close()
         allocator.close()
     }
 }

--- a/core/src/test/resources/node-config.yaml
+++ b/core/src/test/resources/node-config.yaml
@@ -8,4 +8,5 @@ indexer:
   flushDuration: PT4H
 storage: !Local
   path: /tmp/test-storage
-  maxCacheEntries: 1025
+memoryCache:
+  maxSizeBytes: 1025

--- a/docker/aws/aws_config.yaml
+++ b/docker/aws/aws_config.yaml
@@ -10,7 +10,9 @@ storage: !Remote
   objectStore: !S3
     bucket: !Env XTDB_S3_BUCKET
     prefix: "xtdb-object-store"
-  localDiskCache: /var/lib/xtdb/buffers
+
+diskCache:
+  path: /var/lib/xtdb/buffers
 
 healthz:
   host: '*'

--- a/docker/azure/azure_config.yaml
+++ b/docker/azure/azure_config.yaml
@@ -12,7 +12,9 @@ storage: !Remote
     container: !Env XTDB_AZURE_STORAGE_CONTAINER
     prefix: "xtdb-object-store"
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
-  localDiskCache: !Env XTDB_LOCAL_DISK_CACHE
+
+diskCache:
+  path: !Env XTDB_LOCAL_DISK_CACHE
 
 healthz:
   host: '*'

--- a/docker/azure/azure_config_private_auth.yaml
+++ b/docker/azure/azure_config_private_auth.yaml
@@ -16,7 +16,9 @@ storage: !Remote
     container: !Env XTDB_AZURE_STORAGE_CONTAINER
     prefix: "xtdb-object-store"
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
-  localDiskCache: !Env XTDB_LOCAL_DISK_CACHE
+
+diskCache:
+  path: !Env XTDB_LOCAL_DISK_CACHE
 
 healthz:
   host: '*'

--- a/docker/docker-compose/dc_config.yaml
+++ b/docker/docker-compose/dc_config.yaml
@@ -15,7 +15,9 @@ storage: !Remote
       accessKey: !Env ACCESS_KEY
       secretKey: !Env SECRET_KEY
     pathStyleAccessEnabled: true
-  localDiskCache: /var/lib/xtdb/buffers
+
+diskCache:
+  path: /var/lib/xtdb/buffers
 
 healthz:
   host: '*'

--- a/docker/google-cloud/google_cloud_config.yaml
+++ b/docker/google-cloud/google_cloud_config.yaml
@@ -11,7 +11,9 @@ storage: !Remote
     projectId: !Env XTDB_GCP_PROJECT_ID
     bucket: !Env XTDB_GCP_BUCKET
     prefix: "xtdb-object-store"
-  localDiskCache: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH
+
+diskCache:
+  path: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH
 
 healthz:
   host: '*'

--- a/docs/src/content/docs/ops/aws.adoc
+++ b/docs/src/content/docs/ops/aws.adoc
@@ -316,7 +316,10 @@ storage: !Remote
     ## If not provided, will default to the standard S3 endpoint for the resolved region.
     # endpoint: "https://..."
 
-  localDiskCache: /var/cache/xtdb/object-store
+# -- required
+# A local disk path where XTDB can cache files from the remote storage
+diskCache:
+  path: /var/cache/xtdb/object-store
 ----
 
 If configured as an in-process node, you can also specify an `S3Configurator` instance - this is used to modify the requests sent to S3.

--- a/docs/src/content/docs/ops/azure.adoc
+++ b/docs/src/content/docs/ops/azure.adoc
@@ -307,7 +307,10 @@ storage: !Remote
     # (Can be set as an !Env value)
     # userManagedIdentityClientId: user-managed-identity-client-id
 
-  localDiskCache: /var/cache/xtdb/object-store
+# -- required
+# A local disk path where XTDB can cache files from the remote storage
+diskCache:
+  path: /var/cache/xtdb/object-store
 ----
 
 '''

--- a/docs/src/content/docs/ops/config/clojure.adoc
+++ b/docs/src/content/docs/ops/config/clojure.adoc
@@ -95,8 +95,7 @@ Main article: link:/config/storage#local-disk[local-disk storage]
 
             ;; -- optional
 
-            ;; :max-cache-bytes 1024
-            ;; :max-cache-entries 536870912
+            ;; :max-cache-bytes 536870912
            }]}
 ----
 
@@ -111,17 +110,36 @@ Main article: link:/config/storage#remote[remote storage]
                     
                     ;; Each object store implementation has its own configuration - 
                     ;; see below for some examples.
-                    :object-store [:object-store-implementation {}]
+                    :object-store [:object-store-implementation {}]}]
 
-                    ;; accepts `String`, `File` or `Path`
-                    :local-disk-cache "/tmp/local-disk-cache"
+ ;; -- required for remote storage
+ ;; Local directory to store the working-set cache in.
+ :disk-cache {;; -- required
 
-                    ;; -- optional
-                    ;; :max-cache-entries 1024
-                    ;; :max-cache-bytes 536870912
-                    ;; :max-disk-cache-percentage 75
-                    ;; :max-disk-cache-bytes 107374182400
-                    }]}
+              ;; accepts `String`, `File` or `Path`
+              :path "/tmp/local-disk-cache"
+
+              ;; -- optional
+              ;; The maximum proportion of space to use on the filesystem for the diskCache directory
+              ;; (overridden by maxSizeBytes, if set).
+              :max-size-ratio 0.75
+
+              ;; The upper limit of bytes that can be stored within the diskCache directory (unset by default).
+              :max-size-bytes 107374182400}
+
+ ;; -- optional - in-memory cache created with default config if not supplied
+ ;; configuration for XTDB's in-memory cache
+ ;; if not provided, an in-memory cache will still be created, with the default size
+ :memory-cache {;; -- optional
+
+                ;; The maximum proportion of the JVM's direct-memory space to use for the in-memory cache
+                ;; (overridden by `:max-size-bytes`, if set).
+                :max-size-ratio 0.5
+
+                ;; unset by default
+                :max-size-bytes 536870912}
+
+}
 ----
 
 [#s3]

--- a/docs/src/content/docs/ops/config/storage.adoc
+++ b/docs/src/content/docs/ops/config/storage.adoc
@@ -35,13 +35,15 @@ storage: !Local
   # (Can be set as an !Env value)
   path: /var/lib/xtdb/storage
 
-  # -- optional
+## -- optional
+# configuration for XTDB's in-memory cache
+# if not provided, an in-memory cache will still be created, with the default size
+memoryCache:
+  # The maximum proportion of the JVM's direct-memory space to use for the in-memory cache (overridden by maxSizeBytes, if set).
+  # maxSizeRatio: 0.5
 
-  # The maximum number of entries to store in the in-memory cache.
-  # maxCacheEntries: 1024
-
-  # The maximum number of bytes to store in the in-memory cache.
-  # maxCacheBytes: 536870912
+  # The maximum number of bytes to store in the in-memory cache (unset by default).
+  # maxSizeBytes: 536870912
 ----
 
 [#remote]
@@ -64,24 +66,32 @@ storage: !Remote
   # Each of these is configured separately - see below for more information.
   objectStore: <ObjectStoreImplementation>
 
-  # Local directory to store the working-set cache in.
+
+## -- required
+# Local directory to store the working-set cache in.
+diskCache:
+  ## -- required
   # (Can be set as an !Env value)
-  localDiskCache: /var/lib/xtdb/remote-cache
+  path: /var/lib/xtdb/remote-cache
 
   ## -- optional
+  # The maximum proportion of space to use on the filesystem for the diskCache directory (overridden by maxSizeBytes, if set).
+  # maxSizeRatio: 0.75
 
-  # The maximum number of entries to store in the in-memory cache.
-  # maxCacheEntries: 1024
+  # The upper limit of bytes that can be stored within the diskCache directory (unset by default).
+  # maxSizeBytes: 107374182400
 
-  # The maximum number of bytes to store in the in-memory cache.
-  # maxCacheBytes: 536870912
+## -- optional
+# configuration for XTDB's in-memory cache
+# if not provided, an in-memory cache will still be created, with the default size
+memoryCache:
+  # The maximum proportion of the JVM's direct-memory space to use for the in-memory cache (overridden by maxSizeBytes, if set).
+  # maxSizeRatio: 0.5
 
-  # The max percentage of space to use on the filesystem for the localDiskCache directory (overriden by maxDiskCacheBytes, if set).
-  # maxDiskCachePercentage: 75
-
-  # The upper limit of bytes that can be stored within the localDiskCache directory (unset by default).
-  # maxDiskCacheBytes: 107374182400
+  # The maximum number of bytes to store in the in-memory cache (unset by default).
+  # maxSizeBytes: 536870912
 ----
+
 Each Object Store implementation is configured separately - see the individual cloud platform documentation for more information:
 
 * link:../aws#storage[AWS]

--- a/docs/src/content/docs/ops/google-cloud.adoc
+++ b/docs/src/content/docs/ops/google-cloud.adoc
@@ -264,7 +264,10 @@ storage: !Remote
     # (Can be set as an !Env value)
     # prefix: my-xtdb-node
 
-  localDiskCache: /var/cache/xtdb/object-store
+# -- required
+# A local disk path where XTDB can cache files from the remote storage
+diskCache:
+  path: /var/cache/xtdb/object-store
 ----
 
 '''

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -68,7 +68,9 @@ xtdbConfig:
         projectId: !Env GCP_PROJECT_ID
         bucket: !Env GCP_BUCKET
         prefix: xtdb-object-store
-      localDiskCache: /var/lib/xtdb/buffers/disk-cache
+
+    diskCache:
+      path: /var/lib/xtdb/buffers/disk-cache
 
     healthz:
       host: '*'

--- a/modules/aws/README.adoc
+++ b/modules/aws/README.adoc
@@ -63,8 +63,10 @@ We can swap out the implementation of the object store with one based on S3. To 
 
 [source,clojure]
 ----
-{:storage [:remote {:object-store [:s3 {:bucket "xtdb-object-store"}]
-                    :local-disk-cache "local-disk-cache"}]}
+{:storage [:remote {:object-store [:s3 {:bucket "xtdb-object-store"}]}]
+
+ ;; required for remote storage
+ :disk-cache {:path "local-disk-cache"}}
 ----
 
 === Parameters
@@ -102,6 +104,7 @@ By default, we get credentials through the usual AWS credentials provider.
 [source,clojure]
 ----
 {:storage [:remote {:object-store [:s3 {:bucket "xtdb-object-store",
-                                        :configurator (fn [_] (reify S3Configurator...))}]
-                    :local-disk-cache "local-disk-cache"}]}
+                                        :configurator (fn [_] (reify S3Configurator...))}]}]
+ ;; required for remote storage
+ :disk-cache {:path "local-disk-cache"}}
 ----

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -50,7 +50,6 @@ import kotlin.time.Duration.Companion.seconds
  *       objectStore = s3(bucket = "xtdb-bucket") {
  *           prefix = Path.of("my/custom/prefix")
  *       },
- *       localDiskCache = Paths.get("test-path")
  *    ),
  *    ...
  * }

--- a/modules/azure/README.adoc
+++ b/modules/azure/README.adoc
@@ -36,8 +36,8 @@ To do so, we can add the `:azure` object store and it's configuration map, withi
 
 ```clojure
 {:storage [:remote {:object-store [:azure {:storage-account "xtdbstorageaccount"
-                                           :container "xtdb-object-store"}]
-                    :local-disk-cache "local-disk-cache"}]}
+                                           :container "xtdb-object-store"}]}]
+ :disk-cache {:path "local-disk-cache"}}
 ```
 
 Below follows the various parameters used by the module, and some notes around the provided <<resource-manager, Azure Resource Manager template>> which sets up all of the necessary infrastructure.

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -61,7 +61,6 @@ import kotlin.time.Duration.Companion.seconds
  *          userManagedIdentityClientId = "user-managed-identity-client-id"
  *          storageAccountEndpoint = "https://xtdb-storage-account.privatelink.blob.core.windows.net"
  *       },
- *       localDiskCache = Paths.get("test-path")
  *    ),
  *    ...
  * }

--- a/modules/bench/cloud/config/aws.yaml
+++ b/modules/bench/cloud/config/aws.yaml
@@ -9,5 +9,6 @@ storage: !Remote
   objectStore: !S3
     bucket: !Env XTDB_S3_BUCKET
     prefix: "xtdb-object-store"
-  localDiskCache: /var/lib/xtdb/buffers
-  maxDiskCachePercentage: 75
+
+diskCache:
+  path: /var/lib/xtdb/buffers

--- a/modules/bench/cloud/config/azure.yaml
+++ b/modules/bench/cloud/config/azure.yaml
@@ -11,5 +11,6 @@ storage: !Remote
     container: !Env XTDB_AZURE_STORAGE_CONTAINER
     prefix: "xtdb-object-store"
     userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
-  localDiskCache: /var/lib/xtdb/buffers/
-  maxDiskCachePercentage: 75
+
+diskCache:
+  path: /var/lib/xtdb/buffers/

--- a/modules/bench/cloud/config/google-cloud.yaml
+++ b/modules/bench/cloud/config/google-cloud.yaml
@@ -10,8 +10,9 @@ storage: !Remote
     projectId: !Env XTDB_GCP_PROJECT_ID
     bucket: !Env XTDB_GCP_BUCKET
     prefix: "xtdb-object-store"
-  localDiskCache: /var/lib/xtdb/buffers/
-  maxDiskCachePercentage: 75
+
+diskCache:
+  path: /var/lib/xtdb/buffers/
 
 server:
   host: '*'

--- a/modules/google-cloud/README.adoc
+++ b/modules/google-cloud/README.adoc
@@ -43,8 +43,8 @@ We can swap out the implementation of the object store with one based on Google 
 To do so, we add a `:google-cloud` section within the Integrant config for our node, alongside any config:
 ```clojure
 {:storage [:remote {:object-store [:google-cloud {:project-id "your-project-id"
-                                                  :bucket "your-storage-bucket"}]
-                    :local-disk-cache local-disk-cache}]}
+                                                  :bucket "your-storage-bucket"}]}]
+ :disk-cache {:path "local-disk-cache"}}
 ```
 
 Below follows the various parameters used by the module, and some notes around the provided <<deployment-manager, Google Cloud Deployment Manager configuration template>> which sets up all of the necessary infrastructure.

--- a/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
@@ -40,13 +40,9 @@ import kotlin.time.Duration.Companion.seconds
  * ```kotlin
  * Xtdb.openNode {
  *    remoteStorage(
- *       objectStore = googleCloudStorage(
- *          projectId = "xtdb-project",
- *          bucket ="xtdb-bucket"
- *       ) {
+ *       objectStore = googleCloudStorage(projectId = "xtdb-project", bucket ="xtdb-bucket") {
  *          prefix = Path.of("my/custom/prefix")
  *       },
- *       localDiskCache = Paths.get("test-path")
  *    ),
  *    ...
  * }

--- a/src/test/clojure/xtdb/aws/minio_test.clj
+++ b/src/test/clojure/xtdb/aws/minio_test.clj
@@ -1,6 +1,7 @@
 (ns xtdb.aws.minio-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.buffer-pool :as bp]
             [xtdb.buffer-pool-test :as bp-test]
             [xtdb.node :as xtn]
             [xtdb.object-store :as os]
@@ -44,22 +45,22 @@
    {:storage [:remote {:object-store [:s3 {:bucket bucket
                                            :prefix (str prefix)
                                            :credentials test-creds
-                                           :endpoint "http://127.0.0.1:9000"}]
-                       :local-disk-cache (.resolve node-dir "local-cache")}]
+                                           :endpoint "http://127.0.0.1:9000"}]}]
+    :disk-cache {:path (.resolve node-dir "local-cache")}
     :log [:kafka {:topic (str "xtdb.kafka-test." prefix)
                   :bootstrap-servers "localhost:9092"}]}))
 
 (t/deftest ^:minio list-test
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (start-node local-disk-cache (random-uuid))]
-      (let [buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+      (let [buffer-pool (bp/<-node node)]
         (bp-test/test-list-objects buffer-pool)))))
 
 (t/deftest ^:minio list-test-with-prior-objects
   (util/with-tmp-dirs #{local-disk-cache}
     (let [prefix (random-uuid)]
       (util/with-open [node (start-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+        (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
           (bp-test/put-edn buffer-pool (util/->path "alice") :alice)
           (bp-test/put-edn buffer-pool (util/->path "alan") :alan)
           (Thread/sleep 100)
@@ -67,7 +68,7 @@
                    (.listAllObjects buffer-pool)))))
 
       (util/with-open [node (start-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+        (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
           (t/testing "prior objects will still be there, should be available on a list request"
           (Thread/sleep 100)
             (t/is (= [(os/->StoredObject "alan" 5) (os/->StoredObject "alice" 6)]
@@ -84,8 +85,8 @@
     (let [prefix (random-uuid)]
       (util/with-open [node-1 (start-node local-disk-cache prefix)
                        node-2 (start-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool-1 (bp-test/fetch-buffer-pool-from-node node-1)
-              ^RemoteBufferPool buffer-pool-2 (bp-test/fetch-buffer-pool-from-node node-2)]
+        (let [^RemoteBufferPool buffer-pool-1 (bp/<-node node-1)
+              ^RemoteBufferPool buffer-pool-2 (bp/<-node node-2)]
           (bp-test/put-edn buffer-pool-1 (util/->path "alice") :alice)
           (bp-test/put-edn buffer-pool-2 (util/->path "alan") :alan)
           (Thread/sleep 1000)
@@ -139,7 +140,7 @@
 (t/deftest ^:minio node-level-test
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (start-node local-disk-cache (random-uuid))]
-      (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+      (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
         ;; Submit some documents to the node
         (t/is (= true
                  (:committed? (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]

--- a/src/test/clojure/xtdb/aws/s3_test.clj
+++ b/src/test/clojure/xtdb/aws/s3_test.clj
@@ -1,6 +1,7 @@
 (ns xtdb.aws.s3-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.buffer-pool :as bp]
             [xtdb.buffer-pool-test :as bp-test]
             [xtdb.datasets.tpch :as tpch]
             [xtdb.node :as xtn]
@@ -35,22 +36,22 @@
   (xtn/start-node
    {:storage [:remote
               {:object-store [:s3 {:bucket bucket
-                                   :prefix (util/->path (str "xtdb.s3-test." prefix))}]
-               :local-disk-cache local-disk-cache}]
+                                   :prefix (util/->path (str "xtdb.s3-test." prefix))}]}]
+    :disk-cache {:path local-disk-cache}
     :log [:kafka {:topic (str "xtdb.kafka-test." prefix)
                   :bootstrap-servers "localhost:9092"}]}))
 
 (t/deftest ^:s3 list-test
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (start-kafka-node local-disk-cache (random-uuid))]
-      (let [buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+      (let [buffer-pool (bp/<-node node)]
         (bp-test/test-list-objects buffer-pool)))))
 
 (t/deftest ^:s3 list-test-with-prior-objects
   (util/with-tmp-dirs #{local-disk-cache}
     (let [prefix (random-uuid)]
       (util/with-open [node (start-kafka-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+        (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
           (bp-test/put-edn buffer-pool (util/->path "alice") :alice)
           (bp-test/put-edn buffer-pool (util/->path "alan") :alan)
           (Thread/sleep 1000)
@@ -58,7 +59,7 @@
                    (vec (.listAllObjects buffer-pool))))))
 
       (util/with-open [node (start-kafka-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+        (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
           (t/testing "prior objects will still be there, should be available on a list request"
             (t/is (= [(os/->StoredObject "alan" 5) (os/->StoredObject "alice" 6)]
                      (vec (.listAllObjects buffer-pool)))))
@@ -74,8 +75,8 @@
     (let [prefix (random-uuid)]
       (util/with-open [node-1 (start-kafka-node local-disk-cache prefix)
                        node-2 (start-kafka-node local-disk-cache prefix)]
-        (let [^RemoteBufferPool buffer-pool-1 (bp-test/fetch-buffer-pool-from-node node-1)
-              ^RemoteBufferPool buffer-pool-2 (bp-test/fetch-buffer-pool-from-node node-2)]
+        (let [^RemoteBufferPool buffer-pool-1 (bp/<-node node-1)
+              ^RemoteBufferPool buffer-pool-2 (bp/<-node node-2)]
           (bp-test/put-edn buffer-pool-1 (util/->path "alice") :alice)
           (bp-test/put-edn buffer-pool-2 (util/->path "alan") :alan)
           (Thread/sleep 1000)
@@ -121,7 +122,7 @@
 (t/deftest ^:s3 node-level-test
   (util/with-tmp-dirs #{local-disk-cache}
     (util/with-open [node (start-kafka-node local-disk-cache (random-uuid))]
-      (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+      (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
         ;; Submit some documents to the node
         (t/is (= true
                  (:committed? (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]
@@ -150,5 +151,5 @@
       (t/is (nil? (tu/finish-block! node)))
 
       ;; Ensure some files written to buffer-pool 
-      (let [^RemoteBufferPool buffer-pool (bp-test/fetch-buffer-pool-from-node node)]
+      (let [^RemoteBufferPool buffer-pool (bp/<-node node)]
         (t/is (seq (.listAllObjects buffer-pool)))))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -69,8 +69,8 @@
                                                       :poll-duration "PT2S"
                                                       :properties-map {}
                                                       :properties-file nil}]
-                                        :storage [:remote {:object-store [:in-memory {}]
-                                                           :local-disk-cache path}]})]
+                                        :storage [:remote {:object-store [:in-memory {}]}]
+                                        :disk-cache {:path path}})]
         (t/testing "Send a transaction"
           (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))
 

--- a/src/test/kotlin/xtdb/catalog/BlockCatalogTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockCatalogTest.kt
@@ -1,17 +1,17 @@
 package xtdb.catalog
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import kotlinx.coroutines.*
-import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import xtdb.BufferPool
 import xtdb.api.storage.Storage
 import xtdb.block.proto.block
 import xtdb.block.proto.txKey
-import xtdb.buffer_pool.LocalBufferPool
+import xtdb.cache.MemoryCache
+import xtdb.test.AllocatorResolver
 import xtdb.time.InstantUtil.asMicros
 import xtdb.trie.Trie.tablePath
 import xtdb.util.StringUtil.asLexHex
@@ -19,10 +19,9 @@ import xtdb.util.asPath
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
+@ExtendWith(AllocatorResolver::class)
 class BlockCatalogTest {
     private fun writeBlock(bufferPool: BufferPool, index: Long, tableNames: List<String>, basePaths: List<Path>) {
         val block = block {
@@ -43,67 +42,81 @@ class BlockCatalogTest {
     }
 
     @Test
-    fun `garbageCollectBlocks deletes oldest blocks and per-table blocks`(@TempDir tempDir: Path) {
-        val bufferPool: BufferPool = LocalBufferPool(
-            Storage.localStorage(tempDir),
-            Storage.VERSION,
-            RootAllocator(),
-            SimpleMeterRegistry()
-        )
+    fun `garbageCollectBlocks deletes oldest blocks and per-table blocks`(@TempDir tempDir: Path, al: BufferAllocator) {
+        MemoryCache.Factory().open(al).use { memoryCache ->
+            Storage.localStorage(tempDir).open(al, memoryCache, null).use { bufferPool ->
+                // Write dummy blocks and table blocks
+                val blocksPath = "blocks".asPath
+                val table1BlockPath = "foo".tablePath.resolve(blocksPath)
+                val table2BlockPath = "bar".tablePath.resolve(blocksPath)
 
-        // Write dummy blocks and table blocks
-        val blocksPath = "blocks".asPath
-        val table1BlockPath = "foo".tablePath.resolve(blocksPath)
-        val table2BlockPath = "bar".tablePath.resolve(blocksPath)
+                // Write 10 blocks
+                (1L..10L).forEach { index ->
+                    writeBlock(
+                        bufferPool, index, listOf("foo", "bar"),
+                        listOf(blocksPath, table1BlockPath, table2BlockPath)
+                    )
+                }
 
-        // Write 10 blocks
-        (1L..10L).forEach { index ->
-            writeBlock(bufferPool, index, listOf("foo", "bar"), listOf(blocksPath, table1BlockPath, table2BlockPath))
+                // Validate 10 files exist for blocks and table blocks
+                assertBlockCount(bufferPool, blocksPath, 10)
+                assertBlockCount(bufferPool, table1BlockPath, 10)
+                assertBlockCount(bufferPool, table2BlockPath, 10)
+
+                // Create BlockCatalog instance
+                val catalog = BlockCatalog(bufferPool)
+
+                // Validate that the latest block is correct
+                val latestBlockIndex = catalog.currentBlockIndex
+                assertEquals(10L, latestBlockIndex)
+
+                // Validate latest completed transaction
+                val latestCompletedTx = catalog.latestCompletedTx
+                assertEquals(10L, latestCompletedTx?.txId)
+
+                // Trigger block GC
+                catalog.garbageCollectBlocks(blocksToKeep = 3)
+
+                // Validate that the oldest blocks are deleted, leaving only the latest 3 blocks
+                assertBlockCount(bufferPool, blocksPath, 3)
+                assertBlockCount(bufferPool, table1BlockPath, 3)
+                assertBlockCount(bufferPool, table2BlockPath, 3)
+
+                // Validate latest block still exists
+                val latestBlockFile = bufferPool.listAllObjects(blocksPath).toList()
+                    .find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
+                assertNotNull(latestBlockFile, "Expected latest block file to exist after GC, but it was deleted")
+
+                // Attempting to delete the current block should throw an exception
+                assertThrows<IllegalStateException> {
+                    catalog.garbageCollectBlocks(blocksToKeep = 0)
+                }
+
+                // Latest block should still exist - in blocks and table blocks
+                assertBlockCount(bufferPool, blocksPath, 1)
+
+                val latestBlockFileAfterGC = bufferPool.listAllObjects(blocksPath).toList()
+                    .find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
+                val latestTable1BlockFileAfterGC = bufferPool.listAllObjects(table1BlockPath).toList()
+                    .find { it.key == table1BlockPath.resolve("b${10L.asLexHex}.binpb") }
+                val latestTable2BlockFileAfterGC = bufferPool.listAllObjects(table2BlockPath).toList()
+                    .find { it.key == table2BlockPath.resolve("b${10L.asLexHex}.binpb") }
+
+                assertNotNull(
+                    latestBlockFileAfterGC,
+                    "Expected latest block file to exist after GC, but it was deleted"
+                )
+                assertNotNull(
+                    latestTable1BlockFileAfterGC,
+                    "Expected latest table1 block file to exist after GC, but it was deleted"
+                )
+                assertNotNull(
+                    latestTable2BlockFileAfterGC,
+                    "Expected latest table2 block file to exist after GC, but it was deleted"
+                )
+            }
+
         }
-
-        // Validate 10 files exist for blocks and table blocks
-        assertBlockCount(bufferPool, blocksPath, 10)
-        assertBlockCount(bufferPool, table1BlockPath, 10)
-        assertBlockCount(bufferPool, table2BlockPath, 10)
-
-        // Create BlockCatalog instance
-        val catalog = BlockCatalog(bufferPool)
-
-        // Validate that the latest block is correct
-        val latestBlockIndex = catalog.currentBlockIndex
-        assertEquals(10L, latestBlockIndex)
-
-        // Validate latest completed transaction
-        val latestCompletedTx = catalog.latestCompletedTx
-        assertEquals(10L,latestCompletedTx?.txId)
-
-        // Trigger block GC
-        catalog.garbageCollectBlocks(blocksToKeep = 3)
-
-        // Validate that the oldest blocks are deleted, leaving only the latest 3 blocks
-        assertBlockCount(bufferPool, blocksPath, 3)
-        assertBlockCount(bufferPool, table1BlockPath, 3)
-        assertBlockCount(bufferPool, table2BlockPath, 3)
-
-        // Validate latest block still exists
-        val latestBlockFile = bufferPool.listAllObjects(blocksPath).toList().find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
-        assertNotNull(latestBlockFile, "Expected latest block file to exist after GC, but it was deleted")
-
-        // Attempting to delete the current block should throw an exception
-        assertThrows<IllegalStateException> {
-            catalog.garbageCollectBlocks(blocksToKeep = 0)
-        }
-
-        // Latest block should still exist - in blocks and table blocks
-        assertBlockCount(bufferPool, blocksPath, 1)
-
-        val latestBlockFileAfterGC = bufferPool.listAllObjects(blocksPath).toList().find { it.key == blocksPath.resolve("b${10L.asLexHex}.binpb") }
-        val latestTable1BlockFileAfterGC = bufferPool.listAllObjects(table1BlockPath).toList().find { it.key == table1BlockPath.resolve("b${10L.asLexHex}.binpb") }
-        val latestTable2BlockFileAfterGC = bufferPool.listAllObjects(table2BlockPath).toList().find { it.key == table2BlockPath.resolve("b${10L.asLexHex}.binpb") }
-
-        assertNotNull(latestBlockFileAfterGC, "Expected latest block file to exist after GC, but it was deleted")
-        assertNotNull(latestTable1BlockFileAfterGC, "Expected latest table1 block file to exist after GC, but it was deleted")
-        assertNotNull(latestTable2BlockFileAfterGC, "Expected latest table2 block file to exist after GC, but it was deleted")
     }
 
     /*


### PR DESCRIPTION
first part of #4562: rather than the different buffer pool implementations creating their own memory- and disk-caches, this PR makes those two their own top-level components. This means that, eventually, we'll be able to have multiple buffer pools for different object stores, all of which be able to share these components.

I could have decided that the multiple buffer-pools would each have their own individual caches, but I decided not to because I wanted the memory/disk accounting to be valid for the whole JVM, and the idea of configuring each database with its own memory/disk limits seemed fraught. That said, this may put us at risk of one database hogging the resources, so we may choose to add in per-database limits later - i.e. hierarchical limits, not dissimilar to Arrow's allocators/child allocators.

This is a breaking configuration change:

* no cache configuration under either in-memory, local or remote storage
* new `memoryCache` and `diskCache` top-level components
  * `path` (for `diskCache`), `maxSizeBytes` - fairly self explanatory
  * `maxSizeRatio` - a proportion (e.g. 0.75) of the related quantity (disk space, off-heap size)
  * Users must specify `diskCache` when they use remote storage.

Configuration files within our managed Docker images have been updated, but need further checking.

```yaml
### ---------------------
### local storage: before
### ---------------------

storage: !Local
  path: /var/lib/xtdb/storage

  # -- optional

  # The maximum number of entries to store in the in-memory cache.
  maxCacheEntries: 1024

  # The maximum number of bytes to store in the in-memory cache.
  maxCacheBytes: 536870912

### ------------------
### local storage: now
### ------------------

storage: !Local
  path: /var/lib/xtdb/storage

## -- optional
# configuration for XTDB's in-memory cache
# if not provided, an in-memory cache will still be created, with the default size
memoryCache:
  # The maximum proportion of the JVM's direct-memory space to use for the in-memory cache (overridden by maxSizeBytes, if set).
  maxSizeRatio: 0.5

  # The maximum number of bytes to store in the in-memory cache (unset by default).
  maxSizeBytes: 536870912
```

```yaml
### -----------------------
### remote storage, before:
### -----------------------

storage: !Remote
  objectStore: <ObjectStoreImplementation>
  localDiskCache: /var/lib/xtdb/remote-cache

  ## -- optional
  maxCacheEntries: 1024
  maxCacheBytes: 536870912

  # The max percentage of space to use on the filesystem for the localDiskCache directory (overriden by maxDiskCacheBytes, if set).
  maxDiskCachePercentage: 75

  # The upper limit of bytes that can be stored within the localDiskCache directory (unset by default).
  maxDiskCacheBytes: 107374182400

### --------------------
### remote storage, now:
### --------------------

storage: !Remote
  # -- required

  # Configuration of the Object Store to use for remote storage
  # Each of these is configured separately - see below for more information.
  objectStore: <ObjectStoreImplementation>


## -- required for remote storage

# Local directory to store the working-set cache in.
diskCache:
  ## -- required
  path: /var/lib/xtdb/remote-cache

  ## -- optional

  # The maximum proportion of space to use on the filesystem for the diskCache directory (overridden by maxSizeBytes, if set).
  maxSizeRatio: 0.75

  # The upper limit of bytes that can be stored within the diskCache directory (unset by default).
  maxSizeBytes: 107374182400

## -- optional

# configuration for XTDB's in-memory cache
# if not provided, an in-memory cache will still be created, with the default size

memoryCache:
  # The maximum proportion of the JVM's direct-memory space to use for the in-memory cache (overridden by maxSizeBytes, if set).
  maxSizeRatio: 0.5

  # The maximum number of bytes to store in the in-memory cache (unset by default).
  maxSizeBytes: 536870912
```