### PR TITLE
breaking: nesting log/storage config under `databases` -> `xtdb`

### DIFF
--- a/.devcontainer/xtdb.yaml
+++ b/.devcontainer/xtdb.yaml
@@ -1,8 +1,10 @@
-log: !Local
-  path: "/var/lib/xtdb/log"
+databases:
+  xtdb:
+    log: !Local
+      path: "/var/lib/xtdb/log"
 
-storage: !Local
-  path: "/var/lib/xtdb/buffers"
+    storage: !Local
+      path: "/var/lib/xtdb/buffers"
 
 healthz:
   host: '*'

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -66,14 +66,16 @@ xtdbConfig:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-    log: !Kafka
-      cluster: kafkaCluster
-      topic: !Env XTDB_LOG_TOPIC
+    databases:
+      xtdb:
+        log: !Kafka
+          cluster: kafkaCluster
+          topic: !Env XTDB_LOG_TOPIC
 
-    storage: !Remote
-      objectStore: !S3
-        bucket: !Env AWS_S3_BUCKET
-        prefix: xtdb-object-store
+        storage: !Remote
+          objectStore: !S3
+            bucket: !Env AWS_S3_BUCKET
+            prefix: xtdb-object-store
 
     diskCache:
       path: /var/lib/xtdb/buffers/disk-cache

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -69,16 +69,18 @@ xtdbConfig:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-    log: !Kafka
-      cluster: kafkaCluster
-      topic: !Env XTDB_LOG_TOPIC
+    databases:
+      xtdb:
+        log: !Kafka
+          cluster: kafkaCluster
+          topic: !Env XTDB_LOG_TOPIC
 
-    storage: !Remote
-      objectStore: !Azure
-        storageAccount: !Env AZURE_STORAGE_ACCOUNT
-        container: !Env AZURE_STORAGE_CONTAINER
-        prefix: "xtdb-object-store"
-        userManagedIdentityClientId: !Env AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
+        storage: !Remote
+          objectStore: !Azure
+            storageAccount: !Env AZURE_STORAGE_ACCOUNT
+            container: !Env AZURE_STORAGE_CONTAINER
+            prefix: "xtdb-object-store"
+            userManagedIdentityClientId: !Env AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
 
     diskCache:
       path: /var/lib/xtdb/buffers/disk-cache

--- a/cloud-benchmark/aws/aws-config.yaml
+++ b/cloud-benchmark/aws/aws-config.yaml
@@ -6,14 +6,16 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !S3
-    bucket: !Env XTDB_S3_BUCKET
-    prefix: "xtdb-object-store"
+    storage: !Remote
+      objectStore: !S3
+        bucket: !Env XTDB_S3_BUCKET
+        prefix: "xtdb-object-store"
 
 diskCache:
   path: /var/lib/xtdb/buffers

--- a/cloud-benchmark/google-cloud/google-cloud-config.yaml
+++ b/cloud-benchmark/google-cloud/google-cloud-config.yaml
@@ -2,14 +2,16 @@ server:
   host: '*'
   port: 5432
 
-log: !Local
-  path: !Env XTDB_GCP_LOCAL_LOG_PATH
+databases:
+  xtdb:
+    log: !Local
+      path: !Env XTDB_GCP_LOCAL_LOG_PATH
 
-storage: !Remote
-  objectStore: !GoogleCloud
-    projectId: !Env XTDB_GCP_PROJECT_ID
-    bucket: !Env XTDB_GCP_BUCKET
-    prefix: !Env XTDB_GCP_BUCKET_PREFIX
+    storage: !Remote
+      objectStore: !GoogleCloud
+        projectId: !Env XTDB_GCP_PROJECT_ID
+        bucket: !Env XTDB_GCP_BUCKET
+        prefix: !Env XTDB_GCP_BUCKET_PREFIX
 
 diskCache:
   path: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH

--- a/cloud-benchmark/local/local-config-kafka.yaml
+++ b/cloud-benchmark/local/local-config-kafka.yaml
@@ -6,12 +6,14 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Local
-  path: !Env XTDB_STORAGE_DIR
+    storage: !Local
+      path: !Env XTDB_STORAGE_DIR
 
 healthz:
   port: !Env XTDB_HEALTHZ_PORT

--- a/cloud-benchmark/local/local-config.yaml
+++ b/cloud-benchmark/local/local-config.yaml
@@ -2,11 +2,13 @@ server:
   host: '*'
   port: 5432
 
-log: !Local
-  path: /var/lib/xtdb/local-log
+databases:
+  xtdb:
+    log: !Local
+      path: /var/lib/xtdb/local-log
 
-storage: !Local
-  path: /var/lib/xtdb/local-buffers
+    storage: !Local
+      path: /var/lib/xtdb/local-buffers
 
 healthz:
   host: '*'

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -33,17 +33,14 @@
 (defmethod apply-config! :log-clusters [config _ opts]
   (apply-config! config :xtdb.log/clusters opts))
 
-(defmethod apply-config! :log [config _ opts]
-  (apply-config! config :xtdb/log opts))
+(defmethod apply-config! :databases [config _ opts]
+  (apply-config! config :xtdb.db-catalog/databases opts))
 
 (defmethod apply-config! :memory-cache [config _ opts]
   (apply-config! config :xtdb.cache/memory opts))
 
 (defmethod apply-config! :disk-cache [config _ opts]
   (apply-config! config :xtdb.cache/disk opts))
-
-(defmethod apply-config! :storage [config _ opts]
-  (apply-config! config :xtdb.buffer-pool/storage opts))
 
 (defmethod apply-config! :indexer [^Xtdb$Config config _ {:keys [rows-per-block page-limit log-limit flush-duration skip-txs]}]
   (cond-> (.getIndexer config)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -16,6 +16,9 @@ import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.inMemoryStorage
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
+import xtdb.database.Database
+import xtdb.database.DatabaseCatalog
+import xtdb.database.DatabaseName
 import xtdb.util.requiringResolve
 import java.nio.file.Files
 import java.nio.file.Path
@@ -39,8 +42,7 @@ interface Xtdb : DataSource, AutoCloseable {
     data class Config(
         var server: ServerConfig? = ServerConfig(),
         var logClusters: Map<LogClusterAlias, Log.Cluster.Factory<*>> = emptyMap(),
-        var log: Log.Factory = inMemoryLog,
-        var storage: Storage.Factory = inMemoryStorage(),
+        var databases: Map<DatabaseName, Database.Config> = mapOf("xtdb" to Database.Config()),
         val memoryCache: MemoryCache.Factory = MemoryCache.Factory(),
         var diskCache: DiskCache.Factory? = null,
         var healthz: HealthzConfig? = null,
@@ -58,9 +60,8 @@ interface Xtdb : DataSource, AutoCloseable {
         fun logCluster(alias: LogClusterAlias, cluster: Log.Cluster.Factory<*>) =
             apply { logClusters += alias to cluster }
 
-        fun log(log: Log.Factory) = apply { this.log = log }
-
-        fun storage(storage: Storage.Factory) = apply { this.storage = storage }
+        fun databases(databases: Map<DatabaseName, Database.Config>) = apply { this.databases += databases }
+        fun database(name: DatabaseName, config: Database.Config) = apply { databases += name to config }
 
         fun diskCache(diskCache: DiskCache.Factory?) = apply { this.diskCache = diskCache }
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -1,8 +1,10 @@
 package xtdb.database
 
+import kotlinx.serialization.Serializable
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.BufferPool
 import xtdb.api.log.Log
+import xtdb.api.storage.Storage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
@@ -37,4 +39,13 @@ data class Database(
         this === other || (other is Database && name == other.name && part == other.part)
 
     override fun hashCode() = Objects.hash(name, part)
+
+    @Serializable
+    data class Config(
+        val log: Log.Factory = Log.inMemoryLog,
+        val storage: Storage.Factory = Storage.inMemoryStorage(),
+    ) {
+        fun log(log: Log.Factory) = copy(log = log)
+        fun storage(storage: Storage.Factory) = copy(storage = storage)
+    }
 }

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -1,6 +1,9 @@
 package xtdb.database
 
 import clojure.lang.ILookup
+import kotlinx.serialization.Serializable
+import xtdb.api.log.Log
+import xtdb.api.storage.Storage
 
 interface DatabaseCatalog : AutoCloseable, ILookup {
     val databaseNames: Collection<DatabaseName>
@@ -14,6 +17,5 @@ interface DatabaseCatalog : AutoCloseable, ILookup {
     
     val primary: Database get() = this["xtdb"]!![0]
 
-    // TODO will eventually take config
     fun createDatabase(dbName: DatabaseName): List<Database>
 }

--- a/core/src/test/resources/node-config.yaml
+++ b/core/src/test/resources/node-config.yaml
@@ -1,12 +1,14 @@
 defaultTz: "America/Los_Angeles"
 server:
   port: 5433
-log: !Local
-  path: /tmp/test-log
+databases:
+  xtdb:
+    log: !Local
+      path: /tmp/test-log
+    storage: !Local
+      path: /tmp/test-storage
 indexer:
   logLimit: 65
   flushDuration: PT4H
-storage: !Local
-  path: /tmp/test-storage
 memoryCache:
   maxSizeBytes: 1025

--- a/core/src/test/resources/submit-client-config.yaml
+++ b/core/src/test/resources/submit-client-config.yaml
@@ -1,3 +1,6 @@
 defaultTz: "America/Los_Angeles"
-log: !Local
-  path: /tmp/test-log
+databases:
+  xtdb:
+    log: !Local
+      path: /tmp/test-log
+    storage: !InMemory

--- a/docker/aws/aws_config.yaml
+++ b/docker/aws/aws_config.yaml
@@ -6,14 +6,16 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !S3
-    bucket: !Env XTDB_S3_BUCKET
-    prefix: "xtdb-object-store"
+    storage: !Remote
+      objectStore: !S3
+        bucket: !Env XTDB_S3_BUCKET
+        prefix: "xtdb-object-store"
 
 diskCache:
   path: /var/lib/xtdb/buffers

--- a/docker/azure/azure_config.yaml
+++ b/docker/azure/azure_config.yaml
@@ -6,16 +6,18 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !Azure
-    storageAccount: !Env XTDB_AZURE_STORAGE_ACCOUNT
-    container: !Env XTDB_AZURE_STORAGE_CONTAINER
-    prefix: "xtdb-object-store"
-    userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
+    storage: !Remote
+      objectStore: !Azure
+        storageAccount: !Env XTDB_AZURE_STORAGE_ACCOUNT
+        container: !Env XTDB_AZURE_STORAGE_CONTAINER
+        prefix: "xtdb-object-store"
+        userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
 
 diskCache:
   path: !Env XTDB_LOCAL_DISK_CACHE

--- a/docker/azure/azure_config_private_auth.yaml
+++ b/docker/azure/azure_config_private_auth.yaml
@@ -10,16 +10,18 @@ logClusters:
       security.protocol: !Env KAFKA_SECURITY_PROTOCOL
       sasl.jaas.config: !Env KAFKA_SASL_JAAS_CONFIG
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !Azure
-    storageAccountEndpoint: !Env XTDB_AZURE_STORAGE_ACCOUNT_ENDPOINT
-    container: !Env XTDB_AZURE_STORAGE_CONTAINER
-    prefix: "xtdb-object-store"
-    userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
+    storage: !Remote
+      objectStore: !Azure
+        storageAccountEndpoint: !Env XTDB_AZURE_STORAGE_ACCOUNT_ENDPOINT
+        container: !Env XTDB_AZURE_STORAGE_CONTAINER
+        prefix: "xtdb-object-store"
+        userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
 
 diskCache:
   path: !Env XTDB_LOCAL_DISK_CACHE

--- a/docker/docker-compose/dc_config.yaml
+++ b/docker/docker-compose/dc_config.yaml
@@ -6,19 +6,21 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !S3
-    bucket: !Env XTDB_S3_BUCKET
-    prefix: "xtdb-object-store"
-    endpoint: !Env XTDB_S3_ENDPOINT
-    credentials:
-      accessKey: !Env ACCESS_KEY
-      secretKey: !Env SECRET_KEY
-    pathStyleAccessEnabled: true
+    storage: !Remote
+      objectStore: !S3
+        bucket: !Env XTDB_S3_BUCKET
+        prefix: "xtdb-object-store"
+        endpoint: !Env XTDB_S3_ENDPOINT
+        credentials:
+          accessKey: !Env ACCESS_KEY
+          secretKey: !Env SECRET_KEY
+        pathStyleAccessEnabled: true
 
 diskCache:
   path: /var/lib/xtdb/buffers

--- a/docker/google-cloud/google_cloud_config.yaml
+++ b/docker/google-cloud/google_cloud_config.yaml
@@ -6,15 +6,17 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !GoogleCloud
-    projectId: !Env XTDB_GCP_PROJECT_ID
-    bucket: !Env XTDB_GCP_BUCKET
-    prefix: "xtdb-object-store"
+    storage: !Remote
+      objectStore: !GoogleCloud
+        projectId: !Env XTDB_GCP_PROJECT_ID
+        bucket: !Env XTDB_GCP_BUCKET
+        prefix: "xtdb-object-store"
 
 diskCache:
   path: !Env XTDB_GCP_LOCAL_DISK_CACHE_PATH

--- a/docker/standalone/local_config.yaml
+++ b/docker/standalone/local_config.yaml
@@ -2,11 +2,13 @@ server:
   host: '*'
   port: 5432
 
-log: !Local
-  path: "/var/lib/xtdb/log"
+databases:
+  xtdb:
+    log: !Local
+      path: "/var/lib/xtdb/log"
 
-storage: !Local
-  path: "/var/lib/xtdb/buffers"
+    storage: !Local
+      path: "/var/lib/xtdb/buffers"
 
 healthz:
   host: '*'

--- a/docs/src/content/docs/ops/aws.adoc
+++ b/docs/src/content/docs/ops/aws.adoc
@@ -290,31 +290,33 @@ To use the S3 module, include the following in your node configuration:
 
 [source,yaml]
 ----
-storage: !Remote
-  objectStore: !S3
-    ## -- required
+databases:
+  xtdb:
+    storage: !Remote
+      objectStore: !S3
+        ## -- required
 
-    ## The name of the S3 bucket to use for the object store
-    ## (Can be set as an !Env value)
-    bucket: "my-s3-bucket" 
+        ## The name of the S3 bucket to use for the object store
+        ## (Can be set as an !Env value)
+        bucket: "my-s3-bucket"
 
-    ## -- optional
+        ## -- optional
 
-    ## A file path to prefix all of your files with
-    ## - for example, if "foo" is provided, all XTDB files will be located under a "foo" sub-directory
-    ## (Can be set as an !Env value)
-    # prefix: my-xtdb-node
+        ## A file path to prefix all of your files with
+        ## - for example, if "foo" is provided, all XTDB files will be located under a "foo" sub-directory
+        ## (Can be set as an !Env value)
+        # prefix: my-xtdb-node
 
-    ## Basic credentials for AWS.
-    ## If not provided, will default to AWS's standard credential resolution.
-    ## see: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
-    # credentials:
-    #   accessKey: "..."
-    #   secretKey: "..."
+        ## Basic credentials for AWS.
+        ## If not provided, will default to AWS's standard credential resolution.
+        ## see: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
+        # credentials:
+        #   accessKey: "..."
+        #   secretKey: "..."
 
-    ## Endpoint URI
-    ## If not provided, will default to the standard S3 endpoint for the resolved region.
-    # endpoint: "https://..."
+        ## Endpoint URI
+        ## If not provided, will default to the standard S3 endpoint for the resolved region.
+        # endpoint: "https://..."
 
 # -- required
 # A local disk path where XTDB can cache files from the remote storage

--- a/docs/src/content/docs/ops/azure.adoc
+++ b/docs/src/content/docs/ops/azure.adoc
@@ -278,34 +278,36 @@ To use the Azure module, include the following in your node configuration:
 
 [source,yaml]
 ----
-storage: !Remote
-  objectStore: !Azure
-    # -- required
+databases:
+  xtdb:
+    storage: !Remote
+      objectStore: !Azure
+        # -- required
 
-    # --- At least one of storageAccount or storageAccountEndpoint is required
+        # --- At least one of storageAccount or storageAccountEndpoint is required
 
-    # The name of the storage account which has the storage container
-    # (Can be set as an !Env value)
-    storageAccount: storage-account
+        # The name of the storage account which has the storage container
+        # (Can be set as an !Env value)
+        storageAccount: storage-account
 
-    # The full endpoint of the storage account which has the storage container
-    # (Can be set as an !Env value)
-    # storageAccountEndpoint: https://storage-account.privatelink.blob.core.windows.net
+        # The full endpoint of the storage account which has the storage container
+        # (Can be set as an !Env value)
+        # storageAccountEndpoint: https://storage-account.privatelink.blob.core.windows.net
 
-    # The name of the blob storage container to be used as the object store
-    # (Can be set as an !Env value)
-    container: xtdb-container
+        # The name of the blob storage container to be used as the object store
+        # (Can be set as an !Env value)
+        container: xtdb-container
 
-    # -- optional
-    # A file path to prefix all of your files with
-    # - for example, if "foo" is provided, all XTDB files will be located under a "foo" sub-directory
-    # (Can be set as an !Env value)
-    # prefix: my-xtdb-node
-    #
-    # Azure Client ID of a User Assigned Managed Identity -
-    # required when using them for authentication to Azure Services ie, inside of an Azure App Container.
-    # (Can be set as an !Env value)
-    # userManagedIdentityClientId: user-managed-identity-client-id
+        # -- optional
+        # A file path to prefix all of your files with
+        # - for example, if "foo" is provided, all XTDB files will be located under a "foo" sub-directory
+        # (Can be set as an !Env value)
+        # prefix: my-xtdb-node
+        #
+        # Azure Client ID of a User Assigned Managed Identity -
+        # required when using them for authentication to Azure Services ie, inside of an Azure App Container.
+        # (Can be set as an !Env value)
+        # userManagedIdentityClientId: user-managed-identity-client-id
 
 # -- required
 # A local disk path where XTDB can cache files from the remote storage

--- a/docs/src/content/docs/ops/config.adoc
+++ b/docs/src/content/docs/ops/config.adoc
@@ -2,24 +2,67 @@
 title: Configuration
 ---
 
-== Components
 
-An XTDB node consists of a number of components.
+.Changelog (last updated v2.1)
+[%collapsible]
+====
+v2.1: multi-database support::
++
+--
+`databases` was introduced in v2.1.
 
-For information on how to configure these and switch out implementations, see their reference documents:
+Prior to that, the `log` and `storage` keys were at the top-level of the configuration:
 
-* link:config/log[Log]
-* link:config/storage[Storage]
-* link:config/modules[Optional Modules]
+[source,yaml]
+----
+log: !Local
+  path: /path/to/log-file
 
-== Configuring using YAML
+storage: !Local
+  path: /path/to/storage-dir
 
-Currently, all of the examples within the reference docs are in YAML.
-Config for the components is done at the top level of the file, i.e. you can specify the following keys, not nested under anything else: `storage`, `log`, `modules`.
+# became
 
-Within the drivers, we offer the ability to provide and configure the node by passing the path to a YAML config file.
+databases:
+  xtdb:
+    log: !Local
+      path: /path/to/log-file
 
-=== Using `!Env`
+    storage: !Local
+      path: /path/to/storage-dir
+----
+
+For more details on the changes to the log and storage configurations, see the link:config/log[Transaction Logs] and link:config/storage[Object Storage] documentation.
+--
+====
+
+XTDB nodes are configured using YAML files.
+
+The two main pluggable components of XTDB are transaction logs and object storage - these can be configured in the `databases` section of the configuration file.
+
+[source,yaml]
+----
+databases:
+  # Currently only one database is supported, named `xtdb`.
+  xtdb:
+    # -- optional
+
+    # transaction log configuration
+    # defaults to an in-memory transaction log
+    log: !Local
+      path: /path/to/log-file
+
+    # object store configuration
+    # defaults to an in-memory object store
+    storage: !Local
+      path: /path/to/storage-dir
+----
+
+If no `databases` section is specified, XTDB will use the default configuration - an in-memory transaction log and an in-memory object store.
+
+For more details on the log and storage configurations, including the available components, see the link:config/logs[Transaction Logs] and link:config/storage[Object Storage] documentation.
+
+== Using `!Env`
 
 For certain keys, we allow the use of environment variables - typically, the keys where we allow this are things that may change *location* across environments. Generally, they are either "paths" or "strings".
 
@@ -27,22 +70,24 @@ When specifying a key, you can use the `!Env` tag to reference an environment va
 
 [source,yaml]
 ----
-storage: !Local
-  path: !Env XTDB_STORAGE_PATH
+databases:
+  xtdb:
+    storage: !Local
+      path: !Env XTDB_STORAGE_PATH
 ----
 
 Any key that we allow the use of `!Env` will be documented as such.
 
-=== Monitoring & Observability
+== Monitoring & Observability
 
 XTDB provides a suite of tools & templates to facilitate monitoring and observability. See link:config/monitoring[Monitoring & Observability].
 
-=== Authentication
+== Authentication
 
 The pg-wire server and the http-server both support authentication which can be configured via authentication rules.
 See link:config/authentication[Authentication].
 
-=== Other configuration:
+== Other configuration:
 
 XTDB nodes accept other optional configuration, as follows:
 
@@ -77,10 +122,21 @@ compactor:
   # Defaults to min(availableProcessors / 2, 1).
   # Set to 0 to disable the compactor.
   threads: 4
+
+modules:
+  # You can enable optional modules by specifying them under the `modules` key.
+  # For example:
+  - !HttpServer
+    # The HTTP server will listen on the specified port.
+    # Default is 3000.
+    port: 3000
 ----
 
-=== CLI flags
+For details on the available modules, see the link:config/modules[modules] documentation.
+
+== CLI flags
 
 The following flags can be passed, either directly to the CLI or via Docker's arguments:
 
+* `-f <file>`, `--file <file>`: specifies the configuration file to use.
 * `--compactor-only`: runs a compactor-only node.

--- a/docs/src/content/docs/ops/config/clojure.adoc
+++ b/docs/src/content/docs/ops/config/clojure.adoc
@@ -2,115 +2,172 @@
 title: Clojure Configuration Cookbook
 ---
 
-This document provides examples for the EDN configuration of XTDB components, to be supplied to `xtdb.api/start-node`.
+.Changelog (last updated v2.1)
+[%collapsible]
+====
+v2.1: multi-database support::
++
+--
+Prior to 2.1, `:log` and `:storage` were top-level keys, and `:databases` was not used.
 
-== Log
-
-Main article: link:/config/log[Log]
-
-[#in-memory-log]
-=== In-Memory
-
-Main article: link:/config/log#_in_memory[in-memory log]
-
-This is the default, and can be omitted.
-
+For example:
 [source,clojure]
 ----
-{:log [:in-memory
-       {;; -- optional
-
-        ;; :instant-src (java.time.InstantSource/system)
-        }]}
+{:log [:in-memory {...}]
+ :storage [:in-memory {...}]}}
 ----
 
-[#local-log]
-=== Local disk
-
-Main article: link:/config/log#_local_disk[local-disk log]
-
-[source,clojure]
-----
-{:log [:local
-       {;; -- required
-        ;; accepts `String`, `File` or `Path`
-        :path "/tmp/log"
-
-        ;; -- optional
-
-        ;; accepts `java.time.InstantSource`
-        ;; :instant-src (InstantSource/system)
-
-        ;; :buffer-size 4096
-        ;; :poll-sleep-duration "PT1S"
-        }]}
-----
-
-[#kafka]
-=== Kafka
-
-Main article: link:/config/log/kafka[Kafka]
-
-[source,clojure]
-----
-{:log [:kafka
-       {;; -- required
-        :bootstrap-servers "localhost:9092"
-        :topic-name "xtdb-log"
-
-        ;; -- optional
-
-        ;; :create-topic? true
-        ;; :poll-duration #xt/duration "PT1S"
-        ;; :properties-file "kafka.properties"
-        ;; :properties-map {}
-        ;; :replication-factor 1
-        ;; :topic-config {}
-        }]}
-----
-
-== Storage
-
-Main article: link:/config/storage[Storage]
-
-[#in-memory-storage]
-=== In-Memory
-
-Main article: link:/config/storage#in-memory[in-memory storage]
-
-This is the default, and should be omitted.
-
-[#local-storage]
-=== Local disk
-
-Main article: link:/config/storage#local-disk[local-disk storage]
+The `:disk-cache` and `:memory-cache` keys were nested under the local/remote storage:
 
 [source,clojure]
 ----
 {:storage [:local
            {;; -- required
 
-            ;; accepts `String`, `File` or `Path`
             :path "/var/lib/xtdb/storage"
 
             ;; -- optional
 
-            ;; :max-cache-bytes 536870912
+            ;; :max-cache-bytes 1024
+            ;; :max-cache-entries 536870912
            }]}
+
+{:storage [:remote {;; --required
+                    :object-store [:object-store-implementation {}]
+
+                    :local-disk-cache "/tmp/local-disk-cache"
+
+                    ;; -- optional
+                    ;; :max-cache-entries 1024
+                    ;; :max-cache-bytes 536870912
+                    ;; :max-disk-cache-percentage 75
+                    ;; :max-disk-cache-bytes 107374182400
+                    }]}
+----
+--
+====
+
+This document provides examples for the EDN configuration of XTDB components, to be supplied to `xtdb.node/start-node`.
+
+See the link:/ops/config[main configuration documentation] for more details.
+
+== Log
+
+Main article: link:/ops/config/log[Log]
+
+[#in-memory-log]
+=== In-Memory
+
+Main article: link:/ops/config/log#_in_memory[in-memory log]
+
+This is the default, and can be omitted.
+
+[source,clojure]
+----
+{:databases
+ {:xtdb
+  {:log [:in-memory
+         {;; -- optional
+
+          ;; :instant-src (java.time.InstantSource/system)
+          }]}}}
+----
+
+[#local-log]
+=== Local disk
+
+Main article: link:/ops/config/log#_local_disk[local-disk log]
+
+[source,clojure]
+----
+{:databases
+ {:xtdb
+  {:log [:local
+         {;; -- required
+          ;; accepts `String`, `File` or `Path`
+          :path "/tmp/log"
+
+          ;; -- optional
+
+          ;; accepts `java.time.InstantSource`
+          ;; :instant-src (InstantSource/system)
+
+          ;; :buffer-size 4096
+          ;; :poll-sleep-duration "PT1S"
+          }]}}}
+----
+
+[#kafka]
+=== Kafka
+
+Main article: link:/ops/config/log/kafka[Kafka]
+
+[source,clojure]
+----
+{:databases
+ {:xtdb
+  {:log [:kafka
+         {;; -- required
+          :bootstrap-servers "localhost:9092"
+          :topic-name "xtdb-log"
+
+          ;; -- optional
+
+          ;; :create-topic? true
+          ;; :poll-duration #xt/duration "PT1S"
+          ;; :properties-file "kafka.properties"
+          ;; :properties-map {}
+          ;; :replication-factor 1
+          ;; :topic-config {}
+          }]}}}
+----
+
+== Storage
+
+Main article: link:/ops/config/storage[Storage]
+
+[#in-memory-storage]
+=== In-Memory
+
+Main article: link:/ops/config/storage#in-memory[in-memory storage]
+
+This is the default, and should be omitted.
+
+[#local-storage]
+=== Local disk
+
+Main article: link:/ops/config/storage#local-disk[local-disk storage]
+
+[source,clojure]
+----
+{:databases
+ {:xtdb
+  {:storage [:local
+             {;; -- required
+
+              ;; accepts `String`, `File` or `Path`
+              :path "/var/lib/xtdb/storage"
+
+              ;; -- optional
+
+              ;; :max-cache-bytes 536870912
+             }]}}}
 ----
 
 [#remote-storage]
 === Remote
 
-Main article: link:/config/storage#remote[remote storage]
+Main article: link:/ops/config/storage#remote[remote storage]
 
 [source,clojure]
 ----
-{:storage [:remote {;; -- required 
-                    
-                    ;; Each object store implementation has its own configuration - 
-                    ;; see below for some examples.
-                    :object-store [:object-store-implementation {}]}]
+{:databases
+ {:xtdb
+  {:storage [:remote {;; -- required 
+                      
+                      ;; Each object store implementation has its own configuration - 
+                      ;; see below for some examples.
+                      :object-store [:object-store-implementation {}]}]}}
 
  ;; -- required for remote storage
  ;; Local directory to store the working-set cache in.
@@ -149,17 +206,19 @@ Main article: link:/ops/aws#storage[S3]
 
 [source,clojure]
 ----
-{:storage [:remote
-           {:object-store [:s3
-                           {;; -- required
-                            :bucket "my-bucket"
+{:databases
+ {:xtdb
+  {:storage [:remote
+             {:object-store [:s3
+                             {;; -- required
+                              :bucket "my-bucket"
 
-                            ;; -- optional
+                              ;; -- optional
 
-                            ;; :prefix "my-xtdb-node"
-                            ;; :configurator (reify S3Configurator
-                            ;;                 ...)
-                           }]}]}
+                              ;; :prefix "my-xtdb-node"
+                              ;; :configurator (reify S3Configurator
+                              ;;                 ...)
+                             }]}]}}}
 ----
 
 [#azure]
@@ -169,19 +228,21 @@ Main article: link:/ops/azure#storage[Azure Blob Storage]
 
 [source,clojure]
 ----
-{:storage [:remote
-           {:object-store [:azure
-                           {;; -- required
-                            ;; --- At least one of storage-account or storage-account-endpoint is required
-                            :storage-account "storage-account"
-                            ;; :storage-account-endpoint "https://storage-account.privatelink.blob.core.windows.net"
-                            :container "xtdb-container"
+{:databases
+ {:xtdb
+  {:storage [:remote
+             {:object-store [:azure
+                             {;; -- required
+                              ;; --- At least one of storage-account or storage-account-endpoint is required
+                              :storage-account "storage-account"
+                              ;; :storage-account-endpoint "https://storage-account.privatelink.blob.core.windows.net"
+                              :container "xtdb-container"
 
-                            ;; -- optional
+                              ;; -- optional
 
-                            ;; :prefix "my-xtdb-node"
-                            ;; :user-managed-identity-client-id "user-managed-identity-client-id"
-                           }]}]}
+                              ;; :prefix "my-xtdb-node"
+                              ;; :user-managed-identity-client-id "user-managed-identity-client-id"
+                             }]}]}}}
 ----
 
 
@@ -192,15 +253,17 @@ Main article: link:/ops/google-cloud#storage[Google Cloud Storage]
 
 [source,clojure]
 ----
-{:storage [:remote
-           {:object-store [:google-cloud
-                           {;; -- required
-                            :project-id "xtdb-project"
-                            :bucket "xtdb-bucket"
+{:databases
+ {:xtdb
+  {:storage [:remote
+             {:object-store [:google-cloud
+                             {;; -- required
+                              :project-id "xtdb-project"
+                              :bucket "xtdb-bucket"
 
-                            ;; -- optional
+                              ;; -- optional
 
-                            ;; :prefix "my-xtdb-node"
-                           }]}]}
+                              ;; :prefix "my-xtdb-node"
+                             }]}]}}}
 ----
 

--- a/docs/src/content/docs/ops/config/log.adoc
+++ b/docs/src/content/docs/ops/config/log.adoc
@@ -1,6 +1,35 @@
 ---
 title: Log
 ---
+
+.Changelog (last updated v2.1)
+[%collapsible]
+====
+v2.1: multi-database support::
++
+--
+`databases` was introduced in v2.1.
+
+Prior to that, the `log` key was at the top-level of the configuration:
+
+[source,yaml]
+----
+log: !Local
+  path: /var/lib/xtdb/log
+  # bufferSize: 4096
+  # pollSleepDuration: PT0.1S
+
+# became
+
+databases:
+  xtdb:
+    log: !Local
+      path: /var/lib/xtdb/log
+      # bufferSize: 4096
+----
+--
+====
+
 One of the key components of an XTDB node is the log - this is a totally ordered log of all operations that have been applied to the database, generally persistent & shared between nodes.
 
 == Implementations
@@ -19,7 +48,9 @@ By default, the log is a transient, in-memory log:
 [source,yaml]
 ----
 # default, no need to explicitly specify
-# log: !InMemory
+# databases:
+#   xtdb:
+#     log: !InMemory
 ----
 
 If configured as an in-process node, you can also specify an https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/InstantSource.html[InstantSource] implementation - this is used to override the local machine's clock when providing a system-time timestamp for each message.
@@ -30,20 +61,19 @@ A single-node persistent log implementation that writes to a local directory.
 
 [source,yaml]
 ----
-log: !Local
-  # -- required
+databases:
+  xtdb:
+    log: !Local
+      # -- required
 
-  # The path to the local directory to store the log in.
-  # (Can be set as an !Env value)
-  path: /var/lib/xtdb/log
+      # The path to the local directory to store the log in.
+      # (Can be set as an !Env value)
+      path: /var/lib/xtdb/log
 
-  # -- optional
+      # -- optional
 
-  # The number of entries of the buffer to use when writing to the log.
-  # bufferSize: 4096
-
-  # The duration to sleep for when polling for new messages written to the log.
-  # pollSleepDuration: PT0.1S
+      # The number of entries of the buffer to use when writing to the log.
+      # bufferSize: 4096
 ----
 
 If configured as an in-process node, you can also specify an https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/InstantSource.html[InstantSource] implementation - this is used to override the local machine's clock when providing a system-time timestamp for each transaction.
@@ -71,8 +101,10 @@ To configure an epoch, specify the `epoch` field inside the node's log configura
 
 [source,yaml]
 ----
-log: !<LogType>
-  epoch: <new-epoch>
+databases:
+  xtdb:
+    log: !<LogType>
+      epoch: <new-epoch>
 ----
 
 Where:

--- a/docs/src/content/docs/ops/config/log/kafka.adoc
+++ b/docs/src/content/docs/ops/config/log/kafka.adoc
@@ -1,7 +1,48 @@
 ---
 title: Kafka
 ---
+
+.Changelog (last updated v2.1)
+[%collapsible]
+====
+v2.1: multi-database support::
++
+--
+`databases` and `logClusters` were introduced in v2.1.
+
+Prior to that, the `log` key was at the top-level of the configuration, and the configuration in `logClusters` was within that `log`:
+
+[source,yaml]
+----
+log: !Kafka
+  bootstrapServers: "localhost:9092"
+  topic: "xtdb-log"
+  # autoCreateTopic: true
+  # pollDuration: "PT1S"
+  # propertiesFile: "kafka.properties"
+  # propertiesMap:
+
+# became
+
+logClusters:
+  kafkaCluster: !Kafka
+    bootstrapServers: "localhost:9092"
+    # pollDuration: "PT1S"
+    # propertiesFile: "kafka.properties"
+    # propertiesMap:
+
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: "xtdb-log"
+      # autoCreateTopic: true
+----
+--
+====
+
 https://kafka.apache.org/[Apache Kafka] can be used as an XTDB message log.
+
 
 == Setup
 
@@ -64,22 +105,24 @@ logClusters:
     # A map of Kafka connection properties, supplied directly to the Kafka client.
     # propertiesMap:
 
-# We then create a log using the Kafka cluster we just defined:
+# For each database, we then create a log using the Kafka cluster we just defined:
 
-log: !Kafka
-  # -- required
+databases:
+  xtdb:
+    log: !Kafka
+      # -- required
 
-  # The name of the Kafka cluster to use for the primary log.
-  cluster: kafkaCluster
+      # The name of the Kafka cluster to use for the primary log.
+      cluster: kafkaCluster
 
-  # Name of the Kafka topic to use for the primary log.
-  # (Can be set as an !Env value)
-  topic: "xtdb-log"
+      # Name of the Kafka topic to use for the primary log.
+      # (Can be set as an !Env value)
+      topic: "xtdb-log"
 
-  # -- optional
+      # -- optional
 
-  # Whether or not to automatically create the topic, if it does not already exist.
-  # autoCreateTopic: true
+      # Whether or not to automatically create the topic, if it does not already exist.
+      # autoCreateTopic: true
 ----
 
 [#auth_example]
@@ -101,9 +144,11 @@ logClusters:
       security.protocol: SASL_SSL
       sasl.jaas.config: !Env KAFKA_SASL_JAAS_CONFIG
 
-log: !Kafka
-  topic: !Env XTDB_LOG_TOPIC
-  autoCreateTopic: false
+databases:
+  xtdb:
+    log: !Kafka
+      topic: !Env XTDB_LOG_TOPIC
+      autoCreateTopic: false
 ----
 
 The `KAFKA_SASL_JAAS_CONFIG` environment variable will likely contain a string similar to the following, and should be passed in as a secret value:

--- a/docs/src/content/docs/ops/config/storage.adoc
+++ b/docs/src/content/docs/ops/config/storage.adoc
@@ -2,6 +2,64 @@
 title: Storage
 ---
 
+.Changelog (last updated v2.1)
+[%collapsible]
+====
+v2.1: multi-database support::
++
+--
+`databases` was introduced in v2.1.
+
+Prior to that, the `storage` key was at the top-level of the configuration, and the `memoryCache` and `diskCache` keys were nested under the local/remote storage:
+
+[source,yaml]
+----
+storage: !Local
+  path: /var/lib/xtdb/storage
+  # maxCacheEntries: 1024
+  # maxCacheBytes: 536870912
+
+# became
+
+databases:
+  xtdb:
+    storage: !Local
+      path: /var/lib/xtdb/storage
+
+memoryCache:
+  # maxSizeRatio: 0.5
+  # maxSizeBytes: 536870912
+----
+
+[source,yaml]
+----
+storage: !Remote
+  objectStore: <ObjectStoreImplementation>
+  localDiskCache: /var/lib/xtdb/remote-cache
+  # maxCacheEntries: 1024
+  # maxCacheBytes: 536870912
+  # maxDiskCachePercentage: 75
+  # maxDiskCacheBytes: 107374182400
+
+# became
+
+databases:
+  xtdb:
+    storage: !Remote
+      objectStore: <ObjectStoreImplementation>
+
+diskCache:
+  path: /var/lib/xtdb/remote-cache
+  # maxSizeRatio: 0.75
+  # maxSizeBytes: 107374182400
+
+memoryCache:
+  # maxSizeRatio: 0.5
+  # maxSizeBytes: 536870912
+----
+--
+====
+
 One of the key components of an XTDB node is the storage module - used to store the data and indexes that make up the database.
 
 We offer the following implementations of the storage module:
@@ -18,7 +76,9 @@ By default, the storage module is configured to use transient, in-memory storage
 [source,yaml]
 ----
 # default, no need to explicitly specify
-# storage: !InMemory
+# databases:
+#   xtdb:
+#     storage: !InMemory
 ----
 
 [#local-disk]
@@ -28,12 +88,14 @@ A persistent storage implementation that writes to a local directory, also maint
 
 [source,yaml]
 ----
-storage: !Local
-  # -- required
+databases:
+  xtdb:
+    storage: !Local
+      # -- required
 
-  # The path to the local directory to persist the data to.
-  # (Can be set as an !Env value)
-  path: /var/lib/xtdb/storage
+      # The path to the local directory to persist the data to.
+      # (Can be set as an !Env value)
+      path: /var/lib/xtdb/storage
 
 ## -- optional
 # configuration for XTDB's in-memory cache
@@ -59,13 +121,14 @@ We achieve this inter-node messaging using a link:log#Remote[**remote log**] imp
 
 [source,yaml]
 ----
-storage: !Remote
-  # -- required
+databases:
+  xtdb:
+    storage: !Remote
+      # -- required
 
-  # Configuration of the Object Store to use for remote storage
-  # Each of these is configured separately - see below for more information.
-  objectStore: <ObjectStoreImplementation>
-
+      # Configuration of the Object Store to use for remote storage
+      # Each of these is configured separately - see below for more information.
+      objectStore: <ObjectStoreImplementation>
 
 ## -- required
 # Local directory to store the working-set cache in.

--- a/docs/src/content/docs/ops/google-cloud.adoc
+++ b/docs/src/content/docs/ops/google-cloud.adoc
@@ -246,23 +246,25 @@ To use the Google Cloud module, include the following in your node configuration
 
 [source,yaml]
 ----
-storage: !Remote
-  objectStore: !GoogleCloud
-    ## -- required
+databases:
+  xtdb:
+    storage: !Remote
+      objectStore: !GoogleCloud
+        ## -- required
 
-    # The name of the GCP project containing the bucket
-    # (Can be set as an !Env value)
-    projectId: xtdb-project
+        # The name of the GCP project containing the bucket
+        # (Can be set as an !Env value)
+        projectId: xtdb-project
 
-    # The Cloud Storage bucket to store documents
-    # (Can be set as an !Env value)
-    bucket: xtdb-bucket
+        # The Cloud Storage bucket to store documents
+        # (Can be set as an !Env value)
+        bucket: xtdb-bucket
 
-    ## -- optional
-    # A file path to prefix all files with
-    # - for example, if "foo" is provided, all XTDB files will be under a "foo" sub-directory
-    # (Can be set as an !Env value)
-    # prefix: my-xtdb-node
+        ## -- optional
+        # A file path to prefix all files with
+        # - for example, if "foo" is provided, all XTDB files will be under a "foo" sub-directory
+        # (Can be set as an !Env value)
+        # prefix: my-xtdb-node
 
 # -- required
 # A local disk path where XTDB can cache files from the remote storage

--- a/docs/src/content/docs/reference/main/xtql/txs.adoc
+++ b/docs/src/content/docs/reference/main/xtql/txs.adoc
@@ -2,7 +2,7 @@
 title: XTQL Transactions (Clojure)
 ---
 
-Transactions in XTDB are submitted to the link:/config/log[log], to be processed asynchronously.
+Transactions in XTDB are submitted to the link:/ops/config/log[log], to be processed asynchronously.
 They each consist of an array of link:#tx-ops[operations].
 
 This document provides examples for EDN transaction operations, to be submitted to link:/drivers/clojure/codox/xtdb.api.html#var-execute-tx[`xt/execute-tx`] or link:/drivers/clojure/codox/xtdb.api.html#var-submit-tx[`xt/submit-tx`].

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -69,15 +69,17 @@ xtdbConfig:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-    log: !Kafka
-      cluster: kafkaCluster
-      topic: !Env XTDB_LOG_TOPIC
+    databases:
+      xtdb:
+        log: !Kafka
+          cluster: kafkaCluster
+          topic: !Env XTDB_LOG_TOPIC
 
-    storage: !Remote
-      objectStore: !GoogleCloud
-        projectId: !Env GCP_PROJECT_ID
-        bucket: !Env GCP_BUCKET
-        prefix: xtdb-object-store
+        storage: !Remote
+          objectStore: !GoogleCloud
+            projectId: !Env GCP_PROJECT_ID
+            bucket: !Env GCP_BUCKET
+            prefix: xtdb-object-store
 
     diskCache:
       path: /var/lib/xtdb/buffers/disk-cache

--- a/modules/bench/cloud/config/aws.yaml
+++ b/modules/bench/cloud/config/aws.yaml
@@ -5,14 +5,16 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !S3
-    bucket: !Env XTDB_S3_BUCKET
-    prefix: "xtdb-object-store"
+    storage: !Remote
+      objectStore: !S3
+        bucket: !Env XTDB_S3_BUCKET
+        prefix: "xtdb-object-store"
 
 diskCache:
   path: /var/lib/xtdb/buffers

--- a/modules/bench/cloud/config/azure.yaml
+++ b/modules/bench/cloud/config/azure.yaml
@@ -5,16 +5,18 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Remote
-  objectStore: !Azure
-    storageAccount: !Env XTDB_AZURE_STORAGE_ACCOUNT
-    container: !Env XTDB_AZURE_STORAGE_CONTAINER
-    prefix: "xtdb-object-store"
-    userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
+    storage: !Remote
+      objectStore: !Azure
+        storageAccount: !Env XTDB_AZURE_STORAGE_ACCOUNT
+        container: !Env XTDB_AZURE_STORAGE_CONTAINER
+        prefix: "xtdb-object-store"
+        userManagedIdentityClientId: !Env XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID
 
 diskCache:
   path: /var/lib/xtdb/buffers/

--- a/modules/bench/cloud/config/google-cloud.yaml
+++ b/modules/bench/cloud/config/google-cloud.yaml
@@ -2,14 +2,16 @@ healthz:
   host: '*'
   port: 8080
 
-log: !Local
-  path: !Env XTDB_GCP_LOCAL_LOG_PATH
+databases:
+  xtdb:
+    log: !Local
+      path: !Env XTDB_GCP_LOCAL_LOG_PATH
 
-storage: !Remote
-  objectStore: !GoogleCloud
-    projectId: !Env XTDB_GCP_PROJECT_ID
-    bucket: !Env XTDB_GCP_BUCKET
-    prefix: "xtdb-object-store"
+    storage: !Remote
+      objectStore: !GoogleCloud
+        projectId: !Env XTDB_GCP_PROJECT_ID
+        bucket: !Env XTDB_GCP_BUCKET
+        prefix: "xtdb-object-store"
 
 diskCache:
   path: /var/lib/xtdb/buffers/

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -1,5 +1,6 @@
 (ns xtdb.kafka
   (:require [xtdb.api :as xt]
+            [xtdb.db-catalog :as db]
             [xtdb.node :as xtn]
             [xtdb.time :as time]
             [xtdb.util :as util])
@@ -15,8 +16,7 @@
                    properties-map (.propertiesMap properties-map)
                    properties-file (.propertiesFile (util/->path properties-file))))))
 
-(defmethod xtn/apply-config! ::log
-  [^Xtdb$Config config _ {:keys [cluster topic epoch] :as opts}]
-  (doto config
-    (.setLog (cond-> (KafkaCluster$LogFactory. (str (symbol cluster)) topic (boolean (:create-topic? opts true)))
-               epoch (.epoch epoch)))))
+(defmethod db/->log-factory :xtdb/kafka
+  [_ {:keys [cluster topic epoch] :as opts}]
+  (cond-> (KafkaCluster$LogFactory. (str (symbol cluster)) topic (boolean (:create-topic? opts true)))
+    epoch (.epoch epoch)))

--- a/monitoring/docker-image/monitoring_config.yaml
+++ b/monitoring/docker-image/monitoring_config.yaml
@@ -6,12 +6,14 @@ logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
 
-log: !Kafka
-  cluster: kafkaCluster
-  topic: !Env XTDB_LOG_TOPIC
+databases:
+  xtdb:
+    log: !Kafka
+      cluster: kafkaCluster
+      topic: !Env XTDB_LOG_TOPIC
 
-storage: !Local
-  path: "/var/lib/xtdb/buffers"
+    storage: !Local
+      path: "/var/lib/xtdb/buffers"
 
 healthz:
   host: '*'

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -7,7 +7,6 @@
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
             [xtdb.pgwire :as pgw]
-            [xtdb.protocols :as xtp]
             [xtdb.table-catalog :as table-cat]
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie]
@@ -48,8 +47,8 @@
   {::xtdb {:node-opts {:server {:port 5432
                                 :ssl {:keystore (io/file (io/resource "xtdb/pgwire/xtdb.jks"))
                                       :keystore-password "password123"}}
-                       :log [:local {:path (io/file dev-node-dir "log")}]
-                       :storage [:local {:path (io/file dev-node-dir "objects")}]
+                       :databases {:xtdb {:log [:local {:path (io/file dev-node-dir "log")}]
+                                          :storage [:local {:path (io/file dev-node-dir "objects")}]}}
                        :healthz {:port 8080}
                        :flight-sql-server {:port 52358}}}})
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -112,7 +112,7 @@
          (time/->instant (.next it)))))))
 
 (defn with-mock-clock [f]
-  (with-opts {:log [:in-memory {:instant-src (->mock-clock)}]} f))
+  (with-opts {:databases {:xtdb {:log [:in-memory {:instant-src (->mock-clock)}]}}} f))
 
 (defn ->tstz-range ^xtdb.types.ZonedDateTimeRange [from to]
   (ZonedDateTimeRange. (time/->zdt from) (some-> to time/->zdt)))
@@ -267,9 +267,9 @@
   (let [instant-src (or instant-src (->mock-clock))
         healthz-port (if (util/port-free? healthz-port) healthz-port (util/free-port))]
     (xtn/start-node (cond-> {:healthz {:port healthz-port}
-                             :log [:local {:path (.resolve node-dir "log"), :instant-src instant-src
-                                           :instant-source-for-non-tx-msgs? instant-source-for-non-tx-msgs?}]
-                             :storage [:local {:path (.resolve node-dir buffers-dir)}]
+                             :databases {:xtdb {:log [:local {:path (.resolve node-dir "log"), :instant-src instant-src
+                                                              :instant-source-for-non-tx-msgs? instant-source-for-non-tx-msgs?}]
+                                                :storage [:local {:path (.resolve node-dir buffers-dir)}]}}
                              :indexer (->> {:log-limit log-limit, :page-limit page-limit, :rows-per-block rows-per-block}
                                            (into {} (filter val)))
                              :compactor (->> {:threads compactor-threads}

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -48,9 +48,10 @@
 
 (t/deftest test-remote-buffer-pool-setup
   (util/with-tmp-dirs #{path}
-    (util/with-open [node (xtn/start-node (merge tu/*node-opts* {:storage [:remote {:object-store [:in-memory {}]}]
-                                                                 :disk-cache {:path path}
-                                                                 :compactor {:threads 0}}))]
+    (util/with-open [node (xtn/start-node (-> tu/*node-opts*
+                                              (assoc-in [:databases :xtdb :storage] [:remote {:object-store [:in-memory {}]}])
+                                              (assoc :disk-cache {:path path}
+                                                     :compactor {:threads 0})))]
       (xt/submit-tx node [[:put-docs :foo {:xt/id :foo}]])
 
       (t/is (= [{:xt/id :foo}]
@@ -236,9 +237,9 @@
 
 (t/deftest test-latest-available-block
   (tu/with-tmp-dirs #{tmp-dir}
-    (with-open [node1 (xtn/start-node {:storage [:local {:path tmp-dir}]
+    (with-open [node1 (xtn/start-node {:databases {:xtdb {:storage [:local {:path tmp-dir}]}}
                                        :compactor {:threads 0}})
-                node2 (xtn/start-node {:storage [:local {:path tmp-dir}]
+                node2 (xtn/start-node {:databases {:xtdb {:storage [:local {:path tmp-dir}]}}
                                        :compactor {:threads 0}})]
       (let [bp1 (.getBufferPool (db/primary-db node1))
             bp2 (.getBufferPool (db/primary-db node2))]

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -636,7 +636,8 @@
 
 (t/deftest different-recency-partitioning
   (binding [c/*recency-partition* RecencyPartition/YEAR]
-    (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
+    (with-open [node (xtn/start-node (assoc-in tu/*node-opts* [:databases :xtdb :log]
+                                               [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]))]
       (let [tc (.getTrieCatalog (db/primary-db node))]
         (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :version 1}]])
         (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :version 2}]])
@@ -680,7 +681,8 @@
                                          ["split in valid-time" #inst "2022" #inst "2025" #inst "2023" #inst "2024"]
                                          ["overlapping valid-time" #inst "2022" #inst "2025" #inst "2023" #inst "2026"]]]
       (t/testing test-name
-        (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
+        (with-open [node (xtn/start-node (assoc-in tu/*node-opts* [:databases :xtdb :log]
+                                                   [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]))]
           (xt/execute-tx node [[:put-docs :docs
                                 (cond-> {:xt/id 1, :version 1}
                                   vf1 (assoc :xt/valid-from vf1)

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -98,7 +98,9 @@
 
 (t/deftest test-block-lag-healthy-4364
   (let [port (tu/free-port)]
-    (with-open [_node (xtn/start-node {:healthz {:port port}})]
+    (with-open [_node (xtn/start-node {:databases {:xtdb {:log [:in-memory]
+                                                          :storage [:in-memory]}}
+                                       :healthz {:port port}})]
       (t/testing "server thrown error responds with reasonable message"
         (letfn [(alive-resp []
                   (let [{:keys [status headers]} (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -42,8 +42,8 @@
 (t/deftest ^:integration test-kafka
   (let [test-uuid (random-uuid)]
     (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
-                                      :log [:kafka {:cluster :my-kafka
-                                                    :topic (str "xtdb.kafka-test." test-uuid)}]})]
+                                      :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                       :topic (str "xtdb.kafka-test." test-uuid)}]}}})]
       (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))
 
       (t/is (= [{:xt/id :foo}]
@@ -56,9 +56,9 @@
                                                                         :poll-duration "PT2S"
                                                                         :properties-map {}
                                                                         :properties-file nil}]}
-                                      :log [:kafka {:cluster :my-kafka
-                                                    :topic (str "xtdb.kafka-test." test-uuid)
-                                                    :create-topic? true}]})]
+                                      :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                       :topic (str "xtdb.kafka-test." test-uuid)
+                                                                       :create-topic? true}]}}})]
       (t/testing "KafkaLog successfully created"
         (t/is (instance? Log (.getLog (db/primary-db node))))))))
 
@@ -69,9 +69,9 @@
                                                                           :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
-                                        :log [:kafka {:cluster :my-kafka
-                                                      :topic (str "xtdb.kafka-test." test-uuid)}]
-                                        :storage [:remote {:object-store [:in-memory {}]}]
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic (str "xtdb.kafka-test." test-uuid)}]
+                                                           :storage [:remote {:object-store [:in-memory {}]}]}}
                                         :disk-cache {:path path}})]
         (t/testing "Send a transaction"
           (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))))
@@ -88,9 +88,9 @@
                           #"Failed to construct kafka producer"
                           (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers "nonresolvable:9092"
                                                                              :some-secret "foobar"}]}
-                                           :log [:kafka {:cluster :my-kafka
-                                                         :topic "topic"
-                                                         :create-topic? false}]}))))
+                                           :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                            :topic "topic"
+                                                                            :create-topic? false}]}}}))))
 
 (t/deftest ^:integration test-kafka-topic-cleared
   (let [original-topic (str "xtdb.kafka-test." (random-uuid))
@@ -101,10 +101,10 @@
                                                                           :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
-                                        :log [:kafka {:cluster :my-kafka
-                                                      :topic original-topic
-                                                      :create-topic? true}]
-                                        :storage [:local {:path local-disk-path}]})]
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic original-topic
+                                                                         :create-topic? true}]
+                                                           :storage [:local {:path local-disk-path}]}}})]
         ;; Submit a few transactions
         (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
         (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
@@ -131,21 +131,21 @@
                                                            :poll-duration "PT2S"
                                                            :properties-map {}
                                                            :properties-file nil}]}
-                         :log [:kafka {:cluster :my-kafka
-                                       :topic empty-topic
-                                       :create-topic? true}]
-                         :storage [:local {:path local-disk-path}]})))
+                         :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                          :topic empty-topic
+                                                          :create-topic? true}]
+                                            :storage [:local {:path local-disk-path}]}}})))
 
       ;; Node with intact storage and topic 2 (ie, empty topic) along with setting log offset
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
                                                                           :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
-                                        :log [:kafka {:cluster :my-kafka
-                                                      :topic empty-topic
-                                                      :create-topic? true
-                                                      :epoch 1}]
-                                        :storage [:local {:path local-disk-path}]})]
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic empty-topic
+                                                                         :create-topic? true
+                                                                         :epoch 1}]
+                                                           :storage [:local {:path local-disk-path}]}}})]
         (t/testing "can query previous indexed values, unindexed values will be lost"
           (t/is (= (set [{:xt/id :foo} {:xt/id :bar}])
                    (set (xt/q node "SELECT _id FROM xt_docs")))))
@@ -166,11 +166,11 @@
                                                                           :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
-                                        :log [:kafka {:cluster :my-kafka
-                                                      :topic empty-topic
-                                                      :create-topic? true
-                                                      :epoch 1}]
-                                        :storage [:local {:path local-disk-path}]})]
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic empty-topic
+                                                                         :create-topic? true
+                                                                         :epoch 1}]
+                                                           :storage [:local {:path local-disk-path}]}}})]
         (t/testing "can query all previously indexed values, including those after new epoch started"
           (t/is (= (set [{:xt/id :foo} 
                          {:xt/id :bar} 
@@ -187,78 +187,78 @@
                          {:xt/id :new3}])
                    (set (xt/q node "SELECT _id FROM xt_docs")))))))))
 
-  (t/deftest ^:integration test-stale-log-recovery
-    (let [original-topic (str "xtdb.kafka-test." (random-uuid))
-          stale-topic (str "xtdb.kafka-test." (random-uuid))
-          empty-topic (str "xtdb.kafka-test." (random-uuid))]
+(t/deftest ^:integration test-stale-log-recovery
+  (let [original-topic (str "xtdb.kafka-test." (random-uuid))
+        stale-topic (str "xtdb.kafka-test." (random-uuid))
+        empty-topic (str "xtdb.kafka-test." (random-uuid))]
 
-      (util/with-tmp-dirs #{local-disk-path}
-        ;; Start a node, write a few transactions to the original topic
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
-                                          :log [:kafka {:cluster :my-kafka, :topic original-topic}]
-                                          :storage [:local {:path local-disk-path}]})]
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :baz}]])
+    (util/with-tmp-dirs #{local-disk-path}
+      ;; Start a node, write a few transactions to the original topic
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka, :topic original-topic}]
+                                                           :storage [:local {:path local-disk-path}]}}})]
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :baz}]])
+        (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz}])
+                 (set (xt/q node "SELECT _id FROM xt_docs"))))
+
+        ;; Finish the block
+        (t/is (nil? (tu/finish-block! node)))
+
+        ;; Submit a few more transactions
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :willbelost}]])
+        (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz} {:xt/id :willbelost}])
+                 (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+      ;; Setup a "stale log":
+      ;; - Start a node with a new topic and memory storage.
+      ;; - Submit two txes to it.
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic stale-topic
+                                                                         :create-topic? true}]
+                                                           :storage [:in-memory {}]}}})]
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]]))
+
+      ;; Attempt to restart the node with intact storage and the stale topic + original epoch
+      (t/is
+       (thrown-with-msg?
+        IllegalStateException
+        #"Node failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest indexed transaction \(epoch=0 and offset=2\)"
+        (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                           :poll-duration "PT2S"}]}
+                         :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                          :topic stale-topic
+                                                          :create-topic? false}]
+                                            :storage [:local {:path local-disk-path}]}}})))
+
+      ;; Attempt to restart the node with intact storage, a new topic + new epoch
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"
+                                                                          :properties-map {}
+                                                                          :properties-file nil}]}
+                                        :databases {:xtdb {:log [:kafka {:cluster :my-kafka
+                                                                         :topic empty-topic
+                                                                         :create-topic? true
+                                                                         :epoch 1}]
+                                                           :storage [:local {:path local-disk-path}]}}})]
+        (t/testing "can query previous indexed values, unindexed values will be lost"
           (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz}])
-                   (set (xt/q node "SELECT _id FROM xt_docs"))))
-
-          ;; Finish the block
-          (t/is (nil? (tu/finish-block! node)))
-
-          ;; Submit a few more transactions
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :willbelost}]])
-          (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz} {:xt/id :willbelost}])
                    (set (xt/q node "SELECT _id FROM xt_docs")))))
 
-        ;; Setup a "stale log":
-        ;; - Start a node with a new topic and memory storage.
-        ;; - Submit two txes to it.
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
-                                          :log [:kafka {:cluster :my-kafka
-                                                        :topic stale-topic
-                                                        :create-topic? true}]
-                                          :storage [:in-memory {}]})]
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
-          (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]]))
+        (t/testing "can index/query new transactions"
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new}]]))
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new2}]]))
+          (t/is (= (set [{:xt/id :foo}
+                         {:xt/id :bar}
+                         {:xt/id :baz}
+                         {:xt/id :new}
+                         {:xt/id :new2}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
 
-        ;; Attempt to restart the node with intact storage and the stale topic + original epoch
-        (t/is
-         (thrown-with-msg?
-          IllegalStateException
-          #"Node failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest indexed transaction \(epoch=0 and offset=2\)"
-          (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                             :poll-duration "PT2S"}]}
-                           :log [:kafka {:cluster :my-kafka
-                                         :topic stale-topic
-                                         :create-topic? false}]
-                           :storage [:local {:path local-disk-path}]})))
-
-        ;; Attempt to restart the node with intact storage, a new topic + new epoch
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"
-                                                                            :properties-map {}
-                                                                            :properties-file nil}]}
-                                          :log [:kafka {:cluster :my-kafka
-                                                        :topic empty-topic
-                                                        :create-topic? true
-                                                        :epoch 1}]
-                                          :storage [:local {:path local-disk-path}]})]
-          (t/testing "can query previous indexed values, unindexed values will be lost"
-            (t/is (= (set [{:xt/id :foo} {:xt/id :bar} {:xt/id :baz}])
-                     (set (xt/q node "SELECT _id FROM xt_docs")))))
-
-          (t/testing "can index/query new transactions"
-            (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new}]]))
-            (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new2}]]))
-            (t/is (= (set [{:xt/id :foo}
-                           {:xt/id :bar}
-                           {:xt/id :baz}
-                           {:xt/id :new}
-                           {:xt/id :new2}])
-                     (set (xt/q node "SELECT _id FROM xt_docs")))))
-
-          (t/testing "can finish the block"
-            (t/is (nil? (tu/finish-block! node))))))))
+        (t/testing "can finish the block"
+          (t/is (nil? (tu/finish-block! node))))))))

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -151,8 +151,8 @@
 (t/deftest test-memory-log-epochs
   (util/with-tmp-dirs #{local-disk-path}
     ;; Node with local storage and memory log 
-    (with-open [node (xtn/start-node {:log [:in-memory {}]
-                                      :storage [:local {:path local-disk-path}]})]
+    (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {}]
+                                                         :storage [:local {:path local-disk-path}]}}})]
       ;; Submit a few transactions
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
@@ -160,7 +160,7 @@
                (set (xt/q node "SELECT _id FROM xt_docs"))))
       ;; Finish the block
       (t/is (nil? (tu/finish-block! node)))
-  
+
       ;; Submit a few more transactions
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :willbe}]])
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :lost}]])
@@ -175,16 +175,16 @@
      (thrown-with-msg?
       IllegalStateException
       #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
-      (xtn/start-node {:log [:in-memory {}]
-                       :storage [:local {:path local-disk-path}]})))
-  
+      (xtn/start-node {:databases {:xtdb {:log [:in-memory {}]
+                                          :storage [:local {:path local-disk-path}]}}})))
+
     ;; Node with intact storage and empty memory log with epoch set to 1
-    (with-open [node (xtn/start-node {:log [:in-memory {:epoch 1}]
-                                      :storage [:local {:path local-disk-path}]})]
+    (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {:epoch 1}]
+                                                         :storage [:local {:path local-disk-path}]}}})]
       (t/testing "can query previous indexed values, unindexed values will be lost"
         (t/is (= (set [{:xt/id :foo} {:xt/id :bar}])
                  (set (xt/q node "SELECT _id FROM xt_docs")))))
-  
+
       (t/testing "can index/query new transactions"
         (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new}]]))
         (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new2}]]))
@@ -193,15 +193,15 @@
                        {:xt/id :new}
                        {:xt/id :new2}])
                  (set (xt/q node "SELECT _id FROM xt_docs")))))
-  
+
       (t/testing "can finish the block"
         (t/is (nil? (tu/finish-block! node)))))))
 
 (t/deftest test-local-log-epochs
   (util/with-tmp-dirs #{node-dir}
     ;; Node with local storage and local directory log 
-    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
-                                      :storage [:local {:path (.resolve node-dir "objects")}]})]
+    (with-open [node (xtn/start-node {:databases {:xtdb {:log [:local {:path (.resolve node-dir "log")}]
+                                                         :storage [:local {:path (.resolve node-dir "objects")}]}}})]
       ;; Submit a few transactions
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
@@ -224,13 +224,13 @@
      (thrown-with-msg?
       IllegalStateException
       #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
-      (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")}]
-                       :storage [:local {:path (.resolve node-dir "objects")}]})))
+      (xtn/start-node {:databases {:xtdb {:log [:local {:path (.resolve node-dir "new-log")}]
+                                          :storage [:local {:path (.resolve node-dir "objects")}]}}})))
 
     ;; Node with intact storage and empty directory-log with epoch set to 1
-    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")
-                                                    :epoch 1}]
-                                      :storage [:local {:path (.resolve node-dir "objects")}]})]
+    (with-open [node (xtn/start-node {:databases {:xtdb {:log [:local {:path (.resolve node-dir "new-log")
+                                                                       :epoch 1}]
+                                                         :storage [:local {:path (.resolve node-dir "objects")}]}}})]
       (t/testing "can query previous indexed values, unindexed values will be lost"
         (t/is (= (set [{:xt/id :foo} {:xt/id :bar}])
                  (set (xt/q node "SELECT _id FROM xt_docs")))))

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -106,7 +106,7 @@
 
 (deftest test-min-max-on-xt-id
   (binding [c/*page-size* 16]
-    (with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:page-limit 16}}))]
+    (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:page-limit 16}))]
       (xt/execute-tx node (for [i (range 20)] [:put-docs :xt_docs {:xt/id i}]))
 
       (tu/finish-block! node)

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -585,7 +585,8 @@
 
 (deftest test-leaves-are-in-system-order
   (binding [c/*page-size* 1]
-    (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
+    (with-open [node (xtn/start-node (assoc-in tu/*node-opts* [:databases :xtdb]
+                                               {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
 
       (dotimes [i 2]
         (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :version i}]]))
@@ -601,7 +602,8 @@
   (binding [c/*page-size* 1
             cat/*file-size-target* (* 16 1024)
             c/*ignore-signal-block?* true]
-    (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
+    (with-open [node (xtn/start-node (assoc-in tu/*node-opts* [:databases :xtdb]
+                                               {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants :year))}]}))]
       ;; 2020 - 2025
       (let [tx-key (last (for [i (range 6)]
                            (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :col i}]])))]
@@ -658,7 +660,8 @@
             cat/*file-size-target* (* 16 1024)
             c/*ignore-signal-block?* true]
     (let [insts (tu/->instants :year)]
-      (with-open [node (xtn/start-node (merge tu/*node-opts* {:log [:in-memory {:instant-src (tu/->mock-clock insts)}]}))]
+      (with-open [node (xtn/start-node (assoc-in tu/*node-opts* [:databases :xtdb]
+                                                 {:log [:in-memory {:instant-src (tu/->mock-clock insts)}]}))]
         ;; versions 2020 - 2025
         (let [tx-key (last (for [[i [start end]] (->> (partition 2 1 insts)
                                                       (take 6)
@@ -767,8 +770,8 @@
   (doseq [bucketing  [RecencyPartition/WEEK RecencyPartition/YEAR]
           clock-step [:second :year]]
     (binding [c/*recency-partition* bucketing]
-      (util/with-open [n1 (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants clock-step))}]})
-                       n2 (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants clock-step))}]})]
+      (util/with-open [n1 (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants clock-step))}]}}})
+                       n2 (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock (tu/->instants clock-step))}]}}})]
         (let [intervals (vec (for [dir [:normal :inverse]
 
                                    ;; could add in some end-of-times here

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -23,7 +23,7 @@
       (f page-metadata))))
 
 (t/deftest test-find-gt-ivan
-  (with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:rows-per-block 10}}))]
+  (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:rows-per-block 10}))]
     (xt/execute-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]])
 
     (tu/finish-block! node)
@@ -87,7 +87,7 @@
                            {:xt/id :jdt, :name "Jeremy", :ordinal 4}})))))
 
 (t/deftest test-find-eq-ivan
-  (with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:rows-per-block 10}}))]
+  (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:rows-per-block 10}))]
     (xt/execute-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]
                          [:put-docs :xt_docs {:name "James", :xt/id :jms}]
                          [:put-docs :xt_docs {:name "Ivan", :xt/id :iva}]])

--- a/src/test/clojure/xtdb/stats_test.clj
+++ b/src/test/clojure/xtdb/stats_test.clj
@@ -11,7 +11,7 @@
 (t/use-fixtures :each tu/with-allocator)
 
 (deftest test-scan
-  (with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:rows-per-block 2}}))]
+  (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:rows-per-block 2}))]
     (let [scan-emitter (util/component node :xtdb.operator.scan/scan-emitter)
           db (db/primary-db node)]
       (xt/submit-tx node [[:put-docs :foo {:xt/id "foo1"}]

--- a/src/test/resources/test-config.yaml
+++ b/src/test/resources/test-config.yaml
@@ -1,8 +1,10 @@
-log: !InMemory
+databases:
+  xtdb:
+    log: !InMemory
+    storage: !InMemory
 indexer:
   logLimit: 64
   flushDuration: PT4H
-storage: !InMemory
 
 server:
   port: 0

--- a/src/test/resources/xtdb/cli-test.multi-dot.yaml
+++ b/src/test/resources/xtdb/cli-test.multi-dot.yaml
@@ -1,7 +1,9 @@
-log: !InMemory
+databases:
+  xtdb:
+    log: !InMemory
+    storage: !InMemory
 indexer:
   logLimit: 65
   flushDuration: PT4H
-storage: !InMemory
 server:
   port: 0

--- a/src/test/resources/xtdb/cli-test.yaml
+++ b/src/test/resources/xtdb/cli-test.yaml
@@ -1,7 +1,9 @@
-log: !InMemory
+databases:
+  xtdb:
+    log: !InMemory
+    storage: !InMemory
 indexer:
   logLimit: 65
   flushDuration: PT4H
-storage: !InMemory
 server:
   port: 0


### PR DESCRIPTION
so that we can configure multiple databases. #4561

e.g.

```yaml
log: !Kafka
  cluster: kafkaCluster
  topic: !Env XTDB_LOG_TOPIC
storage: !Remote
  objectStore: !S3
    bucket: !Env AWS_S3_BUCKET
    prefix: xtdb-object-store
# becomes
databases:
  xtdb:
    log: !Kafka
      cluster: kafkaCluster
      topic: !Env XTDB_LOG_TOPIC
    storage: !Remote
      objectStore: !S3
        bucket: !Env AWS_S3_BUCKET
        prefix: xtdb-object-store
```

In EDN:

```clojure
{:log [:local {:path (io/file dev-node-dir "log")}]
 :storage [:local {:path (io/file dev-node-dir "objects")}]
 ...}

;; becomes

{:databases {:xtdb {:log [:local {:path (io/file dev-node-dir "log")}]
                    :storage [:local {:path (io/file dev-node-dir "objects")}]}}
 ...}
```

RFC: I have updated the documentation here as appropriate. The RFC, though, is around including a collapsible 'page changelog' within each page, with migration instructions - the thought being that this is one of the main reasons readers want to see the history here?

The counter to that being someone who's stuck on an old version essentially then has to read the diffs...