### PR TITLE
breaking change: `xt/submit-tx` returns `{:tx-id tx-id}` rather than just tx-id (long)

### DIFF
--- a/api/src/main/clojure/xtdb/api.clj
+++ b/api/src/main/clojure/xtdb/api.clj
@@ -263,7 +263,9 @@
 
      \"UPDATE foo SET b = 1\"]
 
-  Returns the tx-id.
+  Returns a map:
+   - :tx-id (long)
+     transaction ID of the submitted transaction
 
   opts (map):
    - :system-time
@@ -273,9 +275,9 @@
    - :default-tz
      overrides the default time zone for the transaction,
      should be an instance of java.time.ZoneId"
-  (^TransactionKey [connectable, tx-ops] (submit-tx connectable tx-ops {}))
+  ([connectable, tx-ops] (submit-tx connectable tx-ops {}))
 
-  (^TransactionKey [connectable, tx-ops tx-opts]
+  ([connectable, tx-ops tx-opts]
    (with-conn [conn connectable]
      (submit-tx* conn tx-ops (-> tx-opts
                                  (assoc :async? true)))
@@ -287,7 +289,7 @@
                                                 {:builder-fn xt-jdbc/builder-fn})]
          (when (instance? xtdb.api.DataSource connectable)
            (.setAwaitToken ^xtdb.api.DataSource connectable tx-id))
-         tx-id)
+         {:tx-id tx-id})
 
        (finally
          (jdbc/execute! conn ["ROLLBACK"]))))))

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -145,7 +145,7 @@
 (t/deftest test-sql-roundtrip
   (let [tx (xt/submit-tx *node* devs)]
 
-    (t/is (= 0 tx))
+    (t/is (= {:tx-id 0} tx))
 
     (t/is (= [{:name "James"}]
              (xt/q *node* "SELECT u.name FROM users u WHERE u.name = 'James'")))))
@@ -236,7 +236,7 @@
   (let [tx (xt/submit-tx *node*
                          ["INSERT INTO foo (_id, _valid_from) VALUES ('foo', DATE '2018-01-01')"])]
 
-    (t/is (= 0 tx))
+    (t/is (= {:tx-id 0} tx))
 
     (t/is (= [{:xt/id "foo", :xt/valid-from (-> (time/->zdt #inst "2018")
                                                 (.withZoneSameLocal (ZoneId/systemDefault))
@@ -554,7 +554,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
           "original node")
 
     (with-open [conn (jdbc/get-connection client)]
-      (t/is (= 1 (xt/submit-tx conn [[:put-docs :docs {:xt/id :bar, :name "Bar"}]])))
+      (t/is (= {:tx-id 1} (xt/submit-tx conn [[:put-docs :docs {:xt/id :bar, :name "Bar"}]])))
 
       (t/is (= [{:name "Bar", :xt/id :bar}
                 {:xt/id :foo, :name "Foo"}]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -92,7 +92,7 @@
         (let [block-cat (block-cat/<-node node)]
           (t/is (nil? (.getCurrentBlockIndex block-cat)))
 
-          (t/is (= magic-last-tx-id
+          (t/is (= {:tx-id magic-last-tx-id}
                    (last (for [tx-ops txs]
                            (xt/submit-tx node tx-ops {:default-tz #xt/zone "Europe/London"})))))
 
@@ -328,7 +328,7 @@
 
         (util/mkdirs object-dir)
 
-        (t/is (= magic-last-tx-id
+        (t/is (= {:tx-id magic-last-tx-id}
                  (last (for [tx-ops txs]
                          (xt/submit-tx node tx-ops
                                        {:default-tz #xt/zone "Europe/London"})))))
@@ -366,11 +366,11 @@
 
         (t/is (nil? (xtp/latest-completed-tx node)))
 
-        (let [last-tx-id (reduce
-                          (fn [_acc tx-ops]
-                            (xt/submit-tx node tx-ops))
-                          nil
-                          (partition-all 100 tx-ops))
+        (let [{last-tx-id :tx-id} (reduce
+                                   (fn [_acc tx-ops]
+                                     (xt/submit-tx node tx-ops))
+                                   nil
+                                   (partition-all 100 tx-ops))
               last-tx-key (serde/->TxKey last-tx-id (time/->instant #inst "2020-04-19"))]
 
           (xt-log/sync-node node (Duration/ofSeconds 15))
@@ -407,11 +407,11 @@
           (t/is (= 5500 (count first-half-tx-ops)))
           (t/is (= 5500 (count second-half-tx-ops)))
 
-          (let [first-half-tx-id (reduce
-                                  (fn [_ tx-ops]
-                                    (xt/submit-tx node1 tx-ops))
-                                  nil
-                                  (partition-all 100 first-half-tx-ops))]
+          (let [{first-half-tx-id :tx-id } (reduce
+                                            (fn [_ tx-ops]
+                                              (xt/submit-tx node1 tx-ops))
+                                            nil
+                                            (partition-all 100 first-half-tx-ops))]
             (.close node1)
 
             (util/with-close-on-catch [node2 (tu/->local-node (assoc node-opts :buffers-dir "objects-1"))]
@@ -441,11 +441,11 @@
                 (t/is (= :utf8
                          (types/field->col-type (.getField tc #xt/table device_readings "_id"))))
 
-                (let [second-half-tx-id (reduce
-                                         (fn [_ tx-ops]
-                                           (xt/submit-tx node2 tx-ops))
-                                         nil
-                                         (partition-all 100 second-half-tx-ops))]
+                (let [{second-half-tx-id :tx-id} (reduce
+                                                  (fn [_ tx-ops]
+                                                    (xt/submit-tx node2 tx-ops))
+                                                  nil
+                                                  (partition-all 100 second-half-tx-ops))]
 
                   (t/is (<= first-half-tx-id
                             (:tx-id (xtp/latest-completed-tx node2))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -802,9 +802,9 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
 (t/deftest copes-with-log-time-going-backwards-3864
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock [#inst "2020" #inst "2019" #inst "2021"])}]})]
-    (t/is (= 0 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 0}]])))
-    (t/is (= 1 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 1}]])))
-    (t/is (= 2 (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 2}]])))
+    (t/is (= {:tx-id 0} (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 0}]])))
+    (t/is (= {:tx-id 1} (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 1}]])))
+    (t/is (= {:tx-id 2} (xt/submit-tx node [[:put-docs :foo {:xt/id 1, :version 2}]])))
 
     (t/is (= [{:xt/id 0, :system-time #xt/zoned-date-time "2020-01-01Z[UTC]"}
               {:xt/id 1, :system-time #xt/zoned-date-time "2020-01-01T00:00:00.000001Z[UTC]"}


### PR DESCRIPTION
eventually going to be adding more (db-name, partition) to this map.

#4492 