### PR TITLE
Add query timer metric into pgwire.

### DIFF
--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -23,6 +23,11 @@
   (when counter
     (.increment counter)))
 
+(defmacro record-callable! [timer & body]
+  `(if ~timer
+     (.recordCallable ^Timer ~timer (fn [] ~@body))
+     (do ~@body)))
+
 (def percentiles [0.75 0.85 0.95 0.98 0.99 0.999])
 
 (defn add-timer ^io.micrometer.core.instrument.Timer [reg name {:keys [^String description]}]


### PR DESCRIPTION
Resolves #4720.

We are currently only using/marking query timer within `then-execute-prepared-query` in impl - which is currently only called to by open-sql-query/open-xtql-query. Essentially this means that queries made through PGWire (and indeed, the API), are not monitored within the query timer metrics - the only query times we really see are for execute-tx.

This PR adds the query timer metric under PGWire and uses `.recordCallable` on `cmd-exec-query`, so when we execute the query itself (regardless of whether it is cancelled/errored), we will time the execution. Added some tests against this, also, at both the connection and node API level.