### PR TITLE
Add github action to bench

### DIFF
--- a/modules/bench/build.gradle.kts
+++ b/modules/bench/build.gradle.kts
@@ -26,8 +26,10 @@ dependencies {
     // bench
     api("com.github.oshi", "oshi-core", "6.3.0")
     api("pro.juxt.clojars-mirrors.hiccup", "hiccup", "2.0.0-alpha2")
+    api("org.testcontainers", "testcontainers", "1.20.1")
 
     api("software.amazon.awssdk", "s3", "2.25.24")
+    api("clj-http", "clj-http", "3.13.1")
 }
 
 

--- a/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
@@ -439,7 +439,7 @@
                                           :or {seed 0, threads 8, sync false
                                                duration "PT30S", scale-factor 0.1}}]
   (let [^Duration duration (cond-> duration (string? duration) Duration/parse)]
-    (log/trace {:scale-factor scale-factor})
+    (log/info {:scale-factor scale-factor :no-load? no-load? :only-load? only-load? :duration duration :seed seed})
     {:title "Auction Mark OLTP"
      :seed seed
      :->state ->initial-state

--- a/modules/bench/src/main/clojure/xtdb/bench/clickbench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/clickbench.clj
@@ -168,6 +168,7 @@
        slurp str/split-lines))
 
 (defmethod b/->benchmark :clickbench [_ {:keys [no-load? limit size], :or {size :small}}]
+  (log/info {:no-load? no-load? :limit limit :size size})
   {:title "Clickbench Hits"
    :tasks [{:t :call, :stage :download
             :f (fn [_]

--- a/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ingest_tx_overhead.clj
@@ -57,6 +57,8 @@
    ["-h" "--help"]])
 
 (defn benchmark [{:keys [seed doc-count batch-sizes], :or {seed 0, doc-count 100000, batch-sizes #{1000 100 10 1}}}]
+  (log/info {:doc-count doc-count :batch-sizes batch-sizes})
+
   {:title "Ingest batch vs individual"
    :seed seed
    :tasks (->> [{:t :call

--- a/modules/bench/src/main/clojure/xtdb/bench/patch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/patch.clj
@@ -67,7 +67,7 @@
 
 (defmethod b/->benchmark :patch [_ {:keys [doc-count patch-count seed no-load?]
                                     :or {doc-count 500000 patch-count 10 seed 0} :as opts}]
-  (log/info {:doc-count doc-count :patch-count patch-count})
+  (log/info {:doc-count doc-count :patch-count patch-count :seed seed})
   
   {:title "PATCH Performance Benchmark"
    :seed seed

--- a/modules/bench/src/main/clojure/xtdb/bench/products.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/products.clj
@@ -40,6 +40,8 @@
    ["-h" "--help"]])
 
 (defmethod b/->benchmark :products [_ {:keys [no-load? limit]}]
+  (log/info {:no-load? no-load? :limit limit})
+
   {:title "Products"
    :tasks [{:t :call, :stage :download
             :f (fn [_]

--- a/modules/bench/src/main/clojure/xtdb/bench/readings.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/readings.clj
@@ -105,6 +105,7 @@
    ["-h" "--help"]])
 
 (defmethod b/->benchmark :readings [_ {:keys [readings devices seed no-load?] :or {seed 0}}]
+  (log/info {:readings readings :devices devices :seed seed :no-load? no-load?})
   {:title "Readings benchmarks"
    :seed seed
    :->state #(do {:!state (atom {})})

--- a/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tpch.clj
@@ -47,7 +47,7 @@
 
 (defmethod b/->benchmark :tpch [_ {:keys [scale-factor seed no-load?],
                                    :or {scale-factor 0.01, seed 0}}]
-  (log/info {:scale-factor scale-factor})
+  (log/info {:scale-factor scale-factor :seed seed :no-load? no-load?})
 
   {:title "TPC-H (OLAP)", :seed seed
    :->state #(do {:!state (atom {})})

--- a/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
@@ -18,6 +18,7 @@
   (bu/download-s3-dataset-file "ts-devices/small/devices_small_device_info.csv.gz" tmp-file))
 
 (defmethod b/->benchmark :ts-devices [_ {:keys [size seed] :or {seed 0}}]
+  (log/info {:size size :seed seed})
   {:title "TS Devices Ingest"
    :seed seed,
    :->state #(do {:!state (atom {})})


### PR DESCRIPTION
Very simply adds a call to GH to invoke the nightly benchmark cleanup job.

Also adds a try catch around the main benchmark run so we can report failures.