### PR TITLE
Add explicit releaseBuffer method called by users of buffers.

### DIFF
--- a/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
@@ -154,11 +154,16 @@ class MemoryCache @JvmOverloads internal constructor(
         val nettyBuf = entry.nettyBuf
 
         // create a new ArrowBuf for each request.
-        // when the ref-count drops to zero, we release a ref-count in the cache.
+        // release0() is now a no-op - callers must explicitly call tryRelease()
         return al.wrapForeignAllocation(
             object : ForeignAllocation(nettyBuf.capacity().toLong(), nettyBuf.memoryAddress()) {
-                override fun release0() = pinningCache.releaseEntry(k)
+                override fun release0() { /* no-op */ }
             })
+    }
+
+
+    fun releaseEntry(k: PathSlice) {
+        pinningCache.releaseEntry(k)
     }
 
     fun invalidate(k: PathSlice) = pinningCache.invalidate(k)

--- a/core/src/main/kotlin/xtdb/storage/BufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/BufferPool.kt
@@ -41,6 +41,12 @@ sealed interface BufferPool : AutoCloseable {
      */
     fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch
 
+    /**
+     * Explicitly called when consumers are done with the ArrowBufs
+     * Release the entry and attempt to unpin - logic handled by the pinning cache
+     */
+    fun releaseEntry(key: Path)
+
     fun putObject(key: Path, buffer: ByteBuffer)
 
     /**
@@ -78,6 +84,7 @@ sealed interface BufferPool : AutoCloseable {
             override fun copyObject(src: Path, dest: Path) = unsupported("copyObject")
             override fun deleteIfExists(key: Path) = unsupported("deleteIfExists")
             override fun openArrowWriter(key: Path, rel: Relation) = unsupported("openArrowWriter")
+            override fun releaseEntry(key: Path) = unsupported("releaseEntry")
 
             override fun close() = Unit
         }

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -120,6 +120,9 @@ internal class MemoryStorage(
         }
     }
 
+    // No-op for MemoryStorage as it doesn't use MemoryCache
+    override fun releaseEntry(key: Path) {}
+
     override fun evictCachedBuffer(key: Path) {}
 
     override fun close() {


### PR DESCRIPTION
A more explicit method of ensuring that entries are unpinned when no longer in use, rather than making using of release0 within the wrapForeignAllocation - equivalence change to make switching to directly allocating arrowBufs easier.