### PR TITLE
database as a secondary Integrant system s.t. it starts up independently to the base system

### DIFF
--- a/core/src/main/clojure/xtdb/authn.clj
+++ b/core/src/main/clojure/xtdb/authn.clj
@@ -6,6 +6,7 @@
             [xtdb.query :as q])
   (:import [java.io Writer]
            (xtdb.api Authenticator Authenticator$Factory Authenticator$Factory$UserTable Authenticator$Method Authenticator$MethodRule Xtdb$Config)
+           xtdb.database.Database
            (xtdb.indexer Watermark$Source)
            (xtdb.query IQuerySource)))
 
@@ -73,11 +74,10 @@
 
 (defmethod ig/prep-key :xtdb/authn [_ opts]
   (into {:q-src (ig/ref :xtdb.query/query-source)
-         :db (ig/ref :xtdb/database)
-         :wm-src (ig/ref :xtdb.indexer/live-index)}
+         :db (ig/ref :xtdb/database)}
         opts))
 
-(defmethod ig/init-key :xtdb/authn [_ {:keys [^Authenticator$Factory authn-factory, q-src, db, wm-src]}]
-  (.open authn-factory q-src db wm-src))
+(defmethod ig/init-key :xtdb/authn [_ {:keys [^Authenticator$Factory authn-factory, q-src, ^Database db]}]
+  (.open authn-factory q-src db (.getLiveIndex db)))
 
 (defn <-node ^xtdb.api.Authenticator [node] (:authn node))

--- a/core/src/main/clojure/xtdb/block_catalog.clj
+++ b/core/src/main/clojure/xtdb/block_catalog.clj
@@ -1,8 +1,8 @@
 (ns xtdb.block-catalog
   (:require [integrant.core :as ig]
+            [xtdb.database :as db]
             [xtdb.serde :as serde]
-            [xtdb.time :as time]
-            [xtdb.util :as util])
+            [xtdb.time :as time])
   (:import (xtdb.block.proto Block TxKey)
            xtdb.catalog.BlockCatalog))
 
@@ -13,7 +13,7 @@
   (BlockCatalog. buffer-pool))
 
 (defn <-node ^xtdb.catalog.BlockCatalog [node]
-  (util/component node :xtdb/block-catalog))
+  (.getBlockCatalog (db/<-node node)))
 
 (defn- <-TxKey [^TxKey tx-key]
   (serde/->TxKey (.getTxId tx-key) (time/micros->instant (.getSystemTime tx-key))))

--- a/core/src/main/clojure/xtdb/database.clj
+++ b/core/src/main/clojure/xtdb/database.clj
@@ -1,26 +1,85 @@
 (ns xtdb.database
   (:require [integrant.core :as ig]
             [xtdb.util :as util])
-  (:import [xtdb.database Database]))
+  (:import xtdb.api.Xtdb$Config
+           [xtdb.database Database]))
 
-(defmethod ig/prep-key :xtdb/database [_ _]
-  {:allocator (ig/ref :xtdb/allocator)
+(defmethod ig/init-key ::allocator [_ {{:keys [allocator]} :base, :keys [db-name]}]
+  (util/->child-allocator allocator (format "database/%s" db-name)))
+
+(defmethod ig/halt-key! ::allocator [_ allocator]
+  (util/close allocator))
+
+(defmethod ig/prep-key ::for-query [_ {:keys [db-name]}]
+  {:db-name db-name
+   :allocator (ig/ref ::allocator)
    :block-cat (ig/ref :xtdb/block-catalog)
    :table-cat (ig/ref :xtdb/table-catalog)
    :trie-cat (ig/ref :xtdb/trie-catalog)
-   :live-idx (ig/ref :xtdb.indexer/live-index)
    :log (ig/ref :xtdb/log)
    :buffer-pool (ig/ref :xtdb/buffer-pool)
-   :metadata-mgr (ig/ref :xtdb.metadata/metadata-manager)})
+   :metadata-manager (ig/ref :xtdb.metadata/metadata-manager)
+   :live-index (ig/ref :xtdb.indexer/live-index)})
 
-(defmethod ig/init-key :xtdb/database [_ {:keys [allocator block-cat table-cat trie-cat log buffer-pool live-idx metadata-mgr]}]
-  (util/with-close-on-catch [allocator (util/->child-allocator allocator "database/xtdb")]
-    (Database. "xtdb"
-               allocator block-cat table-cat trie-cat
-               log buffer-pool metadata-mgr live-idx)))
+(defmethod ig/init-key ::for-query [_ {:keys [allocator db-name block-cat table-cat
+                                             trie-cat log buffer-pool metadata-manager
+                                             live-index]}]
+  (Database. db-name allocator block-cat table-cat trie-cat
+             log buffer-pool metadata-manager live-index
+             nil nil))
 
-(defmethod ig/halt-key! :xtdb/database [_ db]
-  (util/close db))
+(defmethod ig/prep-key :xtdb/database [_ _]
+  {:base {:allocator (ig/ref :xtdb/allocator)
+          :config (ig/ref :xtdb/config)
+          :mem-cache (ig/ref :xtdb.cache/memory)
+          :disk-cache (ig/ref :xtdb.cache/disk)
+          :meter-registry (ig/ref :xtdb.metrics/registry)
+          :indexer (ig/ref :xtdb/indexer)
+          :compactor (ig/ref :xtdb/compactor)}})
+
+(defn- db-system [db-name base]
+  (let [^Xtdb$Config conf (get-in base [:config :config])
+        indexer-conf (.getIndexer conf)
+        opts {:base base, :db-name db-name}]
+    (-> {::allocator opts
+         :xtdb/block-catalog opts
+         :xtdb/table-catalog opts
+         :xtdb/trie-catalog opts
+         :xtdb.metadata/metadata-manager opts
+         :xtdb/log (assoc opts :factory (.getLog conf))
+         :xtdb/buffer-pool (assoc opts :factory (.getStorage conf))
+         :xtdb.indexer/live-index (assoc opts :indexer-conf indexer-conf)
+
+         ::for-query opts
+
+         :xtdb.indexer/for-db opts
+         :xtdb.compactor/for-db opts
+         :xtdb.log/processor (assoc opts :indexer-conf indexer-conf)}
+        (doto ig/load-namespaces))))
+
+(defmethod ig/init-key :xtdb/database [_ {:keys [base]}]
+  (try
+    (let [sys (-> (db-system "xtdb" base)
+                  ig/prep
+                  ig/init)]
+
+      {:db (-> ^Database (::for-query sys)
+               (.withComponents (:xtdb.log/processor sys)
+                                (:xtdb.compactor/for-db sys)))
+       :sys sys})
+    (catch clojure.lang.ExceptionInfo e
+      (try
+        (ig/halt! (:system (ex-data e)))
+        (catch Throwable t
+          (let [^Throwable e (or (ex-cause e) e)]
+            (throw (doto e (.addSuppressed t))))))
+      (throw (ex-cause e)))))
+
+(defmethod ig/resolve-key :xtdb/database [_ {:keys [db]}]
+  db)
+
+(defmethod ig/halt-key! :xtdb/database [_ {:keys [sys]}]
+  (ig/halt! sys))
 
 (defn <-node ^xtdb.database.Database [node]
-  (util/component node :xtdb/database))
+  (:db node))

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -732,5 +732,13 @@
 (defmethod ig/halt-key! :xtdb/indexer [_ indexer]
   (util/close indexer))
 
+(defmethod ig/prep-key ::for-db [_ {:keys [base]}]
+  {:base base
+   :query-db (ig/ref :xtdb.database/for-query)})
+
+(defmethod ig/init-key ::for-db [_ {{:keys [^Indexer indexer]} :base,
+                                    :keys [query-db]}]
+  (.openForDatabase indexer query-db))
+
 (defn <-node ^xtdb.indexer.Indexer [node]
   (util/component node :xtdb/indexer))

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -1,13 +1,13 @@
 (ns xtdb.metadata
   (:require [integrant.core :as ig]
+            [xtdb.database :as db]
             [xtdb.util :as util])
   (:import xtdb.BufferPool
            (xtdb.metadata PageMetadata)))
 
-(defmethod ig/prep-key ::metadata-manager [_ opts]
-  (merge {:allocator (ig/ref :xtdb/allocator)
-          :buffer-pool (ig/ref :xtdb/buffer-pool)}
-         opts))
+(defmethod ig/prep-key ::metadata-manager [_ _]
+  {:allocator (ig/ref :xtdb.database/allocator)
+   :buffer-pool (ig/ref :xtdb/buffer-pool)})
 
 (defmethod ig/init-key ::metadata-manager [_ {:keys [allocator, ^BufferPool buffer-pool, cache-size], :or {cache-size 128}}]
   (PageMetadata/factory allocator buffer-pool cache-size))
@@ -16,4 +16,4 @@
   (util/try-close mgr))
 
 (defn <-node ^xtdb.metadata.PageMetadata$Factory [node]
-  (util/component node ::metadata-manager))
+  (.getMetadataManager (db/<-node node)))

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -8,6 +8,7 @@
             [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.authn :as authn]
+            [xtdb.database :as db]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
             [xtdb.log :as xt-log]
@@ -450,7 +451,7 @@
 
              (when-not (or (neg? watermark-tx-id)
                            (= :read-write (:access-mode tx-opts)))
-               (xt-log/await-tx node watermark-tx-id #xt/duration "PT30S"))
+               (xt-log/await-tx (db/<-node node) watermark-tx-id #xt/duration "PT30S"))
 
              (-> st
                  (update :transaction

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -1,5 +1,6 @@
 (ns xtdb.table-catalog
   (:require [integrant.core :as ig]
+            [xtdb.database :as db]
             [xtdb.table :as table]
             [xtdb.trie :as trie]
             [xtdb.types :as types]
@@ -128,4 +129,4 @@
                    (update-vals table->table-block #(dissoc % :tries)))))
 
 (defn <-node ^xtdb.catalog.TableCatalog [node]
-  (util/component node :xtdb/table-catalog))
+  (.getTableCatalog (db/<-node node)))

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -1,12 +1,13 @@
 (ns xtdb.trie-catalog
   (:require [clojure.tools.logging :as log]
             [integrant.core :as ig]
+            [xtdb.database :as db]
             [xtdb.table-catalog :as table-cat]
             [xtdb.time :as time]
             [xtdb.trie :as trie]
             [xtdb.util :as util])
   (:import [java.nio ByteBuffer]
-           [java.time LocalDate ZoneOffset Instant]
+           [java.time Instant LocalDate ZoneOffset]
            [java.util Map]
            [java.util.concurrent ConcurrentHashMap]
            org.roaringbitmap.buffer.ImmutableRoaringBitmap
@@ -14,7 +15,6 @@
            xtdb.catalog.BlockCatalog
            (xtdb.log.proto TemporalMetadata TrieDetails TrieMetadata)
            xtdb.operator.scan.Metadata
-           (xtdb.trie Trie)
            (xtdb.util TemporalBounds)))
 
 ;; table-tries data structure
@@ -360,5 +360,5 @@
     (log/debug "trie catalog started")
     cat))
 
-(defn trie-catalog ^xtdb.trie.TrieCatalog [node]
-  (util/component node :xtdb/trie-catalog))
+(defn <-node ^xtdb.trie.TrieCatalog [node]
+  (.getTrieCatalog (db/<-node node)))

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -5,21 +5,28 @@ import xtdb.BufferPool
 import xtdb.api.log.Log
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
+import xtdb.compactor.Compactor
 import xtdb.indexer.LiveIndex
+import xtdb.indexer.LogProcessor
 import xtdb.metadata.PageMetadata
 import xtdb.trie.TrieCatalog
 
 typealias DatabaseName = String
 
-class Database(
+// only a data class for `copy` - don't expect these to be equal
+data class Database(
     val name: DatabaseName,
     val allocator: BufferAllocator,
     val blockCatalog: BlockCatalog, val tableCatalog: TableCatalog, val trieCatalog: TrieCatalog,
     val log: Log, val bufferPool: BufferPool,
-    val metadataManager: PageMetadata.Factory, val liveIndex: LiveIndex
-) : AutoCloseable {
+    val metadataManager: PageMetadata.Factory, val liveIndex: LiveIndex,
 
-    override fun close() {
-        allocator.close()
-    }
+    private val logProcessorOrNull: LogProcessor?,
+    private val compactorOrNull: Compactor.ForDatabase?,
+) {
+    val logProcessor: LogProcessor get() = logProcessorOrNull ?: error("log processor not initialised")
+    val compactor: Compactor.ForDatabase get() = compactorOrNull ?: error("compactor not initialised")
+
+    fun withComponents(logProcessor: LogProcessor?, compactor: Compactor.ForDatabase?) =
+        copy(logProcessorOrNull = logProcessor, compactorOrNull = compactor)
 }

--- a/modules/bench/src/main/clojure/xtdb/bench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
             [xtdb.compactor :as c]
-            [xtdb.indexer.live-index :as li]
+            [xtdb.database :as db]
             [xtdb.log :as xt-log]
             [xtdb.logging :as logging]
             [xtdb.node :as xtn]
@@ -292,7 +292,7 @@
   ([node] (sync-node node nil))
 
   ([node ^Duration timeout]
-   (xt-log/await-tx node (xtp/latest-submitted-tx-id node) timeout)))
+   (xt-log/await-tx (db/<-node node) (xtp/latest-submitted-tx-id node) timeout)))
 
 (defn finish-block! [node]
   (xt-log/finish-block! node))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -101,13 +101,13 @@
 ;; TODO inline this now that we have `log/await-tx`
 (defn then-await-tx
   (^TransactionKey [node]
-   (xt-log/await-tx node))
+   (xt-log/await-tx (db/<-node node)))
 
   (^TransactionKey [tx-id node]
-   (xt-log/await-tx node tx-id))
+   (xt-log/await-tx (db/<-node node) tx-id))
 
   (^TransactionKey [tx-id node timeout]
-   (xt-log/await-tx node tx-id timeout)))
+   (xt-log/await-tx (db/<-node node) tx-id timeout)))
 
 (defn ->instants
   ([u] (->instants u 1))

--- a/src/test/clojure/xtdb/cli_test.clj
+++ b/src/test/clojure/xtdb/cli_test.clj
@@ -4,6 +4,7 @@
             [integrant.core :as ig]
             [xtdb.api :as xt]
             [xtdb.cli :as cli]
+            [xtdb.indexer.live-index :as li]
             [xtdb.node :as xtn])
   (:import (xtdb.indexer.live_index LiveIndex)))
 
@@ -109,7 +110,7 @@
 
     (t/testing "node opts passed to start-node passes through yaml file and starts node"
       (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml))]))]
-        (let [index ^LiveIndex (get-in node [:system :xtdb.indexer/live-index])]
+        (let [^LiveIndex index (li/<-node node)]
           (t/is (= 65 (.log-limit index))
                 "using provided config"))
         (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])
@@ -127,7 +128,7 @@
     
     (t/testing "YAML with multiple dots in the filename starts node"
       (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml-multi-dot))]))]
-        (let [index ^LiveIndex (get-in node [:system :xtdb.indexer/live-index])]
+        (let [^LiveIndex index (li/<-node node)]
           (t/is (= 65 (.log-limit index))
                 "using provided config"))
         (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
             [xtdb.block-catalog :as block-cat]
+            [xtdb.buffer-pool :as bp]
             [xtdb.check-pbuf :as cpb]
             [xtdb.compactor :as c]
             [xtdb.database :as db]
@@ -26,7 +27,6 @@
            org.apache.arrow.memory.BufferAllocator
            [org.apache.arrow.vector.types UnionMode]
            [org.apache.arrow.vector.types.pojo ArrowType$Union]
-           (xtdb BufferPool)
            xtdb.arrow.Relation))
 
 (t/use-fixtures :once tu/with-allocator)
@@ -356,7 +356,7 @@
     (with-open [node (tu/->local-node {:node-dir node-dir, :rows-per-block 3000, :rows-per-page 300, :compactor-threads 0})
                 info-reader (io/reader (io/resource "devices_mini_device_info.csv"))
                 readings-reader (io/reader (io/resource "devices_mini_readings.csv"))]
-      (let [^BufferPool bp (tu/component node :xtdb/buffer-pool)
+      (let [bp (bp/<-node node)
             block-cat (block-cat/<-node node)
             device-infos (map ts/device-info-csv->doc (csv/read-csv info-reader))
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
@@ -417,7 +417,7 @@
             (.close node1)
 
             (util/with-close-on-catch [node2 (tu/->local-node (assoc node-opts :buffers-dir "objects-1"))]
-              (let [^BufferPool bp (util/component node2 :xtdb/buffer-pool)
+              (let [bp (bp/<-node node2)
                     block-cat (block-cat/<-node node2)
                     tc (cat/<-node node2)
                     lc-tx (-> first-half-tx-id
@@ -457,7 +457,7 @@
                   (.close node2)
 
                   (with-open [node3 (tu/->local-node (assoc node-opts :buffers-dir "objects-2"))]
-                    (let [^BufferPool bp (tu/component node3 :xtdb/buffer-pool)]
+                    (let [bp (bp/<-node node3)]
                       (t/is (<= first-half-tx-id
                                 (:tx-id (-> first-half-tx-id
                                             (tu/then-await-tx node3 (Duration/ofSeconds 10))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -1,6 +1,7 @@
 (ns ^:kafka xtdb.kafka-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.log :as log]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
@@ -57,8 +58,7 @@
                                                     :properties-map {}
                                                     :properties-file nil}]})]
       (t/testing "KafkaLog successfully created"
-        (let [log (get-in node [:system :xtdb/log])]
-          (t/is (instance? Log log)))))))
+        (t/is (instance? Log (log/<-node node)))))))
 
 (t/deftest ^:integration test-kafka-closes-properly-with-messages-sent
   (let [test-uuid (random-uuid)]

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -3,6 +3,7 @@
             [jsonista.core :as json]
             [xtdb.authn :as authn]
             [xtdb.database :as db]
+            [xtdb.indexer.live-index :as li]
             [xtdb.pgwire :as pgwire]
             [xtdb.pgwire.io :as pgio]
             [xtdb.pgwire.types :as pg-types]
@@ -71,7 +72,7 @@
                                                                     (assoc :authn (authn/->UserTableAuthn authn-rules
                                                                                                           (util/component tu/*node* :xtdb.query/query-source)
                                                                                                           (db/<-node tu/*node*)
-                                                                                                          (util/component tu/*node* :xtdb.indexer/live-index))))}}
+                                                                                                          (li/<-node tu/*node*))))}}
                                        :allocator tu/*allocator*
                                        :frontend frontend
                                        :cid -1

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2837,7 +2837,7 @@ ORDER BY 1,2;")
   (with-open [conn (jdbc-conn)]
     (xt/execute-tx conn [[:put-docs :foo {:xt/id 1}]])
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))
-    (doto (xt-log/node->log tu/*node*)
+    (doto (xt-log/<-node tu/*node*)
       (.appendMessage (Log$Message$FlushBlock. 1)))
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))))
 

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -286,7 +286,7 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
-      (let [cat (cat/trie-catalog node)]
+      (let [cat (cat/<-node node)]
         (xt/execute-tx node [[:put-docs :foo {:xt/id 1}]])
         (tu/finish-block! node)
 
@@ -299,7 +299,7 @@
                       (into #{} (map :trie-key)))))))
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
-      (let [cat (cat/trie-catalog node)]
+      (let [cat (cat/<-node node)]
         (t/is (= #{#xt/table foo, #xt/table xt/txs} (.getTables cat)))
         (t/is (= #{"l00-rc-b01" "l00-rc-b00"}
                  (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
@@ -308,7 +308,7 @@
     (t/testing "artifically adding tries"
 
       (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
-        (let [cat (cat/trie-catalog node)]
+        (let [cat (cat/<-node node)]
           (.addTries cat #xt/table foo
                      (->> [["l00-rc-b00" 1] ["l00-rc-b01" 1] ["l00-rc-b02" 1] ["l00-rc-b03" 1]
                            ["l01-rc-b00" 2] ["l01-rc-b01" 2] ["l01-rc-b02" 2]
@@ -318,7 +318,7 @@
           (tu/finish-block! node))))
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
-      (let [cat (cat/trie-catalog node)]
+      (let [cat (cat/<-node node)]
         (t/is (= #{"l00-rc-b03"
                    "l01-rc-b02"
                    "l02-rc-p0-b01"
@@ -460,7 +460,7 @@
       (with-open [node (tu/->local-node opts)]
         (let [gc (gc/garbage-collector node)
               bp (bp/<-node node)
-              cat (cat/trie-catalog node)]
+              cat (cat/<-node node)]
           (doseq [i (range 4)]
             (xt/execute-tx node [[:put-docs :foo {:xt/id i}]])
             (tu/finish-block! node)


### PR DESCRIPTION
resolves #4562 

This PR (along with the various equivalence changes before it) establishes the concept of a 'database' as a separate Integrant system in XT.

- `:xtdb/database` is a component in the main system. As part of its `ig/init-key`, it creates another Integrant system for the database.
- In `db-system`, we pass the base-system (caches, meter registry, a few other bits) _values_ into each of the components - not as Integrant component references (because we don't want to close the base-system components in the db Integrant system).

Next steps for #4561 will be to turn this into a map of databases, then we can add/remove databases at runtime.