### PR TITLE
Move RelationMap from Clojure -> Kotlin

### DIFF
--- a/core/src/main/clojure/xtdb/expression/map.clj
+++ b/core/src/main/clojure/xtdb/expression/map.clj
@@ -5,49 +5,14 @@
             [xtdb.util :as util]
             [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
-  (:import (java.lang AutoCloseable)
+  (:import (com.carrotsearch.hppc IntObjectHashMap)
+           (java.util Map)
            java.util.function.IntBinaryOperator
-           (java.util List Map)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.memory.util.hash MurmurHasher)
            (org.apache.arrow.vector NullVector VectorSchemaRoot)
            (org.apache.arrow.vector.types.pojo Schema)
-           (org.roaringbitmap IntConsumer RoaringBitmap)
            (xtdb.arrow RelationReader VectorReader)
-           (xtdb.util Hasher$Xx)
-           (com.carrotsearch.hppc IntObjectHashMap)
-           (xtdb.expression.map IndexHasher RelationMapBuilder RelationMapProber RelationMap)))
-
-(defn ->hasher ^xtdb.expression.map.IndexHasher [^List #_<VectorReader> cols]
-  (let [hasher (Hasher$Xx.)]
-    (case (.size cols)
-      1 (let [^VectorReader col (.get cols 0)]
-          (reify IndexHasher
-            (hashCode [_ idx]
-              (.hashCode col idx hasher))))
-
-      (reify IndexHasher
-        (hashCode [_ idx]
-          (loop [n 0
-                 hash-code 0]
-            (if (< n (.size cols))
-              (let [^VectorReader col (.get cols n)]
-                (recur (inc n) (MurmurHasher/combineHashCode hash-code (.hashCode col idx hasher))))
-              hash-code)))))))
-
-(defn- andIBO
-  ([]
-   (reify IntBinaryOperator
-     (applyAsInt [_ _l _r]
-       1)))
-
-  ([^IntBinaryOperator p1, ^IntBinaryOperator p2]
-   (reify IntBinaryOperator
-     (applyAsInt [_ l r]
-       (let [l-res (.applyAsInt p1 l r)]
-         (if (= -1 l-res)
-           -1
-           (Math/min l-res (.applyAsInt p2 l r))))))))
+           (xtdb.expression.map RelationMap)))
 
 (def ^:private left-rel (gensym 'left-rel))
 (def ^:private left-vec (gensym 'left-vec))
@@ -81,8 +46,9 @@
 (def ^:private pg-class-schema-hack
   {"pg_catalog/pg_class" #{}})
 
-(defn- ->equi-comparator [^VectorReader left-col, ^VectorReader right-col, params
-                          {:keys [nil-keys-equal? param-types]}]
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn ->equi-comparator [^VectorReader left-col, ^VectorReader right-col, params
+                         {:keys [nil-keys-equal? param-types]}]
   (let [f (build-comparator {:op :call, :f (if nil-keys-equal? :null-eq :=)
                              :args [{:op :variable, :variable left-vec, :rel left-rel, :idx left-idx}
                                     {:op :variable, :variable right-vec, :rel right-rel, :idx right-idx}]}
@@ -94,7 +60,8 @@
        pg-class-schema-hack
        params)))
 
-(defn- ->theta-comparator [probe-rel build-rel theta-expr params {:keys [build-fields probe-fields param-types]}]
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn ->theta-comparator [probe-rel build-rel theta-expr params {:keys [build-fields probe-fields param-types]}]
   (let [col-types (update-vals (merge build-fields probe-fields) types/field->col-type)
         f (build-comparator (->> (expr/form->expr theta-expr {:col-types col-types, :param-types param-types})
                                  (expr/prepare-expr)
@@ -110,28 +77,6 @@
        build-rel
        pg-class-schema-hack
        params)))
-
-(defn- find-in-hash-bitmap ^long [^RoaringBitmap hash-bitmap, ^IntBinaryOperator comparator, ^long idx, remove-on-match?]
-  (if-not hash-bitmap
-    -1
-    (let [it (.getIntIterator hash-bitmap)]
-      (loop []
-        (if-not (.hasNext it)
-          -1
-          (let [test-idx (.next it)]
-            (if (= 1 (.applyAsInt comparator idx test-idx))
-              (do
-                (when remove-on-match?
-                  (.remove hash-bitmap test-idx))
-                test-idx)
-              (recur))))))))
-
-(defn returned-idx ^long [^long inserted-idx]
-  (-> inserted-idx - dec))
-
-(defn inserted-idx ^long [^long returned-idx]
-  (cond-> returned-idx
-    (neg? returned-idx) (-> inc -)))
 
 (defn ->nil-rel
   "Returns a single row relation where all columns are nil. (Useful for outer joins)."
@@ -181,107 +126,15 @@
             (.copyRow 0)))
 
         (let [build-key-cols (mapv #(vw/vec-wtr->rdr (.vectorFor rel-writer (str %))) build-key-col-names)]
-          (letfn [(compute-hash-bitmap [^long row-hash]
-                    (or (.get hash->bitmap row-hash)
-                        (let [bitmap (RoaringBitmap.)]
-                          (.put hash->bitmap (int row-hash) bitmap)
-                          bitmap)))]
-            (reify
-              RelationMap
-              (buildFields [_] build-fields)
-              (buildKeyColumnNames [_] build-key-col-names)
-              (probeFields [_] probe-fields)
-              (probeKeyColumnNames [_] probe-key-col-names)
-
-              (buildFromRelation [_ in-rel]
-                (let [^RelationReader in-rel (if store-full-build-rel?
-                                               in-rel
-                                               (->> (set build-key-col-names)
-                                                    (mapv #(.vectorForOrNull in-rel (str %)))
-                                                    vr/rel-reader))
-
-                      in-key-cols (mapv #(.vectorForOrNull in-rel (str %))
-                                        build-key-col-names)
-
-                      ;; NOTE: we might not need to compute `comparator` if the caller never requires `addIfNotPresent` (e.g. joins)
-                      !comparator (delay
-                                    (->> (map (fn [build-col in-col]
-                                                (->equi-comparator in-col build-col args
-                                                                   {:nil-keys-equal? nil-keys-equal?,
-                                                                    :param-types param-types}))
-                                              build-key-cols
-                                              in-key-cols)
-                                         (reduce andIBO)))
-
-                      hasher (->hasher in-key-cols)
-
-                      row-copier (.rowCopier rel-writer in-rel)]
-
-                  (letfn [(add ^long [^RoaringBitmap hash-bitmap, ^long idx]
-                            (let [out-idx (.copyRow row-copier idx)]
-                              (.add hash-bitmap out-idx)
-                              (returned-idx out-idx)))]
-
-                    (reify RelationMapBuilder
-                      (add [_ idx]
-                        (add (compute-hash-bitmap (.hashCode hasher idx)) idx))
-
-                      (addIfNotPresent [_ idx]
-                        (let [^RoaringBitmap hash-bitmap (compute-hash-bitmap (.hashCode hasher idx))
-                              out-idx (find-in-hash-bitmap hash-bitmap @!comparator idx false)]
-                          (if-not (neg? out-idx)
-                            out-idx
-                            (add hash-bitmap idx))))))))
-
-              (probeFromRelation [this probe-rel]
-                (let [build-rel (.getBuiltRelation this)
-                      probe-key-cols (mapv #(.vectorForOrNull probe-rel (str %))
-                                           probe-key-col-names)
-
-                      ^IntBinaryOperator
-                      comparator (->> (cond-> (map (fn [build-col probe-col]
-                                                     (->equi-comparator probe-col build-col args
-                                                                        {:nil-keys-equal? nil-keys-equal?
-                                                                         :param-types param-types}))
-                                                   build-key-cols
-                                                   probe-key-cols)
-
-                                        (some? theta-expr)
-                                        (conj (->theta-comparator probe-rel build-rel theta-expr args
-                                                                  {:build-fields build-fields
-                                                                   :probe-fields probe-fields
-                                                                   :param-types param-types})))
-                                      (reduce andIBO))
-
-                      hasher (->hasher probe-key-cols)]
-
-                  (reify RelationMapProber
-                    (indexOf [_ idx remove-on-match?]
-                      (-> ^RoaringBitmap (.get hash->bitmap (.hashCode hasher idx))
-                          (find-in-hash-bitmap comparator idx remove-on-match?)))
-
-                    (forEachMatch [_ idx c]
-                      (some-> ^RoaringBitmap (.get hash->bitmap (.hashCode hasher idx))
-                              (.forEach (reify IntConsumer
-                                          (accept [_ out-idx]
-                                            (when (= 1 (.applyAsInt comparator idx out-idx))
-                                              (.accept c out-idx)))))))
-
-
-                    (matches [_ probe-idx]
-                      ;; TODO: this doesn't use the hashmaps, still a nested loop join
-                      (let [acc (int-array [-1])]
-                        (loop [build-idx 0]
-                          (if (= build-idx (.getRowCount build-rel))
-                            (aget acc 0)
-                            (let [res (.applyAsInt comparator probe-idx build-idx)]
-                              (if (= 1 res)
-                                1
-                                (do
-                                  (aset acc 0 (Math/max (aget acc 0) res))
-                                  (recur (inc build-idx))))))))))))
-
-              (getBuiltRelation [_] (vw/rel-wtr->rdr rel-writer))
-
-              AutoCloseable
-              (close [_] (.close rel-writer)))))))))
+          (RelationMap. (update-keys build-fields str)
+                        (map str build-key-col-names)
+                        (update-keys probe-fields str)
+                        (map str probe-key-col-names)
+                        (boolean store-full-build-rel?)
+                        rel-writer
+                        build-key-cols
+                        hash->bitmap
+                        (boolean nil-keys-equal?)
+                        theta-expr
+                        (update-keys param-types str)
+                        args))))))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -67,7 +67,7 @@
     (let [row-count (.getRowCount in-rel)
           builder (.buildFromRelation rel-map in-rel)]
       (dotimes [idx row-count]
-        (.writeInt group-mapping (emap/inserted-idx (.addIfNotPresent builder idx))))
+        (.writeInt group-mapping (RelationMap/insertedIdx (.addIfNotPresent builder idx))))
 
       group-mapping))
 

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -241,7 +241,7 @@
                           (dotimes [idx (.getRowCount in-rel)]
                             (let [map-idx (.addIfNotPresent rel-builder idx)]
                               (when (neg? map-idx)
-                                (.add new-idxs (emap/inserted-idx map-idx)))))
+                                (.add new-idxs (RelationMap/insertedIdx map-idx)))))
 
                           (let [new-idxs (.toArray (.build new-idxs))]
                             (when-not (empty? new-idxs)

--- a/core/src/main/kotlin/xtdb/Util.kt
+++ b/core/src/main/kotlin/xtdb/Util.kt
@@ -1,5 +1,7 @@
 package xtdb
 
+import clojure.lang.Keyword
+import clojure.lang.Symbol
 import java.nio.ByteBuffer
 import java.util.*
 
@@ -11,3 +13,10 @@ val UUID.asByteBuffer: ByteBuffer
     }
 
 val UUID.asBytes: ByteArray get() = asByteBuffer.array()
+
+val String.kw: Keyword get() = Keyword.intern(this)
+
+val String.symbol: Symbol get() = Symbol.intern(this)
+
+fun Map<*, *>.toClojureMap(): clojure.lang.IPersistentMap =
+    clojure.lang.PersistentHashMap.create(this)

--- a/core/src/main/kotlin/xtdb/arrow/RelationReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RelationReader.kt
@@ -69,6 +69,9 @@ interface RelationReader : ILookup, Seqable, Counted, AutoCloseable {
     }
 
     companion object {
+        fun from(cols: List<VectorReader>): RelationReader =
+            FromCols(cols.associateByTo(linkedMapOf()) { it.name }, cols.firstOrNull()?.valueCount ?: 0)
+
         @JvmStatic
         fun from(cols: Iterable<VectorReader>, rowCount: Int): RelationReader =
             FromCols(cols.associateByTo(linkedMapOf()) { it.name }, rowCount)

--- a/core/src/main/kotlin/xtdb/expression/map/IndexHasher.kt
+++ b/core/src/main/kotlin/xtdb/expression/map/IndexHasher.kt
@@ -1,5 +1,5 @@
 package xtdb.expression.map
 
-interface IndexHasher {
+fun interface IndexHasher {
     fun hashCode(index: Int): Int
 }

--- a/core/src/main/kotlin/xtdb/expression/map/RelationMap.kt
+++ b/core/src/main/kotlin/xtdb/expression/map/RelationMap.kt
@@ -1,14 +1,213 @@
 package xtdb.expression.map
 
+import clojure.lang.IFn
+import com.carrotsearch.hppc.IntObjectHashMap
+import java.util.function.IntBinaryOperator
+import java.util.function.IntConsumer
+import org.apache.arrow.memory.util.hash.MurmurHasher
 import org.apache.arrow.vector.types.pojo.Field
-import xtdb.arrow.RelationReader
+import org.roaringbitmap.RoaringBitmap
+import xtdb.*
 
-interface RelationMap {
-    fun buildFields(): Map<String, Field>
-    fun buildKeyColumnNames(): List<String>
-    fun probeFields(): Map<String, Field>
-    fun probeKeyColumnNames(): List<String>
-    fun buildFromRelation(inRelation: RelationReader): RelationMapBuilder
-    fun probeFromRelation(inRelation: RelationReader): RelationMapProber
-    fun getBuiltRelation(): RelationReader
+import xtdb.arrow.RelationReader
+import xtdb.arrow.RelationWriter
+import xtdb.arrow.VectorReader
+import xtdb.util.Hasher
+import xtdb.util.requiringResolve
+
+class RelationMap(
+    val buildFields : Map<String, Field>,
+    val buildKeyColumnNames: List<String>,
+    val probeFields : Map<String, Field>,
+    val probeKeyColumnNames:  List<String>,
+    private val storeFullBuildRel : Boolean,
+    private val relWriter: RelationWriter,
+    private val buildKeyCols: List<VectorReader>,
+    private val hashToBitmap: IntObjectHashMap<RoaringBitmap>,
+    private val nilKeysEqual: Boolean = false,
+    private val thetaExpr: Any? = null,
+    private val paramTypes: Map<String, Any> = emptyMap(),
+    private val args: RelationReader? = null
+) : AutoCloseable {
+
+    private val equiComparatorFn = requiringResolve("xtdb.expression.map/->equi-comparator") as IFn
+    private val thetaComparatorFn = requiringResolve("xtdb.expression.map/->theta-comparator") as IFn
+
+    @JvmOverloads
+    fun andIBO(p1: IntBinaryOperator? = null, p2: IntBinaryOperator? = null): IntBinaryOperator {
+        return if (p1 == null && p2 == null) {
+            IntBinaryOperator { _, _ -> 1 }
+        } else if (p1 != null && p2 != null) {
+            IntBinaryOperator { l, r ->
+                val lRes = p1.applyAsInt(l, r)
+                if (lRes == -1) -1 else minOf(lRes, p2.applyAsInt(l, r))
+            }
+        } else {
+            p1 ?: p2!!
+        }
+    }
+
+    fun RoaringBitmap?.findInHashBitmap(comparator: IntBinaryOperator, idx: Int, removeOnMatch: Boolean): Int {
+        if (this == null) return -1
+
+        val iterator = this.intIterator
+        while (iterator.hasNext()) {
+            val testIdx = iterator.next()
+            if (comparator.applyAsInt(idx, testIdx) == 1) {
+                if (removeOnMatch) {
+                    this.remove(testIdx)
+                }
+                return testIdx
+            }
+        }
+        return -1
+    }
+
+    private fun createHasher(cols: List<VectorReader>): IndexHasher {
+        val hasher = Hasher.Xx()
+        return IndexHasher { index -> cols.foldRight(0) { col, acc -> MurmurHasher.combineHashCode(acc, col.hashCode(index, hasher)) } }
+    }
+
+    companion object {
+        @JvmStatic
+        fun returnedIdx(insertedIdx: Int): Int = -insertedIdx - 1
+        @JvmStatic
+        fun insertedIdx(returnedIdx: Int): Int = if (returnedIdx < 0) -returnedIdx - 1 else returnedIdx
+    }
+
+    fun computeHashBitmap(rowHash: Int) =
+        hashToBitmap.get(rowHash) ?: run {
+            val bitmap = RoaringBitmap()
+            hashToBitmap.put(rowHash, bitmap)
+            bitmap
+        }
+
+    @Suppress("NAME_SHADOWING")
+    fun buildFromRelation(inRel: RelationReader): RelationMapBuilder {
+        val inRel = if (storeFullBuildRel) {
+            inRel
+        } else {
+            RelationReader.from(buildKeyColumnNames.map { inRel.vectorFor(it) })
+        }
+        
+        val inKeyCols = buildKeyColumnNames.map { inRel.vectorForOrNull(it) as VectorReader }
+        
+        // NOTE: we might not need to compute comparator if the caller never requires addIfNotPresent (e.g. joins)
+        val comparatorLazy by lazy {
+            val equiComparators = buildKeyCols.zip(inKeyCols).map { (buildCol, inCol) ->
+                equiComparatorFn.invoke(
+                    inCol, buildCol, args,
+                    mapOf(
+                        "nil-keys-equal?".kw to nilKeysEqual,
+                        "param-types".kw to paramTypes
+                    ).toClojureMap()
+                ) as IntBinaryOperator
+            }
+            equiComparators.reduceOrNull({ acc, comp -> andIBO(acc, comp) }) ?: andIBO()
+        }
+        
+        val hasher = createHasher(inKeyCols)
+        val rowCopier = relWriter.rowCopier(inRel)
+
+        fun add(hashBitmap: RoaringBitmap, idx: Int): Int {
+            val outIdx = rowCopier.copyRow(idx)
+            hashBitmap.add(outIdx)
+            return returnedIdx(outIdx)
+        }
+
+
+        return object : RelationMapBuilder {
+            override fun add(inIdx: Int) {
+                add(computeHashBitmap(hasher.hashCode(inIdx)), inIdx);
+            }
+            
+            override fun addIfNotPresent(inIdx: Int): Int {
+                val hashBitmap = computeHashBitmap(hasher.hashCode(inIdx))
+                val outIdx = hashBitmap.findInHashBitmap(comparatorLazy, inIdx, false)
+                return if (outIdx >= 0) { outIdx } else { add(hashBitmap, inIdx) }
+            }
+        }
+    }
+    
+    fun probeFromRelation(probeRel: RelationReader): RelationMapProber {
+        val buildRel = getBuiltRelation()
+        val probeKeyCols = probeKeyColumnNames.map { probeRel.vectorForOrNull(it) as VectorReader }
+        
+        // Create equi-comparators for key columns
+        val equiComparators = buildKeyCols.zip(probeKeyCols).map { (buildCol, probeCol) ->
+            equiComparatorFn.invoke(
+                probeCol, buildCol, args,
+                mapOf(
+                    "nil-keys-equal?".kw to nilKeysEqual,
+                    "param-types".kw to paramTypes
+                ).toClojureMap()
+            ) as IntBinaryOperator
+        }
+        
+        // Add theta comparator if needed
+        val comparator = if (thetaExpr != null) {
+            val thetaComparator = thetaComparatorFn.invoke(
+                probeRel, buildRel, thetaExpr, args,
+                mapOf(
+                    "build-fields".kw to buildFields.mapKeys { it.key.symbol } .toClojureMap() ,
+                    "probe-fields".kw to probeFields.mapKeys { it.key.symbol } .toClojureMap(),
+                    "param-types".kw to paramTypes.mapKeys { it.key.symbol } .toClojureMap()
+                ).toClojureMap()
+            ) as IntBinaryOperator
+            
+            (equiComparators + thetaComparator).reduceOrNull({ acc, comp ->
+                andIBO(acc, comp)
+            }) ?: andIBO()
+        } else {
+            equiComparators.reduceOrNull({ acc, comp ->
+                andIBO(acc, comp)
+            }) ?: andIBO()
+        }
+        
+        val hasher = createHasher(probeKeyCols)
+        
+        return object : RelationMapProber {
+            override fun indexOf(inIdx: Int, removeOnMatch: Boolean): Int{
+                val hashCode = hasher.hashCode(inIdx)
+                val hashBitmap = hashToBitmap.get(hashCode)
+                
+                return hashBitmap.findInHashBitmap(comparator, inIdx, removeOnMatch)
+            }
+            
+            override fun forEachMatch(inIdx: Int, c: IntConsumer) {
+                val hashCode = hasher.hashCode(inIdx)
+                val hashBitmap = hashToBitmap.get(hashCode)
+                
+                hashBitmap?.let { bitmap ->
+                    val iterator = bitmap.intIterator
+                    while (iterator.hasNext()) {
+                        val outIdx = iterator.next()
+                        if (comparator.applyAsInt(inIdx.toInt(), outIdx) == 1) {
+                            c.accept(outIdx)
+                        }
+                    }
+                }
+            }
+            
+            override fun matches(inIdx: Int): Int {
+                // TODO: This doesn't use hashmaps, still a nested loop join
+                var acc = -1
+                val buildRowCount = buildRel.rowCount
+                for (buildIdx in 0 until buildRowCount.toInt()) {
+                    val res = comparator.applyAsInt(inIdx.toInt(), buildIdx)
+                    if (res == 1) {
+                        return 1
+                    }
+                    acc = maxOf(acc, res)
+                }
+                return acc
+            }
+        }
+    }
+    
+    fun getBuiltRelation(): RelationReader = relWriter.asReader
+
+    override fun close() {
+        relWriter.close()
+    }
 }


### PR DESCRIPTION
This is a non-functional change. Moving the RelationMap from Clojure to Kotlin.

- [x] ~I think the pattern that needs to be sorted out is how to deal with keyword option maps if Clojure calls Kotlin and Kotlin calls Clojure. This is especially the case for the EE. Currently I map to strings and then back to keywords which feels a bit awkward.~ Pattern ok for now.