### PR TITLE
Return stats from row tables - other table types have no stats.

### DIFF
--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -120,6 +120,7 @@
                    (restrict-cols table-expr))]
 
     {:fields fields
+     :row-count row-count
      :->out-rel (fn [{:keys [allocator] :as opts}]
                   (let [row-count (count rows)]
                     (when (pos? row-count)
@@ -185,12 +186,13 @@
                                                        (.getValueCount el-rdr))
                                             allocator))))}))
 
-(defmethod lp/emit-expr :table [{:keys [table] :as table-expr} opts]
-  (let [{:keys [fields ->out-rel]} (zmatch table
-                                     [:rows rows] (emit-rows-table rows table-expr opts)
-                                     [:column col] (emit-col-table col table-expr opts)
-                                     [:param param] (emit-arg-table param table-expr opts))]
+(defmethod lp/emit-expr :table [{:keys [table] :as table-expr} opts] 
+  (let [{:keys [fields ->out-rel row-count]} (zmatch table
+                                                     [:rows rows] (emit-rows-table rows table-expr opts)
+                                                     [:column col] (emit-col-table col table-expr opts)
+                                                     [:param param] (emit-arg-table param table-expr opts))]
 
     {:fields fields
+     :stats (when row-count {:row-count row-count})
      :->cursor (fn [opts]
                  (TableCursor. (->out-rel opts)))}))

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -1054,3 +1054,18 @@
               '[:mega-join [{id 4}]
                 [[::tu/pages [[{:id 4, :foo 0}]]]
                  [::tu/pages [[{:bar 5}]]]]]))))
+
+(t/deftest test-row-table-mega-join-order
+  (t/testing "row table mega-join order"
+    (let [plan '[:mega-join
+                 [{bar biff} {foo baz} {foo bar}]
+                 [[:table [{:baz 1} {:baz 2} {:baz 2}]]
+                  [:table [{:biff 1} {:biff 2} {:biff 3} {:biff 4}]]
+                  [:table [{:foo 1}]]
+                  [:table [{:bar 1} {:bar 2}]]]]]
+      (t/is (= '[[2 [[:equi-condition {foo bar}]]
+                  3 [[:equi-condition {foo baz}]]
+                  0 [[:equi-condition {bar biff}]]
+                  1]]
+               (:join-order (lp/emit-expr (s/conform ::lp/logical-plan plan) {})))))))
+


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions?query=branch%3Asurface-row-count-for-patch

Currently cannot return stats from within other table types, but we have access to a row-count within the emit-expr side of row tables. For the sake of PATCH planning ( #4555  ) , this should suffice.