### PR TITLE
add `EXPLAIN ANALYZE`

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -14,7 +14,7 @@ directSqlStatement : directlyExecutableStatement ';'? EOF ;
 multiSqlStatement : directlyExecutableStatement ( ';' directlyExecutableStatement )* ';'? EOF ;
 
 directlyExecutableStatement
-    : EXPLAIN? settingQueryVariables? queryExpression #QueryExpr
+    : (EXPLAIN ANALYZE?)? settingQueryVariables? queryExpression #QueryExpr
 
     | 'INSERT' 'INTO' targetTable insertColumnsAndSource returningStatement? #InsertStatement
 

--- a/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
+++ b/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
@@ -78,6 +78,7 @@ PG_NOT_REGEX_I : '!~*' ;
 
 ALL: 'ALL' ;
 ALTER : 'ALTER' ;
+ANALYZE : 'ANALYZE' ;
 AND : 'AND' ;
 ANY : 'ANY' ;
 ARRAY : 'ARRAY' ;

--- a/core/src/main/clojure/xtdb/coalesce.clj
+++ b/core/src/main/clojure/xtdb/coalesce.clj
@@ -14,6 +14,9 @@
                            ^int ideal-min-page-size
                            ^:unsynchronized-mutable ^int seen-rows]
   ICursor
+  (getCursorType [_] (.getCursorType cursor))
+  (getChildCursors [_] (.getChildCursors cursor))
+
   (tryAdvance [this c]
     (let [!rel-writer (volatile! nil)
           !rows-appended (volatile! 0)]

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -446,6 +446,9 @@
 
 (deftype InformationSchemaCursor [^:unsynchronized-mutable ^RelationReader out-rel vsr]
   ICursor
+  (getCursorType [_] "information-schema")
+  (getChildCursors [_] [])
+
   (tryAdvance [this c]
     (boolean
      (when-let [^RelationReader out-rel (.out_rel this)]

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -90,6 +90,9 @@
                              (fn [{:keys [allocator args] :as query-opts}]
                                (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
                                  (reify ICursor
+                                   (getCursorType [_] "apply-mark-join")
+                                   (getChildCursors [_] [dep-cursor])
+
                                    (tryAdvance [_ c]
                                      (.tryAdvance dep-cursor (fn [in-rel]
                                                                (with-open [match-vec (.project projection-spec allocator in-rel {} args)]

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -18,6 +18,9 @@
 
 (deftype ArrowCursor [^ArrowReader rdr on-close-fn]
   ICursor
+  (getCursorType [_] "arrow")
+  (getChildCursors [_] [])
+
   (tryAdvance [_ c]
     (if (.loadNextBatch rdr)
       (do

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -49,8 +49,9 @@
                        ^ArrowReader rdr (path->arrow-reader (util/->file-channel path) al)]
              (->> (.getFields (.getSchema (.getVectorSchemaRoot rdr)))
                   (into {} (map (juxt #(symbol (.getName ^Field %)) identity)))))
-   :->cursor (fn [{:keys [^BufferAllocator allocator]}]
-               (ArrowCursor. (path->arrow-reader (util/->file-channel path) allocator) on-close-fn))})
+   :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze?]}]
+               (cond-> (ArrowCursor. (path->arrow-reader (util/->file-channel path) allocator) on-close-fn)
+                 explain-analyze? (ICursor/wrapExplainAnalyze)))})
 
 (defmethod lp/emit-expr :arrow [{:keys [^URL url]} _args]
   ;; TODO: should we make it possible to disable local files?

--- a/core/src/main/clojure/xtdb/operator/csv.clj
+++ b/core/src/main/clojure/xtdb/operator/csv.clj
@@ -32,6 +32,9 @@
                     col-parsers
                     ^Iterator row-batches]
   ICursor
+  (getCursorType [_] "csv")
+  (getChildCursors [_] [])
+
   (tryAdvance [_ c]
     (if (.hasNext row-batches)
       (let [row-batch (.next row-batches)

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -18,6 +18,9 @@
 (deftype DistinctCursor [^ICursor in-cursor
                          ^DistinctRelationMap rel-map]
   ICursor
+  (getCursorType [_] "distinct")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [_ c]
     (let [advanced? (boolean-array 1)]
       (while (and (not (aget advanced? 0))

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -78,8 +78,9 @@
                    {:op :distinct
                     :children [inner-rel]
                     :fields inner-fields
-                    :->cursor (fn [{:keys [allocator]} in-cursor]
-                                (DistinctCursor. in-cursor (->relation-map allocator
-                                                                           {:build-fields inner-fields
-                                                                            :key-col-names (set (keys inner-fields))
-                                                                            :nil-keys-equal? true})))})))
+                    :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                                (cond-> (DistinctCursor. in-cursor (->relation-map allocator
+                                                                                   {:build-fields inner-fields
+                                                                                    :key-col-names (set (keys inner-fields))
+                                                                                    :nil-keys-equal? true}))
+                                  explain-analyze? (ICursor/wrapExplainAnalyze)))})))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -575,6 +575,9 @@
                         ^List aggregate-specs
                         ^:unsynchronized-mutable ^boolean done?]
   ICursor
+  (getCursorType [_] "group-by")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [this c]
     (boolean
      (when-not done?
@@ -623,11 +626,11 @@
                                                                                types/field->col-type)}))))))]
           {:op :group-by
            :children [inner-rel]
-           :explain {:group-by (vec group-cols)
+           :explain {:group-by (mapv str group-cols)
                      :aggregates (->> aggs
                                       (mapv (fn [[_ agg]]
                                               (let [[to-column agg-form] (first agg)]
-                                                [to-column (pr-str agg-form)]))))}
+                                                [(str to-column) (pr-str agg-form)]))))}
            :fields (into (->> group-cols
                               (into {} (map (juxt identity fields))))
                          (->> agg-factories

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -114,6 +114,9 @@
                           ^:unsynchronized-mutable ^Iterator left-rel-iterator
                           ^:unsynchronized-mutable ^RelationReader right-rel]
   ICursor
+  (getCursorType [_] "cross-join")
+  (getChildCursors [_] [left-cursor right-cursor])
+
   (tryAdvance [this c]
     (.forEachRemaining left-cursor
                        (fn [^RelationReader left-rel]
@@ -191,6 +194,9 @@
                      ^Set pushdown-iids
                      ^JoinType join-type]
   ICursor
+  (getCursorType [_] (.getJoinTypeName join-type))
+  (getChildCursors [_] [build-cursor probe-cursor])
+
   (tryAdvance [this c]
     (when-not probe-cursor
       (build-phase build-side build-cursor pushdown-blooms pushdown-iids)
@@ -253,6 +259,9 @@
                          mark-col-name
                          pushdown-blooms]
   ICursor
+  (getCursorType [_] "mark-join")
+  (getChildCursors [_] [build-cursor])
+
   (tryAdvance [this c]
 
     (when-not probe-cursor
@@ -390,7 +399,7 @@
                                 (mapv #(project/->identity-projection-spec (get merged-fields %))))]
 
     {:op (case join-type
-           ::inner-join :join
+           ::inner-join :inner-join
            ::left-outer-join :left-join
            ::left-outer-join-flipped :left-join
            ::full-outer-join :full-join

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -61,6 +61,7 @@
     {:op :list
      :children []
      :fields (restrict-cols fields list-expr)
-     :->cursor (fn [{:keys [allocator ^RelationReader args]}]
-                 (ListCursor. allocator (->list-expr schema args) named-field
-                              *batch-size* 0))}))
+     :->cursor (fn [{:keys [allocator ^RelationReader args explain-analyze?]}]
+                 (cond-> (ListCursor. allocator (->list-expr schema args) named-field
+                                      *batch-size* 0)
+                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -31,6 +31,9 @@
                      ^long batch-size
                      ^:unsynchronized-mutable ^long current-pos]
   ICursor
+  (getCursorType [_] "list")
+  (getChildCursors [_] [])
+
   (tryAdvance [_ consumer]
     (boolean
      (when (and list-expr (< current-pos (.getSize list-expr)))

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -208,6 +208,9 @@
                         ^:unsynchronized-mutable ^VectorSchemaRoot read-root
                         ^:unsynchronized-mutable ^File sorted-file]
   ICursor
+  (getCursorType [_] "order-by")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [this c]
     (if-not consumed?
       (letfn [(load-next-batch []

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -270,5 +270,6 @@
        :children [rel]
        :explain {:order-specs (pr-str order-specs)}
        :fields fields
-       :->cursor (fn [{:keys [allocator]} in-cursor]
-                   (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil))})))
+       :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                   (cond-> (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil)
+                     explain-analyze? (ICursor/wrapExplainAnalyze)))})))

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -21,6 +21,9 @@
 (deftype RenameCursor [^ICursor in-cursor
                        ^Map #_#_<Symbol, Symbol> col-name-mapping]
   ICursor
+  (getCursorType [_] "rename")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [_ c]
     (.tryAdvance in-cursor
                  (fn [^RelationReader in-rel]

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -57,9 +57,10 @@
                                                (types/field-with-name (str (col-name-mapping (symbol (.getName field)))))))
                                          val)))))
      :stats (:stats emitted-child-relation)
-     :->cursor (fn [opts]
+     :->cursor (fn [{:keys [explain-analyze?] :as opts}]
                  (let [opts (-> opts
                                 (update :pushdown-blooms update-keys #(get col-name-reverse-mapping %))
                                 (update :pushdown-iids update-keys #(get col-name-reverse-mapping %)))]
-                   (util/with-close-on-catch [in-cursor (->inner-cursor opts)]
-                     (RenameCursor. in-cursor col-name-mapping))))}))
+                   (cond-> (util/with-close-on-catch [in-cursor (->inner-cursor opts)]
+                             (RenameCursor. in-cursor col-name-mapping))
+                     explain-analyze? (ICursor/wrapExplainAnalyze))))}))

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -41,6 +41,9 @@
 (deftype UnionAllCursor [^ICursor left-cursor
                          ^ICursor right-cursor]
   ICursor
+  (getCursorType [_] "union-all")
+  (getChildCursors [_] [left-cursor right-cursor])
+
   (tryAdvance [_ c]
     (let [advanced? (boolean-array 1 false)]
       (loop []
@@ -76,6 +79,9 @@
                              difference?
                              ^:unsynchronized-mutable build-phase-ran?]
   ICursor
+  (getCursorType [_] "intersection")
+  (getChildCursors [_] [left-cursor right-cursor])
+
   (tryAdvance [this c]
     (when-not build-phase-ran?
       (.forEachRemaining right-cursor

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -71,15 +71,16 @@
                     {:op :union-all
                      :children [left-rel right-rel]
                      :fields (union-fields left-fields right-fields)
-                     :->cursor (fn [_opts left-cursor right-cursor]
-                                 (UnionAllCursor. left-cursor right-cursor))})))
+                     :->cursor (fn [{:keys [explain-analyze?]} left-cursor right-cursor]
+                                 (cond-> (UnionAllCursor. left-cursor right-cursor)
+                                   explain-analyze? (ICursor/wrapExplainAnalyze)))})))
 
 (deftype IntersectionCursor [^ICursor left-cursor, ^ICursor right-cursor
                              ^BuildSide build-side, ->probe-side
                              difference?
                              ^:unsynchronized-mutable build-phase-ran?]
   ICursor
-  (getCursorType [_] "intersection")
+  (getCursorType [_] (if difference? "difference" "intersection"))
   (getChildCursors [_] [left-cursor right-cursor])
 
   (tryAdvance [this c]
@@ -119,39 +120,41 @@
 
 (defmethod lp/emit-expr :intersect [{:keys [left right]} args]
   (lp/binary-expr (lp/emit-expr left args) (lp/emit-expr right args)
-    (fn [{left-fields :fields :as left-rel} {right-fields :fields :as right-rel}]
-      (let [fields (union-fields left-fields right-fields)
-            key-col-names (set (keys fields))]
-        {:op :intersect
-         :children [left-rel right-rel]
-         :fields fields
-         :->cursor (fn [{:keys [allocator]} left-cursor right-cursor]
-                     (let [build-side (join/->build-side allocator
-                                                         {:fields left-fields
-                                                          :key-col-names key-col-names})]
+                  (fn [{left-fields :fields :as left-rel} {right-fields :fields :as right-rel}]
+                    (let [fields (union-fields left-fields right-fields)
+                          key-col-names (set (keys fields))]
+                      {:op :intersect
+                       :children [left-rel right-rel]
+                       :fields fields
+                       :->cursor (fn [{:keys [allocator explain-analyze?]} left-cursor right-cursor]
+                                   (let [build-side (join/->build-side allocator
+                                                                       {:fields left-fields
+                                                                        :key-col-names key-col-names})]
 
-                       (IntersectionCursor. left-cursor right-cursor
-                                            build-side (join/->probe-side build-side
-                                                                          {:fields right-fields
-                                                                           :key-col-names key-col-names})
-                                            false false)))}))))
+                                     (cond-> (IntersectionCursor. left-cursor right-cursor
+                                                                              build-side (join/->probe-side build-side
+                                                                                                            {:fields right-fields
+                                                                                                             :key-col-names key-col-names})
+                                                                              false false)
+                                       explain-analyze? (ICursor/wrapExplainAnalyze))))}))))
 
 (defmethod lp/emit-expr :difference [{:keys [left right]} args]
   (lp/binary-expr (lp/emit-expr left args) (lp/emit-expr right args)
-    (fn [{left-fields :fields :as left-rel} {right-fields :fields :as right-rel}]
-      (let [fields (union-fields left-fields right-fields)
-            key-col-names (set (keys fields))]
-        {:op :difference
-         :children [left-rel right-rel]
-         :fields fields
-         :->cursor (fn [{:keys [allocator]} left-cursor right-cursor]
-                     (let [build-side (join/->build-side allocator
-                                                         {:fields left-fields
-                                                          :key-col-names key-col-names})]
+                  (fn [{left-fields :fields :as left-rel} {right-fields :fields :as right-rel}]
+                    (let [fields (union-fields left-fields right-fields)
+                          key-col-names (set (keys fields))]
+                      {:op :difference
+                       :children [left-rel right-rel]
+                       :fields fields
+                       :->cursor (fn [{:keys [allocator explain-analyze?]} left-cursor right-cursor]
+                                   (let [build-side (join/->build-side allocator
+                                                                       {:fields left-fields
+                                                                        :key-col-names key-col-names})]
 
-                       (IntersectionCursor. left-cursor right-cursor
-                                            build-side (join/->probe-side build-side
-                                                                          {:build-fields left-fields
-                                                                           :probe-fields right-fields
-                                                                           :key-col-names key-col-names})
-                                            true false)))}))))
+                                     (cond-> (IntersectionCursor. left-cursor right-cursor
+                                                                              build-side (join/->probe-side build-side
+                                                                                                            {:build-fields left-fields
+                                                                                                             :probe-fields right-fields
+                                                                                                             :key-col-names key-col-names})
+                                                                              true false)
+                                       explain-analyze? (ICursor/wrapExplainAnalyze))))}))))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -201,5 +201,6 @@
      :children []
      :fields fields
      :stats (when row-count {:row-count row-count})
-     :->cursor (fn [opts]
-                 (TableCursor. (->out-rel opts)))}))
+     :->cursor (fn [{:keys [explain-analyze?] :as opts}]
+                 (cond-> (TableCursor. (->out-rel opts))
+                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -29,6 +29,9 @@
 
 (deftype TableCursor [^:unsynchronized-mutable ^RelationReader out-rel]
   ICursor
+  (getCursorType [_] "table")
+  (getChildCursors [_] [])
+
   (tryAdvance [this c]
     (boolean
      (when-let [out-rel out-rel]

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -31,6 +31,9 @@
                     ^long limit
                     ^:unsynchronized-mutable ^long idx]
   ICursor
+  (getCursorType [_] "top")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [this c]
     (let [advanced? (boolean-array 1)]
       (while (and (not (aget advanced? 0))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -30,6 +30,9 @@
                        ^Field to-field
                        ^String ordinality-column]
   ICursor
+  (getCursorType [_] "unnest")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [_this c]
     (let [advanced? (boolean-array 1)]
       (while (and (.tryAdvance in-cursor

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -122,7 +122,8 @@
                         :fields (-> fields
                                     (assoc to-col (types/field-with-name unnest-field (str to-col)))
                                     (cond-> ordinality-column (assoc ordinality-column (types/col-type->field ordinality-column :i32))))
-                        :->cursor (fn [{:keys [allocator]} in-cursor]
-                                    (UnnestCursor. allocator in-cursor
-                                                   (str from-col) (types/field-with-name unnest-field (str to-col))
-                                                   (some-> ordinality-column str)))})))))
+                        :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                                    (cond-> (UnnestCursor. allocator in-cursor
+                                                           (str from-col) (types/field-with-name unnest-field (str to-col))
+                                                           (some-> ordinality-column str))
+                                      explain-analyze? (ICursor/wrapExplainAnalyze)))})))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -169,13 +169,14 @@
                                                      [to-column (pr-str window-agg)]))))}
            :fields out-fields
 
-           :->cursor (fn [{:keys [allocator]} in-cursor]
-                       (util/with-close-on-catch [window-fn-specs (LinkedList.)]
-                         (doseq [^IWindowFnSpecFactory factory window-fn-factories]
-                           (.add window-fn-specs (.build factory allocator)))
+           :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                       (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
+                                 (doseq [^IWindowFnSpecFactory factory window-fn-factories]
+                                   (.add window-fn-specs (.build factory allocator)))
 
-                         (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
-                                          (group-by/->group-mapper allocator (select-keys fields partition-cols))
-                                          order-specs
-                                          (vec window-fn-specs)
-                                          false)))})))))
+                                 (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
+                                                  (group-by/->group-mapper allocator (select-keys fields partition-cols))
+                                                  order-specs
+                                                  (vec window-fn-specs)
+                                                  false))
+                         explain-analyze? (ICursor/wrapExplainAnalyze)))})))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -104,6 +104,9 @@
                          ^List window-specs
                          ^:unsynchronized-mutable ^boolean done?]
   ICursor
+  (getCursorType [_] "window")
+  (getChildCursors [_] [in-cursor])
+
   (tryAdvance [this c]
     (boolean
      (when-not done?

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -908,7 +908,7 @@
   (case statement-type
     (:query :execute :show-variable)
     (try
-      (let [{:keys [^Sql$DirectlyExecutableStatementContext parsed-query explain?]} stmt
+      (let [{:keys [^Sql$DirectlyExecutableStatementContext parsed-query explain? explain-analyze?]} stmt
 
             {:keys [session await-token]} @conn-state
             {:keys [^Clock clock]} session
@@ -917,6 +917,7 @@
                         :tx-timeout (Duration/ofMinutes 1)
                         :default-tz (.getZone clock)
                         :explain? explain?
+                        :explain-analyze? explain-analyze?
                         :default-db default-db}
 
             ^PreparedQuery pq (case statement-type

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2693,7 +2693,10 @@
 (defrecord StmtVisitor [env scope]
   SqlVisitor
   (visitQueryExpr [this ctx]
-    (let [query-vars (into {:explain? (boolean (.EXPLAIN ctx))}
+    (let [query-vars (into (cond
+                             (boolean (.ANALYZE ctx)) {:explain-analyze? true}
+                             (boolean (.EXPLAIN ctx)) {:explain? true}
+                             :else {})
                            (keep (partial accept-visitor this))
                            (some-> (.settingQueryVariables ctx)
                                    (.settingQueryVariable)))]
@@ -3057,7 +3060,7 @@
             (-> plan
                 (vary-meta (fn [m]
                              (-> (or m {})
-                                 (into (select-keys stmt [:explain? :current-time :snapshot-token]))
+                                 (into (select-keys stmt [:explain? :explain-analyze? :current-time :snapshot-token]))
                                  (assoc :param-count @!param-count
                                         :warnings @!warnings
                                         :ordered-outer-projection col-syms)))))))))))

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -4,6 +4,8 @@ import xtdb.api.query.IKeyFn
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.RelationReader
 import java.lang.AutoCloseable
+import java.time.Duration
+import java.time.InstantSource
 import java.util.*
 import java.util.function.Consumer
 import java.util.stream.StreamSupport
@@ -13,8 +15,16 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         fun open(): ICursor
     }
 
+    sealed interface ExplainAnalyze {
+        val rowCount: Long
+        val blockCount: Int
+        val timeToFirstBlock: Duration?
+        val totalTime: Duration
+    }
+
     val cursorType: String
     val childCursors: List<ICursor>
+    val explainAnalyze: ExplainAnalyze? get() = null
 
     override fun tryAdvance(c: Consumer<in RelationReader>): Boolean
     override fun trySplit(): Spliterator<RelationReader>? = null
@@ -31,5 +41,44 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         @JvmStatic
         fun <K> ICursor.toMaps(keyFn: IKeyFn<K>): List<Map<K, *>> =
             StreamSupport.stream(this, false).flatMap { it.toMaps(keyFn).stream() }.toList()
+
+        private class ExplainAnalyzeCursor(
+            private val inner: ICursor,
+            private val clock: InstantSource = InstantSource.system()
+        ) : ICursor by inner, ExplainAnalyze {
+            override var blockCount: Int = 0; private set
+            override var rowCount: Long = 0; private set
+
+            override var timeToFirstBlock: Duration? = null; private set
+            override var totalTime: Duration = Duration.ZERO; private set
+
+            override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
+                val blockStart = clock.instant()
+
+                return inner.tryAdvance { rel ->
+                    val blockTime = Duration.between(blockStart, clock.instant())
+
+                    timeToFirstBlock = timeToFirstBlock ?: blockTime
+
+                    rowCount += rel.rowCount
+                    blockCount++
+
+                    c.accept(rel)
+                }.also {
+                    totalTime += Duration.between(blockStart, clock.instant())
+                }
+            }
+
+            override val explainAnalyze get() = this
+
+            @Suppress("RedundantOverride") // otherwise `ICursor by inner` also complains
+            override fun forEachRemaining(action: Consumer<in RelationReader>?) = super.forEachRemaining(action)
+            override fun getExactSizeIfKnown(): Long = inner.exactSizeIfKnown
+            override fun hasCharacteristics(characteristics: Int): Boolean = inner.hasCharacteristics(characteristics)
+            override fun getComparator(): Comparator<in RelationReader>? = inner.comparator
+        }
+
+        @JvmStatic
+        fun ICursor.wrapExplainAnalyze(): ICursor = ExplainAnalyzeCursor(this)
     }
 }

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -13,6 +13,9 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         fun open(): ICursor
     }
 
+    val cursorType: String
+    val childCursors: List<ICursor>
+
     override fun tryAdvance(c: Consumer<in RelationReader>): Boolean
     override fun trySplit(): Spliterator<RelationReader>? = null
     override fun characteristics() = Spliterator.IMMUTABLE

--- a/core/src/main/kotlin/xtdb/PagesCursor.kt
+++ b/core/src/main/kotlin/xtdb/PagesCursor.kt
@@ -13,6 +13,9 @@ class PagesCursor(
     vals: Iterable<List<Map<*, *>>>
 ) : ICursor {
 
+    override val cursorType get() = "pages"
+    override val childCursors get() = emptyList<ICursor>()
+
     constructor(al: BufferAllocator, vals: Iterable<List<Map<*, *>>>): this(al, null, vals)
 
     private val vals = vals.spliterator()

--- a/core/src/main/kotlin/xtdb/PagesCursor.kt
+++ b/core/src/main/kotlin/xtdb/PagesCursor.kt
@@ -16,8 +16,6 @@ class PagesCursor(
     override val cursorType get() = "pages"
     override val childCursors get() = emptyList<ICursor>()
 
-    constructor(al: BufferAllocator, vals: Iterable<List<Map<*, *>>>): this(al, null, vals)
-
     private val vals = vals.spliterator()
 
     override fun tryAdvance(c: Consumer<in RelationReader>) =

--- a/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
@@ -11,7 +11,7 @@ import xtdb.util.closeAllOnCatch
 import java.util.function.Consumer
 
 class LetCursorFactory(
-    private val al: BufferAllocator, private val boundCursor: ICursor,
+    private val al: BufferAllocator, private val boundCursor: ICursor
 ) : ICursor.Factory, AutoCloseable {
 
     class BoundBatch(internal val schema: Schema, internal val recordBatch: ArrowRecordBatch) : AutoCloseable {
@@ -45,7 +45,7 @@ class LetCursorFactory(
 
                     // TODO: don't need all this openAsRoot dance when the operators all use xtdb.arrow
                     rel.openAsRoot(al).use { root ->
-                        c.accept(RelationReader.Companion.from(root))
+                        c.accept(RelationReader.from(root))
                     }
                 }
             }

--- a/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
@@ -35,6 +35,9 @@ class LetCursorFactory(
     override fun open() = object : ICursor {
         private val batches = boundBatches.spliterator()
 
+        override val cursorType get() = "let"
+        override val childCursors get() = emptyList<ICursor>()
+
         override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
             batches.tryAdvance { batch ->
                 Relation(al, batch.schema).use { rel ->
@@ -54,6 +57,9 @@ class LetCursorFactory(
     }
 
     fun wrapBodyCursor(bodyCursor: ICursor) = object : ICursor by bodyCursor {
+        override val cursorType get() = "let-wrapper"
+        override val childCursors get() = listOf(bodyCursor)
+
         override fun close() {
             bodyCursor.close()
             this@LetCursorFactory.close()

--- a/core/src/main/kotlin/xtdb/operator/PatchGapsCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/PatchGapsCursor.kt
@@ -15,6 +15,9 @@ class PatchGapsCursor(
     private val validTo: Long,
 ) : ICursor {
 
+    override val cursorType get() = "patch-gaps"
+    override val childCursors get() = listOf(inner)
+
     private val iidWriter = out.vectorFor("_iid")
     private val vfWriter = out.vectorFor("_valid_from")
     private val vtWriter = out.vectorFor("_valid_to")

--- a/core/src/main/kotlin/xtdb/operator/ProjectCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectCursor.kt
@@ -14,6 +14,10 @@ class ProjectCursor(
     private val schema: Map<String, Any>,
     private val args: RelationReader,
 ) : ICursor {
+
+    override val cursorType get() = "project"
+    override val childCursors get() = listOf(inCursor)
+
     override fun tryAdvance(c: Consumer<in RelationReader>): Boolean = inCursor.tryAdvance { inRel ->
         mutableListOf<VectorReader>().useAll { closeCols ->
             val outCols = specs.map { spec ->

--- a/core/src/main/kotlin/xtdb/operator/SelectCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/SelectCursor.kt
@@ -12,6 +12,9 @@ class SelectCursor(
     private val schema: Map<String, Any>,
     private val args: RelationReader
 ) : ICursor {
+
+    override val cursorType get() = "select"
+    override val childCursors get() = listOf(inCursor)
     override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
         var advanced = false
 

--- a/core/src/main/kotlin/xtdb/operator/apply/ApplyCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/apply/ApplyCursor.kt
@@ -13,6 +13,16 @@ class ApplyCursor(
     private val independentCursor: ICursor,
     private val depCursorFactory: DependentCursorFactory
 ) : ICursor {
+
+    override val cursorType get() = when (mode) {
+        is ApplyMode.MarkJoin -> "apply-mark-join"
+        is ApplyMode.CrossJoin -> "apply-cross-join"
+        is ApplyMode.LeftJoin -> "apply-left-join"
+        is ApplyMode.SemiJoin -> "apply-semi-join"
+        is ApplyMode.AntiJoin -> "apply-anti-join"
+        is ApplyMode.SingleJoin -> "apply-single-join"
+    }
+    override val childCursors get() = listOf(independentCursor)
     override fun tryAdvance(c: Consumer<in RelationReader>) =
         independentCursor.tryAdvance { inRel ->
             val idxs = IntArrayList()

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -32,6 +32,9 @@ class ScanCursor(
     private val iidPushdownBloom: BloomFilter?
 ) : ICursor {
 
+    override val cursorType get() = "scan"
+    override val childCursors get() = emptyList<ICursor>()
+
     private class LeafPointer(val evPtr: EventRowPointer, val relIdx: Int)
 
     private fun RelationReader.maybeSelect(iidPred: SelectionSpec?) =

--- a/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/ts_devices.clj
@@ -1,5 +1,6 @@
 (ns xtdb.bench.ts-devices
   (:require [clojure.test :as t]
+            [clojure.tools.logging :as log]
             [xtdb.bench :as b]
             [xtdb.bench.util :as bu]
             [xtdb.ts-devices :as tsd]

--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -184,8 +184,9 @@
      :children []
      :fields fields
      :stats stats
-     :->cursor (fn [{:keys [allocator]}]
-                 (->cursor allocator schema pages))}))
+     :->cursor (fn [{:keys [allocator explain-analyze?]}]
+                 (cond-> (->cursor allocator schema pages)
+                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))
 
 (defn <-cursor
   ([^ICursor cursor] (<-cursor cursor #xt/key-fn :kebab-case-keyword))

--- a/src/test/clojure/xtdb/tpch_test.clj
+++ b/src/test/clojure/xtdb/tpch_test.clj
@@ -180,6 +180,19 @@
       (dorun
        (map-indexed test-sql-query results-sf-001)))))
 
+(t/deftest test-001-sql-explain
+  (with-tpch-data {:method :dml, :scale-factor 0.001
+                   :node-dir (util/->path "target/tpch-queries-sql-sf-001")}
+    (fn []
+      (dotimes [n 22]
+        (let [q (inc n)]
+          (when (contains? *qs* q)
+            (t/is (xt/q *node* (str "EXPLAIN " (slurp-sql-query q)))
+                  (format "EXPLAIN Q%02d" (inc n)))
+
+            (t/is (xt/q *node* (str "EXPLAIN ANALYZE " (slurp-sql-query q)))
+                  (format "EXPLAIN ANALYZE Q%02d" (inc n)))))))))
+
 (t/deftest ^:integration test-01-sql
   (with-tpch-data {:method :dml, :scale-factor 0.01
                    :node-dir (util/->path "target/tpch-queries-sql-sf-01")}


### PR DESCRIPTION
(resolves #4737)

* When `EXPLAIN ANALYZE` is requested, we wrap each cursor in the tree with an `ExplainAnalyzeCursor`, which tracks the time taken and actual row counts of the result. We also track 'time to first block', which shows when the first block was yielded by each operation - n.b. the difference here between pipelining operators like project/select vs 'pipeline-breakers' which must materialize all/part of the input cursors.
* We run the query in its entirety - but, rather than returning the results of the original query, we then traverse the cursor tree to retrieve the statistics.

e.g. Q04 of TPC-H:

```sql

EXPLAIN ANALYZE
SELECT o.o_orderpriority, COUNT(*) AS order_count
FROM orders AS o
WHERE o.o_orderdate >= DATE '1993-07-01'
  AND o.o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
  AND EXISTS (
    FROM lineitem AS l
    WHERE l.l_orderkey = o.o_orderkey
      AND l.l_commitdate < l.l_receiptdate
  )
ORDER BY o.o_orderpriority;

        depth         |    op     |  total_time   | time_to_first_block | block_count | row_count
----------------------+-----------+---------------+---------------------+-------------+-----------
 ->                   | project   | "PT0.757754S" | "PT0.757717S"       |           1 |         5
   ->                 | order-by  | "PT0.757752S" | "PT0.757713S"       |           1 |         5
     ->               | project   | "PT0.757475S" | "PT0.757423S"       |           1 |         5
       ->             | group-by  | "PT0.757474S" | "PT0.75742S"        |           1 |         5
         ->           | project   | "PT0.757327S" | "PT0.670638S"       |         256 |      2539
           ->         | semi-join | "PT0.757259S" | "PT0.670606S"       |         256 |      2539
             ->       | project   | "PT0.656491S" | "PT0.000828S"       |        1024 |    189646
               ->     | rename    | "PT0.656324S" | "PT0.000816S"       |        1024 |    189646
                 ->   | select    | "PT0.655886S" | "PT0.000792S"       |        1024 |    189646
                   -> | scan      | "PT0.65443S"  | "PT0.00054S"        |        1024 |    299814
             ->       | rename    | "PT0.087767S" | "PT0.000705S"       |         256 |      2765
               ->     | scan      | "PT0.087687S" | "PT0.000694S"       |         256 |      2765
(12 rows)
```

`EXPLAIN`, for comparison:

```sql
        depth         |    op     |


  explain


----------------------+-----------+----------------------------------------------------------------
---------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------
 ->                   | project   | {"append?":false,"project":"[{o_orderpriority o.1\/o_orderprior
ity} order_count]"}
   ->                 | order-by  | {"order_specs":"[[o.1\/o_orderpriority {:direction :asc, :null-
ordering :nulls-last}]]"}
     ->               | project   | {"append?":false,"project":"[o.1\/o_orderpriority {order_count
_row_count_5}]"}
       ->             | group-by  | {"group_by":["o.1\/o_orderpriority"],"aggregates":[["_row_count
_5","[:nullary {:f row-count}]"]]}
         ->           | project   | {"append?":true,"project":"[{_sq_2 true}]"}
           ->         | semi-join | {"condition":"[{o.1\/o_orderkey l_orderkey}]"}
             ->       | rename    | {"prefix":"o.1"}
               ->     | scan      | {"predicates":["(and (< o_orderdate (+ #xt\/date \"1993-07-01\"
 (single-field-interval \"3\" \"MONTH\" 2 6))) (>= o_orderdate #xt\/date \"1993-07-01\"))"],"column
s":["o_orderkey","o_orderpriority","o_orderdate"],"table":"xtdb.public.orders"}
             ->       | project   | {"append?":false,"project":"[{_id l.3\/_id} {l_comment l.3\/l_c
omment} {l_commitdate l.3\/l_commitdate} {l_discount l.3\/l_discount} {l_extendedprice l.3\/l_exten
dedprice} {l_linenumber l.3\/l_linenumber} {l_linestatus l.3\/l_linestatus} {l_orderkey l.3\/l_orde
rkey} {l_partkey l.3\/l_partkey} {l_quantity l.3\/l_quantity} {l_receiptdate l.3\/l_receiptdate} {l
_returnflag l.3\/l_returnflag} {l_shipdate l.3\/l_shipdate} {l_shipinstruct l.3\/l_shipinstruct} {l
_shipmode l.3\/l_shipmode} {l_suppkey l.3\/l_suppkey} {l_tax l.3\/l_tax}]"}
               ->     | rename    | {"prefix":"l.3"}
                 ->   | select    | {"predicate":"(< l_commitdate l_receiptdate)"}
                   -> | scan      | {"predicates":[],"columns":["l_suppkey","l_shipdate","l_tax","l
_orderkey","l_receiptdate","l_partkey","l_extendedprice","l_quantity","l_discount","l_returnflag","
l_comment","_id","l_linestatus","l_shipinstruct","l_shipmode","l_linenumber","l_commitdate"],"table
":"xtdb.public.lineitem"}
(12 rows)
```