### PR TITLE
Handle empty children fields in `arrow-type->col-type`, resolves #4774

### DIFF
--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -1202,3 +1202,14 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b #{}} :xt/id 1}]])
   (xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}]])
   (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT * FROM docs"))))
+
+(t/deftest test-info-schema-with-empty-set-children-4774
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {:b #{}} :xt/id 1}]])
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:h {}, :xt/id 1} {:xt/id 1}]])
+  (t/is (= [{:column-name "_id"}
+            {:column-name "_system_from"}
+            {:column-name "_system_to"}
+            {:column-name "_valid_from"}
+            {:column-name "_valid_to"}
+            {:column-name "h"}]
+           (xt/q tu/*node* "SELECT column_name FROM information_schema.columns WHERE table_name = 'docs'"))))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -379,3 +379,7 @@
                (types/merge-fields nil set-field)))
       (t/is (= (types/->field "b" #xt.arrow/type :list true (types/->field "$data$" #xt.arrow/type :null true)) 
                (types/merge-fields nil list-field))))))
+
+(t/deftest field->col-type-error-on-empty-list-4774
+  (t/is (= [:union #{[:list :null] :null}] (types/field->col-type (types/->field "a" #xt.arrow/type :list true))))
+  (t/is (= [:union #{[:set :null] :null}] (types/field->col-type (types/->field "b" #xt.arrow/type :set true)))))


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Acol-type-issue-4774

Similar to the previous issue we observed within merge-fields - needing to handle the case where a list/set type has null/empty child fields within the arrow-type->col-type multimethod.