### PR TITLE
Fix for merge fields NPE with empty sets.

### DIFF
--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -358,9 +358,15 @@
                             (fn [{:keys [nullable?] :as type-opts}]
                               (into {:nullable? (or nullable? (.isNullable field))}
                                     (condp = (class arrow-type)
-                                      ArrowType$List {:el (merge-field* (:el type-opts) (first (.getChildren field)))}
-                                      SetType {:el (merge-field* (:el type-opts) (first (.getChildren field)))}
-                                      ArrowType$FixedSizeList {:el (merge-field* (:el type-opts) (first (.getChildren field)))}
+                                      ArrowType$List (let [child-field (first (.getChildren field))]
+                                                       {:el (cond-> (:el type-opts)
+                                                              child-field (merge-field* child-field))})
+                                      SetType (let [child-field (first (.getChildren field))]
+                                                {:el (cond-> (:el type-opts)
+                                                       child-field (merge-field* child-field))})
+                                      ArrowType$FixedSizeList (let [child-field (first (.getChildren field))]
+                                                                {:el (cond-> (:el type-opts)
+                                                                       child-field (merge-field* child-field))})
                                       ArrowType$Struct {:fields (let [default-field-mapping (if type-opts {#xt.arrow/type :null {:nullable? true}} nil)
                                                                       children (.getChildren field)]
                                                                   (as-> (:fields type-opts) fields-acc

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -1,6 +1,6 @@
 (ns xtdb.node-test
   (:require [clojure.java.io :as io]
-            [clojure.test :as t :refer [deftest]] 
+            [clojure.test :as t :refer [deftest]]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
             [xtdb.basis :as basis]
@@ -14,7 +14,7 @@
             [xtdb.node.impl] ;;TODO probably move internal methods to main node interface
             [xtdb.object-store :as os]
             [xtdb.protocols :as xtp]
-            [xtdb.serde :as serde] 
+            [xtdb.serde :as serde]
             [xtdb.test-util :as tu]
             [xtdb.time :as time]
             [xtdb.util :as util])
@@ -1199,3 +1199,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
                       (xt/execute-tx node [[:put-docs :docs {:xt/id 1}]])))
 
     (t/is (= [{:v 1}] (xt/q node "SELECT 1 AS v")))))
+
+(t/deftest test-merge-fields-npe-4721
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b #{}} :xt/id 1}]])
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}]])
+  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT * FROM docs"))))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -370,3 +370,12 @@
     (t/is (= {:vs vs
               :vec-types [RegClassVector RegProcVector]}
              (test-round-trip vs)))))
+
+(t/deftest test-npe-on-empty-list-children-4721
+  (t/testing "merge fields with empty list children shouldn't throw NPE"
+    (let [set-field (types/->field "a" #xt.arrow/type :set true)
+          list-field (types/->field "b" #xt.arrow/type :list true)]
+      (t/is (= (types/->field "a" #xt.arrow/type :set true (types/->field "$data$" #xt.arrow/type :null true)) 
+               (types/merge-fields nil set-field)))
+      (t/is (= (types/->field "b" #xt.arrow/type :list true (types/->field "$data$" #xt.arrow/type :null true)) 
+               (types/merge-fields nil list-field))))))


### PR DESCRIPTION
Resolves: #4721  
Github actions runs: https://github.com/danmason/xtdb/actions?query=branch%3Amerge-fields-npe-4721

In summary of the below:
- In certain cases, we lose `$data$` on nested fields within Sets.
- We have decided it's valid/not unexpected that we should receive list types without $data$, so we should handle within merge-fields, treating it as a terminating case/doesnt' require further merge-fields*
  - `$data$` gets added back in to these empty sets by merge-fields anyway.

Investigation was still a useful dive into debugging/indexing process of XTDB, however, so will keep the PR description for future reference :) 

---

## Node test repro and investigating the field types

I wrote a minimal failing test within `node_test`:

```clojure
(t/deftest test-merge-fields-npe-4721
  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b #{}} :xt/id 1}]])
  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}]])
  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT * FROM docs"))))
```

**Observations/questions raised:**
- Why this exact combination of documents?  
  - Removing any one of them makes the test pass.
- Why does it require two separate transactions?
- The failure happens because `.getChildren` on a `Set` returns `nil`, so later calls on that field trigger an NPE.

**Fields passed into `merge-fields*` in the erroring case:**

```clojure
(nil
 #xt.arrow/field ["h"
                  #xt.arrow/field-type [#xt.arrow/type :struct true]
                  #xt.arrow/field ["b" #xt.arrow/field-type [#xt.arrow/type :set true]]])
```

### Alternative case (no error)

If I collapse the transactions into one:

```clojure
(t/deftest test-merge-fields-npe-4721
  (xt/execute-tx tu/*node* [[:put-docs :docs :h {:b #{}} :xt/id 1} {:h {}, :xt/id 1} {:xt/id 1}]])
  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT * FROM docs"))))
```

Then no error occurs, and the merged fields look quite different:

```clojure
(nil
 #xt.arrow/field ["h"
                  #xt.arrow/field-type [#xt.arrow/type :struct true]

                  #xt.arrow/field ["b"
                                   #xt.arrow/field-type [#xt.arrow/type :set false]
                                   #xt.arrow/field ["$data$"
                                                    #xt.arrow/field-type [#xt.arrow/type :union false]
                                                    #xt.arrow/field ["null" #xt.arrow/field-type [#xt.arrow/type :null true]]]]])
```

In essence, I go from a **non-nullable set with a null/union type within its data** → to a **nullable set**.  
- Some issue with promotion, perhaps?  
- Or we’ve acted correctly, but we *do* need to return a null field from its children?

---

## Type-level repro

Wrote the following `type_test`:

```clojure
(t/deftest test-merge-fields-npe-4721
  (let [nil-field nil
        set-field (types/->field "b" #xt.arrow/type :set true)]
    (t/is (some? (types/merge-fields nil-field set-field)))))
```

Sure enough, that is enough to throw the error.  
We see similar if this is a nullable list, also:

```clojure
(t/deftest test-merge-fields-npe-4721
  (let [nil-field nil
        list-field (types/->field "b" #xt.arrow/type :list true)]
    (t/is (some? (types/merge-fields nil-field list-field)))))
```

**Questions raised:**
- Are these fields valid for us to be handling here?  
- Is it correct for us to get this nullable empty set as a field?  

---

### Other experiments

Decided to run through the original `node_test` with an empty list:

```clojure
(t/deftest test-merge-fields-npe-4721
  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b []} :xt/id 1}]])
  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}]])
  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT * FROM docs"))))
```

This does **not** return an NPE, and returns the value correctly.

**Fields passed into `merge-fields`:**

```clojure
(nil 
 #xt.arrow/field ["h"
                  #xt.arrow/field-type [#xt.arrow/type :struct true]
                  #xt.arrow/field ["b"
                                   #xt.arrow/field-type [#xt.arrow/type :list true]
                                   #xt.arrow/field ["$data$" 
                                                    #xt.arrow/field-type [#xt.arrow/type :union false] 
                                                    #xt.arrow/field ["null" #xt.arrow/field-type [#xt.arrow/type :null true]]]]])
```

So it would seem that:
- We really shouldn’t be getting that nullable empty set without `$data`.  
- The issue lies somewhat before `merge-fields` itself.  
- The issue seems specific to **sets**.  

Also interestingly, removing the second doc in the second transaction in the set case _also_ avoids the error, i.e.:

```clojure
(xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b #{}} :xt/id 1}]])
(xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1}]])
```

And the `$data$` field is back in merge-fields:
```
(nil
 #xt.arrow/field ["h"
                  #xt.arrow/field-type [#xt.arrow/type :struct false]
                  #xt.arrow/field ["b" 
                                   #xt.arrow/field-type [#xt.arrow/type :set true] 
                                   #xt.arrow/field ["$data$"
                                                    #xt.arrow/field-type [#xt.arrow/type :union false] 
                                                    #xt.arrow/field ["null" #xt.arrow/field-type [#xt.arrow/type :null true]]]]])
```

This points to something specific with indexing that transaction.

---

## What happens to `$data$`?

Looking at the original failing `node_test` — we can see the `merge-fields` call that causes the NPE originates from `scan.clj`.  
This is the call site:

```clojure
(types/merge-fields (.getField table-catalog table col-name)
                    (some-> (.getLiveIndex snap)
                            (.liveTable table)
                            (.columnField col-name)))
```

- The first value (.getField table-catalog …) is nil.
- The second value (from liveIndex) is our nullable set without any $data$ field.

So - Where does our liveIndex version of h lose its `$data$`?

Debugging the `logPut` calls from indexer, (of which there are 3) - here's the field type of h (as returned from columnField) after each tx:
```
;; After put-docs {:h {:b #{}} :xt/id 1}
h: Struct<b: ExtensionType(set, List)<$data$: Union(Dense, null)<null: Null> not null> not null> not null

;; After put-docs {:h {}, :xt/id 1} 
h: Struct<b: ExtensionType(set, List)>

;; After put-docs {:xt/id 1}
h: Struct<b: ExtensionType(set, List)>
```

Interestingly, if the last put is left out, the second put differs:
```
;; After put-docs {:h {:b #{}} :xt/id 1}
h: Struct<b: ExtensionType(set, List)<$data$: Union(Dense, null)<null: Null> not null> not null> not null

;; After put-docs {:h {}, :xt/id 1} 
h: Struct<b: ExtensionType(set, List)<$data$: Union(Dense, null)<null: Null> not null>> not null
```

That being the case - it WOULD point to the indexing behaving differently with the `put-docs {:xt/id 1}` present - digging into the putIndexer more specifically, this makes some sense: 
- We do use a docs-copier for this purpose, and it seems to be the case that the schema for this changes based on contents of the transaction.
- This is in turn built from table-doc-rdr, which is a relation reader built from a collection of VectorReaders for all document fields present across ALL transactions in the batch (indexer.clj:130-134)

If we view the field types of the VectorReaders for the second transaction
```
;; :put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}
["h" #xt.arrow/field-type [#xt.arrow/type :struct true]]

;; without the second doc, ie
;; :put-docs :docs {:h {}, :xt/id 1}
["h" #xt.arrow/field-type [#xt.arrow/type :struct false]]
```

In both cases, no `b` present, as these VectorReaders have no knowledge of prior transactions/field types of `h` at this point, but perhaps the nullability of the `h` struct is the key difference when we come to create our rowCopier?

## Attempting to repro at the VectorReader level

Trying to "replicate" the strangeness we see within the Vector copying with the following test:
```
(t/deftest type-weirdness
  (with-open [live-idx (Vector/fromList tu/*allocator* "live-index" [{:h {"b" #{}}}])
              docs (Vector/fromList tu/*allocator* "docs" [{:h {}} {}])]
    (let [copier (.rowCopier docs live-idx)]
      (.copyRow copier 0)
      (.copyRow copier 1)
      (t/is (= [{"h" {"b" #{}}} {"h" {}} {}] (.toList live-idx)))
      (t/is (= (types/->field "live-index" #xt.arrow/type :struct false
                              (types/->field "h" #xt.arrow/type :struct true
                                             (types/->field "b" #xt.arrow/type :set true
                                                            (types/->field "$data$" #xt.arrow/type :null true))))
               (.getField live-idx))))))
```
Now - this actually **passes** - the presence of the empty map / nil for **h** doesn't make a huge difference. This seems somewhat odd - though there are some differences between this and current implementation of indexer, primarily:
- Here we are going through the xtdb.arrow.Vector class to create our Vector/VectorReaders.
- Within the indexer, we have two very different "vector readers" we copy from:
  - The live-index docs-writer is created from "Trie/openLogDataWriter", which we then make numerous calls to ".vectorFor" on to get the "put-wtr" or "docs-writer". This evolves over time. 
  - The table-doc-reader/docs is a RelationAsStructReader that wraps a vr/rel-reader built from individual VectorReader instances, extracted from the tx-ops relation reader.
    - This is, in turn, passed from LogProcessor, which takes a stream of docuemnts and goes through **vectorSchemaRoot** to create ValueVectors for them.

To confirm this, wrote the following which goes through similar paths as we do in the actual indexer code:
```
(t/deftest field-type-evolution-test
  (with-open [live-idx-writer (Trie/openLogDataWriter tu/*allocator* (Trie/dataRelSchema nil))
              op-writer (.vectorFor live-idx-writer "op")
              put-writer (.vectorFor op-writer "put" #xt.arrow/field-type [#xt.arrow/type :struct true])]

    ;; First transaction: {:h {:b #{}}}
    (with-open [docs-1 (RelationAsStructReader. "docs" (vr/rel-reader [(vr/vec->reader (vw/open-vec tu/*allocator* "docs" [{"h" {"b" #{}}}]))]))]
      (.copyRow (.rowCopier docs-1 put-writer) 0)
      (prn "After tx1 - h field:" (-> put-writer (.getField) (.getChildren) (first) (.getChildren) (first) (.getChildren))))

    ;; Second transaction: {:h {}} {}
    (with-open [docs-2 (RelationAsStructReader. "docs" (vr/rel-reader [(vr/vec->reader (vw/open-vec tu/*allocator* "docs" [{"h" {}} {}]))]))]
      (.copyRow (.rowCopier docs-2 put-writer) 0)
      (prn "After tx2 - h field:" (-> put-writer (.getField) (.getChildren) (first) (.getChildren) (first) (.getChildren))))))
```

Which returned:
```
"After tx1 - h field:" [#xt.arrow/field ["h" #xt.arrow/field-type [#xt.arrow/type :struct false] #xt.arrow/field ["b" #xt.arrow/field-type [#xt.arrow/type :set false] #xt.arrow/field ["$data$" #xt.arrow/field-type [#xt.arrow/type :union false] #xt.arrow/field ["null" #xt.arrow/field-type [#xt.arrow/type :null true]]]]]]
"After tx2 - h field:" [#xt.arrow/field ["h" #xt.arrow/field-type [#xt.arrow/type :struct true] #xt.arrow/field ["b" #xt.arrow/field-type [#xt.arrow/type :set true]]]]
```

Finally, we see another instance of "$data$" being missing! Similar to before, if we remove the second value in the second tx, ie `{}`, "$data$" is still present on "b".

So - it seems the problem certainly lies in how we are handling copies within those older classes - specifically when the `h` struct is considered nullable. 

Some thoughts:
- All of this is going through older vector paths, using ValueVectors and RelationReaders and such. This may benefit from a general reworking to use our newer Vector class instead.
  - This may be "easier said than done" - our new Vector classes can only copy to/from another new Vector, so we'd potentially need to change a lot to be able to use them here?
- Wonder if there are any other prior similar issues?