### PR TITLE
ability to configure multiple databases, #4561

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -104,11 +104,11 @@
     (-> args (.vectorFor (str expr)) (.getObject 0))
     expr))
 
-(defn- validate-snapshot-not-before [snapshot-token ^Snapshot snap]
+(defn- validate-snapshot-not-before [snapshot-token, ^Database db, ^Snapshot snap]
   (let [snap-tx (.getTxBasis snap)]
     (when snapshot-token
       (let [system-time (-> (basis/<-time-basis-str snapshot-token)
-                            (get-in ["xtdb" 0]))]
+                            (get-in [(.getName db) 0]))]
         (when (and system-time
                    (or (nil? snap-tx)
                        (neg? (compare (.getSystemTime snap-tx) system-time))))
@@ -263,7 +263,7 @@
                                                         (basis/->time-basis-str {(.getName db) [sys-time]})))
                             expr/*await-token* await-token]
 
-                    (validate-snapshot-not-before expr/*snapshot-token* snap)
+                    (validate-snapshot-not-before expr/*snapshot-token* db snap)
 
                     (-> (->cursor {:allocator allocator, :snapshot snap
                                    :default-tz default-tz,

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -8,16 +8,12 @@ import kotlinx.serialization.UseSerializers
 import xtdb.ZoneIdSerde
 import xtdb.api.Authenticator.Factory.UserTable
 import xtdb.api.log.Log
-import xtdb.api.log.Log.Companion.inMemoryLog
 import xtdb.api.log.LogClusterAlias
 import xtdb.api.metrics.HealthzConfig
 import xtdb.api.module.XtdbModule
-import xtdb.api.storage.Storage
-import xtdb.api.storage.Storage.inMemoryStorage
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.Database
-import xtdb.database.DatabaseCatalog
 import xtdb.database.DatabaseName
 import xtdb.util.requiringResolve
 import java.nio.file.Files

--- a/src/test/clojure/xtdb/database_test.clj
+++ b/src/test/clojure/xtdb/database_test.clj
@@ -1,0 +1,76 @@
+(ns xtdb.database-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :as t]
+            [next.jdbc :as jdbc]
+            [xtdb.api :as xt]
+            [xtdb.check-pbuf :as cpb]
+            [xtdb.compactor :as c]
+            [xtdb.node :as xtn]
+            [xtdb.test-json :as tj]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import [java.nio.file Path]))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(t/deftest test-multi-db
+  (with-open [node (xtn/start-node {:databases {:xtdb {}, :new-db {}}})
+              xtdb-conn (.build (.createConnectionBuilder node))
+              new-db-conn (.build (-> (.createConnectionBuilder node)
+                                      (.database "new_db")))]
+    (jdbc/execute! xtdb-conn ["INSERT INTO foo RECORDS {_id: 'xtdb'}"])
+    (t/is (= {:_id "xtdb"} (jdbc/execute-one! xtdb-conn ["SELECT * FROM foo"])))
+
+    (jdbc/execute! new-db-conn ["INSERT INTO foo RECORDS {_id: 'new-db'}"])
+
+    (t/is (= {:_id "new-db"} (jdbc/execute-one! new-db-conn ["SELECT * FROM foo"])))
+    (t/is (= [{:xt/id "new-db"}] (xt/q new-db-conn ["SELECT * FROM foo"])))
+
+    (jdbc/execute! xtdb-conn ["INSERT INTO foo RECORDS {_id: 'xtdb', version: 2}"])
+
+    (t/is (= {:_id "xtdb", :version 2} (jdbc/execute-one! xtdb-conn ["SELECT * FROM foo"])))
+
+    (t/is (= [{:xt/id "new-db"}] (xt/q new-db-conn ["SELECT * FROM foo"])))))
+
+(t/deftest test-block-boundary
+  (binding [c/*ignore-signal-block?* true]
+    (util/with-tmp-dir* "node"
+      (fn [^Path node-dir]
+        (let [mock-clock (tu/->mock-clock)
+              node-config {:databases {:xtdb {:log [:local {:path (.resolve node-dir "xt/log")
+                                                            :instant-src mock-clock}]
+                                              :storage [:local {:path (.resolve node-dir "xt/objects")}]},
+                                       :new-db {:log [:local {:path (.resolve node-dir "new_db/log")
+                                                              :instant-src mock-clock}]
+                                                :storage [:local {:path (.resolve node-dir "new_db/objects")}]}}}]
+          (util/with-open [node (xtn/start-node node-config)
+                           xtdb-conn (-> (.createConnectionBuilder node) (.build))
+                           new-db-conn (.build (-> (.createConnectionBuilder node)
+                                                   (.database "new_db")))]
+            (jdbc/execute! xtdb-conn ["INSERT INTO foo RECORDS {_id: 'xtdb'}"])
+
+            (jdbc/execute! new-db-conn ["INSERT INTO foo RECORDS {_id: 'new-db'}"])
+            (t/is (= {:_id "new-db"} (jdbc/execute-one! new-db-conn ["SELECT * FROM foo"])))
+
+            (tu/flush-block! node))
+
+          (tj/check-json (.toPath (io/as-file (io/resource "xtdb/database-test/block-boundary")))
+                         node-dir)
+
+          (cpb/check-pbuf (.toPath (io/as-file (io/resource "xtdb/database-test/block-boundary")))
+                          node-dir)
+
+          (util/with-open [node2 (xtn/start-node node-config)
+                           xt-db-conn (.build (.createConnectionBuilder node2))
+                           new-db-conn (-> (.createConnectionBuilder node2)
+                                           (.database "new_db")
+                                           (.build))]
+            (t/is (= {:_id "xtdb"} (jdbc/execute-one! xt-db-conn ["SELECT * FROM foo"])))
+
+            (jdbc/execute! new-db-conn ["INSERT INTO foo RECORDS {_id: 'new-db', version: 2}"])
+            (t/is (= [{:_id "new-db", :version 2, :_valid_from #xt/zdt "2020-01-03Z[UTC]"}
+                      {:_id "xtdb", :version nil, :_valid_from #xt/zdt "2020-01-01Z[UTC]"}]
+                     (jdbc/execute! new-db-conn ["SELECT *, _valid_from FROM foo FOR ALL VALID_TIME"])))
+
+            (t/is (= {:_id "xtdb"}
+                     (jdbc/execute-one! xt-db-conn ["SELECT * FROM foo"])))))))))

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/blocks/b00.binpb.edn
@@ -1,0 +1,5 @@
+{:block-idx 0,
+ :latest-completed-tx
+ {:tx-id 0, :system-time #xt/instant "2020-01-02T00:00:00Z"},
+ :latest-processed-msg-id 0,
+ :table-names #{"xt/txs" "public/foo"}}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/blocks/b00.binpb.edn
@@ -1,0 +1,17 @@
+{:row-count 1,
+ :fields
+ {"_id"
+  #xt.arrow/field ["_id" #xt.arrow/field-type [#xt.arrow/type :utf8 false]]},
+ :tries
+ [{:trie-key "l00-rc-b00",
+   :data-file-size 1958,
+   :trie-metadata
+   {:min-valid-from #xt/instant "2020-01-02T00:00:00Z",
+    :max-valid-from #xt/instant "2020-01-02T00:00:00Z",
+    :min-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :max-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :min-system-from #xt/instant "2020-01-02T00:00:00Z",
+    :max-system-from #xt/instant "2020-01-02T00:00:00Z",
+    :row-count 1,
+    :iid-bloom [1913226231 5]}}],
+ :hlls {"_id" [28711359 1.0004885993744506]}}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.json
@@ -1,0 +1,124 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "_system_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_to",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "op",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "put",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "_id",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "delete",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "erase",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "_iid",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["3fba5e4da18c74c343dd6f189d5a19bc"]
+    },{
+      "name" : "_system_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577923200000000]
+    },{
+      "name" : "_valid_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577923200000000]
+    },{
+      "name" : "_valid_to",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [9223372036854775807]
+    },{
+      "name" : "op",
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "put",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "_id",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,6],
+          "DATA" : ["new-db"]
+        }]
+      },{
+        "name" : "delete",
+        "count" : 0
+      },{
+        "name" : "erase",
+        "count" : 0
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.json
@@ -1,0 +1,214 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch-iid",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data$",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "data-page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "columns",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "col",
+            "nullable" : false,
+            "type" : {
+              "name" : "struct"
+            },
+            "children" : [{
+              "name" : "col-name",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "root-col?",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "count",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bytes",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "bloom",
+                "nullable" : true,
+                "type" : {
+                  "name" : "binary"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "date-times",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch-iid",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data$",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "data-page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        },{
+          "name" : "columns",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,5],
+          "children" : [{
+            "name" : "col",
+            "count" : 5,
+            "VALIDITY" : [1,1,1,1,1],
+            "children" : [{
+              "name" : "col-name",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "OFFSET" : [0,4,15,24,36,39],
+              "DATA" : ["_iid","_valid_from","_valid_to","_system_from","_id"]
+            },{
+              "name" : "root-col?",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "DATA" : [1,1,1,1,1]
+            },{
+              "name" : "count",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "DATA" : ["1","1","1","1","1"]
+            },{
+              "name" : "bytes",
+              "count" : 5,
+              "VALIDITY" : [1,0,0,0,1],
+              "children" : [{
+                "name" : "bloom",
+                "count" : 5,
+                "VALIDITY" : [1,0,0,0,0],
+                "OFFSET" : [0,58,58,58,58,58],
+                "DATA" : ["3a3000000500000007000000130000001f0000002b0000003600000030000000320000003400000036000000380000008d89b261d739fc1121ea","","","",""]
+              }]
+            },{
+              "name" : "date-times",
+              "count" : 5,
+              "VALIDITY" : [0,1,1,1,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 5,
+                "VALIDITY" : [0,1,1,1,0],
+                "DATA" : [0.0,1.5779232E9,9.223372036854775E12,1.5779232E9,0.0]
+              },{
+                "name" : "max",
+                "count" : 5,
+                "VALIDITY" : [0,1,1,1,0],
+                "DATA" : [0.0,1.5779232E9,9.223372036854775E12,1.5779232E9,0.0]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -1,0 +1,27 @@
+{:row-count 1,
+ :fields
+ {"system_time"
+  #xt.arrow/field ["system_time" #xt.arrow/field-type [#xt.arrow/type [:timestamp-tz :micro "UTC"] false]],
+  "committed"
+  #xt.arrow/field ["committed" #xt.arrow/field-type [#xt.arrow/type :bool false]],
+  "_id"
+  #xt.arrow/field ["_id" #xt.arrow/field-type [#xt.arrow/type :i64 false]],
+  "error"
+  #xt.arrow/field ["error" #xt.arrow/field-type [#xt.arrow/type :transit true]]},
+ :tries
+ [{:trie-key "l00-rc-b00",
+   :data-file-size 2806,
+   :trie-metadata
+   {:min-valid-from #xt/instant "2020-01-02T00:00:00Z",
+    :max-valid-from #xt/instant "2020-01-02T00:00:00Z",
+    :min-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :max-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :min-system-from #xt/instant "2020-01-02T00:00:00Z",
+    :max-system-from #xt/instant "2020-01-02T00:00:00Z",
+    :row-count 1,
+    :iid-bloom [341758827 5]}}],
+ :hlls
+ {"system_time" [-167449219 1.0004885993744506],
+  "committed" [554809535 1.0004885993744506],
+  "_id" [75145568 1.0004885993744506],
+  "error" [1743287434 1.0004885993744506]}}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.json
@@ -1,0 +1,171 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "_system_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_to",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "op",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "put",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "_id",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 64,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "system_time",
+          "nullable" : false,
+          "type" : {
+            "name" : "timestamp",
+            "unit" : "MICROSECOND",
+            "timezone" : "UTC"
+          },
+          "children" : [ ]
+        },{
+          "name" : "committed",
+          "nullable" : false,
+          "type" : {
+            "name" : "bool"
+          },
+          "children" : [ ]
+        },{
+          "name" : "error",
+          "nullable" : true,
+          "type" : {
+            "name" : "TransitType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "xt/transit+msgpack",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        }]
+      },{
+        "name" : "delete",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "erase",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "_iid",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["a4e167a76a05add8a8654c169b07b044"]
+    },{
+      "name" : "_system_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577923200000000]
+    },{
+      "name" : "_valid_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577923200000000]
+    },{
+      "name" : "_valid_to",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [9223372036854775807]
+    },{
+      "name" : "op",
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "put",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "_id",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : ["0"]
+        },{
+          "name" : "system_time",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [1577923200000000]
+        },{
+          "name" : "committed",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [1]
+        },{
+          "name" : "error",
+          "count" : 1,
+          "VALIDITY" : [0],
+          "OFFSET" : [0,0],
+          "DATA" : [""]
+        }]
+      },{
+        "name" : "delete",
+        "count" : 0
+      },{
+        "name" : "erase",
+        "count" : 0
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/new_db/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.json
@@ -1,0 +1,276 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch-iid",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data$",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "data-page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "columns",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "col",
+            "nullable" : false,
+            "type" : {
+              "name" : "struct"
+            },
+            "children" : [{
+              "name" : "col-name",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "root-col?",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "count",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bytes",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "bloom",
+                "nullable" : true,
+                "type" : {
+                  "name" : "binary"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "date-times",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "numbers",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "bool",
+              "nullable" : true,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "transit",
+              "nullable" : true,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch-iid",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data$",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "data-page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        },{
+          "name" : "columns",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,8],
+          "children" : [{
+            "name" : "col",
+            "count" : 8,
+            "VALIDITY" : [1,1,1,1,1,1,1,1],
+            "children" : [{
+              "name" : "col-name",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "OFFSET" : [0,4,15,24,36,39,50,59,64],
+              "DATA" : ["_iid","_valid_from","_valid_to","_system_from","_id","system_time","committed","error"]
+            },{
+              "name" : "root-col?",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "DATA" : [1,1,1,1,1,1,1,1]
+            },{
+              "name" : "count",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "DATA" : ["1","1","1","1","1","1","1","0"]
+            },{
+              "name" : "bytes",
+              "count" : 8,
+              "VALIDITY" : [1,0,0,0,0,0,0,0],
+              "children" : [{
+                "name" : "bloom",
+                "count" : 8,
+                "VALIDITY" : [1,0,0,0,0,0,0,0],
+                "OFFSET" : [0,58,58,58,58,58,58,58,58],
+                "DATA" : ["3a3000000500000004000000110000001e0000002b00000038000000300000003200000034000000360000003800000043079dfe6104bbfb7f01","","","","","","",""]
+              }]
+            },{
+              "name" : "date-times",
+              "count" : 8,
+              "VALIDITY" : [0,1,1,1,0,1,0,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 8,
+                "VALIDITY" : [0,1,1,1,0,1,0,0],
+                "DATA" : [0.0,1.5779232E9,9.223372036854775E12,1.5779232E9,0.0,1.5779232E9,0.0,0.0]
+              },{
+                "name" : "max",
+                "count" : 8,
+                "VALIDITY" : [0,1,1,1,0,1,0,0],
+                "DATA" : [0.0,1.5779232E9,9.223372036854775E12,1.5779232E9,0.0,1.5779232E9,0.0,0.0]
+              }]
+            },{
+              "name" : "numbers",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,1,0,0,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 8,
+                "VALIDITY" : [0,0,0,0,1,0,0,0],
+                "DATA" : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+              },{
+                "name" : "max",
+                "count" : 8,
+                "VALIDITY" : [0,0,0,0,1,0,0,0],
+                "DATA" : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+              }]
+            },{
+              "name" : "bool",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,0,0,1,0],
+              "DATA" : [0,0,0,0,0,0,1,0]
+            },{
+              "name" : "transit",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,0,0,0,1],
+              "DATA" : [0,0,0,0,0,0,0,1]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/blocks/b00.binpb.edn
@@ -1,0 +1,5 @@
+{:block-idx 0,
+ :latest-completed-tx
+ {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
+ :latest-processed-msg-id 0,
+ :table-names #{"xt/txs" "public/foo"}}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/blocks/b00.binpb.edn
@@ -1,0 +1,17 @@
+{:row-count 1,
+ :fields
+ {"_id"
+  #xt.arrow/field ["_id" #xt.arrow/field-type [#xt.arrow/type :utf8 false]]},
+ :tries
+ [{:trie-key "l00-rc-b00",
+   :data-file-size 1958,
+   :trie-metadata
+   {:min-valid-from #xt/instant "2020-01-01T00:00:00Z",
+    :max-valid-from #xt/instant "2020-01-01T00:00:00Z",
+    :min-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :max-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :min-system-from #xt/instant "2020-01-01T00:00:00Z",
+    :max-system-from #xt/instant "2020-01-01T00:00:00Z",
+    :row-count 1,
+    :iid-bloom [2019652329 5]}}],
+ :hlls {"_id" [1886389216 1.0004885993744506]}}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.json
@@ -1,0 +1,124 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "_system_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_to",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "op",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "put",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "_id",
+          "nullable" : false,
+          "type" : {
+            "name" : "utf8"
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "delete",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "erase",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "_iid",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["539b57dd409fa9a39319edfc45e90c9d"]
+    },{
+      "name" : "_system_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
+    },{
+      "name" : "_valid_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
+    },{
+      "name" : "_valid_to",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [9223372036854775807]
+    },{
+      "name" : "op",
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "put",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "_id",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,4],
+          "DATA" : ["xtdb"]
+        }]
+      },{
+        "name" : "delete",
+        "count" : 0
+      },{
+        "name" : "erase",
+        "count" : 0
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.json
@@ -1,0 +1,214 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch-iid",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data$",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "data-page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "columns",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "col",
+            "nullable" : false,
+            "type" : {
+              "name" : "struct"
+            },
+            "children" : [{
+              "name" : "col-name",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "root-col?",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "count",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bytes",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "bloom",
+                "nullable" : true,
+                "type" : {
+                  "name" : "binary"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "date-times",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch-iid",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data$",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "data-page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        },{
+          "name" : "columns",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,5],
+          "children" : [{
+            "name" : "col",
+            "count" : 5,
+            "VALIDITY" : [1,1,1,1,1],
+            "children" : [{
+              "name" : "col-name",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "OFFSET" : [0,4,15,24,36,39],
+              "DATA" : ["_iid","_valid_from","_valid_to","_system_from","_id"]
+            },{
+              "name" : "root-col?",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "DATA" : [1,1,1,1,1]
+            },{
+              "name" : "count",
+              "count" : 5,
+              "VALIDITY" : [1,1,1,1,1],
+              "DATA" : ["1","1","1","1","1"]
+            },{
+              "name" : "bytes",
+              "count" : 5,
+              "VALIDITY" : [1,0,0,0,1],
+              "children" : [{
+                "name" : "bloom",
+                "count" : 5,
+                "VALIDITY" : [1,0,0,0,0],
+                "OFFSET" : [0,58,58,58,58,58],
+                "DATA" : ["3a3000000500000036000000380000003b0000003d0000003f00000030000000320000003400000036000000380000008d90f3cd590bbf482586","","","",""]
+              }]
+            },{
+              "name" : "date-times",
+              "count" : 5,
+              "VALIDITY" : [0,1,1,1,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 5,
+                "VALIDITY" : [0,1,1,1,0],
+                "DATA" : [0.0,1.5778368E9,9.223372036854775E12,1.5778368E9,0.0]
+              },{
+                "name" : "max",
+                "count" : 5,
+                "VALIDITY" : [0,1,1,1,0],
+                "DATA" : [0.0,1.5778368E9,9.223372036854775E12,1.5778368E9,0.0]
+              }]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -1,0 +1,27 @@
+{:row-count 1,
+ :fields
+ {"system_time"
+  #xt.arrow/field ["system_time" #xt.arrow/field-type [#xt.arrow/type [:timestamp-tz :micro "UTC"] false]],
+  "committed"
+  #xt.arrow/field ["committed" #xt.arrow/field-type [#xt.arrow/type :bool false]],
+  "_id"
+  #xt.arrow/field ["_id" #xt.arrow/field-type [#xt.arrow/type :i64 false]],
+  "error"
+  #xt.arrow/field ["error" #xt.arrow/field-type [#xt.arrow/type :transit true]]},
+ :tries
+ [{:trie-key "l00-rc-b00",
+   :data-file-size 2806,
+   :trie-metadata
+   {:min-valid-from #xt/instant "2020-01-01T00:00:00Z",
+    :max-valid-from #xt/instant "2020-01-01T00:00:00Z",
+    :min-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :max-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
+    :min-system-from #xt/instant "2020-01-01T00:00:00Z",
+    :max-system-from #xt/instant "2020-01-01T00:00:00Z",
+    :row-count 1,
+    :iid-bloom [341758827 5]}}],
+ :hlls
+ {"system_time" [-240381059 1.0004885993744506],
+  "committed" [554809535 1.0004885993744506],
+  "_id" [75145568 1.0004885993744506],
+  "error" [1743287434 1.0004885993744506]}}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.json
@@ -1,0 +1,171 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "_iid",
+      "nullable" : false,
+      "type" : {
+        "name" : "fixedsizebinary",
+        "byteWidth" : 16
+      },
+      "children" : [ ]
+    },{
+      "name" : "_system_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_from",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "_valid_to",
+      "nullable" : false,
+      "type" : {
+        "name" : "timestamp",
+        "unit" : "MICROSECOND",
+        "timezone" : "UTC"
+      },
+      "children" : [ ]
+    },{
+      "name" : "op",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "put",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "_id",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 64,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "system_time",
+          "nullable" : false,
+          "type" : {
+            "name" : "timestamp",
+            "unit" : "MICROSECOND",
+            "timezone" : "UTC"
+          },
+          "children" : [ ]
+        },{
+          "name" : "committed",
+          "nullable" : false,
+          "type" : {
+            "name" : "bool"
+          },
+          "children" : [ ]
+        },{
+          "name" : "error",
+          "nullable" : true,
+          "type" : {
+            "name" : "TransitType"
+          },
+          "children" : [ ],
+          "metadata" : [{
+            "value" : "xt/transit+msgpack",
+            "key" : "ARROW:extension:name"
+          },{
+            "value" : "",
+            "key" : "ARROW:extension:metadata"
+          }]
+        }]
+      },{
+        "name" : "delete",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "erase",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "_iid",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : ["a4e167a76a05add8a8654c169b07b044"]
+    },{
+      "name" : "_system_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
+    },{
+      "name" : "_valid_from",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1577836800000000]
+    },{
+      "name" : "_valid_to",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [9223372036854775807]
+    },{
+      "name" : "op",
+      "count" : 1,
+      "TYPE_ID" : [0],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "put",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "_id",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : ["0"]
+        },{
+          "name" : "system_time",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [1577836800000000]
+        },{
+          "name" : "committed",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [1]
+        },{
+          "name" : "error",
+          "count" : 1,
+          "VALIDITY" : [0],
+          "OFFSET" : [0,0],
+          "DATA" : [""]
+        }]
+      },{
+        "name" : "delete",
+        "count" : 0
+      },{
+        "name" : "erase",
+        "count" : 0
+      }]
+    }]
+  }]
+}

--- a/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.json
+++ b/src/test/resources/xtdb/database-test/block-boundary/xt/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.json
@@ -1,0 +1,276 @@
+{
+  "schema" : {
+    "fields" : [{
+      "name" : "nodes",
+      "nullable" : false,
+      "type" : {
+        "name" : "union",
+        "mode" : "Dense",
+        "typeIds" : [ ]
+      },
+      "children" : [{
+        "name" : "nil",
+        "nullable" : true,
+        "type" : {
+          "name" : "null"
+        },
+        "children" : [ ]
+      },{
+        "name" : "branch-iid",
+        "nullable" : false,
+        "type" : {
+          "name" : "list"
+        },
+        "children" : [{
+          "name" : "$data$",
+          "nullable" : true,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "nullable" : false,
+        "type" : {
+          "name" : "struct"
+        },
+        "children" : [{
+          "name" : "data-page-idx",
+          "nullable" : false,
+          "type" : {
+            "name" : "int",
+            "bitWidth" : 32,
+            "isSigned" : true
+          },
+          "children" : [ ]
+        },{
+          "name" : "columns",
+          "nullable" : false,
+          "type" : {
+            "name" : "list"
+          },
+          "children" : [{
+            "name" : "col",
+            "nullable" : false,
+            "type" : {
+              "name" : "struct"
+            },
+            "children" : [{
+              "name" : "col-name",
+              "nullable" : false,
+              "type" : {
+                "name" : "utf8"
+              },
+              "children" : [ ]
+            },{
+              "name" : "root-col?",
+              "nullable" : false,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "count",
+              "nullable" : false,
+              "type" : {
+                "name" : "int",
+                "bitWidth" : 64,
+                "isSigned" : true
+              },
+              "children" : [ ]
+            },{
+              "name" : "bytes",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "bloom",
+                "nullable" : true,
+                "type" : {
+                  "name" : "binary"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "date-times",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "numbers",
+              "nullable" : true,
+              "type" : {
+                "name" : "struct"
+              },
+              "children" : [{
+                "name" : "min",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              },{
+                "name" : "max",
+                "nullable" : false,
+                "type" : {
+                  "name" : "floatingpoint",
+                  "precision" : "DOUBLE"
+                },
+                "children" : [ ]
+              }]
+            },{
+              "name" : "bool",
+              "nullable" : true,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            },{
+              "name" : "transit",
+              "nullable" : true,
+              "type" : {
+                "name" : "bool"
+              },
+              "children" : [ ]
+            }]
+          }]
+        }]
+      }]
+    }]
+  },
+  "batches" : [{
+    "count" : 1,
+    "columns" : [{
+      "name" : "nodes",
+      "count" : 1,
+      "TYPE_ID" : [2],
+      "OFFSET" : [0],
+      "children" : [{
+        "name" : "nil",
+        "count" : 0
+      },{
+        "name" : "branch-iid",
+        "count" : 0,
+        "VALIDITY" : [ ],
+        "OFFSET" : [0],
+        "children" : [{
+          "name" : "$data$",
+          "count" : 0,
+          "VALIDITY" : [ ],
+          "DATA" : [ ]
+        }]
+      },{
+        "name" : "leaf",
+        "count" : 1,
+        "VALIDITY" : [1],
+        "children" : [{
+          "name" : "data-page-idx",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "DATA" : [0]
+        },{
+          "name" : "columns",
+          "count" : 1,
+          "VALIDITY" : [1],
+          "OFFSET" : [0,8],
+          "children" : [{
+            "name" : "col",
+            "count" : 8,
+            "VALIDITY" : [1,1,1,1,1,1,1,1],
+            "children" : [{
+              "name" : "col-name",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "OFFSET" : [0,4,15,24,36,39,50,59,64],
+              "DATA" : ["_iid","_valid_from","_valid_to","_system_from","_id","system_time","committed","error"]
+            },{
+              "name" : "root-col?",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "DATA" : [1,1,1,1,1,1,1,1]
+            },{
+              "name" : "count",
+              "count" : 8,
+              "VALIDITY" : [1,1,1,1,1,1,1,1],
+              "DATA" : ["1","1","1","1","1","1","1","0"]
+            },{
+              "name" : "bytes",
+              "count" : 8,
+              "VALIDITY" : [1,0,0,0,0,0,0,0],
+              "children" : [{
+                "name" : "bloom",
+                "count" : 8,
+                "VALIDITY" : [1,0,0,0,0,0,0,0],
+                "OFFSET" : [0,58,58,58,58,58,58,58,58],
+                "DATA" : ["3a3000000500000004000000110000001e0000002b00000038000000300000003200000034000000360000003800000043079dfe6104bbfb7f01","","","","","","",""]
+              }]
+            },{
+              "name" : "date-times",
+              "count" : 8,
+              "VALIDITY" : [0,1,1,1,0,1,0,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 8,
+                "VALIDITY" : [0,1,1,1,0,1,0,0],
+                "DATA" : [0.0,1.5778368E9,9.223372036854775E12,1.5778368E9,0.0,1.5778368E9,0.0,0.0]
+              },{
+                "name" : "max",
+                "count" : 8,
+                "VALIDITY" : [0,1,1,1,0,1,0,0],
+                "DATA" : [0.0,1.5778368E9,9.223372036854775E12,1.5778368E9,0.0,1.5778368E9,0.0,0.0]
+              }]
+            },{
+              "name" : "numbers",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,1,0,0,0],
+              "children" : [{
+                "name" : "min",
+                "count" : 8,
+                "VALIDITY" : [0,0,0,0,1,0,0,0],
+                "DATA" : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+              },{
+                "name" : "max",
+                "count" : 8,
+                "VALIDITY" : [0,0,0,0,1,0,0,0],
+                "DATA" : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+              }]
+            },{
+              "name" : "bool",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,0,0,1,0],
+              "DATA" : [0,0,0,0,0,0,1,0]
+            },{
+              "name" : "transit",
+              "count" : 8,
+              "VALIDITY" : [0,0,0,0,0,0,0,1],
+              "DATA" : [0,0,0,0,0,0,0,1]
+            }]
+          }]
+        }]
+      }]
+    }]
+  }]
+}


### PR DESCRIPTION
Well, this is a bit disappointing for 'ability to configure multiple databases', about 40LoC in core code :laughing: (rest of the PR is tests + expectations files)

Anyway, here it is - first increment of multi-db :slightly_smiling_face: 

Configure:

```clojure
{:databases {:xtdb {:log [:local {:path (.resolve node-dir "xt/log")
                                  :instant-src mock-clock}]
                    :storage [:local {:path (.resolve node-dir "xt/objects")}]},

             :new-db {:log [:local {:path (.resolve node-dir "new_db/log")
                                    :instant-src mock-clock}]
                      :storage [:local {:path (.resolve node-dir "new_db/objects")}]}}}
```

```yaml
databases:
  xtdb:
    log: !Local
      path: /var/lib/xtdb/databases/xtdb/log
    storage: !Local
      path: /var/lib/xtdb/databases/xtdb/objects

  new_db:
    log: !Local
      path: /var/lib/xtdb/databases/new_db/log
    storage: !Local
      path: /var/lib/xtdb/databases/new_db/objects
```

Connect to them with a JDBC URL like `jdbc:xtdb://localhost/xtdb` vs `jdbc:xtdb://localhost/new_db`, or (in XT tests) you can use the `javax.sql.DataSource`'s `createConnectionBuilder` (so that you're not figuring out what random port it's started on):

```clojure
(util/with-open [node (xtn/start-node node-config)
                 xtdb-conn (-> (.createConnectionBuilder node)
                               (.build))
                 new-db-conn (-> (.createConnectionBuilder node)
                                 (.database "new_db")
                                 (.build))]
  ...)
```

Documentation to come in #4626, wanted to get this one landed and people playing with it :slightly_smiling_face: 