### PR TITLE
not fencing WITHs unless they're MATERIALIZED

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -273,9 +273,6 @@
     (cond-> (conj (relation-columns relation) (val (first columns)))
       (:ordinality-column opts) (conj (:ordinality-column opts)))
 
-    [:let _ relation]
-    (relation-columns relation)
-
     [:let-mat _ relation]
     (relation-columns relation)
 

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -8,22 +8,6 @@
 
 (s/def ::binding (s/tuple simple-symbol? ::lp/ra-expression))
 
-(defmethod lp/ra-expr :let [_]
-  (s/cat :op #{:let}
-         :binding ::binding
-         :relation ::lp/ra-expression))
-
-(defmethod lp/emit-expr :let [{[binding bound-rel] :binding, :keys [relation]} emit-opts]
-  (let [{->bound-cursor :->cursor, :as emitted-bound-rel} (lp/emit-expr bound-rel emit-opts)
-        {->body-cursor :->cursor, :as emitted-body-rel} (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel))]
-    {:fields (:fields emitted-body-rel)
-     :stats (:stats emitted-body-rel)
-     :->cursor (fn [opts]
-                 (->body-cursor (assoc-in opts [:let-bindings binding]
-                                          (reify ICursor$Factory
-                                            (open [_]
-                                              (->bound-cursor opts))))))}))
-
 (defmethod lp/ra-expr :let-mat [_]
   (s/cat :op #{:let-mat}
          :binding ::binding

--- a/src/test/clojure/xtdb/operator/let_test.clj
+++ b/src/test/clojure/xtdb/operator/let_test.clj
@@ -4,60 +4,6 @@
 
 (t/use-fixtures :each tu/with-allocator)
 
-(t/deftest test-let
-  (t/is (= [{:a 4}]
-           (tu/query-ra '[:let [Foo [::tu/pages
-                                     [[{:a 12}, {:a 0}]
-                                      [{:a 12}, {:a 100}]]]]
-                          [:table [{:a 4}]]]))
-        "unused let")
-
-  (t/is (= [[{:a 12}, {:a 0}]
-            [{:a 12}, {:a 100}]]
-           (tu/query-ra '[:let [Foo [::tu/pages
-                                     [[{:a 12}, {:a 0}]
-                                      [{:a 12}, {:a 100}]]]]
-                          [:relation Foo {:col-names [a]}]]
-                        {:preserve-pages? true}))
-        "normal usage")
-
-  (t/is (= [{:a 1 :b 1}]
-           (tu/query-ra '[:let [X [:table ?x]]
-                          [:let [Y [:join [{a b}]
-                                    [:relation X {:col-names [a]}]
-                                    [:table ?y]]]
-                           [:let [X [:relation Y {:col-names [a b]}]]
-                            [:relation X {:col-names [a b]}]]]]
-
-                        {:args {:x [{:a 1}]
-                                :y [{:b 1}]}}))
-        "can see & override earlier assignments")
-
-  (t/is (= [[{:a 12}, {:a 0}]
-            [{:a 12}, {:a 100}]
-            [{:a 12}, {:a 0}]
-            [{:a 12}, {:a 100}]]
-           (tu/query-ra '[:let [Foo [::tu/pages
-                                     [[{:a 12}, {:a 0}]
-                                      [{:a 12}, {:a 100}]]]]
-                          [:union-all
-                           [:relation Foo {:col-names [a]}]
-                           [:relation Foo {:col-names [a]}]]]
-                        {:preserve-pages? true}))
-        "can use it multiple times")
-
-  (t/is (= [{:a 0} {:a 0}
-            {:a 12} {:a 12} {:a 12} {:a 12}
-            {:a 100} {:a 100}]
-           (tu/query-ra '[:let [Foo [::tu/pages
-                                     [[{:a 12}, {:a 0}]
-                                      [{:a 12}, {:a 100}]]]]
-                          [:order-by [[a]]
-                           [:union-all
-                            [:relation Foo {:col-names [a]}]
-                            [:relation Foo {:col-names [a]}]]]]))
-        "can pass it to other operators"))
-
 (t/deftest test-let-mat
   (t/is (= [{:a 4}]
            (tu/query-ra '[:let-mat [Foo [::tu/pages

--- a/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
@@ -1,11 +1,16 @@
-[:let
- [foo.2
-  [:project
-   [{_id bar.1/_id}]
-   [:rename bar.1 [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]
- [:project
-  [{foo_id foo.3/_id} {baz_id baz.4/_id}]
-  [:mega-join
-   []
-   [[:rename foo.3 [:relation foo.2 {:col-names [_id]}]]
-    [:rename baz.4 [:relation foo.2 {:col-names [_id]}]]]]]]
+[:project
+ [{foo_id foo.3/_id} {baz_id baz.4/_id}]
+ [:mega-join
+  []
+  [[:rename
+    foo.3
+    [:project
+     [{_id bar.1/_id}]
+     [:rename bar.1 [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]
+   [:rename
+    baz.4
+    [:project
+     [{_id bar.1/_id}]
+     [:rename
+      bar.1
+      [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]]]]


### PR DESCRIPTION
This is to reduce the breaking change in #4673 - `WITH` without `MATERIALIZED` is reverted to its previous inlining behaviour.

Now roughly Postgres-compatible (aside from `foo AS MATERIALIZED` / `foo AS NOT MATERIALIZED` vs our `MATERIALIZED foo`, which I took an executive decision to do because `AS` is more commonly used in SQL to give something an alias).