### PR TITLE
Add some further utils for reading crash log contents.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -650,3 +650,13 @@ tasks.register<JavaExec>("readArrowStreamFile") {
     val file = project.property("file") as? String ?: error("Please provide -Pfile")
     this.args = listOf("-m", "xtdb.main", "read-arrow-stream-file", file)
 }
+
+tasks.register<JavaExec>("readHashTrieFile") {
+    dependsOn(":xtdb-core:compileClojure", ":xtdb-core:compileKotlin")
+
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+    val file = project.property("file") as? String ?: error("Please provide -Pfile")
+    this.args = mutableListOf("-m", "xtdb.main", "read-hash-trie-file", file)
+}

--- a/core/src/main/clojure/xtdb/arrow.clj
+++ b/core/src/main/clojure/xtdb/arrow.clj
@@ -3,11 +3,13 @@
   (:require xtdb.mirrors.time-literals
             xtdb.serde.types
             [xtdb.test-util :as tu]
+            [xtdb.trie :as trie]
             [xtdb.util :as util])
   (:import (java.nio.file Files)
            [java.util Spliterators]
            (org.apache.arrow.memory BufferAllocator RootAllocator)
-           (xtdb.arrow Relation)))
+           (xtdb.arrow NullVector Relation) 
+           (xtdb.trie MemoryHashTrie)))
 
 (defn read-arrow-stream-file
   ([path-ish]
@@ -42,4 +44,7 @@
    (with-arrow-file path-ish
      (fn [res]
        (update res :batches vec)))))
+
+(defn read-hash-trie-file [path-ish]
+  (trie/<-MemoryHashTrie (MemoryHashTrie/fromProto (Files/readAllBytes (util/->path path-ish)) (NullVector. "_iid" 0))))
 

--- a/core/src/main/clojure/xtdb/main.clj
+++ b/core/src/main/clojure/xtdb/main.clj
@@ -202,6 +202,25 @@
           (println "Usage: `read-arrow-stream-file <file>`")
           (System/exit 2))))))
 
+(def read-hash-trie-file-cli-spec
+  [["-h" "--help"]])
+
+(defn read-hash-trie-file [args]
+  (let [{{:keys [help]} :options} (-> (parse-args args read-hash-trie-file-cli-spec)
+                                      (handling-arg-errors-or-help))]
+    (if help
+      (do
+        (println "Usage: read-hash-trie-file <file>")
+        (System/exit 0))
+
+      (if-let [file (first args)]
+        (binding [pp/*print-right-margin* 120]
+          (pp/pprint ((requiring-resolve 'xtdb.arrow/read-hash-trie-file) file)))
+
+        (binding [*out* *err*]
+          (println "Usage: `read-hash-trie-file <file>")
+          (System/exit 2))))))
+
 (defn -main [& args]
   (binding [*out* *err*]
     (println (str "Starting " (version-string) " ...")))
@@ -228,6 +247,10 @@
         "read-arrow-stream-file" (do
                                    (read-arrow-stream-file more-args)
                                    (System/exit 0))
+
+        "read-hash-trie-file" (do
+                                (read-hash-trie-file more-args)
+                                (System/exit 0))
 
         ("help" "-h" "--help") (do
                                  (print-help)

--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -132,6 +132,25 @@ These tools output an Arrow file in EDN format
 --
 * `./gradlew -q :readArrowFile -Pfile=<file>`
 * `./gradlew -q :readArrowStreamFile -Pfile=<file>` if it's in 'stream IPC' format.
+* Pipe to a file: `./gradlew -q :readArrowFile -Pfile=<file> > output.edn`
+--
+
+Reading a hash trie file::
++
+--
+* `./gradlew -q :readHashTrieFile -Pfile=<file>`
+* Pipe to a file: `./gradlew -q :readHashTrieFile -Pfile=<file> > output.edn`
+--
+
+Reading crash logs::
++
+--
+Process crash logs into EDN format:
+
+1. Run: `./dev/read-crash-log-folder.sh <crash-log-dir>`
+2. EDN files will be output to `<crash-log-dir>/edn/`
+
+Example: `./dev/read-crash-log-folder.sh /path/to/my-crash-logs` outputs to `/path/to/my-crash-logs/edn/`
 --
 
 == Arrow Fork

--- a/dev/read-crash-log-folder.sh
+++ b/dev/read-crash-log-folder.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: $0 <crash-log-dir>" >&2
+  exit 1
+}
+
+process_file() {
+  local task=$1 in=$2 out=$3
+  [[ -f $in ]] || return
+  echo "Processing $(basename "$in") -> $(basename "$out")"
+  "$PROJECT_ROOT/gradlew" -q "$task" -Pfile="$in" > "$out"
+}
+
+copy_edn_files() {
+  [[ -f "$1/crash.edn" ]] && {
+    echo "Copying crash.edn"
+    cp "$1/crash.edn" "$2/"
+  }
+}
+
+process_arrow_files() {
+  process_file readArrowFile "$1/query-rel.arrow" "$2/query-rel.edn"
+  process_file readArrowFile "$1/tx-ops.arrow" "$2/tx-ops.edn"
+  process_file readArrowFile "$1/live-table-tx.arrow" "$2/live-table-tx.edn"
+}
+
+process_trie_files() {
+  process_file readHashTrieFile "$1/live-trie-tx.binpb" "$2/live-trie-tx.edn"
+  process_file readHashTrieFile "$1/live-trie.binpb" "$2/live-trie.edn"
+}
+
+main() {
+  [[ $# -eq 1 ]] || usage
+  [[ -d $1 ]] || { echo "Error: crash log directory '$1' not found" >&2; exit 1; }
+
+  PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+  local crash_log_dir
+  crash_log_dir=$(cd "$1" && pwd)
+
+  local out_dir="$crash_log_dir/edn"
+  mkdir -p "$out_dir"
+
+  echo "Reading crash log files from $crash_log_dir ..."
+
+  copy_edn_files "$crash_log_dir" "$out_dir"
+  process_arrow_files "$crash_log_dir" "$out_dir"
+  process_trie_files "$crash_log_dir" "$out_dir"
+
+  echo "Done. EDN files in $out_dir"
+}
+
+main "$@"


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aread-crash-log-contents

Adds readHashTrieFile for the binpb files in the crash log.

Adds a script to read contents of a crash log folder and output a number of human readable .edn files 
- Essentially can quickly read off all of the files within an exported  crash log folder by running `./dev/read-crash-log-folder.sh /path/to/my-crash-logs`