### PR TITLE
Prettier EXPLAIN plan

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -112,26 +112,20 @@
   (fn [ra-expr opts]
     (:op ra-expr)))
 
-(defn unary-expr {:style/indent 1} [relation f]
-  (let [{->inner-cursor :->cursor, :as inner-rel} relation
-        {:keys [fields ->cursor stats]} (f inner-rel)]
-    {:fields fields
-     :->cursor (fn [opts]
-                 (util/with-close-on-catch [inner (->inner-cursor opts)]
-                   (->cursor opts inner)))
-     :stats stats}))
+(defn unary-expr {:style/indent 1} [{->inner-cursor :->cursor, :as inner-rel} f]
+  (-> (f inner-rel)
+      (update :->cursor (fn [->cursor]
+                          (fn [opts]
+                            (util/with-close-on-catch [inner (->inner-cursor opts)]
+                              (->cursor opts inner)))))))
 
-(defn binary-expr {:style/indent 2} [left right f]
-  (let [{->left-cursor :->cursor} left
-        {->right-cursor :->cursor} right
-        {:keys [fields ->cursor stats]} (f left right)]
-
-    {:fields fields
-     :->cursor (fn [opts]
-                 (util/with-close-on-catch [left (->left-cursor opts)
-                                            right (->right-cursor opts)]
-                   (->cursor opts left right)))
-     :stats stats}))
+(defn binary-expr {:style/indent 2} [{->left-cursor :->cursor, :as left} {->right-cursor :->cursor, :as right} f]
+  (-> (f left right)
+      (update :->cursor (fn [->cursor]
+                          (fn [opts]
+                            (util/with-close-on-catch [left (->left-cursor opts)
+                                                       right (->right-cursor opts)]
+                              (->cursor opts left right)))))))
 
 ;;;; Rewriting of logical plan.
 

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -40,7 +40,9 @@
 
 ;; HACK: not ideal that we have to open the file in the emitter just to get the fields?
 (defn- path->cursor [^Path path on-close-fn]
-  {:fields (with-open [al (RootAllocator.)
+  {:op :arrow
+   :children []
+   :fields (with-open [al (RootAllocator.)
                        ^ArrowReader rdr (path->arrow-reader (util/->file-channel path) al)]
              (->> (.getFields (.getSchema (.getVectorSchemaRoot rdr)))
                   (into {} (map (juxt #(symbol (.getName ^Field %)) identity)))))

--- a/core/src/main/clojure/xtdb/operator/csv.clj
+++ b/core/src/main/clojure/xtdb/operator/csv.clj
@@ -83,7 +83,9 @@
   (let [fields (->> col-types
                     (into {} (map (juxt (comp name key)
                                         #(types/col-type->field (name (key %)) (get csv-col-type-overrides (val %) (val %)))))))]
-    {:fields fields
+    {:op :csv
+     :children []
+     :fields fields
      :->cursor (fn [{:keys [allocator]}]
                  (let [rdr (Files/newBufferedReader path)
                        rows (rest (csv/read-csv rdr))

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -71,8 +71,10 @@
 
 (defmethod lp/emit-expr :distinct [{:keys [relation]} args]
   (lp/unary-expr (lp/emit-expr relation args)
-                 (fn [{inner-fields :fields}]
-                   {:fields inner-fields
+                 (fn [{inner-fields :fields :as inner-rel}]
+                   {:op :distinct
+                    :children [inner-rel]
+                    :fields inner-fields
                     :->cursor (fn [{:keys [allocator]} in-cursor]
                                 (DistinctCursor. in-cursor (->relation-map allocator
                                                                            {:build-fields inner-fields

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -16,7 +16,9 @@
 (defmethod lp/emit-expr :let [{[binding bound-rel] :binding, :keys [relation]} emit-opts]
   (let [{->bound-cursor :->cursor, :as emitted-bound-rel} (lp/emit-expr bound-rel emit-opts)
         {->body-cursor :->cursor, :as emitted-body-rel} (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel))]
-    {:fields (:fields emitted-body-rel)
+    {:op :let
+     :children [emitted-bound-rel emitted-body-rel]
+     :fields (:fields emitted-body-rel)
      :stats (:stats emitted-body-rel)
      :->cursor (fn [{:keys [allocator] :as opts}]
                  (util/with-close-on-catch [bound-cursor (->bound-cursor opts)
@@ -41,7 +43,9 @@
                                                        {:relation relation
                                                         :available available}))))]
 
-    {:fields fields, :stats stats
+    {:op :relation
+     :children []
+     :fields fields, :stats stats
      :->cursor (fn [opts]
                  (let [^ICursor$Factory cursor-factory (or (get-in opts [:let-bindings relation])
                                                            (let [available (set (keys (:let-bindings opts)))]

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -55,7 +55,9 @@
         {:keys [field ->list-expr]} (expr-list/compile-list-expr expr input-types)
         named-field (types/field-with-name field (str out-col))
         fields {(symbol (.getName named-field)) named-field}]
-    {:fields (restrict-cols fields list-expr)
+    {:op :list
+     :children []
+     :fields (restrict-cols fields list-expr)
      :->cursor (fn [{:keys [allocator ^RelationReader args]}]
                  (ListCursor. allocator (->list-expr schema args) named-field
                               *batch-size* 0))}))

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -262,7 +262,10 @@
 
 (defmethod lp/emit-expr :order-by [{:keys [order-specs relation]} args]
   (lp/unary-expr (lp/emit-expr relation args)
-    (fn [{:keys [fields]}]
-      {:fields fields
+    (fn [{:keys [fields], :as rel}]
+      {:op :order-by
+       :children [rel]
+       :explain {:order-specs (pr-str order-specs)}
+       :fields fields
        :->cursor (fn [{:keys [allocator]} in-cursor]
                    (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil))})))

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -43,7 +43,10 @@
                                    prefix (->> name (symbol (name prefix))))])
                               (into {}))
         col-name-reverse-mapping (set/map-invert col-name-mapping)]
-    {:fields (->> inner-fields
+    {:op :rename
+     :children [emitted-child-relation]
+     :explain {:prefix (some-> prefix str), :columns (some-> columns pr-str)}
+     :fields (->> inner-fields
                   (into {}
                         (map (juxt (comp col-name-mapping key)
                                    (comp (fn [^Field field]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -1,5 +1,6 @@
 (ns xtdb.operator.scan
   (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]
             [integrant.core :as ig]
             [xtdb.basis :as basis]
             [xtdb.expression :as expr]
@@ -231,7 +232,15 @@
 
             row-count (.rowCount table-catalog table)]
 
-        {:fields fields
+        {:op :scan
+         :children []
+         :explain {:table (->> [(.getDbName table) (.getSchemaName table) (.getTableName table)]
+                               (remove nil?)
+                               (str/join "."),)
+                   :columns (vec col-names)
+                   :predicates (mapv pr-str (vals selects))}
+
+         :fields fields
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids]}]
                      (let [^Snapshot snapshot (get snaps db-name)

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -194,7 +194,9 @@
                                                      [:column col] (emit-col-table col table-expr opts)
                                                      [:param param] (emit-arg-table param table-expr opts))]
 
-    {:fields fields
+    {:op :table
+     :children []
+     :fields fields
      :stats (when row-count {:row-count row-count})
      :->cursor (fn [opts]
                  (TableCursor. (->out-rel opts)))}))

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -60,8 +60,13 @@
 
 (defmethod lp/emit-expr :top [{:keys [relation], {[skip-tag skip-arg] :skip, [limit-tag limit-arg] :limit} :top} args]
   (lp/unary-expr (lp/emit-expr relation args)
-    (fn [{fields :fields}]
-      {:fields fields
+    (fn [{fields :fields :as inner-rel}]
+      {:op :top
+       :children [inner-rel]
+       :explain (->> {:skip (some-> skip-arg pr-str),
+                      :limit (some-> limit-arg pr-str)}
+                     (into {} (filter val)))
+       :fields fields
        :->cursor (fn [{:keys [args]} in-cursor]
                    (TopCursor. in-cursor
                                (case skip-tag

--- a/src/test/clojure/xtdb/pgwire/pg2_test.clj
+++ b/src/test/clojure/xtdb/pgwire/pg2_test.clj
@@ -279,8 +279,11 @@
 
 (t/deftest test-explain-query-with-params
   (with-open [conn (pg-conn {})]
-    (let [[{:keys [plan]}] (pg/execute conn "EXPLAIN SELECT $1" {:params [""]})]
-      (t/is (some? plan)))))
+    (t/is (= [{:depth "->", :op "project",
+               :explain {:append? false, :project "[{_column_1 ?_0}]"}}
+              {:depth "  ->", :op "table"
+               :explain nil}]
+             (pg/execute conn "EXPLAIN SELECT $1" {:params [""]})))))
 
 (t/deftest test-sql-with-leading-whitespace
   (with-open [conn (pg-conn {})]


### PR DESCRIPTION
(I mean, it does look nice, but this is mainly so I can add timing columns for `EXPLAIN ANALYZE`)

```
xtdb=> explain select f1._id f1, f2._id AS f2 FROM foo f1 LEFT JOIN foo f2 USING (_id) LIMIT 1;
   depth    |    op     |                            explain
------------+-----------+---------------------------------------------------------------
 ->         | top       | {"limit":"1","skip":"nil"}
   ->       | project   | {"append?":false,"project":"[{f1 f1.1\/_id} {f2 f2.2\/_id}]"}
     ->     | left-join | {"condition":"[[:equi-condition {f1.1\/_id f2.2\/_id}]]"}
       ->   | rename    | {"prefix":"f1.1"}
         -> | scan      | {"predicates":[],"columns":["_id"],"table":"xtdb.public.foo"}
       ->   | rename    | {"prefix":"f2.2"}
         -> | scan      | {"predicates":[],"columns":["_id"],"table":"xtdb.public.foo"}
```