### PR TITLE
Add further property tests for block boundaries, document history and PATCH.

### DIFF
--- a/src/main/clojure/xtdb/test_generators.clj
+++ b/src/main/clojure/xtdb/test_generators.clj
@@ -136,16 +136,14 @@
      (-> (zipmap field-keys field-values)
          (assoc :xt/id id)))))
 
-(defn typed-vector-vs-gen
-  [element-gen min-length max-length]
+(defn typed-vector-vs-gen [element-gen min-length max-length]
   (gen/let [vector-name non-blank-string-gen
             vs (gen/vector element-gen min-length max-length)]
     {:vec-name vector-name
      :vs vs
      :type element-gen}))
 
-(defn single-type-vector-vs-gen
-  [min-length max-length]
+(defn single-type-vector-vs-gen [min-length max-length]
   (gen/let [type-gen (gen/elements simple-type-gens)]
     (typed-vector-vs-gen type-gen min-length max-length)))
 

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -388,3 +388,6 @@
    (let [opts (merge {:num-tests property-test-iterations} opts)
          result (tc/quick-check (:num-tests opts) property (dissoc opts :num-tests))]
      (t/is (:pass? result) (with-out-str (pprint/pprint result))))))
+
+(defn remove-nils [m]
+  (into {} (remove (comp nil? val) m)))

--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -116,6 +116,7 @@
                                 expected-ids (into #{} (map :xt/id (concat records1 records2)))]
                             (= expected-ids (into #{} (map :xt/id res))))))))))
 
+;; TODO: Will fail due to #4721
 (t/deftest ^:property mixed-records-live-boundary
   (tu/run-property-test
    {:num-tests tu/property-test-iterations}

--- a/src/test/clojure/xtdb/operator/patch_test.clj
+++ b/src/test/clojure/xtdb/operator/patch_test.clj
@@ -139,7 +139,7 @@
     (t/is (= [{:xt/id 1, :xt/valid-from #xt/zoned-date-time "2020-01-01T00:00Z[UTC]"}]
              (xt/q tu/*node* "SELECT *,_valid_from, _valid_to FROM docs")))))
 
-;; TODO: Will fail due to #4751
+;; TODO: Will fail due to #4751 + #4752
 (t/deftest ^:property multiple-patches-on-record
   (tu/run-property-test
    {:num-tests tu/property-test-iterations}

--- a/src/test/clojure/xtdb/vector/reader_test.clj
+++ b/src/test/clojure/xtdb/vector/reader_test.clj
@@ -408,6 +408,7 @@
                          actual-data (.toList duv)]
                      (tg/lists-equal-normalized? expected-data actual-data))))))
 
+;; TODO: fails due to #4748
 (t/deftest ^:property copy-two-duvs
   (tu/run-property-test
    {:num-tests tu/property-test-iterations}


### PR DESCRIPTION
Resolves #4730 

- Adds a property test to ensure that writing a block of a single field type followed by a block of another type remains intact and queryable across block boundaries.
- Adds a property test to verify that inserting a block of single-typed values followed by a block of nil fields remains intact and queryable across block boundaries.
- Renames existing block boundary tests.

Also adds a few other tests against record insertion:
- Adds a property test writing to the same document many times across multiple transcations - verifying history of document and final state. 
- Adds a property test to verify that multiple writes to the same document within a single transaction (each document with distinct valid times) - verifying history of document and final state. 
- Adds a property test against patching the same doc multiple times, verifying history is present and resulting doc is as expected.

Have annotated all currently failing property tests with associated issues.