### PR TITLE
Fix TimestampTzVector for zdt period params, resolves #4379

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/TimestampVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/TimestampVector.kt
@@ -87,14 +87,8 @@ class TimestampTzVector private constructor(
     override fun writeObject0(value: Any): Unit =
         when (value) {
             is Instant -> value
-            is ZonedDateTime ->
-                if (value.zone == zone) value.toInstant()
-                else throw InvalidWriteObjectException(fieldType, value)
-
-            is OffsetDateTime ->
-                if (value.offset == zone) value.toInstant()
-                else throw InvalidWriteObjectException(fieldType, value)
-
+            is ZonedDateTime -> value.withZoneSameInstant(zone).toInstant()
+            is OffsetDateTime -> value.atZoneSameInstant(zone).toInstant()
             is Date -> value.toInstant()
             else -> throw InvalidWriteObjectException(fieldType, value)
         }.let {

--- a/core/src/test/kotlin/xtdb/KeyAlreadySetTest.kt
+++ b/core/src/test/kotlin/xtdb/KeyAlreadySetTest.kt
@@ -1,0 +1,297 @@
+package xtdb
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.complex.StructVector
+import org.junit.jupiter.api.Test
+import xtdb.arrow.Relation
+import xtdb.types.ZonedDateTimeRange
+import xtdb.vector.writerFor
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Tests related to the "xtdb/key-already-set" error that occurs in StructVectorWriter.
+ *
+ * This error happens in StructVectorWriter.writeObject0 when writer.valueCount != structPos,
+ * indicating that a key has already been written to the current struct position.
+ *
+ * The error occurs during parameter processing when:
+ * 1. Complex objects (like ZonedDateTimeRange, transit maps) get serialized into struct format
+ * 2. Somehow duplicate keys are created in the struct serialization process
+ * 3. A child writer's valueCount gets ahead of the expected struct position
+ *
+ * Location: /core/src/main/kotlin/xtdb/vector/StructVectorWriter.kt:84-85
+ */
+class KeyAlreadySetTest {
+
+    @Test
+    fun `demonstrates key-already-set error mechanism`() {
+        RootAllocator().use { allocator ->
+            // This test demonstrates the exact conditions under which the error occurs
+            // Even if we can't reproduce the original bug, this shows the mechanism
+
+            StructVector.empty("test", allocator).use { struct ->
+                val writer = writerFor(struct)
+
+                // First, write a normal struct
+                writer.writeObject(mapOf("key1" to "value1", "key2" to 42))
+
+                // The error occurs when writer.valueCount != structPos
+                // This would happen if somehow a child writer gets ahead of the struct position
+                //
+                // In the real bug scenario, this happens during parameter processing when:
+                // 1. A complex object (like ZonedDateTimeRange or transit map) gets serialized
+                // 2. The serialization process somehow causes duplicate key writes to struct children
+                // 3. The child writer's valueCount advances beyond the current struct position
+
+                println("Test completed - demonstrates the mechanism behind xtdb/key-already-set error")
+            }
+        }
+    }
+
+    @Test
+    fun `test simple parameter processing flow`() {
+        RootAllocator().use { allocator ->
+            // Simulate the exact parameter processing flow from open-args
+            // Use simple parameters that won't cause write exceptions
+            val parameters = listOf(
+                0,
+                "simple_string",
+                mapOf("nested" to "value")
+            )
+
+            // This follows the same path as open-args in writer.clj
+            val argsMap = parameters.mapIndexed { idx, value ->
+                "?_$idx" to value
+            }.toMap()
+
+            // This should complete without error in normal cases
+            Relation.openFromRows(allocator, listOf(argsMap)).use { relation ->
+                println("Parameter processing completed successfully")
+                println("Args: $argsMap")
+                println("Relation row count: ${relation.rowCount}")
+
+                // The key-already-set error would occur somewhere in this processing pipeline
+                // when complex objects create duplicate keys in struct serialization
+            }
+        }
+    }
+
+    @Test
+    fun `trace tstz-range serialization structure`() {
+        RootAllocator().use { allocator ->
+            try {
+                // Try to create a tstz-range parameter to see what structure gets created
+                val now = ZonedDateTime.now(ZoneOffset.UTC)
+                val range = ZonedDateTimeRange(now, now.plusHours(1))
+
+                // Follow the exact parameter processing path
+                val argsMap = mapOf("?_0" to range)
+
+                println("Creating relation with tstz-range parameter...")
+                println("Range: $range")
+
+                val relation = Relation.openFromRows(allocator, listOf(argsMap))
+                relation.use {
+                    println("Successfully created relation with tstz-range")
+                    println("Relation schema: ${relation.schema}")
+                    println("Column names: ${relation.vectors.map { it.name }}")
+
+                    // Try to inspect the actual vector structure
+                    val rangeVector = relation.vectorForOrNull("?_0")
+                    if (rangeVector != null) {
+                        println("Range vector field: ${rangeVector.field}")
+                        println("Range vector type: ${rangeVector.field.type}")
+                        println("Range vector children: ${rangeVector.field.children}")
+                    }
+                }
+            } catch (e: Exception) {
+                println("Error during tstz-range serialization: ${e.javaClass.simpleName}: ${e.message}")
+                e.printStackTrace()
+            }
+        }
+    }
+
+    @Test
+    fun `create struct with problematic field names`() {
+        RootAllocator().use { allocator ->
+            // Try to manually create a struct that might cause key collisions
+            // Based on the tstz-range structure, it uses "$data$" as a field name
+
+            try {
+                val struct = StructVector.empty("test_struct", allocator)
+                struct.use {
+                    val writer = writerFor(struct)
+
+                    // Try creating a struct with field names that might collide
+                    val problematicMap = mapOf(
+                        "\$data\$" to "value1",  // This is the field name used by tstz-range
+                        "normal_field" to "value2"
+                    )
+
+                    println("Writing problematic struct with \$data\$ field...")
+                    writer.writeObject(problematicMap)
+
+                    // Now try writing another row with the same field name
+                    println("Writing second row...")
+                    writer.writeObject(mapOf("\$data\$" to "value3", "normal_field" to "value4"))
+
+                    println("Successfully wrote struct with \$data\$ field")
+                    println("Struct field: ${struct.field}")
+                    println("Struct children: ${struct.field.children}")
+                }
+            } catch (e: Exception) {
+                println("Error with problematic struct: ${e.javaClass.simpleName}: ${e.message}")
+                if (e.message?.contains("key-already-set") == true) {
+                    println("*** REPRODUCED THE KEY-ALREADY-SET ERROR! ***")
+                }
+                e.printStackTrace()
+            }
+        }
+    }
+
+    @Test
+    fun `attempt to reproduce struct key collision with simulated complex serialization`() {
+        RootAllocator().use { allocator ->
+            try {
+                // Based on our investigation, the issue might arise when complex objects
+                // get processed multiple times or when nested serialization creates conflicts
+                // Let's try to simulate this by creating a scenario with nested maps
+
+                val complexNestedMap = mapOf(
+                    "outer" to mapOf(
+                        "\$data\$" to "timestamp_data_1",
+                        "normal" to "value1"
+                    ),
+                    "param" to mapOf(
+                        "\$data\$" to "timestamp_data_2", // Same field name as nested struct
+                        "other" to "value2"
+                    )
+                )
+
+                println("Attempting complex nested map with potentially conflicting \$data\$ fields...")
+                val argsMap = mapOf("?_0" to complexNestedMap)
+
+                val relation = Relation.openFromRows(allocator, listOf(argsMap))
+                relation.use {
+                    println("Successfully created relation with complex nested map")
+                    println("Relation schema: ${relation.schema}")
+
+                    // Try to inspect the actual structure
+                    val paramVector = relation.vectorForOrNull("?_0")
+                    if (paramVector != null) {
+                        println("Param vector field: ${paramVector.field}")
+                        println("Param vector children: ${paramVector.field.children}")
+                    }
+                }
+            } catch (e: Exception) {
+                println("Error with complex nested map: ${e.javaClass.simpleName}: ${e.message}")
+                if (e.message?.contains("key-already-set") == true) {
+                    println("*** REPRODUCED THE KEY-ALREADY-SET ERROR! ***")
+                }
+                e.printStackTrace()
+            }
+        }
+    }
+
+    @Test
+    fun `inspect actual tstz-range vector structure with working timestamp`() {
+        RootAllocator().use { allocator ->
+            try {
+                // Try to create a working tstz-range to understand the structure
+                // Use Instant.now() and convert properly
+                val now = java.time.Instant.now()
+                val later = now.plusSeconds(3600)
+
+                // Create ZonedDateTime from Instant to ensure proper UTC handling
+                val fromZdt = now.atZone(ZoneOffset.UTC)
+                val toZdt = later.atZone(ZoneOffset.UTC)
+                val range = ZonedDateTimeRange(fromZdt, toZdt)
+
+                println("Attempting to trace tstz-range structure with proper UTC timestamps...")
+                println("From: $fromZdt")
+                println("To: $toZdt")
+                println("Range: $range")
+
+                // Try direct vector creation to see the internal structure
+                val field = xtdb.vector.extensions.TsTzRangeVector.tsTzRangeField
+                println("TsTzRange field structure: $field")
+                println("TsTzRange field children: ${field.children}")
+
+                // Let's try to understand what the internal serialization does
+                val argsMap = mapOf("?_0" to range)
+                val relation = Relation.openFromRows(allocator, listOf(argsMap))
+                relation.use {
+                    println("Successfully created relation with proper tstz-range!")
+                    println("Schema: ${relation.schema}")
+                }
+
+            } catch (e: Exception) {
+                println("Error with proper tstz-range: ${e.javaClass.simpleName}: ${e.message}")
+                if (e.message?.contains("key-already-set") == true) {
+                    println("*** REPRODUCED THE KEY-ALREADY-SET ERROR! ***")
+                }
+                // Don't print full stack trace for this one, just the first few lines
+                val stackLines = e.stackTrace.take(5).joinToString("\n") { "  at $it" }
+                println("Stack trace (first 5 lines):\n$stackLines")
+            }
+        }
+    }
+
+    @Test
+    fun `understand the root cause - timezone mismatch prevents tstz-range serialization`() {
+        RootAllocator().use { allocator ->
+            println("=== ROOT CAUSE ANALYSIS ===")
+
+            // The actual issue: ZonedDateTime.now(ZoneOffset.UTC) creates a ZonedDateTime
+            // with ZoneOffset.UTC, but TimestampTzVector expects ZoneId.of("UTC")
+
+            val offsetUtc = ZoneOffset.UTC  // This is a ZoneOffset
+            val zoneIdUtc = ZoneId.of("UTC")  // This is a ZoneId
+
+            println("ZoneOffset.UTC: $offsetUtc (${offsetUtc::class.simpleName})")
+            println("ZoneId.of(\"UTC\"): $zoneIdUtc (${zoneIdUtc::class.simpleName})")
+            println("Are they equal? ${offsetUtc == zoneIdUtc}")
+
+            val now = java.time.Instant.now()
+
+            // This will fail because ZoneOffset.UTC != ZoneId.of("UTC")
+            val zonedWithOffset = now.atZone(ZoneOffset.UTC)
+            println("ZonedDateTime with ZoneOffset.UTC: $zonedWithOffset")
+            println("  Zone: ${zonedWithOffset.zone} (${zonedWithOffset.zone::class.simpleName})")
+
+            // This should work because it uses ZoneId.of("UTC")
+            val zonedWithZoneId = now.atZone(ZoneId.of("UTC"))
+            println("ZonedDateTime with ZoneId.of(\"UTC\"): $zonedWithZoneId")
+            println("  Zone: ${zonedWithZoneId.zone} (${zonedWithZoneId.zone::class.simpleName})")
+
+            try {
+                // This should fail - confirms the root cause
+                println("\n--- Testing ZonedDateTimeRange with ZoneOffset.UTC (should fail) ---")
+                val rangeWithOffset = ZonedDateTimeRange(zonedWithOffset, zonedWithOffset.plusHours(1))
+                val argsMap1 = mapOf("?_0" to rangeWithOffset)
+                Relation.openFromRows(allocator, listOf(argsMap1)).use {
+                    println("ERROR: This should have failed!")
+                }
+            } catch (e: Exception) {
+                println("EXPECTED: Failed as expected - ${e.javaClass.simpleName}: ${e.message}")
+            }
+
+            try {
+                // This should work - provides the solution
+                println("\n--- Testing ZonedDateTimeRange with ZoneId.of(\"UTC\") (should work) ---")
+                val rangeWithZoneId = ZonedDateTimeRange(zonedWithZoneId, zonedWithZoneId.plusHours(1))
+                val argsMap2 = mapOf("?_0" to rangeWithZoneId)
+                Relation.openFromRows(allocator, listOf(argsMap2)).use {
+                    println("SUCCESS: ZonedDateTimeRange serialization worked!")
+                    println("The key-already-set error is NOT related to tstz-range serialization.")
+                    println("The issue was that we were using ZoneOffset.UTC instead of ZoneId.of(\"UTC\").")
+                }
+            } catch (e: Exception) {
+                println("UNEXPECTED: This should have worked - ${e.javaClass.simpleName}: ${e.message}")
+            }
+        }
+    }
+
+}

--- a/core/src/test/kotlin/xtdb/arrow/ExtensionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/ExtensionVectorTest.kt
@@ -7,6 +7,7 @@ import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.FieldType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.types.ClojureForm
@@ -20,6 +21,7 @@ import xtdb.vector.extensions.TsTzRangeVector.Companion.tsTzRangeField
 import xtdb.vector.extensions.UuidType
 import xtdb.vector.writerFor
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit.MICROS
 import java.util.*
@@ -67,5 +69,49 @@ class ExtensionVectorTest {
         testEqualHashcode(tsTzRangeField, ZonedDateTimeRange(zdt, zdt))
 
         testEqualHashcode("uuid", FieldType.nullable(UuidType), UUID.randomUUID())
+    }
+
+    @Test
+    fun `test TimestampTzVector timezone compatibility issue`() {
+        // This test demonstrates the issue found in the tstz-range investigation:
+        // ZonedDateTime created with ZoneOffset.UTC vs ZoneId.of("UTC") are not equal
+        // and cause InvalidWriteObjectException in TimestampTzVector.writeObject0
+
+        val instant = java.time.Instant.now().truncatedTo(MICROS)
+
+        // This creates a ZonedDateTime with ZoneOffset.UTC (what timestamp literals with 'Z' produce)
+        val zonedWithOffset = instant.atZone(ZoneOffset.UTC)
+
+        // This creates a ZonedDateTime with ZoneId.of("UTC") (what TimestampTzVector expects)
+        val zonedWithZoneId = instant.atZone(ZoneId.of("UTC"))
+
+        println("ZonedDateTime with ZoneOffset.UTC: $zonedWithOffset")
+        println("  Zone: ${zonedWithOffset.zone} (${zonedWithOffset.zone::class.simpleName})")
+        println("ZonedDateTime with ZoneId.of(\"UTC\"): $zonedWithZoneId")
+        println("  Zone: ${zonedWithZoneId.zone} (${zonedWithZoneId.zone::class.simpleName})")
+        println("Are zones equal? ${zonedWithOffset.zone == zonedWithZoneId.zone}")
+
+        // Verify they represent the same time but have different zone types
+        assertEquals(instant, zonedWithOffset.toInstant())
+        assertEquals(instant, zonedWithZoneId.toInstant())
+        assertNotEquals(zonedWithOffset.zone, zonedWithZoneId.zone, "Zones should NOT be equal")
+
+        // Create a TimestampTzVector with ZoneId.of("UTC") (the default)
+        TimestampTzVector(al, "test_ts", true, org.apache.arrow.vector.types.TimeUnit.MICROSECOND, ZoneId.of("UTC")).use { vector ->
+
+            // This should work - zone matches
+            vector.writeObject(zonedWithZoneId)
+            assertEquals(zonedWithZoneId, vector.getObject(0))
+            println("SUCCESS: ZonedDateTime with ZoneId.of(\"UTC\") worked")
+
+            // With the fix, this should now work - zones should be considered equivalent
+            vector.writeObject(zonedWithOffset)
+            // Both timestamps should represent the same instant in time
+            val retrievedZdt = vector.getObject(1)
+            assertEquals(instant, (retrievedZdt as java.time.ZonedDateTime).toInstant())
+            println("SUCCESS: ZonedDateTime with ZoneOffset.UTC now works with the fix!")
+            println("Retrieved: $retrievedZdt")
+            println("This confirms the fix resolves the tstz-range serialization issue")
+        }
     }
 }


### PR DESCRIPTION
I hit this while updating the driver-examples Clojure ns, which uses a transit map param (which in turn includes a tstzrange literal)

The original issue was that TimestampTzVector.writeObject0 would reject ZonedDateTime values if their timezone didn't exactly match the vector's timezone. This was particularly problematic for:
- ZoneOffset.UTC (from "Z" suffix literals) vs ZoneId.of("UTC")
- Other timezone equivalencies (e.g., "+00:00", "GMT", etc.)
- Any timestamp with a different but compatible timezone

Instead of requiring exact timezone equality (and otherwise throwing exceptions), we now convert all timestamps to the vector's timezone using withZoneSameInstant().

I'll kill / clean up the superfluous tests here, but wanted to "show my working" while confirming the actual fix is sound.