### PR TITLE
rename (live index) Watermark -> Snapshot

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import xtdb.api.Authenticator.Method.TRUST
 import xtdb.api.Authenticator.MethodRule
-import xtdb.indexer.Watermark
+import xtdb.indexer.Snapshot
 import xtdb.database.Database
 import xtdb.query.IQuerySource
 import xtdb.util.requiringResolve
@@ -37,12 +37,12 @@ interface Authenticator : AutoCloseable {
 
         fun rules(rules: List<MethodRule>) = apply { this.rules = rules }
 
-        fun open(querySource: IQuerySource, db: Database, wmSource: Watermark.Source): Authenticator
+        fun open(querySource: IQuerySource, db: Database, wmSource: Snapshot.Source): Authenticator
 
         @Serializable
         @SerialName("!UserTable")
         data class UserTable(override var rules: List<MethodRule> = DEFAULT_RULES) : Factory {
-            override fun open(querySource: IQuerySource, db: Database, wmSource: Watermark.Source): Authenticator =
+            override fun open(querySource: IQuerySource, db: Database, wmSource: Snapshot.Source): Authenticator =
                 requiringResolve("xtdb.authn/->user-table-authn")
                     .invoke(this, querySource, db,wmSource) as Authenticator
         }

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -5,17 +5,17 @@ import xtdb.api.TransactionKey
 import xtdb.table.TableRef
 import xtdb.trie.BlockIndex
 
-interface LiveIndex : Watermark.Source, AutoCloseable {
+interface LiveIndex : Snapshot.Source, AutoCloseable {
 
-    interface Watermark : AutoCloseable {
+    interface Snapshot : AutoCloseable {
         val allColumnFields: Map<TableRef, Map<String, Field>>
-        fun liveTable(table: TableRef): LiveTable.Watermark
+        fun liveTable(table: TableRef): LiveTable.Snapshot
         val liveTables: Iterable<TableRef>
     }
 
     interface Tx : AutoCloseable {
         fun liveTable(table: TableRef): LiveTable.Tx
-        fun openWatermark(): Watermark
+        fun openSnapshot(): Snapshot
 
         fun commit()
         fun abort()
@@ -26,10 +26,10 @@ interface LiveIndex : Watermark.Source, AutoCloseable {
     fun liveTable(table: TableRef): LiveTable
     val liveTables: Iterable<TableRef>
 
-    // N.B. LiveIndex.Watermark and xtdb.indexer.Watermark are different classes
+    // N.B. LiveIndex.Snapshot and xtdb.indexer.Snapshot are different classes
     // there used to be quite a lot of difference between them
     // now - not so much, they could probably be combined
-    override fun openWatermark(): xtdb.indexer.Watermark
+    override fun openSnapshot(): xtdb.indexer.Snapshot
 
     fun startTx(txKey: TransactionKey): Tx
 

--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -59,7 +59,7 @@ constructor(
 
     private val hllCalculator = HllCalculator()
 
-    class Watermark(
+    class Snapshot(
         val columnFields: Map<ColumnName, Field>,
         val liveRelation: RelationReader,
         val liveTrie: MemoryHashTrie
@@ -78,7 +78,7 @@ constructor(
         private var transientTrie = liveTrie
         private val systemFrom: InstantMicros = txKey.systemTime.asMicros
 
-        fun openWatermark(): Watermark = openWatermark(transientTrie)
+        fun openSnapshot(): Snapshot = openSnapshot(transientTrie)
         val docWriter: IVectorWriter = putWtr
         val liveRelation: IRelationWriter = this@LiveTable.liveRelation
 
@@ -154,7 +154,7 @@ constructor(
             .children
             .associateBy { it.name }
 
-    private fun openWatermark(trie: MemoryHashTrie): Watermark {
+    private fun openSnapshot(trie: MemoryHashTrie): Snapshot {
         // this can be openSlice once liveRel is a new-style relation
         liveRelation.openDirectSlice(al).use { wmLiveRel ->
             wmLiveRel.openAsRoot(al).closeOnCatch { root ->
@@ -162,12 +162,12 @@ constructor(
 
                 val wmLiveTrie = trie.withIidReader(relReader["_iid"])
 
-                return Watermark(liveRelation.fields, relReader, wmLiveTrie)
+                return Snapshot(liveRelation.fields, relReader, wmLiveTrie)
             }
         }
     }
 
-    fun openWatermark() = openWatermark(liveTrie)
+    fun openSnapshot() = openSnapshot(liveTrie)
 
     data class FinishedBlock(
         val fields: Map<ColumnName, Field>,

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -3,23 +3,23 @@ package xtdb.indexer
 import xtdb.api.TransactionKey
 import java.util.concurrent.atomic.AtomicInteger
 
-class Watermark(
+class Snapshot(
     val txBasis: TransactionKey?,
-    val liveIndex: LiveIndex.Watermark?,
+    val liveIndex: LiveIndex.Snapshot?,
     val schema: Map<String, Any>
 ) : AutoCloseable {
     interface Source {
-        fun openWatermark(): Watermark
+        fun openSnapshot(): Snapshot
     }
 
     private val refCount = AtomicInteger(1)
 
     fun retain() {
-        if (0 == refCount.getAndIncrement()) throw IllegalStateException("watermark closed")
+        if (0 == refCount.getAndIncrement()) throw IllegalStateException("snapshot closed")
     }
 
     /**
-     * releases a reference to the Watermark.
+     * releases a reference to the Snapshot.
      * if this was the last reference, close it.
      */
     override fun close() {

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -1,8 +1,8 @@
 package xtdb.query
 
 import xtdb.database.Database
-import xtdb.indexer.Watermark
+import xtdb.indexer.Snapshot
 
 interface IQuerySource {
-    fun prepareQuery(query: Any, db: Database, wmSrc: Watermark.Source, opts: Any?): PreparedQuery
+    fun prepareQuery(query: Any, db: Database, wmSrc: Snapshot.Source, opts: Any?): PreparedQuery
 }

--- a/dev/GLOSSARY.adoc
+++ b/dev/GLOSSARY.adoc
@@ -18,6 +18,6 @@
 | object-store           | A core component of XTDB that manages the long-term, durable storage of data. e.g. S3, Google Cloud Storage, Azure Blob Storage.
 | operator               | A relational algebra operator (or some extension thereof). The simplest example is a join.
 | page                   | A group of (ideally ~1024) rows. Where possible, we process rows in page batches to amortize the overhead of parsing data, setting up copiers, etc.
+| snapshot               | An immutable snapshot of the state of the live index, used to give queries an immutable view while the indexer continues indexing concurrently.
 | transaction            | Referring to an atomic sequence of operations (put, delete etc...) to be performed on the db. Or alternatively a SQL transaction string.
-| watermark              | Holds the resources of the system at a particular point in time.
 |===

--- a/dev/doc/high-level-tour.adoc
+++ b/dev/doc/high-level-tour.adoc
@@ -160,7 +160,7 @@ Because the query plan forms an https://en.wikipedia.org/wiki/Abstract_algebra[a
 A few notes on the individual operators:
 
 * The `:scan` operator (`xtdb.operator.scan`) is easily the most complex operator - it's (directly/indirectly) responsible for choosing which files to read, reading those files, merge-sorting those pages (together with the live-index) and applying 'bitemporal resolution' to re-construct the current state of the given entities.
-** After every transaction, the indexer takes a 'watermark' of the current state of the live index, allowing it to be read by queries concurrently to new transactions being indexed.
+** After every transaction, the indexer takes a 'snapshot' of the current state of the live index, allowing it to be read by queries concurrently to new transactions being indexed.
 ** 'Bitemporal resolution' is the process by which the scan operator reduces a system-time descending list of events for each entity into the actual history relevant to the query.
 At this point, system-time-descending is a useful ordering - for as-of-now queries, we can usually skip all bar the most recent event for each entity.
 

--- a/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
+++ b/modules/flight-sql/src/main/clojure/xtdb/flight_sql.clj
@@ -71,7 +71,7 @@
                                       (while (.next flight-stream)
                                         (write-page!)))))
 
-(defn- ->fsql-producer [{:keys [allocator node, ^IQuerySource q-src, db, wm-src, ^Map fsql-txs, ^Map stmts, ^Map tickets]}]
+(defn- ->fsql-producer [{:keys [allocator node, ^IQuerySource q-src, db, snap-src, ^Map fsql-txs, ^Map stmts, ^Map tickets]}]
   (letfn [(exec-dml [dml fsql-tx-id]
             (if fsql-tx-id
               (when-not (.computeIfPresent fsql-txs fsql-tx-id
@@ -150,7 +150,7 @@
         (try
           (let [sql (.toStringUtf8 (.getQueryBytes cmd))
                 ticket-handle (new-id)
-                pq (.prepareQuery q-src sql db wm-src {})
+                pq (.prepareQuery q-src sql db snap-src {})
                 cursor (.openQuery pq {})
                 ticket (Ticket. (-> (doto (FlightSql$TicketStatementQuery/newBuilder)
                                       (.setStatementHandle ticket-handle))
@@ -201,7 +201,7 @@
       (createPreparedStatement [_ req _ctx listener]
         (let [ps-id (new-id)
               sql (.toStringUtf8 (.getQueryBytes req))
-              pq (.prepareQuery q-src sql db wm-src {})
+              pq (.prepareQuery q-src sql db snap-src {})
               ps (cond-> {:id ps-id, :sql sql
                           :fsql-tx-id (when (.hasTransactionId req)
                                         (.getTransactionId req))}
@@ -281,7 +281,7 @@
     (util/with-close-on-catch [allocator (util/->child-allocator allocator "flight-sql")
                                server (doto (-> (FlightServer/builder allocator (Location/forGrpcInsecure host port)
                                                                       (->fsql-producer {:allocator allocator, :node node,
-                                                                                        :q-src q-src, :db db, :wm-src (.getLiveIndex db)
+                                                                                        :q-src q-src, :db db, :snap-src (.getLiveIndex db)
                                                                                         :fsql-txs fsql-txs, :stmts stmts, :tickets tickets}))
 
                                                 #_(doto with-error-logging-middleware)

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -36,7 +36,7 @@
            (xtdb.api.log Log$Message$FlushBlock Log$MessageMetadata)
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader Vector)
-           (xtdb.indexer LiveTable Watermark Watermark$Source)
+           (xtdb.indexer LiveTable Snapshot Snapshot$Source)
            (xtdb.log.proto TemporalMetadata TemporalMetadata$Builder)
            (xtdb.query IQuerySource PreparedQuery)
            (xtdb.trie MetadataFileWriter)
@@ -230,18 +230,18 @@
          db (when node
               (db/<-node node))
 
-         wm-src (if node
-                  (li/<-node node)
-                  (reify Watermark$Source
-                    (openWatermark [_]
-                      (Watermark. nil nil {}))))
+         snap-src (if node
+                    (li/<-node node)
+                    (reify Snapshot$Source
+                      (openSnapshot [_]
+                        (Snapshot. nil nil {}))))
 
          ^IQuerySource q-src (if node
                                (util/component node ::q/query-source)
                                (q/->query-source {:allocator allocator
                                                   :ref-ctr (RefCounter.)}))
 
-         ^PreparedQuery pq (.prepareQuery q-src query db wm-src query-opts)]
+         ^PreparedQuery pq (.prepareQuery q-src query db snap-src query-opts)]
 
      (util/with-open [^RelationReader args-rel (if args
                                                  (vw/open-args allocator args)

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -596,7 +596,7 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
                  :valid-to #xt/zoned-date-time "2023-03-26T01:05Z[UTC]"}]
            (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _valid_from"))))
 
-(t/deftest test-wm-schema-is-updated-within-a-tx
+(t/deftest test-snapshot-schema-is-updated-within-a-tx
   (xt/execute-tx tu/*node* [[:sql "INSERT INTO t1(_id, foo) VALUES(1, 100)"]
                             [:sql "INSERT INTO t1(_id, foo, bar) (SELECT 2, 200, 2000)"]
                             [:sql "INSERT INTO t1(_id, foo, bar) (SELECT 3, x.foo, x.bar FROM (SELECT * FROM t1 WHERE bar = 2000) AS x)"]])


### PR DESCRIPTION
'watermark' was overloaded, and the live-idx version is more of an immutable snapshot than a watermark