### PR TITLE
Minor fix: pgwire-tests error on close

### DIFF
--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -82,9 +82,9 @@
 (defn serve
   (^xtdb.pgwire.Server [] (serve {}))
   (^xtdb.pgwire.Server [opts] (pgw/serve tu/*node* (merge {:num-threads 1
-                                                              :allocator tu/*allocator*
-                                                              :drain-wait 250}
-                                                             opts))))
+                                                           :allocator tu/*allocator*
+                                                           :drain-wait 250}
+                                                          opts))))
 
 (defn jdbc-conn
   (^Connection [] (jdbc-conn nil))
@@ -419,8 +419,8 @@
   ;; quick test for now to confirm canned response mechanism at least doesn't crash!
   ;; this may later be replaced by client driver tests (e.g test sqlalchemy connect & query)
   (with-redefs [pgw/canned-responses [{:q "hello!"
-                                          :cols [{:col-name "greet", :pg-type :json}]
-                                          :rows (fn [_] [["\"hey!\""]])}]]
+                                       :cols [{:col-name "greet", :pg-type :json}]
+                                       :rows (fn [_] [["\"hey!\""]])}]]
     (with-open [conn (jdbc-conn)]
       (is (= [{:greet "hey!"}] (q conn ["hello!"]))))))
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -629,21 +629,19 @@
          (is (= [["a"] ["42"] ["\"hello!\""] ["[1,2,3]"]] (read))))
 
        (testing "error during plan"
-         (with-redefs [clojure.tools.logging/logf (constantly nil)]
-           (send "slect baz.a from baz;\n")
-           (is (-> (second (read :stderr))
-                   (str/includes? "line 1:0 mismatched input 'slect' expecting"))))
+         (send "slect baz.a from baz;\n")
+         (is (-> (second (read :stderr))
+               (str/includes? "line 1:0 mismatched input 'slect' expecting")))
 
          (testing "query error allows session to continue"
            (send "select 'ping';\n")
            (is (= [["_column_1"] ["ping"]] (read)))))
 
        (testing "error during query execution"
-         (with-redefs [clojure.tools.logging/logf (constantly nil)]
-           (send "select (1 / 0) from (values (42)) a (a);\n")
-           (is (= ["ERROR:  data exception - division by zero"
-                   "DETAIL:  {\"category\":\"cognitect.anomalies\\/incorrect\",\"code\":\"xtdb.expression\\/division-by-zero\",\"message\":\"data exception - division by zero\"}"]
-                  (read :stderr))))
+         (send "select (1 / 0) from (values (42)) a (a);\n")
+         (is (= ["ERROR:  data exception - division by zero"
+                 "DETAIL:  {\"category\":\"cognitect.anomalies\\/incorrect\",\"code\":\"xtdb.expression\\/division-by-zero\",\"message\":\"data exception - division by zero\"}"]
+                (read :stderr)))
 
          (testing "query error allows session to continue"
            (send "select 'ping';\n")


### PR DESCRIPTION
There was an error on `infof` when closing the XTDB node after a test, due to having redefined `logf`.

Didn't get to the bottom of it, but it probably has to do with `logf` being a macro. A macro would have an effect at eval-time, not test-time, which to my understanding would render this redefinition useless, but it did have an effect when recompiling the xtdb.pgwire namespace, which I don't understand.

All in all, the test doesn't need to silence logs nowadays for it to work, so I've just removed the redef's. (If it were needed, an alternative could have been to instead redefine `log*`, which is a fn, not a macro). 