### PR TITLE
Attempt at using a transient trie for ingest

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -75,7 +75,7 @@ constructor(
         txKey: TransactionKey,
         private val newLiveTable: Boolean
     ) : AutoCloseable {
-        private var transientTrie = liveTrie
+        private var transientTrie = liveTrie.asTransient()
         private val systemFrom: InstantMicros = txKey.systemTime.asMicros
 
         fun openSnapshot(): Snapshot = openSnapshot(transientTrie)
@@ -133,7 +133,7 @@ constructor(
             trieMetadataCalculator.update(startPos, pos)
             hllCalculator.update(opWtr.asReader, startPos, pos)
 
-            liveTrie = transientTrie
+            liveTrie = transientTrie.asPersistent()
 
             return this@LiveTable
         }
@@ -160,7 +160,7 @@ constructor(
             wmLiveRel.openAsRoot(al).closeOnCatch { root ->
                 val relReader = RelationReader.from(root)
 
-                val wmLiveTrie = trie.withIidReader(relReader["_iid"])
+                val wmLiveTrie = trie.asPersistent().withIidReader(relReader["_iid"])
 
                 return Snapshot(liveRelation.fields, relReader, wmLiveTrie)
             }

--- a/core/src/main/kotlin/xtdb/trie/TrieWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/TrieWriter.kt
@@ -35,6 +35,7 @@ class TrieWriter(
                                 data.forEach { idx -> copier.copyRow(idx) }
                                 metaFileWriter.writeLeaf().also { dataFileWriter.writePage() }
                             }
+                            else -> throw IllegalStateException("Unknown node type: $this")
                         }
 
                     trie.compactLogs().rootNode.writeNode()


### PR DESCRIPTION
This was an attempt to see if any quick gains could be made by using a transient trie for ingest. This was not the case. I suspect that the conversions back and forth between transient and persistent trie are currently too costly, but I didn't check a profiler. Below the numbers for the `ingest-tx-overhead` benchmark.

main:
```json
{"stage":"ingest-batch-1000","time-taken-ms":5537,"bench-id":"8a1130b9-b90e-43ad-83c7-cef1a55a553d","jvm-id":"fin"}
{"stage":"ingest-batch-100","time-taken-ms":20515,"bench-id":"8a1130b9-b90e-43ad-83c7-cef1a55a553d","jvm-id":"fin"}
{"stage":"ingest-batch-10","time-taken-ms":155052,"bench-id":"8a1130b9-b90e-43ad-83c7-cef1a55a553d","jvm-id":"fin"}
```
this branch:
```json
{"stage":"ingest-batch-1000","time-taken-ms":5944,"bench-id":"41205538-55b1-4dd1-b5e0-9c4214323b99","jvm-id":"fin"}
{"stage":"ingest-batch-100","time-taken-ms":24691,"bench-id":"41205538-55b1-4dd1-b5e0-9c4214323b99","jvm-id":"fin"}
{"stage":"ingest-batch-10","time-taken-ms":191371,"bench-id":"41205538-55b1-4dd1-b5e0-9c4214323b99","jvm-id":"fin"}
```