### PR TITLE
Open addressed build map

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -169,7 +169,8 @@
                                (dotimes [build-idx (.getRowCount build-rel)]
                                  (when (and pushdown-iids (= (name build-col-name) "_iid"))
                                    (.add pushdown-iids (.getBytes build-col build-idx)))
-                                 (.add pushdown-bloom ^ints (BloomUtils/bloomHashes build-col build-idx))))))))))
+                                 (.add pushdown-bloom ^ints (BloomUtils/bloomHashes build-col build-idx)))))))))
+  (.build build-side))
 
 (defn- join-rels [^JoinType join-type, ^RelationReader build-rel, ^RelationReader probe-rel, [^ints build-sel, ^ints probe-sel]]
   (let [selected-build-rel (.select build-rel build-sel)
@@ -315,7 +316,7 @@
                                        with-nil-row? types/->nullable-field)))))]
     (BuildSide. allocator schema (map str key-col-names)
                 (when matched-build-idxs? (RoaringBitmap.))
-                (boolean with-nil-row?) )))
+                (boolean with-nil-row?))))
 
 (defn ->probe-side [build-side {:keys [build-fields probe-fields key-col-names theta-expr param-fields args with-nil-row?]}]
   (let [param-types (update-vals param-fields types/field->col-type)]

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -79,6 +79,7 @@
       (.forEachRemaining right-cursor
                          (fn [^RelationReader in-rel]
                            (.append build-side in-rel)))
+      (.build build-side)
       (set! (.build-phase-ran? this) true))
 
 

--- a/core/src/main/kotlin/xtdb/arrow/Buffers.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Buffers.kt
@@ -18,6 +18,7 @@ internal val NULL_CHECKS =
 internal class ExtensibleBuffer(private val allocator: BufferAllocator, private var buf: ArrowBuf) : AutoCloseable {
 
     constructor(allocator: BufferAllocator) : this(allocator, allocator.empty)
+    constructor(allocator: BufferAllocator, initialSize: Long) : this(allocator, allocator.buffer(initialSize))
 
     private fun newCapacity(currentCapacity: Long, targetCapacity: Long): Long {
         var newCapacity = max(currentCapacity, 128)
@@ -79,6 +80,8 @@ internal class ExtensibleBuffer(private val allocator: BufferAllocator, private 
     }
 
     fun getInt(idx: Int) = buf.getInt((idx * Int.SIZE_BYTES).toLong())
+
+    operator fun set(idx: Int, v: Int) = buf.setInt(idx.toLong() * Int.SIZE_BYTES, v)
 
     fun writeInt(value: Int) {
         ensureWritable(Int.SIZE_BYTES.toLong())

--- a/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
@@ -37,6 +37,7 @@ sealed class FixedWidthVector : Vector() {
         writeUndefined()
     }
 
+    protected fun setNotNull(idx: Int) = validityBuffer.setBit(idx, 1)
     protected fun writeNotNull() = validityBuffer.writeBit(valueCount++, 1)
 
     protected fun getByte0(idx: Int) =
@@ -60,6 +61,11 @@ sealed class FixedWidthVector : Vector() {
     protected fun getInt0(idx: Int) =
         if (NULL_CHECKS && isNull(idx)) throw NullPointerException("null at index $idx")
         else dataBuffer.getInt(idx)
+
+    operator fun set(idx: Int, v: Int) {
+        setNotNull(idx)
+        dataBuffer[idx] = v
+    }
 
     protected fun writeInt0(value: Int) {
         dataBuffer.writeInt(value)

--- a/core/src/main/kotlin/xtdb/arrow/IntVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/IntVector.kt
@@ -17,8 +17,18 @@ class IntVector private constructor(
     override val type: ArrowType = I32
     override val byteWidth = Int.SIZE_BYTES
 
-    constructor(al: BufferAllocator, name: String, nullable: Boolean)
-            : this(name, nullable, 0, ExtensibleBuffer(al), ExtensibleBuffer(al))
+    companion object {
+        private fun openBuffer(al: BufferAllocator, valueCount: Int) =
+            ExtensibleBuffer(al, valueCount.toLong() * Int.SIZE_BYTES).also { it.clear() }
+    }
+
+    @JvmOverloads
+    constructor(
+        al: BufferAllocator, name: String, nullable: Boolean, valueCount: Int = 0
+    ) : this(
+        name, nullable, valueCount,
+        openBuffer(al, valueCount), openBuffer(al, valueCount)
+    )
 
     override fun getInt(idx: Int) = getInt0(idx)
     override fun writeInt(v: Int) = writeInt0(v)

--- a/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
@@ -16,25 +16,18 @@ internal const val NULL_ROW_IDX = 0
 
 class BuildSide @JvmOverloads constructor(
     val al: BufferAllocator, val schema: Schema, val keyColNames: List<String>, val matchedBuildIdxs: RoaringBitmap?,
-    withNilRow: Boolean, pageLimit: Int = 64, levelBits: Int = 4
+    private val withNilRow: Boolean, pageLimit: Int = 64, levelBits: Int = 4
 ) : AutoCloseable {
     private val relWriter = OldRelationWriter(al, schema)
 
     private val hashColumn: IntVector = IntVector(al, "xt/join-hash", false)
 
-    var buildHashTrie: MutableMemoryHashTrie
-        private set
+    var buildMap: BuildSideMap? = null
 
     init {
         if (withNilRow) {
             relWriter.endRow()
-            hashColumn.writeInt(0)
         }
-
-        buildHashTrie =
-            MutableMemoryHashTrie.builder(hashColumn.asReader)
-                .setPageLimit(pageLimit).setLevelBits(levelBits)
-                .build()
     }
 
     @Suppress("NAME_SHADOWING")
@@ -45,16 +38,14 @@ class BuildSide @JvmOverloads constructor(
         val rowCopier = relWriter.rowCopier(inRel)
 
         repeat(inRel.rowCount) { inIdx ->
-            // outIndex and used index for hashColumn should be identical
-            val outIdxHashColumn = hashColumn.valueCount
             hashColumn.writeInt(hasher.hashCode(inIdx))
-            buildHashTrie += outIdxHashColumn
-
-            val outIdx = rowCopier.copyRow(inIdx)
-            assert(outIdx == outIdxHashColumn) {
-                "Expected outIdx $outIdx to match hashColumn valueCount $outIdxHashColumn"
-            }
+            rowCopier.copyRow(inIdx)
         }
+    }
+
+    fun build() {
+        buildMap?.close()
+        buildMap = BuildSideMap.from(al, hashColumn, if (withNilRow) 1 else 0)
     }
 
     val builtRel get() = relWriter.asReader
@@ -62,11 +53,13 @@ class BuildSide @JvmOverloads constructor(
     fun addMatch(idx: Int) = matchedBuildIdxs?.add(idx)
 
     fun indexOf(hashCode: Int, cmp: IntUnaryOperator, removeOnMatch: Boolean): Int =
-        buildHashTrie.findValue(hashCode, cmp, removeOnMatch)
+        requireNotNull(buildMap).findValue(hashCode, cmp, removeOnMatch)
 
-    fun forEachMatch(hashCode: Int, c: IntConsumer) = buildHashTrie.forEachMatch(hashCode, c)
+    fun forEachMatch(hashCode: Int, c: IntConsumer) =
+        requireNotNull(buildMap).forEachMatch(hashCode, c)
 
     override fun close() {
+        buildMap?.close()
         relWriter.close()
         hashColumn.close()
     }

--- a/core/src/main/kotlin/xtdb/operator/join/BuildSideMap.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSideMap.kt
@@ -1,0 +1,89 @@
+package xtdb.operator.join
+
+import org.apache.arrow.memory.BufferAllocator
+import org.roaringbitmap.RoaringBitmap
+import xtdb.arrow.IntVector
+import xtdb.util.closeOnCatch
+import java.util.function.IntConsumer
+import java.util.function.IntUnaryOperator
+
+private const val DEFAULT_LOAD_FACTOR = 0.6
+
+class BuildSideMap private constructor(
+    private val srcIdxs: IntVector,
+    private val srcHashes: IntVector,
+    private val hashMask: Int,
+) : AutoCloseable {
+
+    var tombstones: RoaringBitmap? = null
+
+    fun findValue(hash: Int, cmp: IntUnaryOperator, removeOnMatch: Boolean): Int {
+        var lookupIdx = hash and hashMask
+
+        while (true) {
+            if (srcIdxs.isNull(lookupIdx)) return -1
+            val idx = srcIdxs.getInt(lookupIdx)
+            if ((tombstones == null || !tombstones!!.contains(idx)) && srcHashes.getInt(lookupIdx) == hash && cmp.applyAsInt(idx) == 1) {
+                if (removeOnMatch) {
+                    if (tombstones == null) tombstones = RoaringBitmap()
+                    tombstones!!.add(idx)
+                }
+                return idx
+            }
+            lookupIdx = lookupIdx.inc() and hashMask
+        }
+    }
+
+    fun forEachMatch(hash: Int, c: IntConsumer) {
+        var lookupIdx = hash and hashMask
+
+        while (true) {
+            if (srcIdxs.isNull(lookupIdx)) return
+            if (srcHashes.getInt(lookupIdx) == hash) c.accept(srcIdxs.getInt(lookupIdx))
+            lookupIdx = lookupIdx.inc() and hashMask
+        }
+    }
+
+    override fun close() {
+        srcHashes.close()
+        srcIdxs.close()
+    }
+
+    companion object {
+        internal fun hashBits(rowCount: Int, loadFactor: Double = DEFAULT_LOAD_FACTOR) =
+            Long.SIZE_BITS - (rowCount / loadFactor).toLong().countLeadingZeroBits()
+
+        internal fun IntVector.insertionIdx(maskedHash: Int, hashMask: Int): Int {
+            var insertionIdx = maskedHash
+
+            while (true) {
+                if (isNull(insertionIdx)) return insertionIdx
+                insertionIdx = insertionIdx.inc() and hashMask
+            }
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun from(al: BufferAllocator, hashCol: IntVector, offset: Int = 0, loadFactor: Double = DEFAULT_LOAD_FACTOR): BuildSideMap {
+
+            val rowCount = hashCol.valueCount
+
+            val hashBits = hashBits(rowCount, loadFactor)
+            val mapSize = 1 shl hashBits
+            val hashMask = mapSize - 1
+
+            return IntVector(al, "src-idxs", true, mapSize).closeOnCatch { srcIdxs ->
+                IntVector(al, "src-hashes", true, mapSize).closeOnCatch { srcHashes ->
+                    repeat(rowCount) { idx ->
+                        val hash = hashCol.getInt(idx)
+                        val insertionIdx = srcIdxs.insertionIdx(hash and hashMask, hashMask)
+                        srcIdxs[insertionIdx] = idx + offset
+                        srcHashes[insertionIdx] = hash
+                    }
+
+                    BuildSideMap(srcIdxs, srcHashes, hashMask)
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/operator/join/BuildSideMapTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/join/BuildSideMapTest.kt
@@ -1,0 +1,208 @@
+package xtdb.operator.join
+
+import org.apache.arrow.memory.BufferAllocator
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import xtdb.arrow.IntVector
+import xtdb.operator.join.BuildSideMap.Companion.hashBits
+import xtdb.test.AllocatorResolver
+
+@ExtendWith(AllocatorResolver::class)
+class BuildSideMapTest {
+
+    @Test
+    fun testHashBits() {
+        assertEquals(0, hashBits(0))
+        assertEquals(1, hashBits(1))
+        assertEquals(6, hashBits(20))
+        assertEquals(8, hashBits(100))
+        assertEquals(15, hashBits(10000))
+        assertEquals(32, hashBits(Int.MAX_VALUE))
+    }
+
+    private fun BuildSideMap.getMatches(hash: Int): List<Int> {
+        val matches = mutableListOf<Int>()
+        forEachMatch(hash) { matches.add(it) }
+        return matches
+    }
+
+    @Test
+    fun testBasicPutAndGet(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(100)
+            hashCol.writeInt(200)
+            hashCol.writeInt(300)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(100))
+                assertEquals(listOf(1), map.getMatches(200))
+                assertEquals(listOf(2), map.getMatches(300))
+            }
+        }
+    }
+
+    @Test
+    fun testNonExistentHash(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(100)
+            hashCol.writeInt(200)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertTrue(map.getMatches(999).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testCollisionHandling(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            val sameHash = 12345
+            hashCol.writeInt(sameHash)
+            hashCol.writeInt(sameHash)
+            hashCol.writeInt(sameHash)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0, 1, 2), map.getMatches(sameHash).sorted())
+            }
+        }
+    }
+
+    @Test
+    fun testEmptyMap(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertTrue(map.getMatches(100).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testSingleElement(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(42)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(42))
+                assertTrue(map.getMatches(99).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testLargeDataset(al: BufferAllocator) {
+        val size = 1000
+        IntVector(al, "hashes", false).use { hashCol ->
+            repeat(size) { i -> hashCol.writeInt(i * 7) }
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(50), map.getMatches(350))
+                assertEquals(listOf(100), map.getMatches(700))
+                assertTrue(map.getMatches(1).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testQuadraticProbing(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            repeat(20) { i -> hashCol.writeInt(i) }
+            
+            BuildSideMap.from(al, hashCol, 0, 0.5).use { map ->
+                repeat(20) { i ->
+                    assertEquals(listOf(i), map.getMatches(i), "Failed to find element $i")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testZeroHash(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(0)
+            hashCol.writeInt(100)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(0))
+            }
+        }
+    }
+
+    @Test
+    fun testNegativeHashes(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(-100)
+            hashCol.writeInt(-200)
+            hashCol.writeInt(Int.MIN_VALUE)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(-100))
+                assertEquals(listOf(1), map.getMatches(-200))
+                assertEquals(listOf(2), map.getMatches(Int.MIN_VALUE))
+            }
+        }
+    }
+
+    @Test
+    fun testMaxIntHash(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(Int.MAX_VALUE)
+            hashCol.writeInt(Int.MAX_VALUE - 1)
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(Int.MAX_VALUE))
+                assertEquals(listOf(1), map.getMatches(Int.MAX_VALUE - 1))
+            }
+        }
+    }
+
+    @Test
+    fun testMixedCollisionsAndUniqueHashes(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(1000)  // unique
+            hashCol.writeInt(2000)  // collision group
+            hashCol.writeInt(2000)  // collision group
+            hashCol.writeInt(3000)  // unique
+            hashCol.writeInt(2000)  // collision group
+            
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0), map.getMatches(1000))
+                assertEquals(listOf(1, 2, 4), map.getMatches(2000).sorted())
+                assertEquals(listOf(3), map.getMatches(3000))
+                assertTrue(map.getMatches(9999).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun testFindValueAndRemoveOnMatch(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(1000)  // unique
+            hashCol.writeInt(2000)  // collision group
+            hashCol.writeInt(2000)  // collision group
+            hashCol.writeInt(3000)  // unique
+            hashCol.writeInt(2000)  // collision group
+
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(0, map.findValue(1000, {_ -> 1}, false))
+                assertEquals(2, map.findValue(2000, {idx -> if (idx == 2) 1 else -1}, true))
+                assertEquals(-1, map.findValue(2000, {idx -> if (idx == 2) 1 else -1}, true))
+                assertEquals(1, map.findValue(2000, {idx -> if (idx == 1) 1 else -1}, true))
+                assertEquals(4, map.findValue(2000, {idx -> if (idx == 4) 1 else -1}, true))
+                assertEquals(3, map.findValue(3000, {idx -> if (idx == 3) 1 else -1}, true))
+            }
+        }
+    }
+
+    @Test
+    fun testQuadraticProbingCycles(al: BufferAllocator) {
+        IntVector(al, "hashes", false).use { hashCol ->
+            hashCol.writeInt(0)
+            hashCol.writeInt(0)
+
+            BuildSideMap.from(al, hashCol).use { map ->
+                assertEquals(listOf(0, 1), map.getMatches(0))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This switches out the `MutableMemoryHashTrie` on the BuildSide with an open-addressed HashMap (`BuildSideMap`) implementation with underlying Arrow vectors. Preparing work for https://github.com/xtdb/xtdb/issues/4592. 

~Currently too slow which I suspect might be due to to the probing strategy (simple linear probing for now) and the subsequent clustering problems. I need to investigate if that is the case and then might go back to more complex probing or better hashing strategies.~

I addressed this in [224699a](https://github.com/xtdb/xtdb/pull/4710/commits/224699a2aecb16861e1fb7f07c4e1ee5424d9b5b) . The commits adds a skipping functionality so that if hashes clash during initialization it is not taking $O(n^2)$ (n being the number of collision hashes here) when adding the hashes.  