### PR TITLE
Add nightly benchmark jobs

### DIFF
--- a/.github/workflows/nightly-benchmark-cleanup.yml
+++ b/.github/workflows/nightly-benchmark-cleanup.yml
@@ -1,0 +1,129 @@
+name: Nightly Benchmark Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchType:
+        description: 'Type of benchmark to clean up'
+        required: true
+        type: choice
+        options:
+          - tpch
+          - auctionmark
+          - readings
+      status:
+        description: 'Status of the benchmark'
+        required: true
+        type: choice
+        options:
+          - success
+          - failure
+      nodeId:
+        description: 'Node ID of the benchmark'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cleanup-benchmarks
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.BENCHMARK_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.BENCHMARK_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.BENCHMARK_AZURE_SUBSCRIPTION_ID }}
+
+      - name: Acquire Kubernetes Configuration
+        run: |
+          az aks get-credentials --resource-group cloud-benchmark-resources --name xtdb-bench-cluster
+
+      - name: Check Deployment
+        id: check-deployment
+        continue-on-error: true
+        run: |
+          # exit 0 if exists, non-zero if not
+          helm status xtdb-benchmark -n cloud-benchmark >/dev/null 2>&1
+
+      - name: Capture Benchmark Logs
+        if: steps.check-deployment.outcome == 'success'
+        id: logs
+        run: |
+          # Wait for job logs with retries
+          max_attempts=12
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            if kubectl logs ${{ inputs.nodeId }} --namespace cloud-benchmark > benchmark.log 2>/dev/null; then
+              if grep -q '"time-taken-ms":' benchmark.log; then
+                time_taken=$(grep -o '"time-taken-ms":[0-9]\+' benchmark.log | tail -1 | cut -d: -f2)
+                echo "time_taken=$time_taken" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            fi
+            echo "Attempt $attempt: Waiting for benchmark logs..."
+            sleep 5
+            attempt=$((attempt + 1))
+          done
+
+      - name: Set Timestamp
+        id: timestamp
+        run: |
+          echo "value=$(date -u +"%Y-%m-%d-%H-%M-%S")" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +"%Y/%m/%d")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Benchmark Logs
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-logs-${{ inputs.benchType }}-${{ steps.timestamp.outputs.value }}-${{ inputs.nodeId }}-${{ inputs.status }}
+          path: benchmark.log
+          retention-days: 7
+
+      - name: Run Cleanup Script
+        if: ${{ always() && steps.check-deployment.outcome == 'success' }}
+        run: |
+          ./modules/bench/cloud/clear-bench.sh azure
+
+      - name: Compose Slack Message
+        id: compose
+        run: |
+          type="${{ inputs.benchType }}"
+          [ "$type" = "tpch" ] && type="TPC-H"
+
+          if [ -n "${{ steps.logs.outputs.time_taken }}" ]; then
+            base="$type Benchmark completed in ${{ steps.logs.outputs.time_taken }}ms"
+          else
+            base="$type Benchmark cleanup"
+          fi
+
+          {
+            echo "msg<<EOF"
+            echo "$base — {status_message}"
+            if [ "${{ steps.upload.outcome }}" = "success" ]; then
+              echo ":link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view logs>"
+            else
+              echo ":link: (log upload failed)"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+
+      - name: Post Slack Notification
+        uses: ravsamhq/notify-slack-action@v2
+        if: steps.check-deployment.outcome == 'success'
+        with:
+          status: ${{ inputs.status }}
+          notification_title: "*${{ (inputs.benchType == 'tpch') && 'TPC-H' || inputs.benchType }} Benchmark*"
+          message_format: ${{ steps.compose.outputs.msg }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.BENCHMARK_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-benchmark-tpch.yml
+++ b/.github/workflows/nightly-benchmark-tpch.yml
@@ -1,0 +1,88 @@
+name: Nightly Benchmark TPC-H
+
+on:
+  workflow_dispatch:
+    inputs:
+      scale_factor:
+        description: 'TPC-H Scale Factor'
+        required: false
+        default: '0.5'
+        type: string
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: nightly-benchmark-tpch
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run Nightly Benchmark TPC-H
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      SCALE_FACTOR: ${{ inputs.scale_factor || '0.5' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.BENCHMARK_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.BENCHMARK_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.BENCHMARK_AZURE_SUBSCRIPTION_ID }}
+
+      - name: Acquire Kubernetes Configuration
+        run: |
+          az aks get-credentials --resource-group cloud-benchmark-resources --name xtdb-bench-cluster
+
+      - name: Check Existing Deployment
+        id: check-deployment
+        continue-on-error: true
+        run: |
+          # exit 0 if exists, non-zero if not
+          helm status xtdb-benchmark -n cloud-benchmark >/dev/null 2>&1
+
+      - name: Run Benchmark
+        if: steps.check-deployment.outcome != 'success'
+        run: |
+          helm dependency update ./modules/bench/cloud/helm
+          helm upgrade --install "xtdb-benchmark" ./modules/bench/cloud/helm \
+            --namespace "cloud-benchmark" \
+            --create-namespace \
+            -f ./modules/bench/cloud/azure/values.yaml \
+            --set "benchType=tpch" \
+            --set "tpch.scaleFactor=${{ env.SCALE_FACTOR }}" \
+            --set "providerConfig.env.GITHUB_PAT=${{ secrets.BENCHMARK_GITHUB_PAT }}" \
+            --set "providerConfig.env.AZURE_USER_MANAGED_IDENTITY_CLIENT_ID=${{ secrets.BENCHMARK_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID }}" \
+            --set "providerConfig.serviceAccountAnnotations.azure\.workload\.identity/client-id=${{ secrets.BENCHMARK_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID }}"
+
+      - name: Compose Slack Message
+        id: compose
+        run: |
+          if [ "${{ steps.check-deployment.outcome }}" = "success" ]; then
+            echo 'msg=:information_source: TPC-H Benchmark skipped — existing deployment found' >> "$GITHUB_OUTPUT"
+          else
+            echo 'msg=TPC-H Benchmark (Scale Factor: ${{ env.SCALE_FACTOR }}) started' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post Slack Notification
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: "*TPC-H Benchmark*"
+          message_format: "${{ steps.compose.outputs.msg }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.BENCHMARK_SLACK_WEBHOOK_URL }}
+
+      - name: Fail if existing deployment
+        if: steps.check-deployment.outcome == 'success'
+        run: |
+          echo "Failing workflow due to existing deployment"
+          exit 1

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -8,14 +8,14 @@ auctionmark:
   threads: 8
   duration: "PT24H"
 
-tpch: 
+tpch:
   scaleFactor: 0.01
 
 readings:
   devices: 10000
   readings: 10000
 
-xtdbConfig: 
+xtdbConfig:
   # Core environment variables
   kafkaBootstrapServers: xtdb-benchmark-kafka.cloud-benchmark.svc.cluster.local:9092
   logTopic: xtdb-log
@@ -31,11 +31,11 @@ providerConfig:
   serviceAccountAnnotations: {}
   nodeSelector: {}
   nodeConfig:
-  
+
 image:
   repository: ghcr.io/xtdb/xtdb-bench
   pullPolicy: Always
-  tag: "sha-8d029ad"
+  tag: "sha-6b5931e"
 
 resources:
   limits:
@@ -58,4 +58,4 @@ kafka:
     persistence:
       size: 50Gi
     resourcesPreset: medium
-      
+


### PR DESCRIPTION
This adds two jobs:
 - Nightly Benchmark TPC-H (which runs nightly at midnight)
   - Gets k8s credentials
   - Runs benchmark with configuration
   - Posts to slack to notify job start with parameters
 - Nightly Benchmark Cleanup (which is invoked via a callback)
   - Gets k8s credentials
   - Checks whether a helm deployment is present exits early if not
   - Captures logs and uploads to azure
   - Messages slack with status of job, time taken ms and a link to the log

