### PR TITLE
split CLI out into distinct commands

### DIFF
--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -41,7 +41,7 @@ You do not need to install Gradle to develop XT2 - there is a Gradle https://doc
 
 == XTDB 'playground'
 
-XTDB nodes can be started in 'playground' mode - either through `--playground` flag to `clj -m xtdb.main` or the standalone Docker image, or by running the `playground-config` `ir/set-prep` in the `dev` namespace.
+XTDB nodes can be started in 'playground' mode - either through `clj -m xtdb.main playground` or the standalone Docker image, or by running the `playground-config` `ir/set-prep` in the `dev` namespace.
 
 In playground mode, to begin with, we only start the pgwire server, without an associated XTDB node.
 Then, whenever a new connection is initiated, we create a new isolated in-memory node for every distinct 'database' specified in the connection parameters.

--- a/docs/src/content/docs/ops/config.adoc
+++ b/docs/src/content/docs/ops/config.adoc
@@ -134,9 +134,22 @@ modules:
 
 For details on the available modules, see the link:config/modules[modules] documentation.
 
-== CLI flags
+== CLI tools/flags
 
-The following flags can be passed, either directly to the CLI or via Docker's arguments:
+You can run various tools by passing arguments - either directly to the CLI or via Docker's arguments:
 
+`node` (default, can be omitted)::
 * `-f <file>`, `--file <file>`: specifies the configuration file to use.
-* `--compactor-only`: runs a compactor-only node.
+`compactor`:: Starts a compactor-only node - useful for giving the compaction process more compute resources.
+* `-f <file>`, `--file <file>`: specifies the configuration file to use.
+`playground`:: Starts a playground - an in-memory server that will accept any database name, creating it if required.
+* `-p <port>`, `--port <port>` (default 5432): specifies the port to run the playground server on.
+
+e.g.
+
+* Dockerfile: `CMD ["playground", "--port", "5439"]`
+* docker-compose: `command: ["playground", "--port", "5439"]`
+* Java uberjar: `java -jar xtdb.jar playground --port 5439`
+* Clojure (with `xtdb-core` in your `deps.edn`): `clj -M xtdb.main playground --port 5439`
+
+You can also pass `--help` to any of the commands to get command-specific help.

--- a/lang/docker-compose.yml
+++ b/lang/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   xtdb:
     build:
       context: ../docker/standalone
-    command: ["--playground-port=5439"]
+    command: ["playground", "--port", "5439"]
 
   js:
     build:

--- a/src/test/clojure/xtdb/cli_test.clj
+++ b/src/test/clojure/xtdb/cli_test.clj
@@ -1,10 +1,10 @@
 (ns xtdb.cli-test
   (:require [clojure.java.io :as io]
             [clojure.test :as t]
-            [integrant.core :as ig]
             [xtdb.api :as xt]
             [xtdb.cli :as cli]
             [xtdb.db-catalog :as db]
+            [xtdb.error :as err]
             [xtdb.node :as xtn])
   (:import (xtdb.indexer.live_index LiveIndex)))
 
@@ -33,99 +33,83 @@
                                 (apply (some-fn resources og) args))]
       (f))))
 
-(defmethod ig/init-key ::foo [_ opts] opts)
+(defn parse-args [args cli-spec]
+  (let [[tag arg] (cli/parse-args args cli-spec)]
+    (case tag
+      :success arg
+      (throw (err/fault ::failed-parsing-args "Failed to parse CLI args"
+                        {:result [tag arg]})))))
 
 (t/deftest no-config
-  (t/testing "if no config present via file, returns an empty map as the node-opts"
-    (t/is (= {::cli/node-opts {}, ::cli/compactor-only? false} (cli/parse-args [])))))
+  (t/is (= {} (parse-args [] cli/node-cli-spec))
+        "if no config present via file, returns an empty map")
+
+  (t/is (= {} (cli/file->node-opts nil))
+        "if no file provided, returns an empty map as node opts"))
 
 (t/deftest test-config
-  (letfn [(->system [cli-args]
-            (-> (::cli/node-opts (cli/parse-args cli-args))
-                ig/prep
-                ig/init
-                (->> (into {}))))]
-    (t/testing "uses CLI supplied EDN file"
-      (t/is (= {::foo {:bar {}}}
-               (->system ["-f" (str (io/as-file xtdb-cli-edn))]))))
+  (t/is (= {:file (io/as-file xtdb-cli-edn)}
+           (parse-args ["-f" (str (io/as-file xtdb-cli-edn))] cli/node-cli-spec))
+        "uses CLI supplied EDN file")
 
-    (t/testing "uses xtdb.edn if present"
-      (with-file-override {"xtdb.edn" (io/as-file xtdb-cli-edn)}
-        (fn []
-          (t/is (= {::foo {:bar {}}}
-                   (->system []))))))))
+  (t/testing "uses xtdb.edn if present"
+    (with-file-override {"xtdb.edn" (io/as-file xtdb-cli-edn)}
+      (fn []
+        (t/is (= {::foo {:bar {}}} (cli/file->node-opts nil))
+              "uses xtdb.edn if present")))))
 
 (t/deftest test-env-loading
   (with-redefs [cli/read-env-var (fn [env-name]
-                                   (when (= (str env-name) "TEST_ENV") "hello world"))]
-    (letfn [(->system [cli-args]
-              (-> (::cli/node-opts (cli/parse-args cli-args))
-                  ig/prep
-                  ig/init
-                  (->> (into {}))))]
+                                   (when (= (str env-name) "TEST_ENV")
+                                     "hello world"))]
+    (t/testing
+      (t/is (= {::foo "hello world"}
+               (cli/file->node-opts (io/as-file xtdb-cli-edn-env)))
+            "EDN config - #env reader tag fetches from env"))))
 
-      (t/testing "EDN config - #env reader tag fetches from env"
-        (t/is (= {::foo "hello world"}
-                 (->system ["-f" (str (io/as-file xtdb-cli-edn-env))])))))))
+(defn- ->node-opts [cli-args]
+  (cli/file->node-opts (:file (parse-args cli-args cli/node-cli-spec))))
 
-(t/deftest test-parsers
-  (t/testing "Playground port should work as expected"
-    (t/is (= {::cli/playground-port 5432}
-             (cli/parse-args ["--playground"]))))
-  
-  (t/testing "Playground port should work as expected"
-    (t/is (= {::cli/playground-port 5055}
-             (cli/parse-args ["--playground-port" "5055"]))))
-  
-  (t/testing "compaction working as expected"
-    (t/is (= {::cli/node-opts {}, ::cli/compactor-only? true}
-             (cli/parse-args ["--compactor-only"])))))
-
-(defmethod ig/init-key ::bar [_ opts] opts)
-
-;; Expect YAML config file to return the file in `node-opts` - this will get passed to
+;; Expect YAML config file to just return the file - this will get passed to
 ;; start-node and subsequently decoded by the Kotlin API
 (t/deftest test-config-yaml
-  (letfn [(->node-opts [cli-args] (::cli/node-opts (cli/parse-args cli-args)))]
+  (t/testing "Explicitly provided YAML file will output specified file-location"
+    (t/is (= (io/file xtdb-cli-yaml)
+             (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml))]))))
 
-    (t/testing "Explicitly provided YAML file will output specified file-location"
-      (t/is (= (io/file xtdb-cli-yaml)
-               (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml))]))))
+  (t/testing "returns file location of xtdb.yaml if present"
+    (with-file-override {"xtdb.yaml" (io/as-file xtdb-cli-yaml)}
+      (fn []
+        (t/is (= (io/file (io/resource "xtdb/cli-test.yaml"))
+                 (->node-opts []))))))
 
-    (t/testing "returns file location of xtdb.yaml if present"
-      (with-file-override {"xtdb.yaml" (io/as-file xtdb-cli-yaml)}
-        (fn []
-          (t/is (= (io/file (io/resource "xtdb/cli-test.yaml"))
-                   (->node-opts []))))))
+  (t/testing "also returns file location of xtdb.yaml if on the classpath"
+    (with-resource-override {"xtdb.yaml" (io/as-file xtdb-cli-yaml)}
+      (fn []
+        (t/is (= (io/file (io/resource "xtdb/cli-test.yaml"))
+                 (->node-opts []))))))
 
-    (t/testing "also returns file location of xtdb.yaml if on the classpath"
-      (with-resource-override {"xtdb.yaml" (io/as-file xtdb-cli-yaml)}
-        (fn []
-          (t/is (= (io/file (io/resource "xtdb/cli-test.yaml"))
-                   (->node-opts []))))))
-
-    (t/testing "node opts passed to start-node passes through yaml file and starts node"
-      (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml))]))]
-        (let [^LiveIndex live-idx (.getLiveIndex (db/primary-db node))]
-          (t/is (= 65 (.log-limit live-idx))
-                "using provided config"))
-        (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])
-        (t/is (= [{:e :foo}] (xt/q node '(from :docs [{:xt/id e}]))))))))
+  (t/testing "node opts passed to start-node passes through yaml file and starts node"
+    (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml))]))]
+      (let [^LiveIndex live-idx (.getLiveIndex (db/primary-db node))]
+        (t/is (= 65 (.log-limit live-idx))
+              "using provided config"))
+      (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])
+      (t/is (= [{:e :foo}] (xt/q node '(from :docs [{:xt/id e}])))))))
 
 (t/deftest test-multi-dot-yaml
-  (letfn [(->node-opts [cli-args] (::cli/node-opts (cli/parse-args cli-args)))]
-    (t/testing "YAML with multiple dots in the filename"
-      (t/is (= (io/file xtdb-cli-yaml-multi-dot)
-               (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml-multi-dot))]))))
-    
-    (t/testing "EDN with multiple dots in the filename"
-      (t/is (= {:xtdb.cli-test/foo {:bar {}}}
-               (->node-opts ["-f" (str (io/as-file xtdb-cli-edn-multi-dot))]))))
-    
-    (t/testing "YAML with multiple dots in the filename starts node"
-      (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml-multi-dot))]))]
-        (let [^LiveIndex live-idx (.getLiveIndex (db/primary-db node))]
-          (t/is (= 65 (.log-limit live-idx))
-                "using provided config"))
-        (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])
-        (t/is (= [{:e :foo}] (xt/q node '(from :docs [{:xt/id e}]))))))))
+  (t/testing "YAML with multiple dots in the filename"
+    (t/is (= (io/file xtdb-cli-yaml-multi-dot)
+             (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml-multi-dot))]))))
+
+  (t/testing "EDN with multiple dots in the filename"
+    (t/is (= {:xtdb.cli-test/foo {:bar {}}}
+             (->node-opts ["-f" (str (io/as-file xtdb-cli-edn-multi-dot))]))))
+
+  (t/testing "YAML with multiple dots in the filename starts node"
+    (with-open [node (xtn/start-node (->node-opts ["-f" (str (io/as-file xtdb-cli-yaml-multi-dot))]))]
+      (let [^LiveIndex live-idx (.getLiveIndex (db/primary-db node))]
+        (t/is (= 65 (.log-limit live-idx))
+              "using provided config"))
+      (xt/submit-tx node [[:put-docs :docs {:xt/id :foo}]])
+      (t/is (= [{:e :foo}] (xt/q node '(from :docs [{:xt/id e}])))))))


### PR DESCRIPTION
(like git et al) so that we're not trying to do the whole thing with flags. pre-req for #4680 so that we can add a reset-compactor task.

Below copied from new docs.

Breaking change: for anyone who was starting up compact-only nodes, or playgrounds via the CLI - default behaviour (start node) remains unchanged.

---

You can run various tools by passing arguments - either directly to the CLI or via Docker's arguments:

* `node` (default, can be omitted)

  * `-f <file>`, `--file <file>`: specifies the configuration file to use.

* `compactor`: starts a compactor-only node - useful for giving the compaction process more compute resources.
   * `-f <file>`, `--file <file>`: specifies the configuration file to use.
* `playground`: starts a playground - an in-memory server that will accept any database name, creating it if required.
   * `-p <port>`, `--port <port>` (default 5432): specifies the port to run the playground server on.

e.g.

* Dockerfile: `CMD ["playground", "--port", "5439"]`
* docker-compose: `command: ["playground", "--port", "5439"]`
* Java uberjar: `java -jar xtdb.jar playground --port 5439`
* Clojure (with `xtdb-core` in your `deps.edn`): `clj -M xtdb.main playground --port 5439`

You can also pass `--help` to any of the commands to get command-specific help.