### PR TITLE
Add user declaration to docker files

### DIFF
--- a/aws/helm/templates/statefulset.yaml
+++ b/aws/helm/templates/statefulset.yaml
@@ -24,6 +24,8 @@ spec:
         {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -65,8 +67,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/aws/helm/templates/statefulset.yaml
+++ b/aws/helm/templates/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -67,6 +67,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -23,8 +23,10 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
-  runAsUser: 10000
-  runAsGroup: 10000
+  runAsUser: 20000
+  runAsGroup: 20000
+  fsGroup: 20000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -23,6 +23,8 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -22,13 +22,15 @@ resources:
     memory: "10G"
     ephemeral-storage: 100Gi
 
-securityContext:
+podSecurityContext:
   runAsUser: 20000
   runAsGroup: 20000
   fsGroup: 20000
   runAsNonRoot: true
-  allowPrivilegeEscalation: false
+
+containerSecurityContext:
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL

--- a/azure/helm/templates/statefulset.yaml
+++ b/azure/helm/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- toYaml .Values.podSecurityContext | nindent 12 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -72,6 +72,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/azure/helm/templates/statefulset.yaml
+++ b/azure/helm/templates/statefulset.yaml
@@ -25,6 +25,8 @@ spec:
         {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -70,8 +72,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -23,8 +23,10 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
-  runAsUser: 10000
-  runAsGroup: 10000
+  runAsUser: 20000
+  runAsGroup: 20000
+  fsGroup: 20000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -23,6 +23,8 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -22,13 +22,15 @@ resources:
     memory: "10G"
     ephemeral-storage: 100Gi
 
-securityContext:
+podSecurityContext:
   runAsUser: 20000
   runAsGroup: 20000
   fsGroup: 20000
   runAsNonRoot: true
-  allowPrivilegeEscalation: false
+
+containerSecurityContext:
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL

--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -36,7 +36,7 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 ADD aws_config.yaml aws_config.yaml
 ADD build/libs/xtdb-aws.jar xtdb-aws.jar
 
-RUN groupadd -r xtdb && useradd -r -g xtdb xtdb
+RUN groupadd -g 20000 xtdb && useradd -u 20000 -g 20000 -r xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
 RUN chown -R xtdb:xtdb /var/lib/xtdb
 

--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -35,3 +35,9 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 
 ADD aws_config.yaml aws_config.yaml
 ADD build/libs/xtdb-aws.jar xtdb-aws.jar
+
+RUN groupadd -r xtdb && useradd -r -g xtdb xtdb
+RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
+RUN chown -R xtdb:xtdb /var/lib/xtdb
+
+USER xtdb

--- a/docker/azure/Dockerfile
+++ b/docker/azure/Dockerfile
@@ -37,7 +37,7 @@ ADD azure_config.yaml azure_config.yaml
 ADD azure_config_private_auth.yaml azure_config_private_auth.yaml
 ADD build/libs/xtdb-azure.jar xtdb-azure.jar
 
-RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN groupadd -g 20000 xtdb && useradd -u 20000 -g 20000 -r xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
 RUN chown -R xtdb:xtdb /var/lib/xtdb
 

--- a/docker/azure/Dockerfile
+++ b/docker/azure/Dockerfile
@@ -36,3 +36,9 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 ADD azure_config.yaml azure_config.yaml
 ADD azure_config_private_auth.yaml azure_config_private_auth.yaml
 ADD build/libs/xtdb-azure.jar xtdb-azure.jar
+
+RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
+RUN chown -R xtdb:xtdb /var/lib/xtdb
+
+USER xtdb

--- a/docker/google-cloud/Dockerfile
+++ b/docker/google-cloud/Dockerfile
@@ -37,7 +37,7 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 ADD google_cloud_config.yaml google_cloud_config.yaml
 ADD build/libs/xtdb-google-cloud.jar xtdb-google-cloud.jar
 
-RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN groupadd -g 20000 xtdb && useradd -u 20000 -g 20000 -r xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
 RUN chown -R xtdb:xtdb /var/lib/xtdb
 

--- a/docker/google-cloud/Dockerfile
+++ b/docker/google-cloud/Dockerfile
@@ -36,3 +36,9 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 
 ADD google_cloud_config.yaml google_cloud_config.yaml
 ADD build/libs/xtdb-google-cloud.jar xtdb-google-cloud.jar
+
+RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
+RUN chown -R xtdb:xtdb /var/lib/xtdb
+
+USER xtdb

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -38,3 +38,9 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 
 ADD local_config.yaml local_config.yaml
 ADD build/libs/xtdb-standalone.jar xtdb-standalone.jar
+
+RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
+RUN chown -R xtdb:xtdb /var/lib/xtdb
+
+USER xtdb

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -39,7 +39,7 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 ADD local_config.yaml local_config.yaml
 ADD build/libs/xtdb-standalone.jar xtdb-standalone.jar
 
-RUN groupadd -g 10000 xtdb && useradd -u 10000 -g 10000 -r xtdb
+RUN groupadd -g 20000 xtdb && useradd -u 20000 -g 20000 -r xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
 RUN chown -R xtdb:xtdb /var/lib/xtdb
 

--- a/docs/src/content/docs/intro/installation-via-docker.adoc
+++ b/docs/src/content/docs/intro/installation-via-docker.adoc
@@ -36,6 +36,29 @@ This command starts a Postgres wire-compatible endpoint on port 5432.
 
 By default your data will only be stored transiently using a local directory within the Docker container, but you can attach a host volume to preserve your data across container restarts, e.g. by adding `-v /tmp/xtdb-data-dir:/var/lib/xtdb`.
 
+**Running as a non-root user**
+
+The XTDB container runs as a non-root user by default (UID 20000). If you're mounting a host volume (e.g. /tmp/xtdb-data-dir:/var/lib/xtdb), you must ensure the container can write to it:
+
+For Docker, before running the container:
+
+[source,bash]
+----
+sudo chown -R 20000:20000 /tmp/xtdb-data-dir
+----
+
+For Podman, ensure the directory is owned by your user and use `--userns=keep-id`:
+
+[source,bash]
+----
+podman run -it --pull=always \
+  --userns=keep-id \
+  -p 5432:5432 \
+  -p 8080:8080 \
+  -v /tmp/xtdb-data-dir:/var/lib/xtdb \
+  ghcr.io/xtdb/xtdb
+----
+
 After seeing a 'Node started' log message (e.g. `09:00:00 | INFO  xtdb.cli | Node started`) you are able to confirm your XTDB server is running using cURL:
 
 [source,bash]

--- a/google-cloud/helm/templates/statefulset.yaml
+++ b/google-cloud/helm/templates/statefulset.yaml
@@ -24,6 +24,8 @@ spec:
         {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -67,8 +69,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/google-cloud/helm/templates/statefulset.yaml
+++ b/google-cloud/helm/templates/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes: 
         - name: "tmp"
           emptyDir: {}
@@ -69,6 +69,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -25,8 +25,10 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
-  runAsUser: 10000
-  runAsGroup: 10000
+  runAsUser: 20000
+  runAsGroup: 20000
+  fsGroup: 20000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -24,13 +24,15 @@ resources:
     memory: "10G"
     ephemeral-storage: 100Gi
 
-securityContext:
+podSecurityContext:
   runAsUser: 20000
   runAsGroup: 20000
   fsGroup: 20000
   runAsNonRoot: true
-  allowPrivilegeEscalation: false
+
+containerSecurityContext:
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -25,6 +25,8 @@ resources:
     ephemeral-storage: 100Gi
 
 securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:


### PR DESCRIPTION
Very simple change, just chown /var/lib/xtdb and switch user. Also makes the uid and gid >= 10000. Sets security context runAsUser, runAsGroup to 10000.

Resolves #4086.

For release notes:

## Docker Running as a Non-Root User

To improve security and align with container best practices, the XTDB container now runs as a non-root user by default (UID 20000).

If you’re mounting a host volume (e.g. `/tmp/xtdb-data-dir:/var/lib/xtdb`), ensure the container has permission to write to it:

Docker users:
```
sudo chown -R 20000:20000 /tmp/xtdb-data-dir
```

Podman users:
Ensure the directory is owned by your user, and run with `--userns=keep-id`:

```
podman run -it --pull=always \
  --userns=keep-id \
  -p 5432:5432 \
  -p 8080:8080 \
  -v /tmp/xtdb-data-dir:/var/lib/xtdb \
  ghcr.io/xtdb/xtdb
```