### PR TITLE
Move BuildSide to Disk above IN_MEMORY_THRESHOLD

### DIFF
--- a/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
@@ -1,16 +1,22 @@
 package xtdb.operator.join
 
 import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.ipc.ArrowFileReader
+import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.Schema
 import org.roaringbitmap.RoaringBitmap
-import xtdb.arrow.IntVector
-import xtdb.arrow.RelationReader
-import xtdb.arrow.VectorReader
+import xtdb.arrow.*
 import xtdb.expression.map.IndexHasher
-import xtdb.trie.MutableMemoryHashTrie
+import xtdb.util.openReadableChannel
+import xtdb.util.openWritableChannel
 import xtdb.vector.OldRelationWriter
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.function.IntConsumer
 import java.util.function.IntUnaryOperator
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
 
 internal const val NULL_ROW_IDX = 0
 
@@ -19,17 +25,54 @@ class BuildSide(
     val schema: Schema,
     val keyColNames: List<String>,
     val matchedBuildIdxs: RoaringBitmap?,
-    private val withNilRow: Boolean
+    private val withNilRow: Boolean,
+    private val inMemoryThreshold: Int = 100_000
 ) : AutoCloseable {
-    private val relWriter = OldRelationWriter(al, schema)
 
-    private val hashColumn: IntVector = IntVector(al, "xt/join-hash", false)
+    internal var toDisk: Boolean = false
+    private val diskSchema: Schema =  Schema(schema.fields.plus(HASH_COLUMN_FIELD))
+    private val tmpFile: Path =
+        Files.createTempDirectory("xtdb-build-side-tmp").let { rootPath ->
+            Files.createTempFile(rootPath.createDirectories(), "build-side", ".arrow") }
+
+    private fun internalRelToExternalRel(internalRel: OldRelationWriter) =
+        OldRelationWriter(al, internalRel.vectors.filter { it.name != HASH_COLUMN_NAME }).also { it.rowCount = internalRel.rowCount }
+
+    private fun internalRelToHashColumn(internalRel: OldRelationWriter) = internalRel[HASH_COLUMN_NAME]
+
+    // The reference counting should happen on the internalRel
+    private val internalRel = OldRelationWriter(al, diskSchema)
+    private val externalRel = internalRelToExternalRel(internalRel)
+    private val hashColumn: VectorWriter = internalRelToHashColumn(internalRel)
+    private val unloadChannel = tmpFile.openWritableChannel()
+    private val unloader = ArrowUnloader.open(unloadChannel, diskSchema, ArrowUnloader.Mode.FILE)
 
     var buildMap: BuildSideMap? = null
 
     init {
         if (withNilRow) {
-            relWriter.endRow()
+            hashColumn.writeInt(0)
+            externalRel.endRow()
+            internalRel.rowCount = 1
+        }
+    }
+
+    companion object {
+        const val HASH_COLUMN_NAME = "xt/join-hash"
+        val HASH_COLUMN_FIELD: Field = Field.notNullable(HASH_COLUMN_NAME, Types.MinorType.INT.type)
+    }
+
+    private fun finishBatch() {
+        internalRel.rowCount = externalRel.rowCount
+        if (toDisk) {
+            internalRel.asReader.openDirectSlice(al).use { rel ->
+                rel.openArrowRecordBatch().use { recordBatch ->
+                    unloader.writeBatch(recordBatch)
+                }
+            }
+            hashColumn.clear()
+            externalRel.clear()
+            internalRel.clear()
         }
     }
 
@@ -38,20 +81,45 @@ class BuildSide(
         val inKeyCols = keyColNames.map { inRel.vectorForOrNull(it) as VectorReader }
 
         val hasher = IndexHasher.fromCols(inKeyCols)
-        val rowCopier = relWriter.rowCopier(inRel)
+        val rowCopier = externalRel.rowCopier(inRel)
 
         repeat(inRel.rowCount) { inIdx ->
             hashColumn.writeInt(hasher.hashCode(inIdx))
             rowCopier.copyRow(inIdx)
         }
+
+        if (externalRel.rowCount > inMemoryThreshold) {
+            toDisk = true
+            finishBatch()
+        }
+    }
+
+    private fun readInRels() {
+        if (toDisk) {
+            internalRel.clear()
+            ArrowFileReader(tmpFile.openReadableChannel(), al).use { rdr ->
+                while (rdr.loadNextBatch()) {
+                    val root = rdr.vectorSchemaRoot
+                    RelationReader.from(root).use { inRel ->
+                        internalRel.append(inRel)
+                    }
+                }
+            }
+        }
     }
 
     fun build() {
         buildMap?.close()
-        buildMap = BuildSideMap.from(al, hashColumn, if (withNilRow) 1 else 0)
+        finishBatch()
+        unloader.end()
+        readInRels()
+        buildMap = BuildSideMap.from(
+            al,
+            internalRelToHashColumn(internalRel).asReader.let { if (withNilRow) it.select(1, it.valueCount.dec()) else it },
+            if (withNilRow) 1 else 0)
     }
 
-    val builtRel get() = relWriter.asReader
+    val builtRel get() = internalRelToExternalRel(internalRel).asReader
 
     fun addMatch(idx: Int) = matchedBuildIdxs?.add(idx)
 
@@ -63,7 +131,9 @@ class BuildSide(
 
     override fun close() {
         buildMap?.close()
-        relWriter.close()
-        hashColumn.close()
+        internalRel.close()
+        unloader.close()
+        unloadChannel.close()
+        tmpFile.deleteIfExists()
     }
 }

--- a/core/src/main/kotlin/xtdb/operator/join/BuildSideMap.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSideMap.kt
@@ -3,6 +3,8 @@ package xtdb.operator.join
 import org.apache.arrow.memory.BufferAllocator
 import org.roaringbitmap.RoaringBitmap
 import xtdb.arrow.IntVector
+import xtdb.arrow.Vector
+import xtdb.arrow.VectorReader
 import xtdb.util.closeOnCatch
 import java.util.function.IntConsumer
 import java.util.function.IntUnaryOperator
@@ -69,7 +71,7 @@ class BuildSideMap private constructor(
 
         @JvmStatic
         @JvmOverloads
-        fun from(al: BufferAllocator, hashCol: IntVector, offset: Int = 0, loadFactor: Double = DEFAULT_LOAD_FACTOR): BuildSideMap {
+        fun from(al: BufferAllocator, hashCol: VectorReader, offset: Int = 0, loadFactor: Double = DEFAULT_LOAD_FACTOR): BuildSideMap {
 
             val rowCount = hashCol.valueCount
 

--- a/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
@@ -1,0 +1,126 @@
+package xtdb.operator.join
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.types.pojo.Schema
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.roaringbitmap.RoaringBitmap
+import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
+import xtdb.expression.map.IndexHasher
+import xtdb.test.AllocatorResolver
+import xtdb.types.Fields
+import xtdb.vector.OldRelationWriter
+
+@ExtendWith(AllocatorResolver::class)
+class BuildSideTest {
+
+    private fun BuildSide.getMatches(hash: Int): List<Int> {
+        val matches = mutableListOf<Int>()
+        forEachMatch(hash) { matches.add(it) }
+        return matches
+    }
+
+    @Test
+    fun testBuildSideWithDiskSpill(al: BufferAllocator) {
+        val schema = Schema(listOf(
+            Fields.I32.nullable.toArrowField("id"),
+            Fields.UTF8.nullable.toArrowField("name"),
+            Fields.I32.nullable.toArrowField("value")
+        ))
+
+        val rows = listOf(
+            mapOf("id" to 1, "name" to "John", "value" to 100),
+            mapOf("id" to 2, "name" to "Jane", "value" to 200),
+            mapOf("id" to 3, "name" to "Bob", "value" to 300)
+        )
+
+        val relWriter = OldRelationWriter(al, schema)
+        relWriter.writeRows(*rows.toTypedArray())
+
+        relWriter.asReader.use { relation ->
+            // without nil row
+            BuildSide(al, schema, listOf("id"), RoaringBitmap(), false, 5).use { buildSide ->
+                buildSide.append(relation)
+                buildSide.append(relation)
+                buildSide.append(relation)
+
+                buildSide.build()
+
+                assertEquals(buildSide.toDisk, true)
+
+                val builtRelation = buildSide.builtRel
+
+                assertEquals(9, builtRelation.rowCount)
+
+                assertEquals(rows + rows + rows, builtRelation.toMaps(SNAKE_CASE_STRING))
+
+                val idVector = builtRelation.vectorFor("id")
+                val hasher = IndexHasher.fromCols(listOf(idVector))
+                val val2Hash = hasher.hashCode(1) // hash for id=2
+                val expectedMatches = listOf(1, 4, 7)
+                assertEquals(expectedMatches, buildSide.getMatches(val2Hash).sorted())
+            }
+
+            // with nil row
+            BuildSide(al, schema, listOf("id"), RoaringBitmap(), true, 5).use { buildSide ->
+                buildSide.append(relation)
+                buildSide.append(relation)
+                buildSide.append(relation)
+
+                buildSide.build()
+
+                assertEquals(buildSide.toDisk, true)
+
+                val builtRelation = buildSide.builtRel
+
+                assertEquals(10, builtRelation.rowCount)
+
+                assertEquals(
+                    listOf<Map<*, *>>(emptyMap<String, Any>()) + rows + rows + rows,
+                    builtRelation.toMaps(SNAKE_CASE_STRING)
+                )
+
+                val idVector = builtRelation.vectorFor("id")
+                val hasher = IndexHasher.fromCols(listOf(idVector))
+                val val2Hash = hasher.hashCode(2) // hash for id=2
+                val expectedMatches = listOf(2, 5, 8)
+                assertEquals(expectedMatches, buildSide.getMatches(val2Hash).sorted())
+            }
+        }
+    }
+
+    @Test
+    fun testBuildSideWithoutDiskSpill(al: BufferAllocator) {
+        val schema = Schema(listOf(
+            Fields.I32.nullable.toArrowField("id"),
+            Fields.UTF8.nullable.toArrowField("name"),
+            Fields.I32.nullable.toArrowField("value")
+        ))
+
+        val rows = listOf(
+            mapOf("id" to 1, "name" to "John", "value" to 100),
+            mapOf("id" to 2, "name" to "Jane", "value" to 200),
+            mapOf("id" to 3, "name" to "Bob", "value" to 300)
+        )
+
+        val relWriter = OldRelationWriter(al, schema)
+        relWriter.writeRows(*rows.toTypedArray())
+
+        relWriter.asReader.use { rel ->
+            BuildSide(al, schema, listOf("id"), RoaringBitmap(), false, 5).use { buildSide ->
+                buildSide.append(rel)
+
+                buildSide.build()
+
+                assertEquals(buildSide.toDisk, false)
+
+                val builtRelation = buildSide.builtRel
+
+                assertEquals(3  , builtRelation.rowCount)
+
+                assertEquals(rows, builtRelation.toMaps(SNAKE_CASE_STRING))
+            }
+        }
+    }
+}

--- a/src/test/clojure/xtdb/disk_join_test.clj
+++ b/src/test/clojure/xtdb/disk_join_test.clj
@@ -1,0 +1,26 @@
+(ns xtdb.disk-join-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.operator.join :as join]
+            [xtdb.test-util :as tu]))
+
+(defn with-disk-threshold
+  ([threshold] (partial with-disk-threshold threshold))
+  ([threshold f]
+   (binding [join/*disk-join-threshold* threshold]
+     (f))))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node (with-disk-threshold 1000))
+
+(deftest ^:integration test-on-disk-joining
+  (let [ids (range 100000)]
+    (doseq [batch (partition-all 1000 ids)
+            :let [docs (for [id batch]
+                         {:xt/id id})]]
+      (xt/submit-tx tu/*node*
+                    [(into [:put-docs :foo] docs)
+                     (into [:put-docs :bar] docs)]))
+    (t/is (=  [{:cnt 100000}]
+              (xt/q tu/*node* "SELECT COUNT(DISTINCT foo._id) AS cnt
+                               FROM foo, bar
+                               WHERE foo._id = bar._id")))))


### PR DESCRIPTION
This moves the build side to disk in batches of ~100k rows and reads everything back into one relation on the way out. 