### PR TITLE
Ensuring we re-plan again when the underlying table cols change

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -493,28 +493,27 @@
                                                                 (filter :projection)
                                                                 (map :key-col-name))
                                                       equi-specs))
-                                (mapv #(project/->identity-projection-spec (get merged-fields %))))
-
-        pushdown-blooms (when pushdown-blooms? (->pushdown-blooms probe-key-col-names))
-        matched-build-idxs (when matched-build-idxs? (RoaringBitmap.))]
+                                (mapv #(project/->identity-projection-spec (get merged-fields %))))]
 
     {:fields (projection-specs->fields output-projections)
      :->cursor (fn [{:keys [allocator args] :as opts}]
-                 (util/with-close-on-catch [build-cursor (->build-cursor opts)
-                                            relation-map (emap/->relation-map allocator {:build-fields build-fields
-                                                                                         :build-key-col-names build-key-col-names
-                                                                                         :probe-fields probe-fields
-                                                                                         :probe-key-col-names probe-key-col-names
-                                                                                         :store-full-build-rel? true
-                                                                                         :with-nil-row? with-nil-row?
-                                                                                         :theta-expr theta-expr
-                                                                                         :param-fields param-fields
-                                                                                         :args args})]
-                   (project/->project-cursor opts
-                                             (if (= join-type ::mark-join)
-                                               (MarkJoinCursor. allocator build-cursor nil (partial ->probe-cursor opts) relation-map matched-build-idxs mark-col-name pushdown-blooms join-type)
-                                               (JoinCursor. allocator build-cursor nil (partial ->probe-cursor opts) relation-map matched-build-idxs pushdown-blooms join-type))
-                                             output-projections)))}))
+                 (let [pushdown-blooms (when pushdown-blooms? (->pushdown-blooms probe-key-col-names))
+                       matched-build-idxs (when matched-build-idxs? (RoaringBitmap.))]
+                   (util/with-close-on-catch [build-cursor (->build-cursor opts)
+                                              relation-map (emap/->relation-map allocator {:build-fields build-fields
+                                                                                           :build-key-col-names build-key-col-names
+                                                                                           :probe-fields probe-fields
+                                                                                           :probe-key-col-names probe-key-col-names
+                                                                                           :store-full-build-rel? true
+                                                                                           :with-nil-row? with-nil-row?
+                                                                                           :theta-expr theta-expr
+                                                                                           :param-fields param-fields
+                                                                                           :args args})]
+                     (project/->project-cursor opts
+                                               (if (= join-type ::mark-join)
+                                                 (MarkJoinCursor. allocator build-cursor nil (partial ->probe-cursor opts) relation-map matched-build-idxs mark-col-name pushdown-blooms join-type)
+                                                 (JoinCursor. allocator build-cursor nil (partial ->probe-cursor opts) relation-map matched-build-idxs pushdown-blooms join-type))
+                                               output-projections))))}))
 
 (defn emit-join-expr-and-children {:style/indent 2} [join-expr args join-impl]
   (emit-join-expr (emit-join-children join-expr args) args join-impl))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -238,20 +238,21 @@
   ([query] (query-ra query {}))
   ([query {:keys [node args preserve-pages? with-col-types? key-fn] :as query-opts
            :or {key-fn (serde/read-key-fn :kebab-case-keyword)}}]
-   (let [{:keys [live-idx]} node
-         allocator (:allocator node *allocator*)
+   (let [allocator (:allocator node *allocator*)
          query-opts (-> query-opts
                         (cond-> node (-> (update :after-tx-id (fnil identity (xtp/latest-submitted-tx-id node)))
                                          (doto (-> :after-tx-id (then-await-tx node))))))
 
-         ^PreparedQuery pq (if node
-                             (let [^IQuerySource q-src (util/component node ::q/query-source)]
-                               (.prepareQuery q-src query live-idx query-opts))
-                             (q/prepare-query query {:allocator allocator
+         ^IQuerySource q-src (if node
+                               (util/component node ::q/query-source)
+                               (q/->query-source {:allocator allocator
                                                   :ref-ctr (RefCounter.)
                                                   :wm-src (reify Watermark$Source
                                                             (openWatermark [_]
-                                                              (Watermark. nil nil {})))}))]
+                                                              (Watermark. nil nil {})))}))
+
+         ^PreparedQuery pq (.prepareQuery q-src query query-opts)]
+
      (util/with-open [^RelationReader args-rel (if args
                                                  (vw/open-args allocator args)
                                                  vw/empty-args)

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -247,7 +247,7 @@
          ^PreparedQuery pq (if node
                              (let [^IQuerySource q-src (util/component node ::q/query-source)]
                                (.prepareQuery q-src query live-idx query-opts))
-                             (q/prepare-ra query {:allocator allocator
+                             (q/prepare-query query {:allocator allocator
                                                   :ref-ctr (RefCounter.)
                                                   :wm-src (reify Watermark$Source
                                                             (openWatermark [_]

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -24,8 +24,7 @@
 
 (t/deftest test-find-gt-ivan
   (with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:rows-per-block 10}}))]
-    (-> (xt/submit-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]])
-        (tu/then-await-tx node))
+    (xt/execute-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]])
 
     (tu/finish-block! node)
     (c/compact-all! node #xt/duration "PT1S")
@@ -33,9 +32,8 @@
     (xt/submit-tx node [[:put-docs :xt_docs {:name "Dan", :xt/id :dan, :ordinal 0}]
                         [:put-docs :xt_docs {:name "Ivan", :xt/id :iva, :ordinal 1}]])
 
-    (-> (xt/submit-tx node [[:put-docs :xt_docs {:name "James", :xt/id :jms, :ordinal 2}]
-                            [:put-docs :xt_docs {:name "Jon", :xt/id :jon, :ordinal 3}]])
-        (tu/then-await-tx node))
+    (xt/execute-tx node [[:put-docs :xt_docs {:name "James", :xt/id :jms, :ordinal 2}]
+                         [:put-docs :xt_docs {:name "Jon", :xt/id :jon, :ordinal 3}]])
 
     (tu/finish-block! node)
     (c/compact-all! node #xt/duration "PT1S")


### PR DESCRIPTION
resolves #4570 

This PR moves the plan caching within the PreparedQuery, so that if the underlying table-info changes by the time we call openQuery, the query is re-planned and the new cols reflected in the output.

* We do this through two levels of cache: 
  1. first, the plan cache, which depends on the cols in each table (but not their types); 
  2. then, the emit cache (per plan, stored within the plan cache value), which depends on the param types and the types of the scanned columns
* Based on a few refactoring changes from today which I've landed separately - but essentially these mean that:
  * query-source only exposes `prepareQuery` now rather than `planQuery` and `prepareRaQuery`
  * in the SQL planner, we separate figuring out what kind of query a SQL string represents from how to plan it, so that the indexer can just call `prepareQuery` without needing to see/update the intermediate result of `planQuery` and `prepareRaQuery`.