### PR TITLE
Initial property testing work - generators, gradle task and some block boundary tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,6 +160,7 @@ allprojects {
             testImplementation(libs.testcontainers.kafka)
             testImplementation(libs.testcontainers.keycloak)
             testImplementation(libs.testcontainers.minio)
+            testImplementation(libs.clojure.test.check)
         }
 
         if (plugins.hasPlugin("dev.clojurephant.clojure")) {
@@ -419,7 +420,6 @@ dependencies {
     testImplementation("metosin", "jsonista", "0.3.3")
     testImplementation("clj-commons", "clj-yaml", "1.0.27")
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.3.0")
-    testImplementation("org.clojure", "test.check", "1.1.1")
     testImplementation("clj-kondo", "clj-kondo", "2023.12.15")
     testImplementation("com.github.igrishaev", "pg2-core", "0.1.33")
     testImplementation(libs.hato)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,7 +121,7 @@ allprojects {
             // To stub an AWS region
             environment("AWS_REGION", "eu-west-1")
             useJUnitPlatform {
-                excludeTags("integration", "jdbc", "timescale", "s3", "minio", "slt", "docker", "azure", "google-cloud")
+                excludeTags("integration", "property", "jdbc", "timescale", "s3", "minio", "slt", "docker", "azure", "google-cloud")
             }
 
             /*
@@ -144,6 +144,17 @@ allprojects {
             jvmArgs(defaultJvmArgs + sixGBJvmArgs)
             useJUnitPlatform {
                 includeTags("s3", "google-cloud", "azure")
+            }
+        }
+
+        tasks.register("property-test", Test::class) {
+            jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+            
+            val iterations = project.findProperty("iterations")?.toString() ?: "100"
+            systemProperty("xtdb.property-test-iterations", iterations)
+            
+            useJUnitPlatform {
+                includeTags("property")
             }
         }
 

--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -57,6 +57,9 @@ This is particularly useful for non-JVM testing - see the `/lang` README for mor
 == Testing
 
 * Test all with `./gradlew test`; `./gradlew integration-test` for longer tests
+* Property-based testing with `./gradlew property-test`
+** Run with custom iterations: `./gradlew property-test -Piterations=500` (defaults to 100)
+** Uses test.check generators to test with randomized data including composite types
 * Some tests have external dependencies which require `docker-compose`:
 ** `docker-compose up` (`docker-compose up <kafka>` etc for individual containers),
 ** `./gradlew kafka-test`

--- a/src/main/clojure/xtdb/test_generators.clj
+++ b/src/main/clojure/xtdb/test_generators.clj
@@ -1,0 +1,122 @@
+(ns xtdb.test-generators
+  (:require [clojure.string :as str]
+            [clojure.test.check.generators :as gen])
+  (:import [java.math BigDecimal]
+           [java.net URI]
+           [java.nio ByteBuffer]))
+
+;; Simple types
+;; TODO: Ensure all arrow types are covered here
+(def nil-gen (gen/return nil))
+(def bool-gen gen/boolean)
+(def i8-gen gen/byte)
+(def i16-gen (gen/let [v (gen/choose Short/MIN_VALUE Short/MAX_VALUE)] (short v)))
+(def i32-gen (gen/let [v (gen/choose Integer/MAX_VALUE Integer/MAX_VALUE)] (int v)))
+(def i64-gen (gen/choose Long/MIN_VALUE Long/MAX_VALUE))
+(def f64-gen gen/double)
+(def decimal-gen
+  (gen/let [^double v (gen/double* {:infinite? false :NaN? false})]
+    (BigDecimal/valueOf v)))
+
+(def utf8-gen gen/string)
+(def varbinary-gen (gen/let [bs gen/bytes] (ByteBuffer/wrap bs)))
+(def keyword-gen (gen/one-of [gen/keyword gen/keyword-ns]))
+(def uuid-gen gen/uuid)
+(def uri-gen (gen/let [s gen/string-alphanumeric] (URI/create s)))
+
+(def instant-gen
+  (gen/fmap #(java.time.Instant/ofEpochSecond %)
+            (gen/choose 0 2147483647)))
+
+(def local-date-gen
+  (gen/fmap java.time.LocalDate/ofEpochDay
+            (gen/choose 0 50000)))
+
+(def local-time-gen
+  (gen/fmap java.time.LocalTime/ofSecondOfDay
+            (gen/choose 0 86399)))
+
+(def local-datetime-gen
+  (gen/let [date local-date-gen
+            time local-time-gen]
+    (java.time.LocalDateTime/of date time)))
+
+(def offset-datetime-gen
+  (gen/let [ldt local-datetime-gen
+            offset-hours (gen/choose -12 12)]
+    (java.time.OffsetDateTime/of ldt (java.time.ZoneOffset/ofHours offset-hours))))
+
+(def zoned-datetime-gen
+  (gen/let [ldt local-datetime-gen]
+    (java.time.ZonedDateTime/of ldt (java.time.ZoneId/of "UTC"))))
+
+(def duration-gen (gen/return #xt/duration "PT1S"))
+(def interval-gen (gen/return #xt/interval "P1YT1S"))
+
+(def simple-gen
+  (gen/one-of [nil-gen bool-gen
+               i8-gen i16-gen i32-gen i64-gen
+               f64-gen decimal-gen
+               utf8-gen varbinary-gen
+               keyword-gen uuid-gen uri-gen
+               instant-gen local-date-gen local-time-gen
+               local-datetime-gen offset-datetime-gen zoned-datetime-gen
+               duration-gen interval-gen]))
+
+;; Composite Types
+(def list-gen
+  (fn [element-gen] (gen/vector element-gen 1 10)))
+
+(def safe-keyword-gen
+  (gen/let [s (gen/such-that #(not (str/blank? %)) gen/string-alphanumeric 100)]
+    (keyword (str/lower-case s))))
+
+(def struct-gen
+  (fn [value-gen]
+    (gen/let [num-keys (gen/choose 1 10)
+              keys (gen/vector-distinct-by #(str/lower-case (name %)) safe-keyword-gen {:num-elements num-keys})
+              values (gen/vector value-gen num-keys)]
+      (->> (zipmap keys values)
+           (filter val)
+           (into {})))))
+
+(def set-gen
+  (fn [element-gen] (gen/set element-gen {:min-elements 0 :max-elements 10})))
+
+(def union-gen
+  (fn [& generators] (gen/one-of generators)))
+
+(def value-gen
+  (gen/frequency
+   [[8 simple-gen]
+    [2 (list-gen simple-gen)]
+    [2 (struct-gen simple-gen)]
+    [1 (set-gen simple-gen)]
+    [1 (union-gen simple-gen)]]))
+
+(def recursive-value-gen
+  (gen/recursive-gen
+   (fn [inner-gen]
+     (gen/frequency
+      [[8 simple-gen]
+       [2 (list-gen inner-gen)]
+       [2 (struct-gen inner-gen)]
+       [1 (set-gen inner-gen)]
+       [1 (union-gen inner-gen simple-gen)]]))
+   simple-gen))
+
+;; TODO: Generating simple keys here for now, trying to ensure some overlap between records
+(defn generate-record
+  ([]
+   (generate-record {}))
+  ([{:keys [potential-doc-ids]}]
+   (gen/let [id (if potential-doc-ids
+                  (gen/elements potential-doc-ids)
+                  (gen/one-of [i64-gen safe-keyword-gen uuid-gen]))
+             num-fields (gen/choose 1 5)
+             field-keys (gen/vector-distinct
+                         (gen/elements [:a :b :c :d :e :f :g :h :i :j])
+                         {:num-elements num-fields})
+             field-values (gen/vector recursive-value-gen num-fields)]
+     (-> (zipmap field-keys field-values)
+         (assoc :xt/id id)))))

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -1,6 +1,8 @@
 (ns xtdb.test-util
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.pprint :as pprint]
+            [clojure.spec.alpha :as s]
             [clojure.test :as t]
+            [clojure.test.check :as tc]
             [cognitect.anomalies :as-alias anom]
             [xtdb.api :as xt]
             [xtdb.db-catalog :as db]
@@ -374,3 +376,15 @@
       (f c)
       (finally
         (.stop c)))))
+
+(def property-test-iterations
+  (Integer/parseInt (System/getProperty "xtdb.property-test-iterations" "100")))
+
+(defn run-property-test
+  "Takes opts map as first argument which is passed to quick-check (e.g. {:seed 42, :num-tests 100})"
+  ([property]
+   (run-property-test {} property))
+  ([opts property]
+   (let [opts (merge {:num-tests property-test-iterations} opts)
+         result (tc/quick-check (:num-tests opts) property (dissoc opts :num-tests))]
+     (t/is (:pass? result) (with-out-str (pprint/pprint result))))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -1,6 +1,8 @@
 (ns xtdb.node-test
   (:require [clojure.java.io :as io]
-            [clojure.test :as t :refer [deftest]]
+            [clojure.test :as t :refer [deftest]] 
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
             [xtdb.basis :as basis]
@@ -15,6 +17,7 @@
             [xtdb.object-store :as os]
             [xtdb.protocols :as xtp]
             [xtdb.serde :as serde]
+            [xtdb.test-generators :as tg]
             [xtdb.test-util :as tu]
             [xtdb.time :as time]
             [xtdb.util :as util])
@@ -1196,3 +1199,81 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
   (t/is (= [{:xt/id 1, :a 3} {:xt/id 2} {:xt/id 3, :a 4} {:xt/id 4, :a "hello"}]
            (xt/q tu/*node* "SELECT * FROM docs ORDER BY _id"))))
+
+(t/deftest ^:property block-boundary-consistency-flush
+  (tu/run-property-test
+   {:num-tests tu/property-test-iterations}
+   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
+                 (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock)}]}}
+                                                   :compactor {:threads 0}})]
+                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                   (tu/flush-block! node)
+
+                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                   (tu/flush-block! node)
+
+                   (and (t/testing "two transactions recorded"
+                          (= 2 (count (xt/q node "FROM xt.txs"))))
+                        (t/testing "all expected document IDs present"
+                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
+                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                            (= expected-ids (into #{} (map :xt/id res))))))))))
+
+(t/deftest ^:property block-boundary-consistency-flush+compact
+  (tu/run-property-test
+   {:num-tests tu/property-test-iterations}
+   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
+                 (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock)}]}}
+                                                   :compactor {:threads 0}})]
+                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                   (tu/flush-block! node)
+
+                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                   (tu/flush-block! node)
+
+                   (c/compact-all! node #xt/duration "PT1S")
+
+                   (and (t/testing "two transactions recorded"
+                          (= 2 (count (xt/q node "FROM xt.txs"))))
+                        (t/testing "all expected document IDs present"
+                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
+                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                            (= expected-ids (into #{} (map :xt/id res))))))))))
+
+(t/deftest ^:property block-boundary-consistency-flush+live
+  (tu/run-property-test
+   {:num-tests tu/property-test-iterations}
+   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
+                 (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock)}]}}
+                                                   :compactor {:threads 0}})]
+                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                   (tu/flush-block! node)
+
+                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+
+                   (and (t/testing "two transactions recorded"
+                          (= 2 (count (xt/q node "FROM xt.txs"))))
+                        (t/testing "all expected document IDs present"
+                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
+                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                            (= expected-ids (into #{} (map :xt/id res))))))))))
+
+(t/deftest ^:property block-boundary-consistency-live
+  (tu/run-property-test
+   {:num-tests tu/property-test-iterations}
+   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
+                 (with-open [node (xtn/start-node {:databases {:xtdb {:log [:in-memory {:instant-src (tu/->mock-clock)}]}}
+                                                   :compactor {:threads 0}})]
+                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+
+                   (and (t/testing "two transactions recorded"
+                          (= 2 (count (xt/q node "FROM xt.txs"))))
+                        (t/testing "all expected document IDs present"
+                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
+                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                            (= expected-ids (into #{} (map :xt/id res))))))))))


### PR DESCRIPTION
Resolves #4722 

(Based on some initial pairing work within #4691, and the contents of `arrow_generative_test`)

This PR introduces an early implementation of property-based testing infrastructure for XTDB, with a focus on block boundary behavior and type handling across database operations.

Added within this PR:
- Type Generators
  - Generators for XTDB’s supported "simple" data types (numerical, temporal, etc.)
  - Generators for collections, structs, and onions
  - Recursive generators for nested values
  - Document/record generators with configurable ID sets, ensuring overlapping keys across test runs
  - Safe keyword generation to avoid case-sensitivity conflicts in struct fields
- Some initial plumbing for running property tests: 
  - `run-property-test` utility with configurable iteration counts and reproducible seeds
    - As a note, did attempt to use `defspec` from clojure.test though ran into issues surfacing errors.  
  - Property tests tagged using ^:property metadata
  - New Gradle task for running property tests, supporting configurable iteration counts
- Initial Block Boundary Tests
  - Covering ingestion and query behavior of documents with differing types across block boundaries

Property tests are isolated from unit tests and run via a dedicated Gradle task (similar to `integration-test`):
```
# Default 100 iterations
./gradlew property-test

# Custom iteration count
./gradlew property-test -Piterations=10000
```