### PR TITLE
Pass _iid pushdown bloom to ScanCursor, use to filter rows.

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -14,7 +14,7 @@
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import [clojure.lang IFn]
-           (java.util ArrayList Iterator List HashSet)
+           (java.util ArrayList HashSet Iterator List Set)
            (java.util.function IntConsumer)
            (java.util.stream IntStream)
            (org.apache.arrow.memory BufferAllocator)
@@ -160,7 +160,7 @@
 (defmethod lp/emit-expr :cross-join [join-expr args]
   (emit-cross-join (emit-join-children join-expr args)))
 
-(defn- build-phase [^ICursor build-cursor, ^IRelationMap rel-map, pushdown-blooms, ^HashSet iid-set]
+(defn- build-phase [^ICursor build-cursor, ^IRelationMap rel-map, pushdown-blooms, ^Set iid-set]
   (.forEachRemaining build-cursor
                      (fn [^RelationReader build-rel]
                        (let [rel-map-builder (.buildFromRelation rel-map build-rel)
@@ -335,7 +335,7 @@
                      ^IRelationMap rel-map
                      ^RoaringBitmap matched-build-idxs
                      pushdown-blooms
-                     ^HashSet iid-set
+                     ^Set iid-set
                      join-type]
   ICursor
   (tryAdvance [this c]

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -1,7 +1,7 @@
 (ns xtdb.operator.join
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
-            [clojure.string]
+            [clojure.string :as string]
             [clojure.walk :as walk]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -14,7 +14,7 @@
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import [clojure.lang IFn]
-           (java.util ArrayList Iterator List)
+           (java.util ArrayList Iterator List HashSet)
            (java.util.function IntConsumer)
            (java.util.stream IntStream)
            (org.apache.arrow.memory BufferAllocator)
@@ -160,7 +160,7 @@
 (defmethod lp/emit-expr :cross-join [join-expr args]
   (emit-cross-join (emit-join-children join-expr args)))
 
-(defn- build-phase [^ICursor build-cursor, ^IRelationMap rel-map, pushdown-blooms]
+(defn- build-phase [^ICursor build-cursor, ^IRelationMap rel-map, pushdown-blooms, ^HashSet iid-set]
   (.forEachRemaining build-cursor
                      (fn [^RelationReader build-rel]
                        (let [rel-map-builder (.buildFromRelation rel-map build-rel)
@@ -174,6 +174,8 @@
                                    build-col (.vectorForOrNull build-rel (str build-col-name))
                                    ^MutableRoaringBitmap pushdown-bloom (nth pushdown-blooms col-idx)]
                                (dotimes [build-idx (.getRowCount build-rel)]
+                                 (when (and iid-set (string/includes? (str build-col-name) "iid"))
+                                   (.add iid-set (.getBytes build-col build-idx)))
                                  (.add pushdown-bloom ^ints (BloomUtils/bloomHashes build-col build-idx))))))))))
 
 #_{:clj-kondo/ignore [:unused-binding]}
@@ -327,25 +329,27 @@
          (join-rels join-type probe-rel rel-map))))
 
 (deftype JoinCursor [^BufferAllocator allocator, ^ICursor build-cursor,
-                     ^:unsynchronized-mutable ^ICursor probe-cursor 
+                     ^:unsynchronized-mutable ^ICursor probe-cursor
                      ^:unsynchronized-mutable ^RelationWriter nil-rel-writer
                      ^IFn ->probe-cursor
                      ^IRelationMap rel-map
                      ^RoaringBitmap matched-build-idxs
                      pushdown-blooms
+                     ^HashSet iid-set
                      join-type]
   ICursor
   (tryAdvance [this c]
-    (build-phase build-cursor rel-map pushdown-blooms)
+    (build-phase build-cursor rel-map pushdown-blooms iid-set)
 
     (boolean
      (or (let [advanced? (boolean-array 1)]
            (binding [scan/*column->pushdown-bloom* (cond-> scan/*column->pushdown-bloom*
-                                                     (some? pushdown-blooms) (conj (zipmap (.probeKeyColumnNames rel-map) pushdown-blooms)))]
+                                                     (some? pushdown-blooms) (conj (zipmap (.probeKeyColumnNames rel-map) pushdown-blooms)))
+                     scan/*iid-set* iid-set]
              (when-not probe-cursor
                (util/with-close-on-catch [probe-cursor (->probe-cursor)]
                  (set! (.probe-cursor this) probe-cursor)))
-             
+
              (when (and matched-build-idxs (not nil-rel-writer))
                (util/with-close-on-catch [nil-rel-writer (emap/->nillable-rel-writer allocator (.probeFields rel-map))]
                  (set! (.nil-rel-writer this) nil-rel-writer)))
@@ -365,7 +369,7 @@
            (let [build-rel (.getBuiltRelation rel-map)
                  build-row-count (long (.getRowCount build-rel))
                  unmatched-build-idxs (RoaringBitmap/flip matched-build-idxs 0 build-row-count)]
-             
+
              ;; Only need to remove the nil-row-idx for full outer joins
              (when (= join-type ::full-outer-join)
                (.remove unmatched-build-idxs emap/nil-row-idx))
@@ -405,7 +409,7 @@
                          join-type]
   ICursor
   (tryAdvance [this c]
-    (build-phase build-cursor rel-map pushdown-blooms)
+    (build-phase build-cursor rel-map pushdown-blooms nil)
 
     (boolean
      (let [advanced? (boolean-array 1)]
@@ -514,7 +518,8 @@
     {:fields (projection-specs->fields output-projections)
      :->cursor (fn [{:keys [allocator args] :as opts}]
                  (let [pushdown-blooms (when pushdown-blooms? (->pushdown-blooms probe-key-col-names))
-                       matched-build-idxs (when matched-build-idxs? (RoaringBitmap.))]
+                       matched-build-idxs (when matched-build-idxs? (RoaringBitmap.))
+                       iid-set (HashSet.)]
                    (util/with-close-on-catch [build-cursor (->build-cursor opts)
                                               relation-map (emap/->relation-map allocator {:build-fields build-fields
                                                                                            :build-key-col-names build-key-col-names
@@ -528,7 +533,7 @@
                      (project/->project-cursor opts
                                                (if (= join-type ::mark-join)
                                                  (MarkJoinCursor. allocator build-cursor nil (partial ->probe-cursor opts) relation-map matched-build-idxs mark-col-name pushdown-blooms join-type)
-                                                 (JoinCursor. allocator build-cursor nil nil (partial ->probe-cursor opts) relation-map matched-build-idxs pushdown-blooms join-type))
+                                                 (JoinCursor. allocator build-cursor nil nil (partial ->probe-cursor opts) relation-map matched-build-idxs pushdown-blooms iid-set join-type))
                                                output-projections))))}))
 
 (defn emit-join-expr-and-children {:style/indent 2} [join-expr args join-impl]

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -26,7 +26,10 @@
   (tryAdvance [_ c]
     (binding [scan/*column->pushdown-bloom* (->> (for [[k v] scan/*column->pushdown-bloom*]
                                                    [(get col-name-reverse-mapping k) v])
-                                                 (into {}))]
+                                                 (into {}))
+              scan/*column->iid-set* (->> (for [[k v] scan/*column->iid-set*]
+                                            [(get col-name-reverse-mapping k) v])
+                                          (into {}))] 
       (.tryAdvance in-cursor
                    (fn [^RelationReader in-rel]
                      (let [out-cols (LinkedList.)]
@@ -59,6 +62,9 @@
      :->cursor (fn [opts]
                  (binding [scan/*column->pushdown-bloom* (->> (for [[k v] scan/*column->pushdown-bloom*]
                                                                 [(get col-name-reverse-mapping k) v])
-                                                              (into {}))]
+                                                              (into {}))
+                           scan/*column->iid-set* (->> (for [[k v] scan/*column->iid-set*]
+                                                         [(get col-name-reverse-mapping k) v])
+                                                       (into {}))]
                    (util/with-close-on-catch [in-cursor (->inner-cursor opts)]
                      (RenameCursor. in-cursor col-name-mapping col-name-reverse-mapping))))}))


### PR DESCRIPTION
## Summary

Resolves #4555

This PR adds support for pushing down `_iid` info from JOIN into scan, and using that within `ScanCursor` to filter rows more efficiently. This speeds up operations like `PATCH` by avoiding unnecessary row processing when `_iid` values are known ahead of time.

### Implementation

- If a single `_iid` is present (ie, single patch join), we construct an `IidSelector` and apply `maybeSelect` for fast binary search filtering.
- If multiple `_iid`s are present, we filtering by the _iid bloom filters.
- This hybrid approach gives us a fast path for single-record PATCH operations, while also speeding up multi document patches significantly.

---

## PATCH Performance

The above comparisons are captured using the PATCH benchmark - we take averages for each of these from ten runs, also using execute-tx to ensure it has been fully indexed (which adds it's own overhead):

### PATCHING against 500k docs on main:
```
patching a single existing document: 3636.05ms
patching a single non-existing document: 3742.57ms
patching multiple (4) existing documents: 4000.65ms
```

### PATCHING against 500k docs on this branch:
```
patching a single existing document: 27.27 ms
patching a single non-existing document: 15.66 ms
patching multiple (4) existing documents: 144.33 ms
```

### PATCHING against 2million docs on this branch:
```
patching a single existing document: 37.88 ms
patching a single non-existing document: 23.06 ms
patching multiple (4) existing documents: 1357.25 ms
```

This doesn't even run on `main` due to `/tmp` exhaustion during sort. Additionally, it shows that the table size doesn't have a massive performance impact on this branch.