### PR TITLE
Retire kotlin-stdlib-jdk8

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     api(libs.arrow.vector)
     api(libs.arrow.memory.netty)
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     api(libs.kotlinx.serialization.json)
     
     api(libs.protobuf.kotlin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -429,7 +429,7 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit5"))
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     api(libs.micrometer.core)
     api(libs.micrometer.registry.prometheus)
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     api(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
     api(libs.kaml)

--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
     api(libs.transit.clj)
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     implementation(kotlin("reflect"))
     implementation(libs.kotlinx.serialization.json)
 

--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     api("software.amazon.awssdk", "cloudwatch", "2.25.50")
     api("software.amazon.awssdk", "sts", "2.25.50")
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     api(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     // metrics
     api(libs.micrometer.registry.azuremonitor)
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     api(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/modules/flight-sql/build.gradle.kts
+++ b/modules/flight-sql/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api("org.apache.arrow", "arrow-vector", "15.0.2")
     api("org.apache.arrow", "flight-sql", "15.0.2")
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
 
     testImplementation(project(":"))
 

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     api("com.google.guava","guava","32.1.1-jre")
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     api(libs.kotlinx.coroutines)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/modules/kafka-connect/build.gradle.kts
+++ b/modules/kafka-connect/build.gradle.kts
@@ -18,7 +18,7 @@ java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 dependencies {
     api(project(":xtdb-api"))
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     implementation("org.apache.kafka:connect-api:4.0.0")
 
     api(libs.clojure.tools.logging)

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
     api("org.apache.kafka", "kafka-clients", "4.0.0")
 
-    api(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib"))
     testImplementation(libs.mockk)
 
     implementation(libs.kotlinx.coroutines)


### PR DESCRIPTION
While looking into dependencies, I have incidentally seen that kotlin-stdlib-jdk8 is deprecated, we should use kotlin-stdlib instead. See https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target