### PR TITLE
`MutableMemoryHashTrie` for `RelationMap`.

### DIFF
--- a/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/ArrowHashTrie.kt
@@ -7,8 +7,7 @@ private const val BRANCH_IID = "branch-iid"
 private const val LEAF = "leaf"
 private const val DATA_PAGE_IDX = "data-page-idx"
 
-class ArrowHashTrie(private val nodesVec: Vector) :
-    HashTrie<ArrowHashTrie.Node, ArrowHashTrie.Leaf> {
+class ArrowHashTrie(private val nodesVec: Vector) : HashTrie<ArrowHashTrie.Node, ArrowHashTrie.Leaf> {
 
     private val iidBranchVec = nodesVec[BRANCH_IID]
     private val iidBranchElVec = iidBranchVec.listElements
@@ -21,7 +20,7 @@ class ArrowHashTrie(private val nodesVec: Vector) :
         private val startIdx = iidBranchVec.getListStartIndex(branchVecIdx)
         private val count = iidBranchVec.getListCount(branchVecIdx)
 
-        override val iidChildren: Array<Node?>
+        override val hashChildren: Array<Node?>
             get() = Array(count) { childBucket ->
                 val childIdx = childBucket + startIdx
                 if (iidBranchElVec.isNull(childIdx))
@@ -34,7 +33,7 @@ class ArrowHashTrie(private val nodesVec: Vector) :
     inner class Leaf(override val path: ByteArray, private val leafOffset: Int) : Node {
         val dataPageIndex get() = dataPageIdxVec.getInt(leafOffset)
 
-        override val iidChildren = null
+        override val hashChildren = null
     }
 
     private fun forIndex(path: ByteArray, idx: Int) =

--- a/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
+++ b/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
@@ -20,7 +20,7 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
         var mid: Int
         while (left < right) {
             mid = (left + right) / 2
-            if (HashTrie.compareToPath(iidReader.getPointer(mid), path) < 0) left = mid + 1
+            if (Bucketer.DEFAULT.compareToPath(iidReader.getPointer(mid), path) < 0) left = mid + 1
             else right = mid
         }
         this.index = left
@@ -36,7 +36,7 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
     val op get() = opReader.getLeg(index)!!
 
     fun isValid(reuse: ArrowBufPointer, path: ByteArray): Boolean =
-        index < relReader.rowCount && HashTrie.compareToPath(getIidPointer(reuse), path) <= 0
+        index < relReader.rowCount && Bucketer.DEFAULT.compareToPath(getIidPointer(reuse), path) <= 0
 
     companion object {
         @JvmStatic

--- a/core/src/main/kotlin/xtdb/trie/HashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/HashTrie.kt
@@ -18,6 +18,52 @@ fun conjPath(path: ByteArray, idx: Byte): ByteArray {
     return childPath
 }
 
+const val DEFAULT_LEVEL_BITS = 2
+const val DEFAULT_LEVEL_WIDTH = 1 shl DEFAULT_LEVEL_BITS
+
+data class Bucketer(val levelBits: Int = DEFAULT_LEVEL_BITS) {
+
+    val levelWidth: Int = 1 shl levelBits
+    val levelMask: Int = levelWidth - 1
+
+    init {
+        require(levelBits in setOf(2,4,8), {"levelBits must be one of 2, 4 or 8, got $levelBits"})
+    }
+
+    fun bucketFor(byteArray: ByteArray, level: Int): Byte {
+        assert(level * levelBits < byteArray.size * java.lang.Byte.SIZE)
+        val bitIdx = level * levelBits
+        val byteIdx = bitIdx / java.lang.Byte.SIZE
+        val bitOffset = bitIdx % java.lang.Byte.SIZE
+
+        val b = byteArray.get(byteIdx)
+        return ((b.toInt() ushr ((java.lang.Byte.SIZE - levelBits) - bitOffset)) and levelMask).toByte()
+    }
+
+    fun bucketFor(pointer: ArrowBufPointer, level: Int): Byte {
+        assert(level * levelBits < pointer.length * java.lang.Byte.SIZE)
+        val bitIdx = level * levelBits
+        val byteIdx = bitIdx / java.lang.Byte.SIZE
+        val bitOffset = bitIdx % java.lang.Byte.SIZE
+
+        val b = pointer.buf!!.getByte(pointer.offset + byteIdx)
+        return ((b.toInt() ushr ((java.lang.Byte.SIZE - levelBits) - bitOffset)) and levelMask).toByte()
+    }
+
+    fun compareToPath(pointer: ArrowBufPointer, path: ByteArray): Int {
+        for (level in path.indices) {
+            val cmp = bucketFor(pointer, level).toInt() compareTo (path[level].toInt())
+            if (cmp != 0) return cmp
+        }
+        return 0
+    }
+
+    companion object {
+        @JvmField
+        val DEFAULT = Bucketer()
+    }
+}
+
 interface HashTrie<N : Node<N>, L : N> {
     val rootNode: N?
 
@@ -26,44 +72,15 @@ interface HashTrie<N : Node<N>, L : N> {
     interface Node<N : Node<N>> {
         val path: ByteArray
 
-        val iidChildren: Array<N?>?
+        val hashChildren: Array<N?>?
 
         fun leafStream(): Stream<out Node<N>> =
             when {
-                iidChildren != null -> Arrays.stream(iidChildren).flatMap { child -> child?.leafStream() }
+                hashChildren != null -> Arrays.stream(hashChildren).flatMap { child -> child?.leafStream() }
                 else -> Stream.of(this)
             }
 
         val leaves: List<Node<N>> get() = leafStream().toList()
-    }
-
-    @Suppress("MemberVisibilityCanBePrivate")
-    companion object {
-
-        const val LEVEL_BITS: Int = 2
-        const val LEVEL_WIDTH: Int = 1 shl LEVEL_BITS
-        const val LEVEL_MASK: Int = LEVEL_WIDTH - 1
-
-        @JvmStatic
-        fun bucketFor(pointer: ArrowBufPointer, level: Int): Byte {
-            assert(level * LEVEL_BITS < pointer.length * java.lang.Byte.SIZE)
-            val bitIdx = level * LEVEL_BITS
-            val byteIdx = bitIdx / java.lang.Byte.SIZE
-            val bitOffset = bitIdx % java.lang.Byte.SIZE
-
-            val b = pointer.buf!!.getByte(pointer.offset + byteIdx)
-            return ((b.toInt() ushr ((java.lang.Byte.SIZE - LEVEL_BITS) - bitOffset)) and LEVEL_MASK).toByte()
-        }
-
-        @JvmStatic
-        fun compareToPath(pointer: ArrowBufPointer, path: ByteArray): Int {
-            for (level in path.indices) {
-                val cmp = bucketFor(pointer, level).toInt() compareTo (path[level].toInt())
-                if (cmp != 0) return cmp
-            }
-
-            return 0
-        }
     }
 }
 
@@ -106,9 +123,9 @@ fun List<ISegment<*, *>>.toMergePlan(
             pathPred != null && !pathPred.test(mergePlanTask.path) -> null
 
             mpNodes.any { it.node is IidBranch || it.node is MemoryHashTrie.Branch } -> {
-                val nodeChildren = mpNodes.map { it.node.iidChildren }
+                val nodeChildren = mpNodes.map { it.node.hashChildren }
                 // do these in reverse order so that they're on the stack in path-prefix order
-                for (bucketIdx in HashTrie.LEVEL_WIDTH - 1 downTo 0) {
+                for (bucketIdx in DEFAULT_LEVEL_WIDTH - 1 downTo 0) {
                     val newMpNodes = nodeChildren.mapIndexedNotNull { idx, children ->
                         if (children != null) {
                             children[bucketIdx]?.let { MergePlanNode.create(mpNodes[idx].segment, it) }

--- a/core/src/main/kotlin/xtdb/trie/MutableMemoryHashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/MutableMemoryHashTrie.kt
@@ -1,0 +1,289 @@
+package xtdb.trie
+
+import com.carrotsearch.hppc.IntArrayList
+import org.apache.arrow.memory.util.ArrowBufPointer
+import org.apache.arrow.memory.util.ByteFunctionHelpers
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeBinary
+import org.roaringbitmap.RoaringBitmap
+import xtdb.arrow.VectorReader
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.function.IntUnaryOperator
+
+private const val PAGE_LIMIT = 1024
+
+// hashReader is assumed to be a fixed-width vector
+// for iids this is ArrowType.FixedSizeBinary(16)
+// for hashes this is ArrowType.Int
+class MutableMemoryHashTrie(override val rootNode: Node, val hashReader: VectorReader, levelBits: Int) : HashTrie<MutableMemoryHashTrie.Node, MutableMemoryHashTrie.Leaf> {
+    private val bucketer = Bucketer(levelBits)
+
+    private val hashByteWidth : Int = when(val type = hashReader.field.type) {
+        is FixedSizeBinary -> type.byteWidth
+        is ArrowType.Int -> 4
+        else -> throw IllegalArgumentException("Unsupported Arrow type for hashReader: ${hashReader.field.type}")
+    }
+    private val maxLevel : Int = when(val type = hashReader.field.type) {
+        is FixedSizeBinary -> type.byteWidth * 8 / bucketer.levelBits
+        is ArrowType.Int -> type.bitWidth / bucketer.levelBits
+        else -> throw IllegalArgumentException("Unsupported Arrow type for hashReader: ${hashReader.field.type}")
+    }
+    private val reusePtr1 = ArrowBufPointer()
+    private val reusePtr2 = ArrowBufPointer()
+
+    sealed interface Node : HashTrie.Node<Node> {
+        fun add(trie: MutableMemoryHashTrie, newIdx: Int): Node
+        fun addIfNotPresent(trie: MutableMemoryHashTrie, hash: ByteArray, newIdx: Int, comparator: IntUnaryOperator, onAddition: Runnable): Pair<Int, Node?>
+
+        fun findCandidates(trie: MutableMemoryHashTrie, hash: ByteArray): IntArrayList
+        fun findValue(trie: MutableMemoryHashTrie, hash: ByteArray, comparator: IntUnaryOperator, removeOnMatch: Boolean): Int
+
+        fun sortData(trie: MutableMemoryHashTrie)
+    }
+
+    @Suppress("unused")
+    class Builder(private val hashReader: VectorReader) {
+        private var pageLimit = PAGE_LIMIT
+        private var levelBits = DEFAULT_LEVEL_BITS
+        private var rootPath = ByteArray(0)
+
+        fun setPageLimit(pageLimit: Int) = this.apply { this.pageLimit = pageLimit }
+        fun setRootPath(path: ByteArray) = this.apply { this.rootPath = path }
+        fun setLevelBits(levelBits: Int) = this.apply { this.levelBits = levelBits }
+        fun build(): MutableMemoryHashTrie = MutableMemoryHashTrie(Leaf(pageLimit, rootPath), hashReader, levelBits)
+    }
+
+    operator fun plus(idx: Int) = MutableMemoryHashTrie(rootNode.add(this, idx), hashReader, bucketer.levelBits)
+
+    private fun intToByteArray(hash: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(hash).array()
+
+    fun addIfNotPresent(hash: Int, newIdx: Int, comparator: IntUnaryOperator, onAddition: Runnable): Pair<Int, MutableMemoryHashTrie>  {
+        val (idx, node) = rootNode.addIfNotPresent(this, intToByteArray(hash), newIdx, comparator, onAddition)
+        return Pair(idx, node?.let { MutableMemoryHashTrie(it, hashReader, bucketer.levelBits) } ?: this)
+    }
+
+    fun findCandidates (hash: ByteArray) : IntArrayList = rootNode.findCandidates(this, hash)
+
+    fun findCandidates(hash: Int) : IntArrayList =
+        findCandidates(intToByteArray(hash))
+
+    // This assumes the trie has been compacted
+    fun findValue (hash: ByteArray, comparator: IntUnaryOperator, removeOnMatch: Boolean) : Int =
+        rootNode.findValue(this, hash, comparator, removeOnMatch)
+
+    fun findValue(hash: Int, comparator: IntUnaryOperator, removeOnMatch: Boolean) : Int =
+        findValue(intToByteArray(hash), comparator, removeOnMatch)
+
+    @Suppress("unused")
+    fun withIidReader(hashReader: VectorReader) = MutableMemoryHashTrie(rootNode, hashReader, bucketer.levelBits)
+
+    fun sortData() {
+       rootNode.sortData(this)
+    }
+
+    private fun bucketFor(idx: Int, level: Int, reusePtr: ArrowBufPointer): Int =
+        bucketer.bucketFor(hashReader.getPointer(idx, reusePtr), level).toInt()
+
+    private fun compare(leftIdx: Int, rightIdx: Int, leftPtr: ArrowBufPointer, rightPtr: ArrowBufPointer): Int {
+        val cmp =
+            hashReader.getPointer(leftIdx, leftPtr)
+                .compareTo(hashReader.getPointer(rightIdx, rightPtr))
+
+        return if (cmp != 0) cmp else rightIdx compareTo leftIdx
+    }
+
+    private fun compare(idx: Int, ptr: ArrowBufPointer, hash: ByteArray) : Int {
+        val buf = hashReader.getPointer(idx, ptr).buf
+        val index = idx * hashByteWidth
+        return ByteFunctionHelpers.compare(buf, index, index + hashByteWidth, hash, 0, hash.size)
+    }
+
+    class Branch(
+        private val pageLimit: Int,
+        override val path: ByteArray,
+        override val hashChildren: Array<Node?>,
+    ) : Node {
+
+        override fun add(trie: MutableMemoryHashTrie, newIdx: Int): Node {
+            val bucket = trie.bucketFor(newIdx, path.size, trie.reusePtr1)
+
+            if (hashChildren[bucket] == null) {
+                hashChildren[bucket] = Leaf(pageLimit, conjPath(path, bucket.toByte()))
+            }
+
+            hashChildren[bucket] = hashChildren[bucket]!!.add(trie, newIdx)
+
+            return this
+        }
+
+        override fun addIfNotPresent(trie: MutableMemoryHashTrie, hash: ByteArray, newIdx: Int, comparator: IntUnaryOperator, onAddition: Runnable): Pair<Int, Node?> {
+            val bucket = trie.bucketer.bucketFor(hash, path.size).toInt()
+
+            if (hashChildren[bucket] == null) {
+                hashChildren[bucket] = Leaf(pageLimit, conjPath(path, bucket.toByte()))
+            }
+
+            val res = hashChildren[bucket]!!.addIfNotPresent(trie, hash, newIdx, comparator, onAddition)
+            if (res.second == null) {
+                return res
+            }
+            hashChildren[bucket] = res.second
+            return Pair(res.first, this)
+        }
+
+        override fun findCandidates(trie: MutableMemoryHashTrie, hash: ByteArray): IntArrayList {
+            val bucket = trie.bucketer.bucketFor(hash, path.size).toInt()
+            val child = hashChildren[bucket] ?: return IntArrayList(0)
+            return child.findCandidates(trie, hash)
+        }
+
+        override fun findValue(trie: MutableMemoryHashTrie, hash: ByteArray, comparator: IntUnaryOperator, removeOnMatch: Boolean ): Int {
+            val bucket = trie.bucketer.bucketFor(hash, path.size).toInt()
+            val child = hashChildren[bucket] ?: return -1
+            return child.findValue(trie, hash, comparator, removeOnMatch)
+        }
+
+        override fun sortData(trie: MutableMemoryHashTrie) {
+            hashChildren.map { child -> child?.sortData(trie) }
+
+        }
+    }
+
+    class Leaf(
+        private val pageLimit: Int,
+        override val path: ByteArray,
+        val data: IntArray = IntArray(pageLimit),
+        private var dataCount: Int = 0,
+        private var deletions: RoaringBitmap? = null,
+        private var sorted: Boolean = false
+    ) : Node {
+
+        override val hashChildren = null
+
+        private fun split(trie: MutableMemoryHashTrie): Node {
+            val res = Branch(pageLimit, path, arrayOfNulls(trie.bucketer.levelWidth))
+            for (i in 0 until dataCount) {
+                res.add(trie, data[i])
+            }
+            return res
+        }
+
+        private fun binarySearch(trie: MutableMemoryHashTrie, hash: ByteArray): Int {
+            var left = 0
+            var right = dataCount - 1
+            while (left < right) {
+                val mid = (left + right) / 2
+                val cmp = trie.compare(data[mid], trie.reusePtr1, hash)
+                if (cmp < 0) left = mid + 1 else right = mid
+            }
+            if (left < dataCount) {
+                if (trie.compare(data[left], trie.reusePtr1, hash) == 0) return left
+            }
+            return -1
+        }
+
+        override fun add(trie: MutableMemoryHashTrie, newIdx: Int): Node {
+            if (dataCount >= pageLimit) {
+                return if (path.size < trie.maxLevel) {
+                    split(trie).add(trie, newIdx)
+                } else {
+                    val newPageLimit = pageLimit * 2
+                    val newData = IntArray(newPageLimit)
+                    data.copyInto(newData)
+                    newData[dataCount++] = newIdx
+                    return Leaf(newPageLimit, path, newData, dataCount, deletions)
+                }
+            }
+            data[dataCount++] = newIdx
+            return this
+        }
+
+        override fun addIfNotPresent(trie: MutableMemoryHashTrie, hash: ByteArray, newIdx: Int, comparator: IntUnaryOperator, onAddition: Runnable): Pair<Int, Node?> {
+            // can't use binary search here because we might not be sorted
+            for (i in 0 until dataCount) {
+                val testIdx = data[i]
+                if (trie.compare(testIdx, trie.reusePtr1, hash) == 0 && comparator.applyAsInt(testIdx) == 1) {
+                    return Pair(testIdx, null)
+                }
+            }
+            onAddition.run()
+            return Pair(newIdx, add(trie, newIdx))
+        }
+
+        override fun sortData(trie: MutableMemoryHashTrie) {
+            if (dataCount == 0) return
+            val tmp = data.take(dataCount).toTypedArray()
+            tmp.sortWith { leftIdx, rightIdx -> trie.compare(leftIdx, rightIdx, trie.reusePtr1, trie.reusePtr2) }
+            tmp.forEachIndexed { index, i -> data[index] = i }
+            sorted = true
+        }
+
+
+        // Beware that this method doesn't honour deletions (see findValue below)
+        // Any operator that uses these methods through RelationMapProber either uses one or the other, hence no need to check deletions in this case.
+        override fun findCandidates(trie: MutableMemoryHashTrie, hash: ByteArray): IntArrayList {
+            val res = IntArrayList()
+            if (dataCount <= 16) {
+                for (i in 0 until dataCount) {
+                    if (trie.compare(data[i], trie.reusePtr1, hash) == 0) res.add(data[i])
+                }
+               return res
+            }
+            if (!sorted) sortData(trie)
+            var idx = binarySearch(trie, hash)
+            if (idx < 0) return res
+            while (idx < dataCount && trie.compare(data[idx], trie.reusePtr1, hash) == 0) {
+                res.add(data[idx])
+                idx++
+            }
+            return res
+        }
+
+        override fun findValue(trie: MutableMemoryHashTrie, hash: ByteArray, comparator: IntUnaryOperator, removeOnMatch: Boolean): Int {
+            if (dataCount <= 16) {
+                for(i in 0 until dataCount) {
+                    val testIdx = data[i]
+                    if (trie.compare(testIdx, trie.reusePtr1, hash) == 0 && deletions?.contains(testIdx) != true && comparator.applyAsInt(testIdx) == 1) {
+                        if (removeOnMatch) {
+                            deletions = (deletions ?: RoaringBitmap()).apply { add(testIdx) }
+                        }
+                        return testIdx
+                    }
+                }
+            } else {
+                if (!sorted) sortData(trie)
+                var idx = binarySearch(trie, hash)
+                if (idx < 0) return -1
+                while (idx < dataCount && trie.compare(data[idx], trie.reusePtr1, hash) == 0) {
+                    val testIdx = data[idx]
+                    if (deletions?.contains(testIdx) != true && comparator.applyAsInt(testIdx) == 1) {
+                        if (removeOnMatch) {
+                            deletions = (deletions ?: RoaringBitmap()).apply { add(testIdx) }
+                        }
+                        return testIdx
+                    }
+                    idx++
+                }
+            }
+            return -1
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(hashReader: VectorReader) = Builder(hashReader)
+
+        @JvmStatic
+        @Suppress("unused")
+        fun emptyTrie(hashReader: VectorReader) = builder(hashReader).build()
+
+        private fun conjPath(path: ByteArray, idx: Byte): ByteArray {
+            val currentPathLength = path.size
+            val childPath = ByteArray(currentPathLength + 1)
+            System.arraycopy(path, 0, childPath, 0, currentPathLength)
+            childPath[currentPathLength] = idx
+            return childPath
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/trie/MutableMemoryHashTrieTest.kt
+++ b/core/src/test/kotlin/xtdb/trie/MutableMemoryHashTrieTest.kt
@@ -1,0 +1,78 @@
+package xtdb.trie
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import xtdb.arrow.IntVector
+import kotlin.random.Random
+
+class MutableMemoryHashTrieTest {
+    private lateinit var allocator: BufferAllocator
+    private lateinit var hashReader: IntVector
+    private lateinit var trie: MutableMemoryHashTrie
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+        hashReader = IntVector(allocator, "hash", true)
+        trie= MutableMemoryHashTrie.builder(hashReader).build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        hashReader.close()
+        allocator.close()
+    }
+
+
+    @Test
+    fun `test add of MutableMemoryHashTrie`() {
+        val r = Random(42)
+        val testSize = 10000
+        val hashes = List(testSize) {r.nextInt() }
+        hashes.forEachIndexed( {index, hash ->
+            hashReader.writeInt(hash)
+            trie += index
+        })
+
+        trie.sortData()
+
+        for (i in 0 until testSize) {
+            val hash = hashes[i]
+            val idx = trie.findValue(hash, { _ -> 1}, false)
+            assertTrue(idx >= 0, "Hash $hash at position $i not found in trie")
+            assertEquals(hashes[i], hashes[idx])
+            val idxs = trie.findCandidates(hashes[i])
+            assertTrue(idxs.size() > 0, "Candidates for hash $i not found in trie")
+            assertTrue(idxs.toArray().all { hashes[it] == hashes[i] }, "All candidates for hash $i should match the original hash")
+        }
+    }
+
+    @Test
+    fun `test addIfNotPresent of MutableMemoryHashTrie`() {
+        val r = Random(42)
+        val testSize = 100000
+        val hashes = List(testSize) {r.nextInt() }
+        hashes.forEachIndexed( {index, hash ->
+            hashReader.writeInt(hash)
+            trie += index
+        })
+
+
+        hashes.forEachIndexed( { index, hash ->
+            val newIndex = hashes.size + index
+            assertTrue(trie.addIfNotPresent(hash, newIndex, {_ -> 1}, { error("Should not happen!") }).first != newIndex, "Hash $hash should already be present")
+        })
+
+        val newHashes = List(testSize) { Random(42).nextInt() }.filter { it !in hashes }
+
+        newHashes.forEachIndexed( {index, hash ->
+            val newIndex = hashes.size + index
+            val (addedIdx, _) = trie.addIfNotPresent(hash, index + hashes.size, {_ -> 1}, { hashReader.writeInt(hash) })
+            assertEquals(newIndex == addedIdx, "addedIndex should be newIndex")
+        })
+    }
+}

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -147,7 +147,7 @@
     (letfn [(render-trie [^ArrowHashTrie$Node node]
               (cond
                 (instance? ArrowHashTrie$Leaf node) (.getDataPageIndex ^ArrowHashTrie$Leaf node)
-                (instance? ArrowHashTrie$IidBranch node) (mapv render-trie (.getIidChildren ^ArrowHashTrie$IidBranch node))
+                (instance? ArrowHashTrie$IidBranch node) (mapv render-trie (.getHashChildren ^ArrowHashTrie$IidBranch node))
                 :else node))]
 
       (render-trie (-> (.getVectorSchemaRoot rdr)


### PR DESCRIPTION
(for #4592)

This adds a `MutableMemoryHashTrie` class that has a similar interface to the existing `MemoryHashTrie`. We are using the new HashTrie implementation on the build side of RelationMap. It replaces the `IntObjectHashMap` + `RoaringBitmap` values that we are currently using. The idea is that this will make it easier to use existing tooling (currently mainly used in the compactor) for the `HashTrie` interface for off disk joining, grouping and set operations. Currently this implementation runs a bit slower (the comparison is TPCH 0.1) then `main`.

The following table shows TPCH 0.1 run times (all queries except Q21) for different branching factors and page-sizes
```
"Page Size: " 32 " branch-factor: " 16
"Elapsed time: 29540.182785 msecs"
"Page Size: " 64 " branch-factor: " 16
"Elapsed time: 28970.345773 msecs"
"Page Size: " 96 " branch-factor: " 16
"Elapsed time: 29521.322433 msecs"
"Page Size: " 128 " branch-factor: " 16
"Elapsed time: 29487.788614 msecs"
"Page Size: " 256 " branch-factor: " 16
"Elapsed time: 31607.618253 msecs"
"Page Size: " 32 " branch-factor: " 32
"Elapsed time: 36701.340508 msecs"
"Page Size: " 64 " branch-factor: " 32
"Elapsed time: 29450.644377 msecs"
"Page Size: " 96 " branch-factor: " 32
"Elapsed time: 29932.627244 msecs"
"Page Size: " 128 " branch-factor: " 32
"Elapsed time: 30089.853236 msecs"
"Page Size: " 256 " branch-factor: " 32
"Elapsed time: 29792.72954 msecs"
"Page Size: " 32 " branch-factor: " 64
"Elapsed time: 29262.566839 msecs"
"Page Size: " 64 " branch-factor: " 64
"Elapsed time: 28986.29487 msecs"
"Page Size: " 96 " branch-factor: " 64
"Elapsed time: 29258.650799 msecs"
"Page Size: " 128 " branch-factor: " 64
"Elapsed time: 29044.098769 msecs"
"Page Size: " 256 " branch-factor: " 64
"Elapsed time: 29795.626605 msecs"
``` 

