### PR TITLE
Autoscaling in azure benchmark cluster

### DIFF
--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -83,19 +83,23 @@ module "aks" {
 
   # Default/System node pool config
   agents_size               = var.aks_system_pool_vm_size
-  agents_count              = var.aks_system_pool_node_count
+  agents_max_count          = var.aks_system_pool_node_max_count
+  agents_min_count          = var.aks_system_pool_node_min_count
   agents_availability_zones = var.aks_system_pool_availability_zones
+  enable_auto_scaling       = true
 
   # Node pools
   node_pools = {
     application = {
-      name              = "xtdbpool"
-      mode              = "User"
-      vm_size           = var.aks_application_pool_vm_size
-      node_count        = var.aks_application_pool_node_count
-      zones             = var.aks_application_pool_availability_zones
-      os_disk_type      = var.aks_application_pool_os_disk_type
-      os_disk_size_gb   = var.aks_application_pool_os_disk_size_gb
+      name                = "xtdbpool"
+      mode                = "User"
+      vm_size             = var.aks_application_pool_vm_size
+      max_count           = var.aks_application_pool_node_max_count
+      min_count           = var.aks_application_pool_node_min_count
+      zones               = var.aks_application_pool_availability_zones
+      os_disk_type        = var.aks_application_pool_os_disk_type
+      os_disk_size_gb     = var.aks_application_pool_os_disk_size_gb
+      enable_auto_scaling = true
       node_labels = {
         "node_pool" = "xtdbpool"
       }

--- a/azure/terraform/terraform.tfvars
+++ b/azure/terraform/terraform.tfvars
@@ -13,12 +13,14 @@ aks_cluster_name = "xtdb-aks-cluster"
 
 ## System Pool Config
 aks_system_pool_vm_size            = "Standard_D2pds_v6"
-aks_system_pool_node_count         = 2
+aks_system_pool_node_max_count     = 2
+aks_system_pool_node_min_count     = 2
 aks_system_pool_availability_zones = ["1", "2"]
 
 ## Application Pool Config
 aks_application_pool_vm_size            = "Standard_D4pds_v6"
-aks_application_pool_node_count         = 3
+aks_application_pool_node_max_count     = 3
+aks_application_pool_node_min_count     = 3
 aks_application_pool_availability_zones = ["1", "2", "3"]
 aks_application_pool_os_disk_type       = "Ephemeral"
 aks_application_pool_os_disk_size_gb    = 220

--- a/azure/terraform/variables.tf
+++ b/azure/terraform/variables.tf
@@ -46,8 +46,14 @@ variable "aks_system_pool_vm_size" {
   default     = "Standard_D2pds_v6"
 }
 
-variable "aks_system_pool_node_count" {
-  description = "Number of nodes in the XTDB AKS system node pool"
+variable "aks_system_pool_node_max_count" {
+  description = "Maximum number of nodes in the XTDB AKS system node pool"
+  type        = number
+  default     = 2
+}
+
+variable "aks_system_pool_node_min_count" {
+  description = "Minimum number of nodes in the XTDB AKS system node pool"
   type        = number
   default     = 2
 }
@@ -66,6 +72,18 @@ variable "aks_application_pool_vm_size" {
 
 variable "aks_application_pool_node_count" {
   description = "Number of nodes in the XTDB AKS application node pool"
+  type        = number
+  default     = 3
+}
+
+variable "aks_application_pool_node_max_count" {
+  description = "Maximum number of nodes in the XTDB AKS application node pool"
+  type        = number
+  default     = 3
+}
+
+variable "aks_application_pool_node_min_count" {
+  description = "Minimum number of nodes in the XTDB AKS application node pool"
   type        = number
   default     = 3
 }

--- a/modules/bench/cloud/azure/main.tf
+++ b/modules/bench/cloud/azure/main.tf
@@ -42,12 +42,14 @@ module "xtdb_azure_bench" {
 
   ## System Pool Config
   aks_system_pool_vm_size            = "Standard_D2pds_v6"
-  aks_system_pool_node_count         = 2
+  aks_system_pool_node_max_count     = 2
+  aks_system_pool_node_min_count     = 1
   aks_system_pool_availability_zones = ["1", "2"]
 
   ## Application Pool Config
   aks_application_pool_vm_size            = "Standard_D4pds_v6"
-  aks_application_pool_node_count         = 3
+  aks_application_pool_node_max_count     = 3
+  aks_application_pool_node_min_count     = 0
   aks_application_pool_availability_zones = ["1", "2", "3"]
   aks_application_pool_os_disk_type       = "Ephemeral"
   aks_application_pool_os_disk_size_gb    = 220


### PR DESCRIPTION
I've checked the autoscaling behaviour on AKS and looks to be what we expect i.e. scale to max when in high use (auctionmark multiple nodes) and scale down following although not immediately to 0, I haven't seen it fall below 1 after an hour.

Closes #4706.