### PR TITLE
fix for #4577 - erases in blocks where there are no puts for the given table

### DIFF
--- a/core/src/main/kotlin/xtdb/vector/MultiVectorRelationFactory.kt
+++ b/core/src/main/kotlin/xtdb/vector/MultiVectorRelationFactory.kt
@@ -9,17 +9,20 @@ import xtdb.trie.ColumnName
 
 class MultiVectorRelationFactory(leafRels: List<RelationReader>, colNames: List<ColumnName>) {
 
-    private val readers: Map<ColumnName, List<VectorReader>>
+    private val readers: Map<ColumnName, List<VectorReader?>>
 
     init {
-        val putReaders = leafRels.map { it["op"].vectorForOrNull("put") }
+        val putReaders = leafRels.map {
+            it["op"].vectorForOrNull("put")?.takeIf { putVec -> putVec.vectorForOrNull("_id") != null }
+        }
 
         readers = colNames.associateWith { colName ->
             if (colName == "_iid") {
                 leafRels.map { it["_iid"] }
             } else {
-                putReaders.filterNotNull().map { putReader ->
-                    putReader.vectorForOrNull(colName)?.withName(colName)
+                putReaders.map { putReader ->
+                    if (putReader == null) null
+                    else putReader.vectorForOrNull(colName)?.withName(colName)
                         ?: ValueVectorReader.from(NullVector(colName, putReader.valueCount))
                 }
             }

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b01.arrow.json
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b01.arrow.json
@@ -51,7 +51,7 @@
         },
         "children" : [{
           "name" : "_id",
-          "nullable" : true,
+          "nullable" : false,
           "type" : {
             "name" : "UuidType"
           },

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b02.arrow.json
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b02.arrow.json
@@ -51,7 +51,7 @@
         },
         "children" : [{
           "name" : "_id",
-          "nullable" : true,
+          "nullable" : false,
           "type" : {
             "name" : "UuidType"
           },


### PR DESCRIPTION
resolves #4577 

As a result of no puts to the given table, the 'put' vec in that block for that table had a type of `[:struct {}]`, which, when merged with other segments, marked all of their columns (including the `_id` column) nullable. 

Unfortunately, this wasn't reflected in the col-types (stored in the table block file), which is what we use at query compile-time to determine the output fields of each cursor so, when it came to query run-time, there was an unexpected nullable type.

Fix is two-fold:
- when we read pages in in the scan operator, exclude put vectors without any children (put vectors with any rows in must contain an `_id` child)
- when we compact, ensure that we don't let pages without puts affect the output type of the merged file.

Requires a small migration to clear the compacted files if the user is seeing the original issue (instructions in that issue); otherwise no action required.

Other solutions we considered:
- don't throw field-mismatch in this case: a bit hacky, and only kicked the can down the road a little - the same test case then failed with invalid copy source.
- create put vectors lazily: the live-idx relies on having the putWriter available eagerly, so that it doesn't have to look up the putWriter for every row added - i.e. a hot path.
- try to avoid the migration, fix on read: not only was this quite brittle, we also didn't want to accept the complexity and risk/technical debt of having these files continue to be in the reporting user's production system indefinitely.

(not strictly a breaking change, but one I'll want to write up in the release notes)