### PR TITLE
Implement openid connect based authentication.

### DIFF
--- a/api/src/main/kotlin/xtdb/Serde.kt
+++ b/api/src/main/kotlin/xtdb/Serde.kt
@@ -5,8 +5,11 @@ package xtdb
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import java.net.URI
+import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
@@ -49,4 +52,13 @@ object PathSerde : KSerializer<Path> {
     override fun serialize(encoder: Encoder, value: Path) { encoder.encodeString(value.toString()) }
 
     override fun deserialize(decoder: Decoder): Path { return Paths.get(decoder.decodeString()) }
+}
+
+/**
+ * @suppress
+ */
+object UrlSerializer : KSerializer<URL> {
+    override val descriptor = PrimitiveSerialDescriptor("URL", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: URL) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): URL = URI(decoder.decodeString()).toURL()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,6 +158,7 @@ allprojects {
             testRuntimeOnly(libs.junit.platform.launcher)
             testImplementation(libs.testcontainers)
             testImplementation(libs.testcontainers.kafka)
+            testImplementation(libs.testcontainers.keycloak)
             testImplementation(libs.testcontainers.minio)
         }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     antlr(libs.antlr)
     implementation(libs.antlr.runtime)
 
+    api(libs.hato)
     testImplementation(libs.pgjdbc)
     testImplementation(libs.mockk)
     testImplementation(libs.clojure.test.check)

--- a/core/src/main/clojure/xtdb/authn.clj
+++ b/core/src/main/clojure/xtdb/authn.clj
@@ -1,22 +1,32 @@
 (ns xtdb.authn
   (:require [buddy.hashers :as hashers]
             [integrant.core :as ig]
+            [hato.client :as http]
             [xtdb.api :as xt]
             [xtdb.node :as xtn]
-            [xtdb.query :as q])
+            [xtdb.query :as q]
+            [xtdb.error :as err])
   (:import [java.io Writer]
-           (xtdb.api Authenticator Authenticator$Factory Authenticator$Factory$UserTable Authenticator$Method Authenticator$MethodRule Xtdb$Config)
-           (xtdb.query IQuerySource)))
+           (xtdb.api Authenticator Authenticator$DeviceAuthResponse Authenticator$Factory Authenticator$Factory$OpenIdConnect
+                     Authenticator$Factory$UserTable Authenticator$Method Authenticator$MethodRule Xtdb$Config
+                     SimpleResult OAuthPasswordResult OAuthClientCredentialsResult OAuthResult)
+           (xtdb.query IQuerySource)
+           [java.net URI]
+           [java.time Duration Instant InstantSource]))
 
-(defn verify-pw [^IQuerySource q-src, db-cat, user password]
-  (when password
-    (with-open [res (-> (.prepareQuery q-src "SELECT passwd AS encrypted FROM pg_user WHERE username = ?"
-                                       db-cat {:default-db "xtdb"})
-                        (.openQuery {:args [user]}))]
+(defn verify-pw
+  [^IQuerySource q-src db-cat user password]
+  (when-not password
+    (throw (err/incorrect :xtdb/authn-failed (format "password authentication failed for user: %s" user))))
 
-      (when-let [{:keys [encrypted]} (first (.toList (q/cursor->stream res {:key-fn #xt/key-fn :kebab-case-keyword})))]
-        (when (:valid (hashers/verify password encrypted))
-          user)))))
+  (with-open [res (-> (.prepareQuery q-src
+                                     "SELECT passwd AS encrypted FROM pg_user WHERE username = ?"
+                                     db-cat {:default-db "xtdb"})
+                      (.openQuery {:args [user]}))]
+    (let [{:keys [encrypted]} (first (.toList (q/cursor->stream res {:key-fn #xt/key-fn :kebab-case-keyword})))]
+      (if (and encrypted (:valid (hashers/verify password encrypted)))
+        user
+        (throw (err/incorrect :xtdb/authn-failed (format "password authentication failed for user: %s" user)))))))
 
 (defn- method-for [rules {:keys [remote-addr user]}]
   (some (fn [{rule-user :user, rule-address :address, :keys [method]}]
@@ -28,11 +38,13 @@
 (defn read-authn-method [method]
   (case method
     :trust Authenticator$Method/TRUST
-    :password Authenticator$Method/PASSWORD))
+    :password Authenticator$Method/PASSWORD
+    :device-auth Authenticator$Method/DEVICE_AUTH
+    :client-credentials Authenticator$Method/CLIENT_CREDENTIALS))
 
 (defmethod print-dup Authenticator$Method [^Authenticator$Method m, ^Writer w]
   (.write w "#xt.authn/method ")
-  (print-method (case (str m) "TRUST" :trust, "PASSWORD" :password) w))
+  (print-method (case (str m) "TRUST" :trust, "PASSWORD" :password, "DEVICE_AUTH" :device-auth, "CLIENT_CREDENTIALS" :client-credentials) w))
 
 (defmethod print-method Authenticator$Method [^Authenticator$Method m, ^Writer w]
   (print-dup m w))
@@ -53,7 +65,9 @@
 (defmethod xtn/apply-config! :xtdb/authn [^Xtdb$Config config, _, [tag opts]]
   (xtn/apply-config! config
                      (case tag
-                       :user-table ::user-table-authn)
+                       :user-table ::user-table-authn
+                       :openid-connect ::openid-connect-authn
+                       tag)
                      opts))
 
 (defmethod xtn/apply-config! ::user-table-authn [^Xtdb$Config config, _, {:keys [rules]}]
@@ -65,7 +79,8 @@
     (method-for rules {:user user, :remote-addr remote-addr}))
 
   (verifyPassword [_ user password]
-    (verify-pw q-src db-cat user password)))
+    (let [user-id (verify-pw q-src db-cat user password)]
+      (SimpleResult. user-id))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn ->user-table-authn [^Authenticator$Factory$UserTable cfg, q-src, db-cat]
@@ -75,6 +90,211 @@
   (into {:q-src (ig/ref :xtdb.query/query-source)
          :db-cat (ig/ref :xtdb/db-catalog)}
         opts))
+
+(defn- validate-oidc-config [config discovery-url]
+  (let [{:keys [token_endpoint userinfo_endpoint]} config]
+    (cond
+      (not token_endpoint)
+      (throw (err/incorrect :xtdb/oidc-config-discovery-error
+                            (format "OIDC configuration missing required token_endpoint from %s" discovery-url)
+                            {:body config}))
+
+      (not userinfo_endpoint)
+      (throw (err/incorrect :xtdb/oidc-config-discovery-error
+                            (format "OIDC configuration missing required userinfo_endpoint from %s" discovery-url)
+                            {:body config}))
+
+      :else config)))
+
+(defn discover-oidc-config [issuer-url]
+  (let [discovery-url (str issuer-url "/.well-known/openid-configuration")]
+    (try
+      (let [{:keys [status body]} (http/get discovery-url
+                                            {:throw-exceptions false
+                                             :as :json})]
+        (if (= 200 status)
+          (validate-oidc-config body discovery-url)
+          (throw (err/incorrect :xtdb/oidc-config-discovery-error
+                                (format "Failed to discover OIDC configuration from %s: %s" discovery-url (:error body))
+                                {:status status, :body body}))))
+      (catch Exception e
+        (throw (err/incorrect :xtdb/oidc-config-discovery-error
+                              (format "Error thrown when fetching OIDC configuration from %s: %s" discovery-url (.getMessage e))
+                              {:exception e}))))))
+
+(defn calculate-expires-at [{:keys [expires_in]} ^Instant now]
+  (some->> expires_in (.plusSeconds now)))
+
+(defn oauth-token [{:keys [oidc-config client-id client-secret ^InstantSource instant-src]} opts]
+  (let [token-endpoint (:token_endpoint oidc-config)
+        {:keys [status body]} (http/post token-endpoint
+                                         {:form-params (into {:client_id client-id
+                                                              :client_secret client-secret}
+                                                             opts)
+                                          :throw-exceptions false
+                                          :coerce :always
+                                          :as :json})]
+    {:status status
+     :body {:access-token (:access_token body)
+            :refresh-token (:refresh_token body)
+            :expires-at (calculate-expires-at body (.instant instant-src))}}))
+
+(defn oauth-userinfo [{:keys [oidc-config]} token]
+  (let [userinfo-endpoint (:userinfo_endpoint oidc-config)
+        {:keys [status body]} (http/get userinfo-endpoint
+                                        {:oauth-token token
+                                         :throw-exceptions false
+                                         :as :json})]
+    (if (= 200 status)
+      {:user-id (:sub body)}
+      (throw (err/incorrect :xtdb/authn-failed
+                            (format "Failed to obtain user info from %s: %s" userinfo-endpoint (:error body))
+                            {:status status, :body body})))))
+
+(defn token-expired? [^OAuthResult auth-result ^Instant now]
+  (when-let [expires-at (.getExpiresAt ^OAuthResult auth-result)]
+    (.isAfter now expires-at)))
+
+;; TODO: Could live in Kotlin
+(defn refresh-token [authn ^OAuthResult auth-result]
+  (cond
+    ;; For password/device auth flows - use refresh token from OAuthPasswordResult
+    (instance? OAuthPasswordResult auth-result)
+    (let [oauth-result ^OAuthPasswordResult auth-result
+          refresh-token (.getRefreshToken oauth-result)
+          {:keys [status body]} (oauth-token authn {:grant_type "refresh_token"
+                                                    :refresh_token refresh-token})]
+      (if (= 200 status)
+        (.withExpiry oauth-result ^Instant (:expires-at body))
+        (throw (err/incorrect :xtdb/authn-failed
+                              (format "Failed to refresh OAuth token: %s" (:error body))
+                              {:status status, :body body}))))
+
+    ;; For client credentials flow - get a fresh token using stored client credentials
+    (instance? OAuthClientCredentialsResult auth-result)
+    (let [creds-result ^OAuthClientCredentialsResult auth-result
+          client-id (.getClientId creds-result)
+          client-secret (.getClientSecret creds-result)
+          {:keys [status body]} (oauth-token authn {:grant_type "client_credentials"
+                                                    :scope "openid"
+                                                    :client_id client-id
+                                                    :client_secret client-secret})]
+      (if (= 200 status)
+        (.withExpiry creds-result ^Instant (:expires-at body))
+        (throw (err/incorrect :xtdb/authn-failed
+                              (format "Failed to refresh client credentials token: %s" (:error body))
+                              {:status status, :body body}))))
+
+    :else
+    (throw (err/incorrect :xtdb/authn-failed "No valid token or refresh token available for refresh"))))
+
+(defn oauth-device-info [{:keys [oidc-config client-id client-secret]}]
+  (let [device-endpoint (:device_authorization_endpoint oidc-config)]
+    (when-not device-endpoint
+      (throw (err/incorrect :xtdb/authn-failed
+                            "OIDC provider does not support device authorization flow - missing device_authorization_endpoint")))
+    (let [{:keys [status body]} (http/post device-endpoint
+                                           {:form-params {:client_id client-id
+                                                          :client_secret client-secret
+                                                          :scope "openid"}
+                                            :throw-exceptions false
+                                            :as :json})]
+      (if (= 200 status)
+        {:device-code (:device_code body)
+         :verification-uri-complete (:verification_uri_complete body)
+         :interval (:interval body)
+         :expires-at (calculate-expires-at body (.instant (InstantSource/system)))}
+        (throw (err/incorrect :xtdb/authn-failed
+                              (format "Failed to obtain device info from %s: %s" device-endpoint (:error body))
+                              {:status status, :body body}))))))
+
+
+(defrecord DeviceAuthResponse [authn url device-code ^Duration interval ^Instant expires-at]
+  Authenticator$DeviceAuthResponse
+  (getUrl [_] url)
+
+  (await [_]
+    (let [{:keys [oidc-config ^InstantSource instant-src]} authn]
+      (loop []
+        (when (.isAfter (.instant instant-src) expires-at) (throw (err/incorrect :xtdb/authn-failed "Device authorization has expired")))
+
+        (let [token-endpoint (:token_endpoint oidc-config)
+              {:keys [status body]} (http/post token-endpoint
+                                               {:form-params {:client_id (:client-id authn)
+                                                              :client_secret (:client-secret authn)
+                                                              :grant_type "urn:ietf:params:oauth:grant-type:device_code"
+                                                              :device_code device-code}
+                                                :throw-exceptions false
+                                                :coerce :always
+                                                :as :json})]
+          (case (long status)
+            200 (let [access-token (:access_token body)
+                      refresh-token (:refresh_token body)
+                      expires-at (calculate-expires-at body (.instant instant-src))
+                      {:keys [user-id]} (oauth-userinfo authn access-token)]
+                  (OAuthPasswordResult. user-id expires-at access-token refresh-token))
+            400 (if (= "authorization_pending" (:error body))
+                  (do (Thread/sleep (.toMillis interval)) (recur))
+                  (throw (err/incorrect :xtdb/authn-failed
+                                        (format "Device authentication failed: %s" (:error body))
+                                        {:status status, :body body})))
+            (throw (err/incorrect :xtdb/authn-failed
+                                  (format "Device authentication failed with status %d" status)
+                                  {:status status, :body body}))))))))
+
+(defrecord OpenIdConnect [oidc-config client-id client-secret rules ^InstantSource instant-src]
+  Authenticator
+  (methodFor [_ user remote-addr]
+    (method-for rules {:user user, :remote-addr remote-addr}))
+
+  (verifyPassword [this user password]
+    (let [{:keys [status body]} (oauth-token this {:grant_type "password", :scope "openid"
+                                                   :username user, :password password})]
+      (if (= 200 status)
+        (let [{:keys [access-token refresh-token expires-at]} body
+              {:keys [user-id]} (oauth-userinfo this access-token)]
+          (OAuthPasswordResult. user-id expires-at access-token refresh-token))
+        (throw (err/incorrect :xtdb/authn-failed
+                              (format "Password authentication failed for user: %s" user)
+                              {:status status, :body body})))))
+
+  (startDeviceAuth [this _user]
+    (let [{:keys [device-code verification-uri-complete interval expires-at]} (oauth-device-info this)]
+      (->DeviceAuthResponse this (.toURL (URI. verification-uri-complete)) device-code (Duration/ofSeconds interval) expires-at)))
+
+  (verifyClientCredentials [this client-id client-secret]
+    (let [{:keys [status body]} (oauth-token this {:grant_type "client_credentials",
+                                                   :scope "openid",
+                                                   :client_id client-id
+                                                   :client_secret client-secret})]
+      (if (= 200 status)
+        (let [{:keys [access-token expires-at]} body
+              {:keys [user-id]} (oauth-userinfo this access-token)]
+          (OAuthClientCredentialsResult. user-id expires-at access-token client-id client-secret))
+        (throw (err/incorrect :xtdb/authn-failed
+                              (format "Client credentials authentication failed for client: %s" client-id)
+                              {:status status, :body body})))))
+
+  (revalidate [this auth-result]
+    (when (token-expired? auth-result (.instant instant-src))
+      (refresh-token this auth-result))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn ->oidc-authn [^Authenticator$Factory$OpenIdConnect cfg]
+  (let [oidc-config (discover-oidc-config (.getIssuerUrl cfg))]
+    (->OpenIdConnect oidc-config
+                     (.getClientId cfg)
+                     (.getClientSecret cfg)
+                     (<-rules-cfg (.getRules cfg))
+                     (.getInstantSource cfg))))
+
+(defmethod xtn/apply-config! ::openid-connect-authn [^Xtdb$Config config, _, {:keys [issuer-url client-id client-secret rules ^InstantSource instant-src]}]
+  (.authn config
+          (cond-> (Authenticator$Factory$OpenIdConnect. (.toURL (URI. issuer-url))
+                                                        client-id
+                                                        client-secret
+                                                        (->rules-cfg rules))
+            instant-src (.instantSource instant-src))))
 
 (defmethod ig/init-key :xtdb/authn [_ {:keys [^Authenticator$Factory authn-factory, q-src, db-cat]}]
   (.open authn-factory q-src db-cat))

--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -1,20 +1,74 @@
+@file:UseSerializers(UrlSerializer::class)
+
 package xtdb.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import xtdb.UrlSerializer
 import xtdb.api.Authenticator.Method.TRUST
 import xtdb.api.Authenticator.MethodRule
 import xtdb.database.Database
 import xtdb.query.IQuerySource
 import xtdb.util.requiringResolve
+import java.net.URL
+import xtdb.error.Unsupported
+import java.time.Instant
+import java.time.InstantSource
+
+interface AuthResult {
+    val userId: String
+}
+
+interface OAuthResult : AuthResult {
+    val expiresAt: Instant
+    fun withExpiry(expiresAt: Instant): OAuthResult
+}
+
+data class SimpleResult(
+    override val userId: String
+) : AuthResult
+
+data class OAuthPasswordResult(
+    override val userId: String,
+    override var expiresAt: Instant,
+    val accessToken: String,
+    val refreshToken: String
+) : OAuthResult {
+    override fun withExpiry(expiresAt: Instant) = copy(expiresAt = expiresAt)
+}
+
+data class OAuthClientCredentialsResult(
+    override val userId: String,
+    override var expiresAt: Instant,
+    val accessToken: String,
+    val clientId: String,
+    val clientSecret: String
+) : OAuthResult {
+    override fun withExpiry(expiresAt: Instant) = copy(expiresAt = expiresAt)
+}
 
 val DEFAULT_RULES = listOf(MethodRule(TRUST))
 
 interface Authenticator : AutoCloseable {
     fun methodFor(user: String?, remoteAddress: String?): Method
 
-    fun verifyPassword(user: String, password: String): String =
-        throw UnsupportedOperationException("password auth not supported")
+    fun verifyPassword(user: String, password: String): AuthResult =
+        throw Unsupported(errorCode="verifyPassword")
+
+    interface DeviceAuthResponse {
+        val url: URL
+        fun await(): OAuthPasswordResult
+    }
+
+    fun startDeviceAuth(user: String): DeviceAuthResponse =
+        throw Unsupported(errorCode="startDeviceAuth")
+
+    fun verifyClientCredentials(clientId: String, clientSecret: String): OAuthClientCredentialsResult =
+        throw Unsupported(errorCode="verifyClientCredentials")
+
+    fun revalidate(authResult: OAuthResult): OAuthResult =
+        throw Unsupported(errorCode="revalidate")
 
     override fun close() = Unit
 
@@ -22,13 +76,15 @@ interface Authenticator : AutoCloseable {
     enum class Method {
         TRUST,
         PASSWORD,
+        DEVICE_AUTH,
+        CLIENT_CREDENTIALS,
     }
 
     @Serializable
     data class MethodRule(
         val method: Method,
         val user: String? = null,
-        val remoteAddress: String? = null,
+        val remoteAddress: String? = null
     )
 
     interface Factory {
@@ -44,6 +100,23 @@ interface Authenticator : AutoCloseable {
             override fun open(querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
                 requiringResolve("xtdb.authn/->user-table-authn")
                     .invoke(this, querySource, dbCatalog) as Authenticator
+        }
+
+        @Serializable
+        @SerialName("!OpenIdConnect")
+        data class OpenIdConnect @JvmOverloads constructor(
+            val issuerUrl: URL,
+            @Serializable(with = StringWithEnvVarSerde::class) val clientId: String,
+            @Serializable(with = StringWithEnvVarSerde::class) val clientSecret: String,
+            override var rules: List<MethodRule> = DEFAULT_RULES,
+            @Transient var instantSource: InstantSource = InstantSource.system()
+        ) : Factory {
+            @Suppress("unused")
+            fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
+        
+            override fun open(querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
+                requiringResolve("xtdb.authn/->oidc-authn")
+                    .invoke(this) as Authenticator
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -159,6 +159,7 @@ val YAML_SERDE = Yaml(
 
         polymorphic(Authenticator.Factory::class) {
             subclass(Authenticator.Factory.UserTable::class)
+            subclass(Authenticator.Factory.OpenIdConnect::class)
         }
 
         ServiceLoader.load(XtdbModule.Registration::class.java)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,16 @@ services:
       mc admin user add myminio xtdb test-password;
       mc admin policy attach myminio readwrite --user xtdb;
       "
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    ports:
+      - "8080:8080"
+    environment:
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: 8080
+      KC_HOSTNAME_STRICT: false
+      KC_HOSTNAME_STRICT_HTTPS: false
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    command: start-dev

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -147,7 +147,13 @@ export default defineConfig({
 
                                 { label: 'Storage', link: '/ops/config/storage' },
                                 { label: 'Monitoring & Observability', link: '/ops/config/monitoring' },
-                                { label: 'Authentication', link: '/ops/config/authentication' }
+                                {
+                                    label: 'Authentication',
+                                    items: [
+                                        { label: 'Overview', link: '/ops/config/authentication' },
+                                        { label: 'OpenID Connect', link: '/ops/config/authentication/oidc' },
+                                    ],
+                                }
                             ]
                         },
                         { label: 'AWS', link: '/ops/aws' },

--- a/docs/src/content/docs/ops/config/authentication.adoc
+++ b/docs/src/content/docs/ops/config/authentication.adoc
@@ -2,28 +2,24 @@
 title: Authentication
 ---
 
-== Server-level settings
+XTDB provides authentication to control database access and secure connections. 
+Authentication rules determine which users can connect and what credentials they must provide.
 
-XTDB lets you configure which users can connect to the database and which type of authentication method they need to use.
-An authentication rule matches against a user and/or an IP address (in IPv4 or IPv6 format), and specifies the method to be used for that connection.
+== Authentication Providers
+
+XTDB supports two authentication providers:
+
+* **User Table** (`!UserTable`): Uses an internal user table with password-based authentication
+* **OpenID Connect** (`!OpenIdConnect`): Integrates with external identity providers like Keycloak, Auth0, AWS Cognito or Azure Entra.
+
+== User Table
+
+The `!UserTable` authentication method uses an internal user table with password-based authentication.
+
+=== Configuration
+
 [source,yaml]
 ----
-- user: admin
-  remoteAddress: 127.0.0.1
-  method: PASSWORD
-----
-The above authentication rule means that the `admin` user requires a password connecting from `localhost`.
-The authentication rules are passed to the server at startup and can be configured as below.
-The rules are considered in order until the first one matches.
-If none matches the connection is rejected.
-
-Below is a Postgres-compatible server configuration with 3 different rules.
-
-[source,yaml]
-----
-server:
-  port: 5432
-
 authn: !UserTable
   rules:
     # admin always requires a password
@@ -32,23 +28,79 @@ authn: !UserTable
     # We trust local connections
     - remoteAddress: 127.0.0.1
       method: TRUST
-    # Everything else requires a password.
+    # Everything else requires a password
     - method: PASSWORD
 ----
 
-A similar setup can be passed to the `http-server` module. Authentication (if required) needs to be passed to the http clients on every request as http is stateless.
+=== User Management
 
-== Connection-level settings
+**Default User**::
+The `pg_user` table contains a default user "xtdb" with password "xtdb".
 
-When a password is required for authentication it will be matched against the entries of the `pg_user` table. By default the `pg_user` table only contains the user "xtdb" with password "xtdb".
-
-You can add/alter users and their passwords with
+**Creating Users**::
 [source,sql]
 ----
 CREATE USER alan WITH PASSWORD 'TURING'
 ----
-and
+
+**Modifying Users**::
 [source,sql]
 ----
 ALTER USER ada WITH PASSWORD 'LOVELACE'
 ----
+
+**Password Validation**::
+When `PASSWORD` method is specified, credentials are validated against the `pg_user` table entries.
+
+== OpenID Connect (OIDC)
+
+The `!OpenIdConnect` authentication method integrates with external identity providers like Keycloak, Auth0, AWS Cognito or Azure Entra.
+
+=== Basic Configuration
+
+[source,yaml]
+----
+authn: !OpenIdConnect
+  issuerUrl: https://your-keycloak.example.com/realms/master
+  clientId: xtdb-client
+  clientSecret: !Env OIDC_CLIENT_SECRET
+  rules:
+    - user: oidc-client
+      method: CLIENT_CREDENTIALS
+    - method: PASSWORD
+----
+
+For complete OIDC configuration, setup guides, and troubleshooting, see link:authentication/oidc[OpenID Connect Authentication].
+
+== Rule Configuration
+
+XTDB controls database access through authentication rules that match users and IP addresses to determine the required authentication method.
+
+=== Authentication Rules
+
+Authentication rules are evaluated in order until the first match. If no rules match, the connection is rejected.
+
+**Rule Parameters**::
+* `user` (optional): Match specific username
+* `remoteAddress` (optional): Match IP address or CIDR block (IPv4 or IPv6)
+* `method` (required): Authentication method to use
+
+**Available Methods**::
+* `TRUST`: No authentication required
+* `PASSWORD`: Require username/password validation
+* `CLIENT_CREDENTIALS`: OAuth client credentials flow (OIDC only)
+* `DEVICE_AUTH`: OAuth device authorization flow (OIDC only)
+
+**Example Rule**::
+[source,yaml]
+----
+- user: admin
+  remoteAddress: 127.0.0.1
+  method: PASSWORD
+----
+
+This rule requires the `admin` user to provide a password when connecting from `localhost`.
+
+**Server Configuration**::
+Authentication rules are configured at server startup and apply to both Postgres wire protocol and HTTP connections. 
+For HTTP, authentication must be provided with each request as HTTP is stateless.

--- a/docs/src/content/docs/ops/config/authentication/oidc.adoc
+++ b/docs/src/content/docs/ops/config/authentication/oidc.adoc
@@ -1,0 +1,152 @@
+---
+title: OpenID Connect Authentication
+---
+
+XTDB integrates with OpenID Connect identity providers (Keycloak, Auth0, AWS Cognito, Azure Entra) for external authentication. 
+OIDC authentication supports multiple OAuth 2.0 flows for different client types.
+
+== Identity Provider Requirements
+
+**Required Capabilities**::
+* OpenID Connect Discovery (/.well-known/openid_configuration)
+* At least one of the following OAuth 2.0 grant types:
+** Client Credentials flow (widely supported)
+** Resource Owner Password Credentials flow (optional, provider-dependent)
+** Device Authorization Grant flow (optional, provider-dependent)
+* Token refresh capabilities (for flows that support it)
+
+== Configuration
+
+To use OpenID Connect authentication, include the following in your node configuration:
+
+[source,yaml]
+----
+authn: !OpenIdConnect
+  # -- required
+
+  # The OpenID Connect issuer URL for your identity provider.
+  # This is the base URL from which OIDC discovery will be performed
+  # (Can be set as an !Env value)
+  issuerUrl: https://your-keycloak.example.com/realms/master
+
+  # The client identifier registered with your identity provider.
+  # (Can be set as an !Env value)
+  clientId: xtdb-client
+
+  # The client secret for confidential clients.
+  # Should be stored as an environment variable for security.
+  # (Can be set as an !Env value)
+  clientSecret: !Env OIDC_CLIENT_SECRET
+
+  # Authentication rules determine which OAuth flow applies to each connection.
+  # Rules are evaluated in order until the first match.
+  # See the main Authentication page for complete rule syntax.
+  rules:
+    # Client credentials flow for service accounts
+    # When connecting, specify "oidc-client" as your username with colon-delimited password (client-id:client-secret)
+    - user: oidc-client
+      method: CLIENT_CREDENTIALS
+
+    # Device authorization flow 
+    # When connecting, specify "oidc-device" as your username
+    - user: oidc-device
+      method: DEVICE_AUTH
+
+    # Default: password flow for interactive users
+    - method: PASSWORD
+----
+
+---
+
+== Username Handling
+
+The username provided in database connections serves different purposes depending on the authentication method:
+
+**PASSWORD Method**::
+The username is used both for rule matching AND for actual OIDC authentication with your identity provider.
+
+**CLIENT_CREDENTIALS and DEVICE_AUTH Methods**::
+The username is used ONLY for rule matching to determine which authentication method to apply. The actual username value is ignored during authentication.
+
+**Rule Filtering**::
+- If using only CLIENT_CREDENTIALS or only DEVICE_AUTH, you don't need user-specific rules - you can use a catch-all rule with just `method: CLIENT_CREDENTIALS` or `method: DEVICE_AUTH`
+- User filtering is needed when supporting multiple flows and you want to differentiate by the connection's username
+
+---
+
+== Authentication Flows
+
+NOTE: Not all OIDC providers support all OAuth 2.0 flows. 
+PASSWORD and DEVICE_AUTH flows require specific provider support and configuration. 
+Check your provider's documentation for supported grant types.
+
+=== CLIENT_CREDENTIALS Method
+
+Uses OAuth Client Credentials flow for service accounts and automated processes.
+
+**Connection Details**::
+* **Username**: Must match the `user` value in your CLIENT_CREDENTIALS rule (e.g., `oidc-client` in the example above)
+* **Password**: `client-id:client-secret` (colon-delimited)
+
+**Client Usage Example**::
+[source,bash]
+----
+# Using the username from your configuration rule
+PGPASSWORD="your-client-id:your-client-secret" psql -h localhost -p 5432 -U oidc-client -d xtdb
+----
+
+---
+
+=== PASSWORD Method
+
+Uses OAuth Resource Owner Password Credentials flow for interactive users.
+
+**Client Usage**::
+[source,bash]
+----
+psql -h localhost -p 5432 -U username -d xtdb
+# Enter OIDC password when prompted
+----
+
+---
+
+=== DEVICE_AUTH Method
+
+Uses OAuth Device Authorization flow for applications that cannot securely store secrets.
+
+**Connection Details**::
+* **Username**: Must match the `user` value in your DEVICE_AUTH rule (e.g., `oidc-device` in the example above)
+
+**Flow Process**::
+1. Client requests device code from XTDB
+2. User visits verification URL and enters user code
+3. XTDB polls identity provider until user completes authentication
+4. Access token issued upon successful authentication
+
+**Client Usage Example**::
+[source,bash]
+----
+# Using the username from your configuration rule
+psql -h localhost -p 5432 -U oidc-device -d xtdb
+# Follow device authorization flow prompts
+----
+
+---
+
+== Token Management
+
+**Validation**::
+Tokens are validated before query and data operations. 
+Connections terminate if validation fails.
+
+**Refresh**::
+* PASSWORD/DEVICE_AUTH: Automatic refresh using refresh tokens
+* CLIENT_CREDENTIALS: New tokens requested using client credentials
+
+== Troubleshooting
+
+**Authentication Failed**::
+Verify client ID/secret configuration and issuer URL accessibility.
+
+**Token Expired**::
+Check access token lifespan settings in identity provider.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,7 @@ jetty-alpn-server = { group = "org.eclipse.jetty", name = "jetty-alpn-server", v
 testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
 testcontainers-kafka = { group = "org.testcontainers", name = "kafka", version.ref = "testcontainers" }
 testcontainers-minio = { group = "org.testcontainers", name = "minio", version.ref = "testcontainers" }
+testcontainers-keycloak={ group="com.github.dasniko", name="testcontainers-keycloak", version="3.4.0" }
 
 micrometer-core = { group = "io.micrometer", name = "micrometer-core", version.ref = "micrometer" }
 micrometer-registry-prometheus = { group = "io.micrometer", name = "micrometer-registry-prometheus", version.ref = "micrometer" }

--- a/http-server/src/main/clojure/xtdb/server.clj
+++ b/http-server/src/main/clojure/xtdb/server.clj
@@ -345,11 +345,13 @@
                 success-ctx
 
                 #xt.authn/method :password
-                (if (.verifyPassword authn user password)
+                (try 
+                  (.verifyPassword authn user password)
                   success-ctx
-                  (assoc ctx :error (ex-info (str "password authentication failed for user: " user)
-                                             {:type :unauthenticated
-                                              ::status 401})))
+                  (catch Anomaly _
+                    (assoc ctx :error (ex-info (str "password authentication failed for user: " user)
+                                               {:type :unauthenticated
+                                                ::status 401}))))
 
                 (assoc ctx :error (ex-info "authn failed" {:type :unauthenticated
                                                            ::status 401})))))})

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -27,7 +27,8 @@
            (java.util.stream IntStream)
            (org.apache.arrow.memory BufferAllocator RootAllocator)
            (org.apache.arrow.vector.types.pojo Field Schema)
-           (xtdb BufferPool ICursor)
+           (org.testcontainers.containers GenericContainer)
+           (xtdb BufferPool ICursor) 
            (xtdb.api TransactionKey)
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader Vector)
@@ -363,3 +364,12 @@
    (let [^PreparedQuery prepared-q (xtp/prepare-sql node query (merge {:default-db "xtdb"} opts))]
      {:res (xt/q node query opts)
       :res-type (mapv (juxt #(.getName ^Field %) types/field->col-type) (.getColumnFields prepared-q []))})))
+
+(defn with-container [^GenericContainer c, f]
+  (if (.getContainerId c)
+    (f c)
+    (try
+      (.start c)
+      (f c)
+      (finally
+        (.stop c)))))

--- a/src/test/clojure/xtdb/authn_test.clj
+++ b/src/test/clojure/xtdb/authn_test.clj
@@ -1,0 +1,180 @@
+(ns xtdb.authn-test
+  (:require [clojure.test :as t]
+            [xtdb.authn :as authn] 
+            [xtdb.test-util :as tu])
+  (:import [dasniko.testcontainers.keycloak KeycloakContainer]
+           [java.net URI] 
+           [java.time Instant InstantSource]
+           [org.keycloak.representations.idm ClientRepresentation CredentialRepresentation UserRepresentation RealmRepresentation]
+           [xtdb.api Authenticator OAuthPasswordResult OAuthClientCredentialsResult]))
+ 
+(defonce ^KeycloakContainer container
+  (KeycloakContainer. "quay.io/keycloak/keycloak:26.0"))
+
+(defn seed! 
+  ([^KeycloakContainer c] (seed! c {}))
+  ([^KeycloakContainer c {:keys [access-token-lifespan]}]
+   (with-open [admin-client (.getKeycloakAdminClient c)]
+     (when access-token-lifespan
+       (let [realm-resource (-> admin-client (.realm "master"))] 
+         (.update realm-resource (doto (RealmRepresentation.)
+                                   (.setAccessTokenLifespan access-token-lifespan)))))
+     {:users (let [users (-> admin-client
+                             (.realm "master")
+                             (.users))]
+
+               (.create users
+                        (doto (UserRepresentation.)
+                          (.setEnabled true)
+                          (.setUsername "test-user")
+                          (.setEmail "test@example.com")))
+
+               (let [user-id (some-> ^UserRepresentation (first (.search users "test-user"))
+                                     (.getId))]
+                 (-> (.get users user-id)
+                     (.resetPassword (doto (CredentialRepresentation.)
+                                       (.setType "password")
+                                       (.setValue "password124"))))
+                 {:test-user user-id}))
+
+      :clients (let [clients (-> admin-client
+                                 (.realm "master")
+                                 (.clients))]
+                 (.create clients (doto (ClientRepresentation.)
+                                    (.setName "xtdb")
+                                    (.setClientId "xtdb")
+                                    (.setSecret "xtdb-secret")
+                                    (.setDirectAccessGrantsEnabled true)))
+                 (.create clients (doto (ClientRepresentation.)
+                                    (.setName "test-client")
+                                    (.setId "test-client")
+                                    (.setClientId "test-client")
+                                    (.setSecret "test-secret")
+                                    (.setServiceAccountsEnabled true)))
+                 {:xtdb {:client-id "xtdb", :client-secret "xtdb-secret"}
+                  :test {:client-id "test-client",
+                         :client-secret "test-secret",
+                         :service-account-user-id (-> (.get clients "test-client")
+                                                      (.getServiceAccountUser)
+                                                      (.getId))}})})))
+
+(t/use-fixtures :once
+  (fn [f]
+    (tu/with-container container
+      (fn [_]
+        (f)))))
+
+(t/deftest test-token-expiry
+  (t/testing "calculates expiry correctly"
+    (let [time (Instant/parse "2020-01-01T12:00:00Z")
+          token-response {:expires_in 3600}
+          expires-at (authn/calculate-expires-at token-response time)]
+      (t/is (= (Instant/parse "2020-01-01T13:00:00Z") expires-at))))
+
+  (t/testing "expires at handles missing expires_in"
+    (t/is (nil? (authn/calculate-expires-at {} (Instant/parse "2020-01-01T12:00:00Z")))))
+
+  (t/testing "token-expired?"
+    (let [oauth-result (OAuthPasswordResult. "user-id" (Instant/parse "2020-01-01T12:00:00Z") "access-token" "refresh-token")]
+      (t/is (authn/token-expired? oauth-result (Instant/parse "2020-01-01T13:00:00Z")))
+      (t/is (not (authn/token-expired? oauth-result (Instant/parse "2020-01-01T11:00:00Z")))))))
+
+(t/deftest test-invalid-issuer-url
+  (t/testing "error caught when issuer URL is invalid"
+    (let [invalid-url (.toURL (URI. "http://invalid-url"))]
+      (t/is (anomalous? [:incorrect :xtdb/oidc-config-discovery-error
+                         #"Error thrown when fetching OIDC configuration from http://invalid-url"]
+                        (authn/discover-oidc-config invalid-url)))))
+  
+  (t/testing "discovery fails with unknown realm"
+    (let [unknown-realm-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/other-realm")))]
+      (t/is (anomalous? [:incorrect :xtdb/oidc-config-discovery-error
+                         #"Failed to discover OIDC configuration from"]
+                        (authn/discover-oidc-config unknown-realm-url))))))
+
+(t/deftest test-refresh-token-errors
+  (let [issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
+        oidc-config (authn/discover-oidc-config issuer-url)
+        authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
+                                     [{:method #xt.authn/method :password}]
+                                     (InstantSource/system))]
+
+    (t/is (anomalous? [:incorrect :xtdb/authn-failed "No valid token or refresh token available for refresh"]
+                      (authn/refresh-token authn nil)))))
+
+(t/deftest test-revalidate
+  (let [issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
+        oidc-config (authn/discover-oidc-config issuer-url)
+        base-time (Instant/parse "2020-01-01T12:00:00Z")
+        after-expiry (.plusSeconds base-time 7200)
+        mock-instant-source (tu/->mock-clock [base-time base-time base-time after-expiry after-expiry]) 
+        ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
+                                                    [{:method #xt.authn/method :client-credentials}]
+                                                    mock-instant-source)
+        clients (:clients (seed! container {:access-token-lifespan (int 3600)})) 
+        {:keys [client-id client-secret]} (:test clients)]
+    
+    (t/testing "revalidate returns nil for valid token"
+      (let [auth-result (.verifyClientCredentials authn client-id client-secret)] ; uses base-time
+        (t/is (nil? (.revalidate authn auth-result))))) ; uses base-time - token still valid
+    
+    (t/testing "revalidate returns refreshed token for expired token"
+      (let [auth-result (.verifyClientCredentials authn client-id client-secret) ; uses base-time
+            refreshed-result (.revalidate authn auth-result)] ; uses after-expiry - token expired, fetched a new token at after-expiry
+        (t/is (some? refreshed-result))
+        (t/is (= client-id (.getClientId refreshed-result)))
+        (t/is (.isAfter (.getExpiresAt refreshed-result) (.getExpiresAt auth-result)))))))
+
+(t/deftest test-oidc-password-flow
+  (let [test-user-id (-> (seed! container) 
+                         (get-in [:users :test-user]))
+        issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
+        oidc-config (authn/discover-oidc-config issuer-url)
+        ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
+                                                    [{:method #xt.authn/method :password}]
+                                                    (InstantSource/system))]
+    
+    (t/testing "method routing"
+      (t/is (= #xt.authn/method :password
+               (.methodFor authn "test-user" "127.0.0.1"))))
+
+    (t/testing "successful password authentication"
+      (let [^OAuthPasswordResult auth-result (.verifyPassword authn "test-user" "password124")]
+        (t/is (= test-user-id (.getUserId auth-result)))))
+
+    (t/testing "authentication failures"
+      (t/is (anomalous? [:incorrect :xtdb/authn-failed "Password authentication failed for user: test-user"] 
+                        (.verifyPassword authn "test-user" "password123"))))))
+
+(t/deftest test-oidc-client-credential-flow
+  (let [clients (:clients (seed! container))
+        {:keys [^String client-id ^String client-secret service-account-user-id]} (:test clients)
+        issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
+        oidc-config (authn/discover-oidc-config issuer-url)
+        ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
+                                                    [{:method #xt.authn/method :client-credentials}]
+                                                    (InstantSource/system))]
+    
+    (t/testing "method routing"
+      (t/is (= #xt.authn/method :client-credentials (.methodFor authn "oid-client" "127.0.0.1"))))
+
+    (t/testing "successful client credentials authentication"
+      (let [^OAuthClientCredentialsResult auth-result (.verifyClientCredentials authn client-id client-secret)]
+        (t/is (= service-account-user-id (.getUserId auth-result)))
+        (t/is (= client-id (.getClientId auth-result)))
+        (t/is (= client-secret (.getClientSecret auth-result)))))
+
+    (t/testing "authentication failures" 
+      (t/is (anomalous? [:incorrect :xtdb/authn-failed "Client credentials authentication failed for client: bad-client"]
+                        (.verifyClientCredentials authn "bad-client" "client-secret"))))))
+
+(comment
+  ;; start these once when you're developing,
+  ;; save the time of starting the container for each run
+  (.start container)
+
+  (seed! container)
+
+  (.getAuthServerUrl container)
+
+  (.stop container))

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -11,7 +11,8 @@
             [xtdb.pgwire-test :as pgw-test]
             [xtdb.test-util :as tu]
             [xtdb.time :as time]
-            [xtdb.util :as util]))
+            [xtdb.util :as util])
+  (:import [xtdb.api SimpleResult]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
 
@@ -326,18 +327,18 @@
   (t/is (= [{:username "xtdb", :usesuper true, :xt/valid-from (time/->zdt #inst "1970")}]
            (xt/q tu/*node* "SELECT username, usesuper, _valid_from, _valid_to FROM pg_user")))
 
-  (t/is (= "xtdb" (.verifyPassword (authn/<-node tu/*node*) "xtdb" "xtdb")))
+  (t/is (= (SimpleResult. "xtdb") (.verifyPassword (authn/<-node tu/*node*) "xtdb" "xtdb")))
 
   (xt/execute-tx tu/*node* ["CREATE USER ada WITH PASSWORD 'lovelace'"])
 
   (t/is (= [{:username "ada", :usesuper false}]
            (xt/q tu/*node* "SELECT username, usesuper FROM pg_user WHERE username = 'ada'")))
-  (t/is (= "ada" (.verifyPassword (authn/<-node tu/*node*) "ada" "lovelace")))
+  (t/is (= (SimpleResult. "ada") (.verifyPassword (authn/<-node tu/*node*) "ada" "lovelace")))
 
   (xt/execute-tx tu/*node* ["ALTER USER anonymous WITH PASSWORD 'anonymous'"])
 
   (t/is (= [{:username "anonymous", :usesuper false}] (xt/q tu/*node* "SELECT username, usesuper FROM pg_user WHERE username = 'anonymous'")))
-  (t/is (= "anonymous" (.verifyPassword (authn/<-node tu/*node*) "anonymous" "anonymous"))))
+  (t/is (= (SimpleResult. "anonymous") (.verifyPassword (authn/<-node tu/*node*) "anonymous" "anonymous"))))
 
 ;; required for Postgrex
 (deftest test-pg-range-3737

--- a/src/test/clojure/xtdb/oidc_integration_test.clj
+++ b/src/test/clojure/xtdb/oidc_integration_test.clj
@@ -1,0 +1,153 @@
+(ns xtdb.oidc-integration-test
+  (:require [clojure.test :as t]
+            [next.jdbc :as jdbc] 
+            [xtdb.authn-test :as authn-test]
+            [xtdb.node :as xtn]
+            [xtdb.test-util :as tu])
+  (:import [org.postgresql.util PSQLException]))
+
+(def ^:dynamic *clients* nil)
+
+(defn seed-container [f]
+  (let [{:keys [clients]} (authn-test/seed! authn-test/container {:access-token-lifespan (int 2)})]
+    (binding [*clients* clients]
+      (f))))
+
+(t/use-fixtures :once
+  (fn [f]
+    (tu/with-container authn-test/container
+      (fn [_]
+        (f)))))
+
+(t/use-fixtures :each seed-container)
+
+(t/deftest ^:integration test-oidc-password-flow
+  (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
+                                                             :client-id "xtdb"
+                                                             :client-secret "xtdb-secret"
+                                                             :rules [{:user "test-user" :method :password :address "127.0.0.1"}
+                                                                     {:user "oid-client" :method :client-credentials}]}]})]
+    (let [user-connection-builder (-> (.createConnectionBuilder node) (.user "test-user"))]
+      (t/testing "successful password authentication"
+        (with-open [conn (-> user-connection-builder
+                             (.password "password124")
+                             (.build))]
+          (let [result (jdbc/execute-one! conn ["SELECT 1 as test"])]
+            (t/is (= 1 (:test result))))))
+
+      (t/testing "failed password authentication"
+        (t/is (thrown-with-msg? PSQLException #"Password authentication failed for user: test-user"
+                                (-> user-connection-builder
+                                    (.password "wrong-password")
+                                    (.build))))))))
+
+(t/deftest ^:integration test-oidc-client-credentials
+  (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
+                                                             :client-id "xtdb"
+                                                             :client-secret "xtdb-secret"
+                                                             :rules [{:user "oid-client" :method :client-credentials}]}]})]
+    (let [{:keys [client-id client-secret]} (:test *clients*)
+          client-connection-builder (-> (.createConnectionBuilder node) (.user "oid-client"))]
+
+      (t/testing "successful client credentials authentication"
+        (with-open [conn (-> client-connection-builder
+                             (.password (format "%s:%s" client-id client-secret))
+                             (.build))]
+          (let [result (jdbc/execute-one! conn ["SELECT 'authenticated' as status"])]
+            (t/is (= "authenticated" (:status result))))))
+
+      (t/testing "failed client credentials authentication with badly written credentials"
+        (t/is (thrown-with-msg? PSQLException #"Client credentials must be provided in the format 'client-id:client-secret'"
+                                (-> client-connection-builder
+                                    (.password "too:many:colons")
+                                    (.build)))))
+
+      (t/testing "failed client credentials authentication with non-existent credentials"
+        (t/is (thrown-with-msg? PSQLException #"Client credentials authentication failed for client: bad-client"
+                                (-> client-connection-builder
+                                    (.password "bad-client:bad-secret")
+                                    (.build))))))))
+
+(t/deftest ^:integration test-oidc-session-management
+  (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
+                                                             :client-id "xtdb"
+                                                             :client-secret "xtdb-secret"
+                                                             :rules [{:user "test-user" :method :password :address "127.0.0.1"}]}]})]
+    (let [user-connection-builder (-> (.createConnectionBuilder node)
+                                      (.user "test-user")
+                                      (.password "password124"))]
+
+      (t/testing "session persists across multiple queries"
+        (with-open [conn (.build user-connection-builder)]
+          (let [result1 (jdbc/execute-one! conn ["SELECT 1 as first_query"])
+                result2 (jdbc/execute-one! conn ["SELECT 2 as second_query"])]
+            (t/is (= 1 (:first_query result1)))
+            (t/is (= 2 (:second_query result2))))))
+
+      (t/testing "multiple concurrent connections work"
+        (with-open [conn1 (.build user-connection-builder)
+                    conn2 (.build user-connection-builder)]
+          (let [result1 (jdbc/execute-one! conn1 ["SELECT 'conn1' as source"])
+                result2 (jdbc/execute-one! conn2 ["SELECT 'conn2' as source"])]
+            (t/is (= "conn1" (:source result1)))
+            (t/is (= "conn2" (:source result2)))))))))
+
+(t/deftest ^:integration test-oidc-multiple-auth-methods
+  (let [{:keys [client-id client-secret]} (:test *clients*)]
+    (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
+                                                               :client-id "xtdb"
+                                                               :client-secret "xtdb-secret"
+                                                               :rules [{:user "test-user" :method :password :address "127.0.0.1"}
+                                                                       {:user "oid-client" :method :client-credentials}]}]})]
+
+      (t/testing "password flow works"
+        (with-open [conn (-> (.createConnectionBuilder node)
+                             (.user "test-user")
+                             (.password "password124")
+                             (.build))]
+          (let [result (jdbc/execute-one! conn ["SELECT 'password-auth' as method"])]
+            (t/is (= "password-auth" (:method result))))))
+
+      (t/testing "client credentials flow works"
+        (with-open [conn (-> (.createConnectionBuilder node)
+                             (.user "oid-client")
+                             (.password (format "%s:%s" client-id client-secret))
+                             (.build))]
+          (let [result (jdbc/execute-one! conn ["SELECT 'client-creds-auth' as method"])]
+            (t/is (= "client-creds-auth" (:method result))))))
+
+      (t/testing "wrong method for user fails"
+        (t/is (thrown? Exception (-> (.createConnectionBuilder node)
+                                     (.user "oid-client")
+                                     (.password "password123")
+                                     (.build))))))))
+
+(t/deftest ^:integration test-oidc-client-credentials-token-expiry
+  (let [{:keys [client-id client-secret]} (:test *clients*)
+        mock-instant-source (tu/->mock-clock
+                             [#inst "2020-01-01T12:00:00Z" ; initial connection time
+                              #inst "2020-01-01T12:00:00Z" ; used to calculate token expiry for connection
+                              #inst "2020-01-01T12:00:01Z" ; used to validate if token expired within :msg-parse (not yet expired)
+                              #inst "2020-01-01T12:00:01Z" ; used to validate if token expired within :msg-bind (not yet expired)
+                              #inst "2020-01-01T12:00:05Z" ; used to validate if token expired within :msg-parse (expired)
+                              #inst "2020-01-01T12:00:05Z" ; used to calculate refreshed-token expiry time
+                              #inst "2020-01-01T12:00:06Z" ; used to validate if token expired within :msg-bind (refreshed)
+                              ])]
+    (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
+                                                               :client-id "xtdb"
+                                                               :client-secret "xtdb-secret"
+                                                               :instant-src mock-instant-source
+                                                               :rules [{:user "oid-client" :method :client-credentials}]}]})]
+      (let [client-connection-builder (-> (.createConnectionBuilder node)
+                                          (.user "oid-client")
+                                          (.password (format "%s:%s" client-id client-secret)))]
+
+        (t/testing "token expiry and automatic refresh works"
+          (with-open [conn (.build client-connection-builder)]
+            (t/testing "initial connection and first revalidate"
+              (let [result (jdbc/execute-one! conn ["SELECT 'initial' as status"])]
+                (t/is (= "initial" (:status result)))))
+
+            (t/testing "after first expiry, token is refreshed"
+              (let [result (jdbc/execute-one! conn ["SELECT 'after-expiry' as status"])]
+                (t/is (= "after-expiry" (:status result)))))))))))

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as t :refer [deftest]]
             [jsonista.core :as json]
             [xtdb.authn :as authn]
+            [xtdb.authn-test :as authn-test]
             [xtdb.db-catalog :as db]
             [xtdb.indexer.live-index :as li]
             [xtdb.pgwire :as pgwire]
@@ -11,7 +12,7 @@
             [xtdb.util :as util])
   (:import [java.lang AutoCloseable]
            [java.nio.charset StandardCharsets]
-           [java.time Clock]))
+           [java.time Clock InstantSource]))
 
 (def ^:dynamic ^:private *port* nil)
 
@@ -64,14 +65,15 @@
   (^java.lang.AutoCloseable [frontend startup-opts]
    (->conn frontend startup-opts [{:user nil, :method #xt.authn/method :trust, :address nil}]))
   (^java.lang.AutoCloseable [frontend startup-opts authn-rules]
-   (let [conn (pgwire/map->Connection {:server {:server-state (atom {:parameters {"server_encoding" "UTF8"
+   (let [authn (authn/->UserTableAuthn authn-rules
+                                       (util/component tu/*node* :xtdb.query/query-source)
+                                       (db/<-node tu/*node*)) 
+         conn (pgwire/map->Connection {:server {:server-state (atom {:parameters {"server_encoding" "UTF8"
                                                                                   "client_encoding" "UTF8"
                                                                                   "DateStyle" "ISO"
                                                                                   "IntervalStyle" "ISO_8601"}})
-                                                :node (-> tu/*node*
-                                                          (assoc :authn (authn/->UserTableAuthn authn-rules
-                                                                                                (util/component tu/*node* :xtdb.query/query-source)
-                                                                                                (db/<-node tu/*node*))))}
+                                                :node tu/*node*
+                                                :authn authn}
                                        :allocator tu/*allocator*
                                        :frontend frontend
                                        :cid -1
@@ -118,7 +120,6 @@
                    :message "password authentication failed for user: xtdb"
                    :detail nil}}]]
                @!in-msgs)))))
-
 
 (deftest test-simple-query
   (let [{:keys [!in-msgs] :as frontend} (->recording-frontend {})]
@@ -349,3 +350,108 @@
                                        :detail nil}}]
                 [:msg-ready {:status :idle}]]
                (test "SELECT 1 one; BEGIN"))))))
+
+(t/use-fixtures :once
+  (fn [f]
+    (tu/with-container authn-test/container
+      (fn [_]
+        (f)))))
+
+;; OIDC Authentication Protocol Tests
+(defn ->oidc-conn ^java.lang.AutoCloseable [frontend startup-opts] 
+  (let [oidc-config (authn/discover-oidc-config (str (.getAuthServerUrl authn-test/container) "/realms/master"))
+        authn (authn/->OpenIdConnect oidc-config
+                                     "xtdb"
+                                     "xtdb-secret"
+                                     [{:user "test-user" :method #xt.authn/method :password :address "127.0.0.1"}
+                                      {:user "oid-client" :method #xt.authn/method :client-credentials}]
+                                     (InstantSource/system))
+        conn (pgwire/map->Connection {:server {:server-state (atom {:parameters {"server_encoding" "UTF8"
+                                                                                 "client_encoding" "UTF8"
+                                                                                 "DateStyle" "ISO"
+                                                                                 "IntervalStyle" "ISO_8601"}})
+                                               :node tu/*node*
+                                               :authn authn}
+                                      :allocator tu/*allocator*
+                                      :frontend frontend
+                                      :cid -1
+                                      :!closing? (atom false)
+                                      :conn-state (atom {:session {:clock (Clock/systemUTC)}})
+                                      :default-db "xtdb"})]
+    (try
+      (pgwire/cmd-startup-pg30 conn startup-opts)
+      (catch Exception e 
+        (if (#{:xtdb/authn-failed :xtdb/invalid-client-credentials} (:xtdb.error/code (ex-data e)))
+          (doto conn
+            (pgwire/send-ex e)
+            (pgwire/handle-msg* {:msg-name :msg-terminate}))
+          (throw e))))))
+
+(deftest ^:integration test-oidc-password-auth-successs
+  (let [{{user-id :test-user} :users} (authn-test/seed! authn-test/container) 
+        {:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-password :password "password124"}])]
+    (with-open [_ (->oidc-conn frontend {"user" "test-user", "database" "xtdb"})]
+      (t/is (= [[:msg-auth {:result 3}]
+                [:msg-auth {:result 0}]
+                [:msg-parameter-status {:parameter "server_encoding", :value "UTF8"}]
+                [:msg-parameter-status {:parameter "client_encoding", :value "UTF8"}]
+                [:msg-parameter-status {:parameter "DateStyle", :value "ISO"}]
+                [:msg-parameter-status {:parameter "IntervalStyle", :value "ISO_8601"}]
+                [:msg-parameter-status {:parameter "user", :value user-id}]
+                [:msg-parameter-status {:parameter "database", :value "xtdb"}]
+                [:msg-backend-key-data {:process-id -1, :secret-key 0}]
+                [:msg-ready {:status :idle}]]
+               @!in-msgs)))))
+
+(deftest ^:integration test-oidc-password-auth-failure 
+  (let [_ (authn-test/seed! authn-test/container)
+        {:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-password :password "wrong-password"}])]
+    (with-open [_ (->oidc-conn frontend {"user" "test-user", "database" "xtdb"})]
+      (t/is (= [[:msg-auth {:result 3}]
+                [:msg-error-response
+                 {:error-fields
+                  {:severity "ERROR",
+                   :localized-severity "ERROR",
+                   :sql-state "28P01",
+                   :message "Password authentication failed for user: test-user"
+                   :detail {:category "cognitect.anomalies/incorrect",
+                            :status 401,
+                            :code "xtdb/authn-failed",
+                            :body {:refresh-token nil, :expires-at nil, :access-token nil}
+                            :message "Password authentication failed for user: test-user"}}}]]
+               @!in-msgs)))))
+
+(deftest ^:integration test-oidc-client-credentials-auth-success
+  (let [{:keys [clients]} (authn-test/seed! authn-test/container)
+        {:keys [client-id client-secret service-account-user-id]} (:test clients)
+        client-password (format "%s:%s" client-id client-secret)
+        {:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-password :password client-password}])]
+    (with-open [_ (->oidc-conn frontend {"user" "oid-client", "database" "xtdb"})]
+      (t/is (= [[:msg-auth {:result 3}]
+                [:msg-auth {:result 0}]
+                [:msg-parameter-status {:parameter "server_encoding", :value "UTF8"}]
+                [:msg-parameter-status {:parameter "client_encoding", :value "UTF8"}]
+                [:msg-parameter-status {:parameter "DateStyle", :value "ISO"}]
+                [:msg-parameter-status {:parameter "IntervalStyle", :value "ISO_8601"}]
+                [:msg-parameter-status {:parameter "user", :value service-account-user-id}]
+                [:msg-parameter-status {:parameter "database", :value "xtdb"}]
+                [:msg-backend-key-data {:process-id -1, :secret-key 0}]
+                [:msg-ready {:status :idle}]]
+               @!in-msgs)))))
+
+(deftest ^:integration test-oidc-client-credentials-auth-failure
+  (let [_ (authn-test/seed! authn-test/container)
+        {:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-password :password "too:many:colons"}])]
+    (with-open [_ (->oidc-conn frontend {"user" "oid-client", "database" "xtdb"})]
+      (t/is (= [[:msg-auth {:result 3}]
+                [:msg-error-response
+                 {:error-fields
+                  {:severity "ERROR",
+                   :localized-severity "ERROR",
+                   :sql-state "28P01",
+                   :message "Client credentials must be provided in the format 'client-id:client-secret'",
+                   :detail {:category "cognitect.anomalies/incorrect",
+                            :code "xtdb/invalid-client-credentials",
+                            :message "Client credentials must be provided in the format 'client-id:client-secret'"}}}]]
+               @!in-msgs)))))
+

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -159,6 +159,21 @@
         :unsupported
         (throw e)))))
 
+(t/deftest test-parse-client-creds
+  (t/testing "test correct encoding"
+    (t/is (= {:client-id "test-client" :client-secret "test-secret"}
+             (pgw/parse-client-creds "test-client:test-secret"))))
+
+  (t/testing "test invalid inputs"
+    (t/is (anomalous? [:incorrect :xtdb/invalid-client-credentials #"Client credentials were not provided"]
+                      (pgw/parse-client-creds nil)))
+    (t/is (anomalous? [:incorrect :xtdb/invalid-client-credentials #"Client credentials were empty"]
+                      (pgw/parse-client-creds "")))
+    (t/is (anomalous? [:incorrect :xtdb/invalid-client-credentials #"Client credentials must be provided in the format 'client-id:client-secret'"]
+                      (pgw/parse-client-creds "no-colon")))
+    (t/is (anomalous? [:incorrect :xtdb/invalid-client-credentials #"Client credentials must be provided in the format 'client-id:client-secret'"]
+                      (pgw/parse-client-creds "client:secret:extra")))))
+
 (deftest gssenc-test
   (t/is (= :ok (try-gssencmode "disable")))
   (t/is (= :ok (try-gssencmode "prefer")))


### PR DESCRIPTION
Resolves #3999 
Github action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aoidc-authn

Implements OpenID Connect (OIDC) authentication for pgwire connections, supporting multiple OAuth2/OIDC grant flows for different use cases.

- Added OpenIdConnect authenticator with support for password, client credentials, and device authorization flows
  - We take in an "issuer-url", from which we fetch the "/.well-known/openid-configuration" for the sake of route discovery.
- Updated Kotlin Authenticator interface, adding in new methods which return different data class types depending on the type of auth.
  - All of these implement `AuthResult` which at it's minimum contains a `user-id`.
  - Existing user table password auth returns a `SimpleResult`.
  - All OpenIdConnect auth methods return some implemenation of `OAuthResult`, which contains additional fields (used currently for the sake of checking token expiry/handling refresh - in the future we can return authz claims and such) 
- Supported flows:
    - Uses `methodFor` to route authentication based on user/address rules
    - **Password flow**: Standard username/password authentication for end users
    - **Client credentials**:`client_id:client_secret` passed as password, mapped via user rules (e.g., `oid-client` user)
    - **Device auth**: Interactive flow with verification URL, polls for completion
- Implemented OAuth token management with automatic refresh and expiry handling
  - OAuth results are stored within pgwire connection state after the initial msg-auth call.
  - We implement and use the "revalidate" method on the authenticator to:
    - Check if a token is expired.
    - Attempt to refresh the token if it is expired. 
  - We wrap most XTDB api calls within pgwire in a `with-auth-check` macro that calls down to this method.
- Testing and documentation:
  - Have a set of unit and integration levels tests of the various oauth flows.
  - Docker Compose setup with Keycloak service for development.

### Updates since last review

- Client credential password handling - no longer base64, client-id:client-secret 
  - Parsing these out in pgwire and passing separately into verification.
- authn now uses and passes around Kotlin data objects for auth responses.
- Using anomalies for authn errors, and then send-ex  handling for these errors on pgwire side.
- Adding and passing around InstantSource to OpenIdConnect - using this within numerous tests also, so I don't have to rely on thread sleeps.
- Making revalidate a method on the authenticator implementation, testing revalidate logic within authn_test.
  - We use this in pgwire with a macro that wraps individual api XTDB calls, rather than checking that at the handle-msg level.
- oidc_integration_test now uses  createConnectionBuilder on the node and is generally much simpler.
- Fetch expires-in from initial device_auth and using this to check if the device auth has timed out.
  - I think that the token endpoint actually does something similar when handling device auth - it will return an auth_expired error code, so this may not be entirely necessary - still, serves as an explicit loop break for us, though, so can't hurt.
- We now transform the results of OAuth HTTP calls fairly specifically, grabbing and renaming specific keys which we are using. 
- Added a set of OIDC auth pgwire protocol tests.
