### PR TITLE
Helm template fixes

### DIFF
--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -238,6 +238,7 @@ Auctionmark typically runs in two stages: an initial load phase and an OLTP phas
 ./cloud/run-bench.sh azure auctionmark \
   --set auctionmark.threads=8 \
   --set auctionmark.duration=PT10M \
+  --set auctionmark.noLoad=true \
   --no-cleanup
 ----
 

--- a/modules/bench/cloud/helm/templates/_helpers.tpl
+++ b/modules/bench/cloud/helm/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- /* Return Kafka host from a bootstrap servers string (first entry) */ -}}
+{{- define "xtdb.kafka.host" -}}
+{{- $bootstrap := (default "" .) -}}
+{{- $first := (splitList "," $bootstrap | first) -}}
+{{- $parts := splitList ":" $first -}}
+{{- $host := "localhost" -}}
+{{- if ge (len $parts) 1 -}}
+{{- $host = index $parts 0 -}}
+{{- end -}}
+{{- $host -}}
+{{- end -}}
+
+{{- /* Return Kafka port from a bootstrap servers string (first entry) */ -}}
+{{- define "xtdb.kafka.port" -}}
+{{- $bootstrap := (default "" .) -}}
+{{- $first := (splitList "," $bootstrap | first) -}}
+{{- $parts := splitList ":" $first -}}
+{{- $port := "9092" -}}
+{{- if ge (len $parts) 2 -}}
+{{- $port = index $parts 1 -}}
+{{- end -}}
+{{- $port -}}
+{{- end -}}

--- a/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
@@ -37,7 +37,7 @@ spec:
       initContainers:
         - name: wait-for-kafka
           image: busybox
-          command: ['sh', '-c', 'until nc -z xtdb-benchmark-kafka.cloud-benchmark.svc.cluster.local 9092; do echo waiting for kafka; sleep 5; done;']
+          command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
           resources:
             requests:
               memory: "256Mi"

--- a/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
@@ -69,12 +69,15 @@ spec:
             - auctionmark
             - -f
             - "/var/lib/xtdb-config/xtdbconfig.yaml"
+            {{- if and .Values.auctionmark.onlyLoad .Values.auctionmark.noLoad -}}
+            {{- fail "auctionmark.onlyLoad and auctionmark.noLoad cannot both be true" -}}
+            {{- end -}}
+            {{- if .Values.auctionmark.onlyLoad }}
             - --only-load
-            - {{ .Values.auctionmark.onlyLoad | quote }}
-            {{ if not .Values.auctionmark.onlyLoad }}
+            {{- end }}
+            {{- if .Values.auctionmark.noLoad }}
             - --no-load
-            - {{ .Values.auctionmark.noLoad | quote }}
-            {{- end}}
+            {{- end }}
             - --threads
             - {{ .Values.auctionmark.threads | quote }}
             - --duration

--- a/modules/bench/cloud/helm/templates/benchmark-readings.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-readings.yaml
@@ -32,7 +32,7 @@ spec:
       initContainers:
       - name: wait-for-kafka
         image: busybox
-        command: ['sh', '-c', 'until nc -z xtdb-benchmark-kafka.cloud-benchmark.svc.cluster.local 9092; do echo waiting for kafka; sleep 5; done;']
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
         resources:
           requests:
             memory: "256Mi"

--- a/modules/bench/cloud/helm/templates/benchmark-tpch.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-tpch.yaml
@@ -17,7 +17,7 @@ spec:
         "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     spec:
       nodeSelector:
-        {{ toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
       serviceAccountName: xtdb-service-account
       restartPolicy: Never
       volumes:
@@ -32,7 +32,7 @@ spec:
       initContainers:
       - name: wait-for-kafka
         image: busybox
-        command: ['sh', '-c', 'until nc -z xtdb-benchmark-kafka.cloud-benchmark.svc.cluster.local 9092; do echo waiting for kafka; sleep 5; done;']
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
         resources:
           requests:
             memory: "256Mi"

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -2,7 +2,7 @@ benchType: tpch
 
 auctionmark:
   onlyLoad: false
-  noLoad: true
+  noLoad: false
   scaleFactor: 0.1
   nodeCount: 3 # only applies if not onlyLoad
   threads: 8
@@ -58,4 +58,3 @@ kafka:
     persistence:
       size: 50Gi
     resourcesPreset: medium
-


### PR DESCRIPTION
A couple of fixes/improvements for the bench helm templates:
 - Fix auctionmark flags, we were being tripped up by the presence of --no-load even though we were passing false: 10:48:56.558 [main] INFO  xtdb.bench.auctionmark - {:scale-factor 0.1, :no-load? true, :only-load? true, :duration #xt/duration "PT10M", :seed 0}
   - Now we just pass the flag if noLoad or loadOnly is true, throwing if we see both as true
 - Use the xtdbConfig.kafkaBootstrapServers to configure the wait-for-kafka containers, just removing a potential foot gun that I've fired myself