### PR TITLE
Add github action for property tests - ran on every build and nightly.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,5 +176,13 @@ jobs:
   #       uses: gradle/actions/setup-gradle@v4
 
   #     - name: SLT 2
-  #       run: ./gradlew slt-test-2
   #       timeout-minutes: 40
+
+  # FIXME #4721
+  # property-test:
+  #   uses: ./.github/workflows/property-test.yml
+  #   with:
+  #     iteration_count: "100"
+  #   permissions:
+  #     contents: read
+  #     checks: write

--- a/.github/workflows/nightly-property-test.yml
+++ b/.github/workflows/nightly-property-test.yml
@@ -1,0 +1,16 @@
+name: XTDB nightly property tests
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron:  '0 19 * * 1-5'
+
+jobs:
+  nightly-property-test:
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'xtdb/xtdb'
+    uses: ./.github/workflows/property-test.yml
+    with:
+      iteration_count: "10000"
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/property-test.yml
+++ b/.github/workflows/property-test.yml
@@ -1,0 +1,49 @@
+name: XTDB Property Tests
+
+on:
+  workflow_call:
+    inputs:
+      iteration_count:
+        description: 'Number of property test iterations to run'
+        required: true
+        type: string
+
+jobs:
+  property-test:
+    name: Property Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Property Test
+        run: ./gradlew property-test -Piterations=${{ inputs.iteration_count }}
+
+      - name: Publish Property Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          check_name: JUnit Property Test Report
+          report_paths: '**/build/test-results/property-test/TEST-*.xml'
+
+      - name: Post Slack Notification (On Fail)
+        if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notification_title: "*Property Test* has {status_message}:"
+          message_format: "{emoji} `property-test` job has {status_message} with ${{ inputs.iteration_count }} iterations"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Resolves #4723 - based on top of #4719

(As a note - this will currently fail both of those, primarily due to #4721) 

- Adds a shared workflow file for running property tests - uses the Junit reporter and reports failures on main into slack.
- Runs this within `build.yml` on every push, and also runs a higher iteration version of this on a nightly basis.  