### PR TITLE
latest-completed-tx + latest-submitted-tx-id -> latest-completed-txs + latest-submitted-tx-ids for multi-db #4562

### DIFF
--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -13,10 +13,12 @@
   (^xtdb.query.PreparedQuery prepare-ra [node ra-plan query-opts]))
 
 (defprotocol PStatus
-  (^long latest-submitted-tx-id [node])
+  (latest-submitted-tx-ids [node])
+  (latest-completed-txs [node])
+
   (await-token [node])
-  (latest-completed-tx [node])
   (snapshot-token [node])
+
   (status [node] [node opts]))
 
 (def http-routes

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -77,7 +77,11 @@
                                                         (into {}
                                                               (map (fn [[k v]]
                                                                      (let [k (symbol k)
-                                                                           expr (expr/form->expr v (assoc opts :param-types param-types))
+                                                                           expr (try
+                                                                                  (expr/form->expr v (assoc opts :param-types param-types))
+                                                                                  (catch Exception e
+                                                                                    (clojure.tools.logging/warn "fail" {:expr v, :param-types param-types})
+                                                                                    (throw e)))
                                                                            ^Set field-set (.computeIfAbsent field-sets k (fn [_] (HashSet.)))]
                                                                        (case (:op expr)
                                                                          :literal (do

--- a/modules/bench/src/main/clojure/xtdb/bench/readings.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/readings.clj
@@ -113,7 +113,8 @@
 
                   [{:t :call
                     :f (fn [{:keys [node !state]}]
-                         (let [{:keys [latest-completed-tx]} (xt/status node)
+                         (let [latest-completed-tx (-> (xt/status node)
+                                                       (get-in [:latest-completed-txs "xtdb" 0]))
                                max-valid-time (-> (xt/q node max-valid-time-q)
                                                   first
                                                   :max-valid-time)]

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -875,7 +875,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
             (let [{:keys [tx-id]} (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])]
               (reset! !skiptxid tx-id)))
 
-          (t/is (= @!skiptxid (:tx-id (:latest-completed-tx (xt/status node)))))))
+          (t/is (= @!skiptxid (-> (xt/status node)
+                                  (get-in [:latest-completed-txs "xtdb" 0 :tx-id]))))))
 
       (t/testing "node with txs to skip"
         (with-open [node (xtn/start-node {:log [:local {:path (str path "/log")}]
@@ -888,7 +889,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
             (t/is (= (set [{:xt/id :foo}]) (set (xt/q node "SELECT * from xt_docs")))))
 
           (t/testing "Latest submitted tx id should be the one that was skipped"
-            (t/is (= @!skiptxid (:tx-id (:latest-completed-tx (xt/status node))))))
+            (t/is (= @!skiptxid (-> (xt/status node)
+                                    (get-in [:latest-completed-txs "xtdb" 0 :tx-id])))))
 
           ;; Call finish-block! to write files
           (tu/finish-block! node)))
@@ -899,7 +901,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
                                           :compactor {:threads 0}})]
 
           (t/testing "Latest submitted tx id should still be the one that was skipped"
-            (t/is (= @!skiptxid (:tx-id (:latest-completed-tx (xt/status node))))))
+            (t/is (= @!skiptxid (-> (xt/status node)
+                                    (get-in [:latest-completed-txs "xtdb" 0 :tx-id])))))
 
           (t/testing "Can send a new transaction after skipping one"
             (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :baz}]])

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -1726,8 +1726,8 @@
     (t/is (= [{:await-token (basis/->tx-basis-str {"xtdb" [0]})}]
              (q conn ["SHOW AWAIT_TOKEN"])))
 
-    (t/is (= [{:tx-id 0, :system-time #xt/zdt "2020-01-01Z[UTC]"}]
-             (q conn ["SHOW LATEST_COMPLETED_TX"])))
+    (t/is (= [{:db-name "xtdb", :part 0, :tx-id 0, :system-time #xt/zdt "2020-01-01Z[UTC]"}]
+             (q conn ["SHOW LATEST_COMPLETED_TXS"])))
 
     (jdbc/execute! conn ["INSERT INTO foo (_id) VALUES (2)"])
 
@@ -1739,8 +1739,8 @@
     (t/is (= [{:await-token (basis/->tx-basis-str {"xtdb" [0]})}]
              (q conn ["SHOW AWAIT_TOKEN"])))
 
-    (t/is (= [{:tx-id 1, :system-time #xt/zdt "2020-01-02Z[UTC]"}]
-             (q conn ["SHOW LATEST_COMPLETED_TX"])))
+    (t/is (= [{:db-name "xtdb", :part 0, :tx-id 1, :system-time #xt/zdt "2020-01-02Z[UTC]"}]
+             (q conn ["SHOW LATEST_COMPLETED_TXS"])))
 
     (jdbc/execute! conn ["INSERT INTO foo (_id) VALUES (2)"])
 
@@ -1771,6 +1771,9 @@
     (t/is (= [{:tx-id 0, :system-time #xt/zdt "2020-01-01T00:00Z[UTC]", :committed true,
                :await-token (basis/->tx-basis-str {"xtdb" [0]})}]
              (q conn ["SHOW LATEST_SUBMITTED_TX"])))
+
+    (t/is (= [{:db-name "xtdb", :part 0, :tx-id 0}]
+             (q conn ["SHOW LATEST_SUBMITTED_TXS"])))
 
     (t/is (thrown? PSQLException (jdbc/execute! conn ["ASSERT FALSE"])))
 

--- a/src/test/clojure/xtdb/ts_devices_small_test.clj
+++ b/src/test/clojure/xtdb/ts_devices_small_test.clj
@@ -17,13 +17,13 @@
 
       (with-open [node (tu/->local-node {:node-dir node-dir})]
         (binding [*node* node]
-          (t/is (nil? (xtp/latest-completed-tx node)))
+          (t/is (= {"xtdb" [nil]} (xtp/latest-completed-txs node)))
 
           (let [last-tx-key (tsd/submit-ts-devices node {:size :small})]
 
             (log/info "transactions submitted, last tx" (pr-str last-tx-key))
             (xt-log/await-db node last-tx-key (Duration/ofMinutes 15))
-            (t/is (= last-tx-key (xtp/latest-completed-tx node)))
+            (t/is (= {"xtdb" [last-tx-key]} (xtp/latest-completed-txs node)))
             (tu/finish-block! node))
 
           (f))))))


### PR DESCRIPTION
included as a PR because it's another breaking change:

* `SHOW LATEST_COMPLETED_TX` -> `SHOW LATEST_COMPLETED_TXS` - and now returns 'db-name', 'part' in addition to tx-id and system-time.
* `SHOW LATEST_SUBMITTED_TXS` - added, also additionally returns 'db-name', 'part'.
* `SHOW LATEST_SUBMITTED_TX_ID` not affected - this returns the latest submitted tx on this connection.