### PR TITLE
XT Arrow migration part n-1 (hopefully)

### DIFF
--- a/core/src/main/clojure/xtdb/coalesce.clj
+++ b/core/src/main/clojure/xtdb/coalesce.clj
@@ -1,6 +1,5 @@
 (ns xtdb.coalesce
   (:require [xtdb.util :as util]
-            [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import org.apache.arrow.memory.BufferAllocator
            (xtdb.arrow Relation RelationReader)
@@ -26,30 +25,29 @@
           (let [!passed-on? (volatile! false)
                 advanced? (.tryAdvance cursor
                                        (fn [^RelationReader read-rel]
-                                         (util/with-open [read-rel (.openDirectSlice read-rel allocator)]
-                                           (let [row-count (.getRowCount read-rel)
-                                                 seen-rows (.seen-rows this)]
-                                             (cond
-                                               ;; haven't seen many rows yet, send this one straight through
-                                               (< seen-rows pass-through)
-                                               (with-open [root (.openAsRoot read-rel allocator)]
-                                                 (set! (.seen-rows this) (+ seen-rows row-count))
-                                                 (.accept c (vr/<-root root))
-                                                 (vreset! !passed-on? true))
+                                         (let [row-count (.getRowCount read-rel)
+                                               seen-rows (.seen-rows this)]
+                                           (cond
+                                             ;; haven't seen many rows yet, send this one straight through
+                                             (< seen-rows pass-through)
+                                             (do
+                                               (set! (.seen-rows this) (+ seen-rows row-count))
+                                               (.accept c read-rel)
+                                               (vreset! !passed-on? true))
 
-                                               ;; this page is big enough, and we don't have rows waiting
-                                               ;; send it straight through, no copy.
-                                               (and (>= row-count ideal-min-page-size)
-                                                    (nil? @!out-rel))
-                                               (with-open [root (.openAsRoot read-rel allocator)]
-                                                 (.accept c (vr/<-root root))
-                                                 (vreset! !passed-on? true))
+                                             ;; this page is big enough, and we don't have rows waiting
+                                             ;; send it straight through, no copy.
+                                             (and (>= row-count ideal-min-page-size)
+                                                  (nil? @!out-rel))
+                                             (do
+                                               (.accept c read-rel)
+                                               (vreset! !passed-on? true))
 
-                                               ;; otherwise, add it to the pending rows.
-                                               :else
-                                               (let [out-rel (vswap! !out-rel #(or % (Relation. allocator)))]
-                                                 (vw/append-rel out-rel read-rel)
-                                                 (vswap! !rows-appended + row-count)))))))
+                                             ;; otherwise, add it to the pending rows.
+                                             :else
+                                             (let [out-rel (vswap! !out-rel #(or % (Relation. allocator)))]
+                                               (vw/append-rel out-rel read-rel)
+                                               (vswap! !rows-appended + row-count))))))
                 rows-appended @!rows-appended]
 
             (cond
@@ -60,9 +58,10 @@
               (and advanced? (< rows-appended ideal-min-page-size)) (recur)
 
               ;; we've got rows, and either the source is done or there's enough already - send them through
-              (pos? rows-appended) (with-open [root (.openAsRoot ^Relation @!out-rel allocator)]
-                                     (.accept c (vr/<-root root))
-                                     true)
+              (pos? rows-appended)
+              (do
+                (.accept c @!out-rel)
+                true)
 
               ;; no more rows in input, and none to pass through, we're done
               :else false)))

--- a/core/src/main/clojure/xtdb/coalesce.clj
+++ b/core/src/main/clojure/xtdb/coalesce.clj
@@ -1,9 +1,10 @@
 (ns xtdb.coalesce
   (:require [xtdb.util :as util]
+            [xtdb.vector.reader :as vr]
             [xtdb.vector.writer :as vw])
   (:import org.apache.arrow.memory.BufferAllocator
-           xtdb.ICursor
-           (xtdb.arrow RelationReader)))
+           (xtdb.arrow Relation RelationReader)
+           xtdb.ICursor))
 
 ;; We pass the first 100 results through immediately, so that any limit-like queries don't need to wait for a full page to return rows.
 ;; Then, we coalesce small pages together into pages of at least 100, to share the per-page costs.
@@ -18,36 +19,37 @@
   (getChildCursors [_] (.getChildCursors cursor))
 
   (tryAdvance [this c]
-    (let [!rel-writer (volatile! nil)
+    (let [!out-rel (volatile! nil)
           !rows-appended (volatile! 0)]
       (try
         (loop []
           (let [!passed-on? (volatile! false)
                 advanced? (.tryAdvance cursor
                                        (fn [^RelationReader read-rel]
-                                         (let [row-count (.getRowCount read-rel)
-                                               seen-rows (.seen-rows this)]
-                                           (cond
-                                             ;; haven't seen many rows yet, send this one straight through
-                                             (< seen-rows pass-through)
-                                             (do
-                                               (set! (.seen-rows this) (+ seen-rows row-count))
-                                               (.accept c read-rel)
-                                               (vreset! !passed-on? true))
+                                         (util/with-open [read-rel (.openDirectSlice read-rel allocator)]
+                                           (let [row-count (.getRowCount read-rel)
+                                                 seen-rows (.seen-rows this)]
+                                             (cond
+                                               ;; haven't seen many rows yet, send this one straight through
+                                               (< seen-rows pass-through)
+                                               (with-open [root (.openAsRoot read-rel allocator)]
+                                                 (set! (.seen-rows this) (+ seen-rows row-count))
+                                                 (.accept c (vr/<-root root))
+                                                 (vreset! !passed-on? true))
 
-                                             ;; this page is big enough, and we don't have rows waiting
-                                             ;; send it straight through, no copy.
-                                             (and (>= row-count ideal-min-page-size)
-                                                  (nil? @!rel-writer))
-                                             (do
-                                               (.accept c read-rel)
-                                               (vreset! !passed-on? true))
+                                               ;; this page is big enough, and we don't have rows waiting
+                                               ;; send it straight through, no copy.
+                                               (and (>= row-count ideal-min-page-size)
+                                                    (nil? @!out-rel))
+                                               (with-open [root (.openAsRoot read-rel allocator)]
+                                                 (.accept c (vr/<-root root))
+                                                 (vreset! !passed-on? true))
 
-                                             ;; otherwise, add it to the pending rows.
-                                             :else
-                                             (let [rel-writer (vswap! !rel-writer #(or % (vw/->rel-writer allocator)))]
-                                               (vw/append-rel rel-writer read-rel)
-                                               (vswap! !rows-appended + row-count))))))
+                                               ;; otherwise, add it to the pending rows.
+                                               :else
+                                               (let [out-rel (vswap! !out-rel #(or % (Relation. allocator)))]
+                                                 (vw/append-rel out-rel read-rel)
+                                                 (vswap! !rows-appended + row-count)))))))
                 rows-appended @!rows-appended]
 
             (cond
@@ -58,15 +60,15 @@
               (and advanced? (< rows-appended ideal-min-page-size)) (recur)
 
               ;; we've got rows, and either the source is done or there's enough already - send them through
-              (pos? rows-appended) (do
-                                     (.accept c (vw/rel-wtr->rdr @!rel-writer))
+              (pos? rows-appended) (with-open [root (.openAsRoot ^Relation @!out-rel allocator)]
+                                     (.accept c (vr/<-root root))
                                      true)
 
               ;; no more rows in input, and none to pass through, we're done
               :else false)))
 
         (finally
-          (util/try-close @!rel-writer)))))
+          (util/try-close @!out-rel)))))
 
   (close [_]
     (.close cursor)))

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -313,6 +313,28 @@
   :hierarchy #'types/col-type-hierarchy)
 
 #_{:clj-kondo/ignore [:unused-binding]}
+(defmulti set-value-code
+  (fn [col-type & args]
+    (types/col-type-head col-type))
+  :default ::default
+  :hierarchy #'types/col-type-hierarchy)
+
+(defmethod set-value-code :null [_ w idx _val] `(.setNull ~w ~idx))
+(defmethod set-value-code :bool [_ w idx val] `(.setBoolean ~w ~idx ~val))
+(defmethod set-value-code :i32 [_ w idx val] `(.setInt ~w ~idx ~val))
+(defmethod set-value-code :i64 [_ w idx val] `(.setLong ~w ~idx ~val))
+(defmethod set-value-code :f32 [_ w idx val] `(.setFloat ~w ~idx ~val))
+(defmethod set-value-code :f64 [_ w idx val] `(.setDouble ~w ~idx ~val))
+(defmethod set-value-code :duration [_ w idx val] `(.setLong ~w ~idx ~val))
+(defmethod set-value-code :timestamp-local [_ w idx val] `(.setLong ~w ~idx ~val))
+(defmethod set-value-code :timestamp-tz [_ w idx val] `(.setLong ~w ~idx ~val))
+
+(defmethod set-value-code :date [[_ date-unit] w idx val]
+  (case date-unit
+    :day `(.setInt ~w ~idx ~val)
+    :milli `(.setLong ~w ~idx ~val)))
+
+#_{:clj-kondo/ignore [:unused-binding]}
 (defmulti write-value-code
   (fn [col-type & args]
     (types/col-type-head col-type))

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -88,7 +88,8 @@
                                               :param-types (update-vals param-fields types/field->col-type)}
                                  projection-spec (expr/->expression-projection-spec "_expr" (expr/form->expr form input-types) input-types)]
                              (fn [{:keys [allocator args explain-analyze?] :as query-opts}]
-                               (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
+                               (let [^ICursor dep-cursor (-> (->dependent-cursor query-opts)
+                                                             (ICursor/wrapDirectSlice allocator))]
                                  (cond-> (reify ICursor
                                            (getCursorType [_] "apply-mark-join")
                                            (getChildCursors [_] [dep-cursor])
@@ -104,16 +105,18 @@
                            [:otherwise _] ->dependent-cursor)]
 
                      (fn [{:keys [allocator explain-analyze?] :as query-opts} independent-cursor]
-                       (cond-> (ApplyCursor. allocator mode-strat independent-cursor out-dep-fields
+                       (cond-> (ApplyCursor. allocator mode-strat (-> independent-cursor (ICursor/wrapDirectSlice allocator)) out-dep-fields
                                              (reify DependentCursorFactory
                                                (open [_this in-rel idx]
-                                                 (open-dependent-cursor (-> query-opts
-                                                                            (update :args
-                                                                                    (fn [^RelationReader args]
-                                                                                      (RelationReader/from (concat args
-                                                                                                                   (for [[ik dk] columns]
-                                                                                                                     (-> (.vectorForOrNull in-rel (str ik))
-                                                                                                                         (.select (int-array [idx]))
-                                                                                                                         (.withName (str dk)))))
-                                                                                                           1))))))))
-                         explain-analyze? (ICursor/wrapExplainAnalyze))))}))))
+                                                 (-> (open-dependent-cursor (-> query-opts
+                                                                                (update :args
+                                                                                        (fn [^RelationReader args]
+                                                                                          (RelationReader/from (concat args
+                                                                                                                       (for [[ik dk] columns]
+                                                                                                                         (-> (.vectorForOrNull in-rel (str ik))
+                                                                                                                             (.select (int-array [idx]))
+                                                                                                                             (.withName (str dk)))))
+                                                                                                               1)))))
+                                                     (ICursor/wrapDirectSlice allocator)))))
+                         explain-analyze? (ICursor/wrapExplainAnalyze)
+                         true (ICursor/wrapAsOldRel allocator))))}))))

--- a/core/src/main/clojure/xtdb/operator/csv.clj
+++ b/core/src/main/clojure/xtdb/operator/csv.clj
@@ -51,8 +51,7 @@
                       (.getVectors rel)))
 
         (.setRowCount rel row-count)
-        (with-open [root (.openAsRoot rel allocator)]
-          (.accept c (vr/<-root root)))
+        (.accept c rel)
         true)
       false))
 

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -28,22 +28,18 @@
       (while (and (not (aget advanced? 0))
                   (.tryAdvance in-cursor
                                (fn [^RelationReader in-rel]
-                                 ;; HACK while we're migrating to xt-arrow
-                                 (with-open [in-rel (.openDirectSlice in-rel al)]
-                                   (let [row-count (.getRowCount in-rel)]
-                                     (when (pos? row-count)
-                                       (let [builder (.buildFromRelation rel-map in-rel)
-                                             idxs (IntStream/builder)]
-                                         (dotimes [idx row-count]
-                                           (when (neg? (.addIfNotPresent builder idx))
-                                             (.add idxs idx)))
+                                 (let [row-count (.getRowCount in-rel)]
+                                   (when (pos? row-count)
+                                     (let [builder (.buildFromRelation rel-map in-rel)
+                                           idxs (IntStream/builder)]
+                                       (dotimes [idx row-count]
+                                         (when (neg? (.addIfNotPresent builder idx))
+                                           (.add idxs idx)))
 
-                                         (let [idxs (.toArray (.build idxs))]
-                                           (when-not (empty? idxs)
-                                             (aset advanced? 0 true)
-                                             (with-open [out-rel (.openDirectSlice (.select in-rel idxs) al)
-                                                         root (.openAsRoot out-rel al)]
-                                               (.accept c (vr/<-root root)))))))))))))
+                                       (let [idxs (.toArray (.build idxs))]
+                                         (when-not (empty? idxs)
+                                           (aset advanced? 0 true)
+                                           (.accept c (.select in-rel idxs)))))))))))
       (aget advanced? 0)))
 
   (close [_]

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -3,7 +3,8 @@
             [xtdb.expression.map :as emap]
             [xtdb.logical-plan :as lp]
             [xtdb.types :as types]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr])
   (:import java.util.stream.IntStream
            org.apache.arrow.memory.BufferAllocator
            org.apache.arrow.vector.types.pojo.Schema
@@ -15,7 +16,8 @@
   (s/cat :op #{:δ :distinct}
          :relation ::lp/ra-expression))
 
-(deftype DistinctCursor [^ICursor in-cursor
+(deftype DistinctCursor [^BufferAllocator al
+                         ^ICursor in-cursor
                          ^DistinctRelationMap rel-map]
   ICursor
   (getCursorType [_] "distinct")
@@ -26,18 +28,22 @@
       (while (and (not (aget advanced? 0))
                   (.tryAdvance in-cursor
                                (fn [^RelationReader in-rel]
-                                 (let [row-count (.getRowCount in-rel)]
-                                   (when (pos? row-count)
-                                     (let [builder (.buildFromRelation rel-map in-rel)
-                                           idxs (IntStream/builder)]
-                                       (dotimes [idx row-count]
-                                         (when (neg? (.addIfNotPresent builder idx))
-                                           (.add idxs idx)))
+                                 ;; HACK while we're migrating to xt-arrow
+                                 (with-open [in-rel (.openDirectSlice in-rel al)]
+                                   (let [row-count (.getRowCount in-rel)]
+                                     (when (pos? row-count)
+                                       (let [builder (.buildFromRelation rel-map in-rel)
+                                             idxs (IntStream/builder)]
+                                         (dotimes [idx row-count]
+                                           (when (neg? (.addIfNotPresent builder idx))
+                                             (.add idxs idx)))
 
-                                       (let [idxs (.toArray (.build idxs))]
-                                         (when-not (empty? idxs)
-                                           (aset advanced? 0 true)
-                                           (.accept c (.select in-rel idxs)))))))))))
+                                         (let [idxs (.toArray (.build idxs))]
+                                           (when-not (empty? idxs)
+                                             (aset advanced? 0 true)
+                                             (with-open [out-rel (.openDirectSlice (.select in-rel idxs) al)
+                                                         root (.openAsRoot out-rel al)]
+                                               (.accept c (vr/<-root root)))))))))))))
       (aget advanced? 0)))
 
   (close [_]
@@ -79,8 +85,9 @@
                     :children [inner-rel]
                     :fields inner-fields
                     :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
-                                (cond-> (DistinctCursor. in-cursor (->relation-map allocator
-                                                                                   {:build-fields inner-fields
-                                                                                    :key-col-names (set (keys inner-fields))
-                                                                                    :nil-keys-equal? true}))
+                                (cond-> (DistinctCursor. allocator in-cursor
+                                                         (->relation-map allocator
+                                                                         {:build-fields inner-fields
+                                                                          :key-col-names (set (keys inner-fields))
+                                                                          :nil-keys-equal? true}))
                                   explain-analyze? (ICursor/wrapExplainAnalyze)))})))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -14,11 +14,9 @@
            (java.util ArrayList LinkedList List Spliterator)
            (java.util.stream IntStream IntStream$Builder)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector BigIntVector Float8Vector ValueVector)
-           (org.apache.arrow.vector.complex ListVector)
            (org.apache.arrow.vector.types.pojo Field FieldType)
            (xtdb ICursor)
-           (xtdb.arrow IntVector RelationReader VectorReader VectorWriter)
+           (xtdb.arrow IntVector ListVector LongVector RelationReader Vector VectorReader VectorWriter)
            (xtdb.expression.map RelationMapBuilder)
            xtdb.operator.distinct.DistinctRelationMap))
 
@@ -66,19 +64,15 @@
                       ^VectorWriter group-mapping]
   IGroupMapper
   (groupMapping [_ in-rel]
-    (util/with-open [in-rel (.openDirectSlice in-rel al)]
-      (.clear group-mapping)
-      (let [row-count (.getRowCount in-rel)
-            builder (.buildFromRelation rel-map in-rel)]
-        (dotimes [idx row-count]
-          (.writeInt group-mapping (DistinctRelationMap/insertedIdx (.addIfNotPresent builder idx))))
+    (.clear group-mapping)
+    (let [row-count (.getRowCount in-rel)
+          builder (.buildFromRelation rel-map in-rel)]
+      (dotimes [idx row-count]
+        (.writeInt group-mapping (DistinctRelationMap/insertedIdx (.addIfNotPresent builder idx))))
 
-        group-mapping)))
+      group-mapping))
 
-  (finish [_]
-    (with-open [out-rel (.openDirectSlice (.getBuiltRelation rel-map) al)]
-      (util/with-close-on-catch [root (.openAsRoot out-rel al)]
-        (vr/<-root root))))
+  (finish [_] (.getBuiltRelation rel-map))
 
   Closeable
   (close [_]
@@ -116,24 +110,21 @@
     (getField [_] (types/col-type->field to-name :i64))
 
     (build [_ al]
-      (let [^BigIntVector out-vec (-> (types/col-type->field to-name :i64)
-                                      (.createVector al))]
+      (let [out-vec (LongVector. al (str to-name) false)]
         (reify
           IAggregateSpec
           (aggregate [_ in-rel group-mapping]
             (dotimes [idx (.getRowCount in-rel)]
               (let [group-idx (.getInt group-mapping idx)]
                 (when (<= (.getValueCount out-vec) group-idx)
-                  (.setValueCount out-vec (inc group-idx))
-                  (.set out-vec group-idx 0))
+                  (.setLong out-vec group-idx 0))
 
-                (.set out-vec group-idx (inc (.get out-vec group-idx))))))
+                (.setLong out-vec group-idx (inc (.getLong out-vec group-idx))))))
 
           (finish [_]
             (when (and zero-row? (zero? (.getValueCount out-vec)))
-              (.setValueCount out-vec 1)
-              (.set out-vec 0 0))
-            (vr/vec->reader out-vec))
+              (.setLong out-vec 0 0))
+            (.openSlice out-vec al))
 
           Closeable
           (close [_] (.close out-vec)))))))
@@ -143,8 +134,7 @@
     (getField [_] (types/col-type->field to-name :i64))
 
     (build [_ al]
-      (let [^BigIntVector out-vec (-> (types/col-type->field to-name :i64)
-                                      (.createVector al))]
+      (let [out-vec (LongVector. al (str to-name) false)]
         (reify
           IAggregateSpec
           (aggregate [_ in-rel group-mapping]
@@ -152,27 +142,27 @@
               (dotimes [idx (.getRowCount in-rel)]
                 (let [group-idx (.getInt group-mapping idx)]
                   (when (<= (.getValueCount out-vec) group-idx)
-                    (.setValueCount out-vec (inc group-idx))
                     (.set out-vec group-idx 0))
 
                   (when-not (.isNull in-col idx)
-                    (.set out-vec group-idx (inc (.get out-vec group-idx))))))))
+                    (.setLong out-vec group-idx
+                              (inc (if-not (.isNull out-vec group-idx)
+                                     (.getLong out-vec group-idx)
+                                     0))))))))
 
           (finish [_]
             (when (and zero-row? (zero? (.getValueCount out-vec)))
-              (.setValueCount out-vec 1)
-              (.set out-vec 0 0))
-            (vr/vec->reader out-vec))
+              (.writeLong out-vec 0))
+
+            (.openSlice out-vec al))
 
           Closeable
           (close [_] (.close out-vec)))))))
 
 (def ^:private acc-sym (gensym 'acc))
-(def ^:private acc-col-sym (gensym 'acc_col))
 (def ^:private group-idx-sym (gensym 'group_idx))
 (def ^:private acc-local (gensym 'acc_local))
 (def ^:private val-local (gensym 'val_local))
-(def ^:private acc-writer-sym (gensym 'acc_writer))
 
 (def emit-agg
   (-> (fn [{:keys [to-type val-expr step-expr]} input-opts]
@@ -180,7 +170,7 @@
 
               return-type [:union (conj #{:null} to-type)]
 
-              acc-expr {:op :variable, :variable acc-col-sym, :idx group-idx-sym
+              acc-expr {:op :variable, :variable acc-sym, :idx group-idx-sym
                         :extract-vec-from-rel? false}
               agg-expr (-> {:op :if-some, :local val-local, :expr val-expr
                             :then {:op :if-some, :local acc-local,
@@ -194,21 +184,16 @@
               {:keys [continue] :as emitted-expr} (expr/codegen-expr agg-expr input-opts)]
 
           {:return-type return-type
-           :eval-agg (-> `(fn [~(-> acc-sym (expr/with-tag ValueVector))
+           :eval-agg (-> `(fn [~(-> acc-sym (expr/with-tag Vector))
                                ~(-> expr/rel-sym (expr/with-tag RelationReader))
                                ~(-> group-mapping-sym (expr/with-tag VectorReader))]
-                            (let [~acc-col-sym (vr/vec->reader ~acc-sym)
-                                  ~acc-writer-sym (vw/->writer ~acc-sym)
-                                  ~@(expr/batch-bindings emitted-expr)]
+                            (let [~@(expr/batch-bindings emitted-expr)]
                               (dotimes [~expr/idx-sym (.getRowCount ~expr/rel-sym)]
                                 (let [~group-idx-sym (.get ~group-mapping-sym ~expr/idx-sym)]
-                                  (when (<= (.getValueCount ~acc-sym) ~group-idx-sym)
-                                    (.setValueCount ~acc-sym (inc ~group-idx-sym)))
+                                  (.ensureCapacity ~acc-sym (inc ~group-idx-sym))
 
                                   ~(continue (fn [acc-type acc-code]
-                                               `(do
-                                                  (.setValueCount ~acc-writer-sym ~group-idx-sym)
-                                                  ~(expr/write-value-code acc-type acc-writer-sym acc-code))))))))
+                                               (expr/set-value-code acc-type acc-sym group-idx-sym acc-code)))))))
                          #_(doto clojure.pprint/pprint) ;; <<no-commit>>
                          eval)}))
       (util/lru-memoize))) ;; <<no-commit>>
@@ -221,12 +206,12 @@
       (getField [_] to-field)
 
       (build [_ al]
-        (let [^ValueVector out-vec (.createVector to-field al)]
+        (let [out-vec (Vector/open al to-field)]
           (reify
             IAggregateSpec
             (aggregate [_ in-rel group-mapping]
               (let [input-opts {:var->col-type (->> in-rel
-                                                    (into {acc-col-sym to-type}
+                                                    (into {acc-sym to-type}
                                                           (map (juxt #(symbol (.getName ^VectorReader %))
                                                                      #(-> (.getField ^VectorReader %) types/field->col-type)))))}
                     {:keys [eval-agg]} (emit-agg agg-opts input-opts)]
@@ -234,9 +219,9 @@
 
             (finish [_]
               (when (and zero-row? (zero? (.getValueCount out-vec)))
-                (.setValueCount out-vec 1))
+                (.writeNull out-vec))
 
-              (vr/vec->reader out-vec))
+              (.openSlice out-vec al))
 
             Closeable
             (close [_] (.close out-vec))))))))
@@ -359,8 +344,7 @@
       (getField [_] (.getField finish-projecter))
 
       (build [_ al]
-        (let [variance-agg (.build variance-agg al)
-              res-vec (Float8Vector. (str to-name) al)]
+        (let [variance-agg (.build variance-agg al)]
           (reify
             IAggregateSpec
             (aggregate [_ in-rel group-mapping]
@@ -372,7 +356,6 @@
 
             Closeable
             (close [_]
-              (util/close res-vec)
               (util/close variance-agg))))))))
 
 (defmethod ->aggregate-factory :stddev_pop [agg-opts]
@@ -489,7 +472,6 @@
 (deftype ArrayAggAggregateSpec [^BufferAllocator allocator
                                 from-name to-name to-type
                                 ^VectorWriter acc-col
-                                ^:unsynchronized-mutable ^ListVector out-vec
                                 ^:unsynchronized-mutable ^long base-idx
                                 ^List group-idxmaps
                                 on-empty]
@@ -508,35 +490,28 @@
 
       (set! (.base-idx this) (+ base-idx row-count))))
 
-  (finish [this]
-    (let [out-vec (-> (types/col-type->field to-name to-type)
-                      (.createVector allocator))]
-      (set! (.out-vec this) out-vec)
-
-      (let [list-writer (vw/->writer out-vec)
-            el-writer (.getListElements list-writer)
-            row-copier (.rowCopier (vw/vec-wtr->rdr acc-col) el-writer)]
+  (finish [_]
+    (util/with-close-on-catch [out-vec (Vector/open allocator (types/col-type->field to-name to-type))]
+      (let [el-writer (.getListElements out-vec)
+            row-copier (.rowCopier acc-col el-writer)]
         (doseq [^IntStream$Builder isb group-idxmaps]
           (.forEach (.build isb)
                     (fn [^long idx]
                       (.copyRow row-copier idx)))
-          (.endList list-writer))
+          (.endList out-vec))
 
         (let [value-count (.size group-idxmaps)]
-          (when (and (zero? value-count) (= :empty-vec on-empty))
-            (.endList list-writer))
-          (.setValueCount out-vec (if (zero? value-count)
-                                    (case on-empty
-                                      :null 1
-                                      :empty-rel 0
-                                      :empty-vec 1)
-                                    value-count)))
-        (vr/vec->reader out-vec))))
+          (when (zero? value-count)
+            (case on-empty
+              :null (.writeNull out-vec)
+              :empty-vec (.endList out-vec)
+              nil)))
+
+        out-vec)))
 
   Closeable
   (close [_]
-    (util/close acc-col)
-    (util/close out-vec)))
+    (util/close acc-col)))
 
 (defmethod ->aggregate-factory :array_agg [{:keys [from-name from-type to-name zero-row?]}]
   (let [to-type (if zero-row?
@@ -546,9 +521,9 @@
       (getField [_] (types/col-type->field to-name to-type))
 
       (build [_ al]
-        (ArrayAggAggregateSpec. al from-name to-name to-type
-                                (vw/->vec-writer al (str to-name) (FieldType/notNullable #xt.arrow/type :union))
-                                nil 0 (ArrayList.) (if zero-row? :null :empty-rel))))))
+        (util/with-close-on-catch [acc-col (Vector/open al (types/col-type->field "$data$" from-type))]
+          (ArrayAggAggregateSpec. al from-name to-name to-type acc-col
+                                  0 (ArrayList.) (if zero-row? :null :empty-rel)))))))
 
 (defmethod ->aggregate-factory :array_agg_distinct [{:keys [from-name from-type] :as agg-opts}]
   (-> (->aggregate-factory (assoc agg-opts :f :array_agg))
@@ -560,9 +535,9 @@
       (getField [_] (types/col-type->field to-name to-type))
 
       (build [_ al]
-        (ArrayAggAggregateSpec. al from-name to-name to-type
-                                (vw/->vec-writer al (str to-name) (FieldType/notNullable #xt.arrow/type :union))
-                                nil 0 (ArrayList.) (if zero-row? :empty-vec :empty-rel))))))
+        (util/with-close-on-catch [acc-col (Vector/open al (types/col-type->field "$data$" from-type))]
+          (ArrayAggAggregateSpec. al from-name to-name to-type acc-col
+                                  0 (ArrayList.) (if zero-row? :empty-vec :empty-rel)))))))
 
 (defn- bool-agg-factory [step-f-kw {:keys [from-name] :as agg-opts}]
   (reducing-agg-factory (into agg-opts
@@ -591,18 +566,20 @@
        (set! (.done? this) true)
 
        (.forEachRemaining in-cursor
-                          (fn [in-rel]
-                            (let [group-mapping (.groupMapping group-mapper in-rel)]
-                              (doseq [^IAggregateSpec agg-spec aggregate-specs]
-                                (.aggregate agg-spec in-rel group-mapping)))))
+                          (fn [^RelationReader in-rel]
+                            (util/with-open [in-rel (.openDirectSlice in-rel allocator)]
+                              (let [group-mapping (.groupMapping group-mapper in-rel)]
+                                (doseq [^IAggregateSpec agg-spec aggregate-specs]
+                                  (.aggregate agg-spec in-rel group-mapping))))))
 
-       (util/with-open [gm-rel (.finish group-mapper)
-                        agg-cols (map #(.finish ^IAggregateSpec %) aggregate-specs)]
-         (let [^RelationReader out-rel (vr/rel-reader (concat (.getVectors gm-rel) agg-cols)
+       (util/with-open [agg-cols (map #(.finish ^IAggregateSpec %) aggregate-specs)]
+         (let [gm-rel (.finish group-mapper)
+               ^RelationReader out-rel (vr/rel-reader (concat (.getVectors gm-rel) agg-cols)
                                                       (.getRowCount gm-rel))]
            (if (pos? (.getRowCount out-rel))
-             (do
-               (.accept c out-rel)
+             (with-open [out-rel (.openDirectSlice out-rel allocator)
+                         root (.openAsRoot out-rel allocator)]
+               (.accept c (vr/<-root root))
                true)
              false))))))
 

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -243,21 +243,17 @@
        (while (and (not (aget advanced? 0))
                    (.tryAdvance ^ICursor (.probe-cursor this)
                                 (fn [^RelationReader probe-rel]
-                                  (util/with-open [probe-rel (.openDirectSlice probe-rel allocator)]
-                                    (let [cmp (ComparatorFactory/build cmp-factory build-side probe-rel probe-key-col-names)
-                                          ^ProbeSide probe-side (ProbeSide. build-side probe-rel probe-key-col-names cmp)
-                                          row-count (.getRowCount probe-rel)]
-                                      (when (pos? row-count)
-                                        (aset advanced? 0 true)
+                                  (let [cmp (ComparatorFactory/build cmp-factory build-side probe-rel probe-key-col-names)
+                                        ^ProbeSide probe-side (ProbeSide. build-side probe-rel probe-key-col-names cmp)
+                                        row-count (.getRowCount probe-rel)]
+                                    (when (pos? row-count)
+                                      (aset advanced? 0 true)
 
-                                        (with-open [mark-col (doto (BitVector. allocator (name mark-col-name) true)
-                                                               (.ensureCapacity row-count))]
-                                          (JoinType/mark probe-side mark-col)
-                                          (let [out-cols (conj (seq probe-rel) mark-col)]
-                                            (with-open [out-rel (-> ^RelationReader (vr/rel-reader out-cols row-count)
-                                                                    (.openDirectSlice allocator))
-                                                        out-root (.openAsRoot out-rel allocator)]
-                                              (.accept c (vr/<-root out-root))))))))))))
+                                      (with-open [mark-col (doto (BitVector. allocator (name mark-col-name) true)
+                                                             (.ensureCapacity row-count))]
+                                        (JoinType/mark probe-side mark-col)
+                                        (let [out-cols (conj (seq probe-rel) mark-col)]
+                                          (.accept c (vr/rel-reader out-cols row-count))))))))))
        (aget advanced? 0))))
 
   (close [_]

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -37,8 +37,7 @@
      (when out-rel
        (try
          (set! (.out-rel this) nil)
-         (util/with-open [root (.openAsRoot out-rel al)]
-           (.accept c (vr/<-root root)))
+         (.accept c out-rel)
          true
          (finally
            (.close out-rel))))))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -36,8 +36,7 @@
     (let [advanced? (boolean-array 1)]
       (while (and (.tryAdvance in-cursor
                                (fn [^RelationReader in-rel]
-                                 (with-open [in-rel (.openDirectSlice in-rel allocator)
-                                             out-vec (Vector/open allocator to-field)]
+                                 (with-open [out-vec (Vector/open allocator to-field)]
                                    (let [out-cols (LinkedList.)
 
                                          vec-rdr (.vectorForOrNull in-rel from-column-name)
@@ -86,10 +85,7 @@
 
                                              (.add out-cols (.select in-col idxs)))
 
-                                           (util/with-open [out-rel (-> ^RelationReader (vr/rel-reader out-cols (alength idxs))
-                                                                        (.openDirectSlice allocator))
-                                                            root (.openAsRoot out-rel allocator)]
-                                             (.accept c (vr/<-root root)))
+                                           (.accept c (vr/rel-reader out-cols (alength idxs)))
                                            (aset advanced? 0 true))))))))
 
                   (not (aget advanced? 0))))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -8,10 +8,9 @@
   (:import (java.util LinkedList)
            (java.util.stream IntStream)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector IntVector)
            (org.apache.arrow.vector.types.pojo ArrowType$List ArrowType$Union Field FieldType)
            (xtdb ICursor)
-           (xtdb.arrow RelationReader RowCopier VectorReader VectorWriter)
+           (xtdb.arrow IntVector RelationReader RowCopier VectorReader VectorWriter Vector)
            xtdb.vector.extensions.SetType))
 
 (s/def ::ordinality-column ::lp/column)
@@ -37,9 +36,9 @@
     (let [advanced? (boolean-array 1)]
       (while (and (.tryAdvance in-cursor
                                (fn [^RelationReader in-rel]
-                                 (with-open [out-vec (.createVector to-field allocator)]
-                                   (let [out-writer (vw/->writer out-vec)
-                                         out-cols (LinkedList.)
+                                 (with-open [in-rel (.openDirectSlice in-rel allocator)
+                                             out-vec (Vector/open allocator to-field)]
+                                   (let [out-cols (LinkedList.)
 
                                          vec-rdr (.vectorForOrNull in-rel from-column-name)
                                          vec-type (.getType (.getField vec-rdr))
@@ -48,33 +47,27 @@
                                          (condp instance? vec-type
                                            ArrowType$List
                                            [[vec-rdr (-> (.getListElements vec-rdr)
-                                                         (.rowCopier out-writer))]]
+                                                         (.rowCopier out-vec))]]
 
                                            SetType
                                            [[vec-rdr (-> (.getListElements vec-rdr)
-                                                         (.rowCopier out-writer))]]
+                                                         (.rowCopier out-vec))]]
 
                                            ArrowType$Union
                                            (concat (when-let [list-rdr (.vectorForOrNull vec-rdr "list")]
-                                                     [[list-rdr (-> (.rowCopier (.getListElements list-rdr) out-writer))]])
+                                                     [[list-rdr (-> (.rowCopier (.getListElements list-rdr) out-vec))]])
                                                    (when-let [set-rdr (.vectorForOrNull vec-rdr "set")]
-                                                     [[set-rdr (-> (.rowCopier (.getListElements set-rdr) out-writer))]]))
+                                                     [[set-rdr (-> (.rowCopier (.getListElements set-rdr) out-vec))]]))
 
                                            nil)
 
-                                         idxs (IntStream/builder)
+                                         idxs (IntStream/builder)]
 
-                                         ordinal-vec (when ordinality-column
-                                                       (IntVector. ordinality-column
-                                                                   (FieldType/notNullable #xt.arrow/type :i32)
-                                                                   allocator))
+                                     (util/with-open [ordinal-vec (when ordinality-column
+                                                                    (IntVector/open allocator ordinality-column false 0))]
+                                       (when ordinal-vec
+                                         (.add out-cols ordinal-vec))
 
-                                         _ (when ordinal-vec
-                                             (.add out-cols (vr/vec->reader ordinal-vec)))
-
-                                         ^VectorWriter ordinal-wtr (some-> ordinal-vec vw/->writer)]
-
-                                     (try
                                        (dotimes [n (.getValueCount vec-rdr)]
                                          (doseq [[^VectorReader coll-rdr, ^RowCopier el-copier] rdrs+copiers]
                                            (when (and coll-rdr (not (.isNull coll-rdr n)))
@@ -83,22 +76,21 @@
                                                (dotimes [el-idx len]
                                                  (.copyRow el-copier (+ start-pos el-idx))
                                                  (.add idxs n)
-                                                 (some-> ordinal-wtr (.writeInt (inc el-idx))))))))
+                                                 (some-> ordinal-vec (.writeInt (inc el-idx))))))))
 
                                        (let [idxs (.toArray (.build idxs))]
                                          (when (pos? (alength idxs))
-                                           (some-> ordinal-vec (.setValueCount (alength idxs)))
-
                                            (doseq [^VectorReader in-col in-rel]
                                              (when (= from-column-name (.getName in-col))
-                                               (.add out-cols (vw/vec-wtr->rdr out-writer)))
+                                               (.add out-cols out-vec))
 
                                              (.add out-cols (.select in-col idxs)))
 
-                                           (.accept c (vr/rel-reader out-cols (alength idxs)))
-                                           (aset advanced? 0 true)))
-                                       (finally
-                                         (util/try-close ordinal-vec)))))))
+                                           (util/with-open [out-rel (-> ^RelationReader (vr/rel-reader out-cols (alength idxs))
+                                                                        (.openDirectSlice allocator))
+                                                            root (.openAsRoot out-rel allocator)]
+                                             (.accept c (vr/<-root root)))
+                                           (aset advanced? 0 true))))))))
 
                   (not (aget advanced? 0))))
       (aget advanced? 0)))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -114,9 +114,8 @@
                           group-mapping (IntVector/open allocator (str window-groups) false)]
 
            (.forEachRemaining in-cursor (fn [^RelationReader in-rel]
-                                          (util/with-open [in-rel (.openDirectSlice in-rel allocator)]
-                                            (vw/append-rel out-rel in-rel)
-                                            (.append group-mapping (.groupMapping group-mapper in-rel)))))
+                                          (vw/append-rel out-rel in-rel)
+                                          (.append group-mapping (.groupMapping group-mapper in-rel))))
 
            (let [sort-mapping (order-by/sorted-idxs (RelationReader/from (conj (seq out-rel) group-mapping) (.getValueCount group-mapping))
                                                     (into [[window-groups]] order-specs))]
@@ -124,9 +123,8 @@
                                                (mapv #(.aggregate ^IWindowFnSpec % group-mapping sort-mapping out-rel)))]
                (let [out-rel (vr/rel-reader (concat (.select out-rel sort-mapping) window-cols))]
                  (if (pos? (.getRowCount out-rel))
-                   (with-open [out-rel (.openDirectSlice out-rel allocator)
-                               root (.openAsRoot out-rel allocator)]
-                     (.accept c (vr/<-root root))
+                   (do
+                     (.accept c out-rel)
                      true)
                    false)))))))))
 

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -79,25 +79,5 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
 
         @JvmStatic
         fun ICursor.wrapExplainAnalyze(): ICursor = ExplainAnalyzeCursor(this)
-
-        @JvmStatic
-        fun ICursor.wrapDirectSlice(al: BufferAllocator): ICursor = object : ICursor by this {
-            override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
-                this@wrapDirectSlice.tryAdvance { inRel ->
-                    inRel.openDirectSlice(al).use { directRel -> c.accept(directRel) }
-                }
-        }
-
-        @JvmStatic
-        fun ICursor.wrapAsOldRel(al: BufferAllocator): ICursor = object : ICursor by this {
-            override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
-                this@wrapAsOldRel.tryAdvance { outRel ->
-                    outRel.openDirectSlice(al).use { outRel ->
-                        outRel.openAsRoot(al).use { root ->
-                            c.accept(RelationReader.from(root))
-                        }
-                    }
-                }
-        }
     }
 }

--- a/core/src/main/kotlin/xtdb/PagesCursor.kt
+++ b/core/src/main/kotlin/xtdb/PagesCursor.kt
@@ -27,10 +27,10 @@ class PagesCursor(
                     Relation(al, schema).closeOnCatch {
                         it.apply { writeRows(*rows.toTypedArray()) }
                     }
-
-            rel.use { rel ->
-                // TODO won't need openAsRoot call when operators use xtdb.arrow
-                rel.openAsRoot(al).use { root -> c.accept(RelationReader.from(root)) }
+            try {
+                c.accept(rel)
+            } finally {
+                rel.close()
             }
         }
 }

--- a/core/src/main/kotlin/xtdb/arrow/Buffers.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Buffers.kt
@@ -48,7 +48,7 @@ internal class ExtensibleBuffer private constructor(private val allocator: Buffe
         return buf
     }
 
-    private fun ensureCapacity(capacity: Long): ArrowBuf {
+    fun ensureCapacity(capacity: Long): ArrowBuf {
         while (buf.capacity() < capacity) realloc(capacity)
         return buf
     }
@@ -100,6 +100,8 @@ internal class ExtensibleBuffer private constructor(private val allocator: Buffe
         buf.writeLong(value)
     }
 
+    operator fun set(idx: Int, v: Long) = buf.setLong(idx.toLong() * Long.SIZE_BYTES, v)
+
     fun getFloat(idx: Int) = buf.getFloat((idx * Float.SIZE_BYTES).toLong())
 
     fun writeFloat(value: Float) {
@@ -107,12 +109,16 @@ internal class ExtensibleBuffer private constructor(private val allocator: Buffe
         buf.writeFloat(value)
     }
 
+    operator fun set(idx: Int, v: Float) = buf.setFloat(idx.toLong() * Float.SIZE_BYTES, v)
+
     fun getDouble(idx: Int) = buf.getDouble((idx * Double.SIZE_BYTES).toLong())
 
     fun writeDouble(value: Double) {
         ensureWritable(Double.SIZE_BYTES.toLong())
         buf.writeDouble(value)
     }
+
+    operator fun set(idx: Int, v: Double) = buf.setDouble(idx.toLong() * Double.SIZE_BYTES, v)
 
     fun getBytes(start: Int, len: Int): ByteBuffer = buf.nioBuffer(start.toLong(), len)
 

--- a/core/src/main/kotlin/xtdb/arrow/NullVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/NullVector.kt
@@ -28,6 +28,14 @@ class NullVector(
         valueCount++
     }
 
+    override fun ensureCapacity(valueCount: Int) {
+        this.valueCount = this.valueCount.coerceAtLeast(valueCount)
+    }
+
+    override fun setNull(idx: Int) {
+        valueCount = valueCount.coerceAtLeast(idx + 1)
+    }
+
     override fun writeNull() {
         if (!nullable) nullable = true
         valueCount++
@@ -88,5 +96,5 @@ class NullVector(
     override fun close() {
     }
 
-    override fun openSlice(al: BufferAllocator) = NullVector(name)
+    override fun openSlice(al: BufferAllocator) = NullVector(name, nullable, valueCount)
 }

--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -128,11 +128,16 @@ class Relation(
         rowCount = recordBatch.length
     }
 
-    class StreamLoader(al: BufferAllocator, ch: ReadableByteChannel) : AutoCloseable {
+    interface ILoader : AutoCloseable {
+        val schema: Schema
+        fun loadNextPage(rel: Relation): Boolean
+    }
+
+    class StreamLoader(al: BufferAllocator, ch: ReadableByteChannel) : ILoader {
 
         private val reader = MessageChannelReader(ReadChannel(ch), al)
 
-        val schema: Schema
+        override val schema: Schema
 
         init {
             val schemaMessage = (reader.readNext() ?: error("empty stream")).message
@@ -141,7 +146,7 @@ class Relation(
             schema = MessageSerializer.deserializeSchema(schemaMessage)
         }
 
-        fun loadNextPage(rel: Relation): Boolean {
+        override fun loadNextPage(rel: Relation): Boolean {
             val msg = reader.readNext() ?: return false
 
             msg.message.headerType().let {
@@ -157,9 +162,9 @@ class Relation(
         override fun close() = reader.close()
     }
 
-    class Loader(private val arrowFileLoader: ArrowFileLoader) : AutoCloseable {
+    class Loader(private val arrowFileLoader: ArrowFileLoader) : ILoader {
 
-        val schema: Schema get() = arrowFileLoader.schema
+        override val schema: Schema get() = arrowFileLoader.schema
         val pageCount get() = arrowFileLoader.pageCount
 
         private var lastPageIndex = -1
@@ -171,7 +176,7 @@ class Relation(
             lastPageIndex = idx
         }
 
-        fun loadNextPage(rel: Relation): Boolean {
+        override fun loadNextPage(rel: Relation): Boolean {
             if (lastPageIndex + 1 >= pageCount) return false
 
             loadPage(++lastPageIndex, rel)
@@ -218,6 +223,9 @@ class Relation(
 
         @JvmStatic
         fun loader(buf: ArrowBuf) = Loader(ArrowFileLoader.openFromArrowBuf(buf))
+
+        @JvmStatic
+        fun streamLoader(al: BufferAllocator, path: Path) = StreamLoader(al, path.openReadableChannel())
 
         @JvmStatic
         fun fromRoot(al: BufferAllocator, vsr: VectorSchemaRoot) =

--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -68,7 +68,7 @@ class Relation(
         rowCount = root.rowCount
     }
 
-    internal fun openArrowRecordBatch(): ArrowRecordBatch {
+    fun openArrowRecordBatch(): ArrowRecordBatch {
         val nodes = mutableListOf<ArrowFieldNode>()
         val buffers = mutableListOf<ArrowBuf>()
 

--- a/core/src/main/kotlin/xtdb/arrow/UriVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/UriVector.kt
@@ -22,5 +22,10 @@ class UriVector(override val inner: Utf8Vector) : ExtensionVector(), MetadataFla
 
     override val metadataFlavours get() = listOf(this)
 
+    override fun valueReader(pos: VectorPosition) = object : ValueReader {
+        override val isNull: Boolean get() = this@UriVector.isNull(pos.position)
+        override fun readObject(): Any? = getObject(pos.position)
+    }
+
     override fun openSlice(al: BufferAllocator) = UriVector(inner.openSlice(al))
 }

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -53,6 +53,15 @@ sealed class Vector : VectorReader, VectorWriter {
     internal abstract fun getObject0(idx: Int, keyFn: IKeyFn<*>): Any
     override fun getObject(idx: Int, keyFn: IKeyFn<*>) = if (isNull(idx)) null else getObject0(idx, keyFn)
 
+    open fun ensureCapacity(valueCount: Int): Unit = unsupported("ensureCapacity")
+
+    open fun setNull(idx: Int): Unit = unsupported("setNull")
+    open fun setBoolean(idx: Int, v: Boolean): Unit = unsupported("setBoolean")
+    open fun setInt(idx: Int, v: Int): Unit = unsupported("setInt")
+    open fun setLong(idx: Int, v: Long): Unit = unsupported("setLong")
+    open fun setFloat(idx: Int, v: Float): Unit = unsupported("setFloat")
+    open fun setDouble(idx: Int, v: Double): Unit = unsupported("setDouble")
+
     override fun writeNull() {
         if (!nullable) nullable = true
         writeUndefined()

--- a/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
@@ -43,10 +43,7 @@ class LetCursorFactory(
                 Relation(al, batch.schema).use { rel ->
                     rel.load(batch.recordBatch)
 
-                    // TODO: don't need all this openAsRoot dance when the operators all use xtdb.arrow
-                    rel.openAsRoot(al).use { root ->
-                        c.accept(RelationReader.from(root))
-                    }
+                    c.accept(rel)
                 }
             }
 

--- a/core/src/main/kotlin/xtdb/operator/ProjectCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectCursor.kt
@@ -2,9 +2,9 @@ package xtdb.operator
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.ICursor
+import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorReader
 import xtdb.util.useAll
-import xtdb.arrow.RelationReader
 import java.util.function.Consumer
 
 class ProjectCursor(
@@ -18,19 +18,26 @@ class ProjectCursor(
     override val cursorType get() = "project"
     override val childCursors get() = listOf(inCursor)
 
-    override fun tryAdvance(c: Consumer<in RelationReader>): Boolean = inCursor.tryAdvance { inRel ->
-        mutableListOf<VectorReader>().useAll { closeCols ->
-            val outCols = specs.map { spec ->
-                spec.project(al, inRel, schema, args)
-                    .also {
-                        if (spec !is ProjectionSpec.Identity && spec !is ProjectionSpec.Rename)
-                            closeCols.add(it)
+    override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
+        inCursor.tryAdvance { inRel ->
+            inRel.openDirectSlice(al).use { inRel ->
+                mutableListOf<VectorReader>().useAll { closeCols ->
+                    val outCols = specs.map { spec ->
+                        spec.project(al, inRel, schema, args)
+                            .also {
+                                if (spec !is ProjectionSpec.Identity && spec !is ProjectionSpec.Rename)
+                                    closeCols.add(it)
+                            }
                     }
-            }
 
-            c.accept(RelationReader.from(outCols, inRel.rowCount))
+                    RelationReader.from(outCols, inRel.rowCount).openDirectSlice(al).use { outRel ->
+                        outRel.openAsRoot(al).use { root ->
+                            c.accept(RelationReader.from(root))
+                        }
+                    }
+                }
+            }
         }
-    }
 
     override fun close() = inCursor.close()
 }

--- a/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
@@ -68,8 +68,7 @@ interface ProjectionSpec {
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
         ) =
-            (field.name ofType Type.structOf(inRel.vectors.map { it.field.withName(it.name) })
-                    )
+            (field.name ofType Type.structOf(inRel.vectors.map { it.field.withName(it.name) }))
                 .createVector(allocator)
                 .let { it as StructVector }
                 .closeOnCatch { structVec ->

--- a/core/src/main/kotlin/xtdb/operator/apply/ApplyMode.kt
+++ b/core/src/main/kotlin/xtdb/operator/apply/ApplyMode.kt
@@ -1,14 +1,15 @@
 package xtdb.operator.apply
 
 import com.carrotsearch.hppc.IntArrayList
-import org.apache.arrow.vector.NullVector
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.ICursor
+import xtdb.arrow.NullVector
 import xtdb.arrow.RelationWriter
 import xtdb.error.Incorrect
 import xtdb.trie.ColumnName
 import xtdb.types.Type
 import xtdb.types.Type.Companion.BOOL
+import xtdb.types.Type.Companion.maybe
 import xtdb.vector.ValueVectorReader
 
 sealed interface ApplyMode {
@@ -22,7 +23,7 @@ sealed interface ApplyMode {
             idxs: IntArrayList, inIdx: Int
         ) {
             idxs.add(inIdx)
-            val outWriter = dependentOutWriter.vectorFor(columnName, Type.Companion.maybe(BOOL).fieldType)
+            val outWriter = dependentOutWriter.vectorFor(columnName, maybe(BOOL).fieldType)
             var match = -1
             while (match != 1) {
                 dependentCursor.tryAdvance { depRel ->
@@ -73,7 +74,7 @@ sealed interface ApplyMode {
                 idxs.add(inIdx)
                 for (field in dependentFields) {
                     dependentOutWriter.vectorFor(field.name, field.fieldType)
-                        .append(ValueVectorReader.from(NullVector(field.name).also { it.valueCount = 1 }))
+                        .append(NullVector(field.name).also { it.valueCount = 1 })
                 }
             }
         }
@@ -143,7 +144,7 @@ sealed interface ApplyMode {
                 idxs.add(inIdx)
                 for (field in dependentFields) {
                     dependentOutWriter.vectorFor(field.name, field.fieldType)
-                        .append(ValueVectorReader.from(NullVector(field.name).also { it.valueCount = 1 }))
+                        .append(NullVector(field.name).also { it.valueCount = 1 })
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
@@ -35,14 +35,12 @@ class BuildSide(
 
     @Suppress("NAME_SHADOWING")
     fun append(inRel: RelationReader) {
-        inRel.openDirectSlice(al).use { inRel ->
-            val rowCopier = inRel.rowCopier(dataRel)
+        val rowCopier = inRel.rowCopier(dataRel)
 
-            repeat(inRel.rowCount) { inIdx -> rowCopier.copyRow(inIdx) }
+        repeat(inRel.rowCount) { inIdx -> rowCopier.copyRow(inIdx) }
 
-            if (dataRel.rowCount > inMemoryThreshold)
-                (this.spill ?: openSpill()).spill()
-        }
+        if (dataRel.rowCount > inMemoryThreshold)
+            (this.spill ?: openSpill()).spill()
     }
 
     var shuffle: Shuffle? = null; private set

--- a/core/src/main/kotlin/xtdb/operator/join/ComparatorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/ComparatorFactory.kt
@@ -16,7 +16,7 @@ interface ComparatorFactory {
         fun ComparatorFactory.build(
             buildSide: BuildSide, probeRel: RelationReader, probeKeyColNames: List<FieldName>
         ): IntBinaryOperator {
-            val buildRel = buildSide.builtRel
+            val buildRel = buildSide.dataRel
 
             val buildKeyCols = buildSide.keyColNames.map { buildRel[it] }
             val probeKeyCols = probeKeyColNames.map { probeRel[it] }

--- a/core/src/main/kotlin/xtdb/operator/join/DiskHashJoin.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/DiskHashJoin.kt
@@ -75,11 +75,7 @@ class DiskHashJoin(
                 val joinedRel = joinType.probe(probeSide)
 
                 if (joinedRel.rowCount > 0) {
-                    joinedRel.openDirectSlice(al).use { outRel ->
-                        outRel.openAsRoot(al).use { root ->
-                            c.accept(RelationReader.from(root))
-                        }
-                    }
+                    c.accept(joinedRel)
                     return true
                 }
             }
@@ -105,10 +101,8 @@ class DiskHashJoin(
             Relation(al, probeFields).use { tmpRel ->
                 Spill.open(al, tmpRel).use { spill ->
                     probeCursor.forEachRemaining { inRel ->
-                        inRel.openDirectSlice(al).use { inRel ->
-                            tmpRel.append(inRel)
-                            if (tmpRel.rowCount > buildSide.inMemoryThreshold) spill.spill()
-                        }
+                        tmpRel.append(inRel)
+                        if (tmpRel.rowCount > buildSide.inMemoryThreshold) spill.spill()
                     }
 
                     spill.end()

--- a/core/src/main/kotlin/xtdb/operator/join/JoinType.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/JoinType.kt
@@ -1,7 +1,7 @@
 package xtdb.operator.join
 
 import com.carrotsearch.hppc.IntArrayList
-import org.apache.arrow.vector.BitVector
+import xtdb.arrow.BitVector
 import xtdb.arrow.RelationReader
 import xtdb.error.Incorrect
 import xtdb.operator.join.JoinType.OuterJoinType.*
@@ -90,8 +90,8 @@ interface JoinType {
             repeat(rowCount) { probeIdx ->
                 when (matches(probeIdx)) {
                     0 -> markCol.setNull(probeIdx)
-                    1 -> markCol.set(probeIdx, 1)
-                    -1 -> markCol.set(probeIdx, 0)
+                    1 -> markCol.setBoolean(probeIdx, true)
+                    -1 -> markCol.setBoolean(probeIdx, false)
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/operator/join/ProbeSide.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/ProbeSide.kt
@@ -12,7 +12,7 @@ class ProbeSide(
     val keyColNames: List<String>, private val comparator: IntBinaryOperator,
 ) {
 
-    internal val buildRel = buildSide.builtRel
+    internal val buildRel = buildSide.dataRel
     val nullRowIdx get() = buildSide.nullRowIdx
     val rowCount = probeRel.rowCount
 

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -120,7 +120,9 @@ class ScanCursor(
                     }
 
                 if (rel.rowCount > 0) {
-                    c.accept(rel)
+                    rel.openDirectSlice(al).use { rel ->
+                        c.accept(rel)
+                    }
                     return true
                 }
             }

--- a/core/src/main/kotlin/xtdb/vector/DenseUnionVectorWriter.kt
+++ b/core/src/main/kotlin/xtdb/vector/DenseUnionVectorWriter.kt
@@ -195,7 +195,7 @@ class DenseUnionVectorWriter(
         return RowCopier { srcIdx ->
             val typeId = src.getTypeId(srcIdx)
             if (typeId < 0)
-                writeUndefined()
+                valueCount.also { writeUndefined() }
             else
                 copierMapping[src.getTypeId(srcIdx).toInt()]
                     .copyRow(src.getOffset(srcIdx))

--- a/core/src/main/kotlin/xtdb/vector/IVectorWriter.kt
+++ b/core/src/main/kotlin/xtdb/vector/IVectorWriter.kt
@@ -44,7 +44,7 @@ interface IVectorWriter : VectorWriter, AutoCloseable {
 
     fun rowCopier(src: ValueVector): RowCopier
 
-    override fun writeUndefined() = TODO("writeUndefined on IVectorWriter...? could probably do this")
+    override fun writeUndefined() = writeNull()
 
     override fun writeNull() {
         vector.setNull(valueCount++)

--- a/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
@@ -60,7 +60,7 @@ class BuildSideTest {
 
                 assertEquals(4, buildSide.partCount)
                 buildSide.loadPart(0)
-                buildSide.builtRel.let { rel ->
+                buildSide.dataRel.let { rel ->
                     assertEquals(3, rel.rowCount)
                     assertEquals(partOneRows, rel.toMaps(SNAKE_CASE_STRING))
 
@@ -70,7 +70,7 @@ class BuildSideTest {
                 }
 
                 buildSide.loadPart(1)
-                buildSide.builtRel.let { rel ->
+                buildSide.dataRel.let { rel ->
                     assertEquals(6, rel.rowCount)
                     assertEquals(partTwoRows, rel.toMaps(SNAKE_CASE_STRING))
 
@@ -80,10 +80,10 @@ class BuildSideTest {
                 }
 
                 buildSide.loadPart(2)
-                assertEquals(0, buildSide.builtRel.rowCount)
+                assertEquals(0, buildSide.dataRel.rowCount)
 
                 buildSide.loadPart(3)
-                assertEquals(0, buildSide.builtRel.rowCount)
+                assertEquals(0, buildSide.dataRel.rowCount)
             }
 
             // with nil row
@@ -104,24 +104,24 @@ class BuildSideTest {
                 assertEquals(4, buildSide.partCount)
 
                 buildSide.loadPart(0)
-                buildSide.builtRel.let { rel ->
+                buildSide.dataRel.let { rel ->
                     assertEquals(4, rel.rowCount)
 
                     assertEquals(partOneRows + emptyMap(), rel.toMaps(SNAKE_CASE_STRING))
                 }
 
                 buildSide.loadPart(1)
-                buildSide.builtRel.let { rel ->
+                buildSide.dataRel.let { rel ->
                     assertEquals(7, rel.rowCount)
 
                     assertEquals(partTwoRows + emptyMap(), rel.toMaps(SNAKE_CASE_STRING))
                 }
 
                 buildSide.loadPart(2)
-                assertEquals(1, buildSide.builtRel.rowCount)
+                assertEquals(1, buildSide.dataRel.rowCount)
 
                 buildSide.loadPart(3)
-                assertEquals(1, buildSide.builtRel.rowCount)
+                assertEquals(1, buildSide.dataRel.rowCount)
             }
         }
     }
@@ -155,7 +155,7 @@ class BuildSideTest {
 
                 assertNull(buildSide.spill)
 
-                val builtRelation = buildSide.builtRel
+                val builtRelation = buildSide.dataRel
 
                 assertEquals(3, builtRelation.rowCount)
 

--- a/src/test/clojure/xtdb/compactor/segment_merge_test.clj
+++ b/src/test/clojure/xtdb/compactor/segment_merge_test.clj
@@ -29,112 +29,112 @@
                     [{:xt/id "foo", :v 2}
                      {:xt/id "bar", :v 2}])
 
-      (with-open [live-rel0 (.openDirectSlice (.getLiveRelation lt0) tu/*allocator*)
-                  live-rel1 (.openDirectSlice (.getLiveRelation lt1) tu/*allocator*)]
+      (let [live-rel0 (.getLiveRelation lt0)
+            live-rel1 (.getLiveRelation lt1)
 
-        (let [segments [(MemorySegment. (.compactLogs (.getLiveTrie lt0)) live-rel0)
-                        (MemorySegment. (.compactLogs (.getLiveTrie lt1)) live-rel1)]]
+            segments [(MemorySegment. (.compactLogs (.getLiveTrie lt0)) live-rel0)
+                      (MemorySegment. (.compactLogs (.getLiveTrie lt1)) live-rel1)]]
 
-          (t/testing "merge segments"
-            (util/with-open [results (.mergeSegments seg-merge segments nil (SegmentMerge$RecencyPartitioning$Preserve. nil))]
-              (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from #xt/zdt "2023-01-01Z[UTC]"
-                          :xt/valid-from #xt/zdt "2023-01-01Z[UTC]"
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
-                         {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from (time/->zdt #inst "2021")
-                          :xt/valid-from (time/->zdt #inst "2021")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
-                         {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from (time/->zdt #inst "2020")
-                          :xt/valid-from (time/->zdt #inst "2020")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}
-                         {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                          :xt/system-from (time/->zdt #inst "2023")
-                          :xt/valid-from (time/->zdt #inst "2023")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 2, :xt/id "foo"}]}
-                         {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                          :xt/system-from (time/->zdt #inst "2022")
-                          :xt/valid-from (time/->zdt #inst "2022")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 1, :xt/id "foo"}]}
-                         {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                          :xt/system-from (time/->zdt #inst "2020")
-                          :xt/valid-from (time/->zdt #inst "2020")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 0, :xt/id "foo"}]}]]
+        (t/testing "merge segments"
+          (util/with-open [results (.mergeSegments seg-merge segments nil (SegmentMerge$RecencyPartitioning$Preserve. nil))]
+            (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from #xt/zdt "2023-01-01Z[UTC]"
+                        :xt/valid-from #xt/zdt "2023-01-01Z[UTC]"
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
+                       {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from (time/->zdt #inst "2021")
+                        :xt/valid-from (time/->zdt #inst "2021")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
+                       {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from (time/->zdt #inst "2020")
+                        :xt/valid-from (time/->zdt #inst "2020")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}
+                       {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                        :xt/system-from (time/->zdt #inst "2023")
+                        :xt/valid-from (time/->zdt #inst "2023")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 2, :xt/id "foo"}]}
+                       {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                        :xt/system-from (time/->zdt #inst "2022")
+                        :xt/valid-from (time/->zdt #inst "2022")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 1, :xt/id "foo"}]}
+                       {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                        :xt/system-from (time/->zdt #inst "2020")
+                        :xt/valid-from (time/->zdt #inst "2020")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 0, :xt/id "foo"}]}]]
 
-                       (for [^SegmentMerge$Result res results]
-                         (with-open [rel (.openAllAsRelation seg-merge res)]
-                           (->> (.getAsMaps rel)
-                                (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
+                     (for [^SegmentMerge$Result res results]
+                       (with-open [rel (.openAllAsRelation seg-merge res)]
+                         (->> (.getAsMaps rel)
+                              (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
 
-          (t/testing "merge segments with path predicate"
-            (util/with-open [results (.mergeSegments seg-merge segments (byte-array [2]) (SegmentMerge$RecencyPartitioning$Preserve. nil))]
-              (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from (time/->zdt #inst "2023")
-                          :xt/valid-from (time/->zdt #inst "2023")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
-                         {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from (time/->zdt #inst "2021")
-                          :xt/valid-from (time/->zdt #inst "2021")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
-                         {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                          :xt/system-from (time/->zdt #inst "2020")
-                          :xt/valid-from (time/->zdt #inst "2020")
-                          :xt/valid-to (time/->zdt time/end-of-time)
-                          :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}]]
+        (t/testing "merge segments with path predicate"
+          (util/with-open [results (.mergeSegments seg-merge segments (byte-array [2]) (SegmentMerge$RecencyPartitioning$Preserve. nil))]
+            (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from (time/->zdt #inst "2023")
+                        :xt/valid-from (time/->zdt #inst "2023")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
+                       {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from (time/->zdt #inst "2021")
+                        :xt/valid-from (time/->zdt #inst "2021")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
+                       {:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                        :xt/system-from (time/->zdt #inst "2020")
+                        :xt/valid-from (time/->zdt #inst "2020")
+                        :xt/valid-to (time/->zdt time/end-of-time)
+                        :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}]]
 
-                       (for [^SegmentMerge$Result res results]
-                         (with-open [rel (.openAllAsRelation seg-merge res)]
-                           (->> (.getAsMaps rel)
-                                (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
+                     (for [^SegmentMerge$Result res results]
+                       (with-open [rel (.openAllAsRelation seg-merge res)]
+                         (->> (.getAsMaps rel)
+                              (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
 
-          (t/testing "merge segments partitioning by recency"
-            (util/with-open [results (.mergeSegments seg-merge segments nil SegmentMerge$RecencyPartitioning$Partition/INSTANCE)]
-              (t/is (= {"r20210104.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                                            :xt/system-from (time/->zdt #inst "2020")
-                                            :xt/valid-from (time/->zdt #inst "2020")
-                                            :xt/valid-to (time/->zdt time/end-of-time)
-                                            :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}]
+        (t/testing "merge segments partitioning by recency"
+          (util/with-open [results (.mergeSegments seg-merge segments nil SegmentMerge$RecencyPartitioning$Partition/INSTANCE)]
+            (t/is (= {"r20210104.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                                          :xt/system-from (time/->zdt #inst "2020")
+                                          :xt/valid-from (time/->zdt #inst "2020")
+                                          :xt/valid-to (time/->zdt time/end-of-time)
+                                          :op #xt/tagged [:put {:v 0, :xt/id "bar"}]}]
 
-                        "r20220103.arrow" [{:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                                            :xt/system-from (time/->zdt #inst "2020")
-                                            :xt/valid-from (time/->zdt #inst "2020")
-                                            :xt/valid-to (time/->zdt time/end-of-time)
-                                            :op #xt/tagged [:put {:v 0, :xt/id "foo"}]}]
+                      "r20220103.arrow" [{:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                                          :xt/system-from (time/->zdt #inst "2020")
+                                          :xt/valid-from (time/->zdt #inst "2020")
+                                          :xt/valid-to (time/->zdt time/end-of-time)
+                                          :op #xt/tagged [:put {:v 0, :xt/id "foo"}]}]
 
-                        "r20230102.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                                            :xt/system-from (time/->zdt #inst "2021")
-                                            :xt/valid-from (time/->zdt #inst "2021")
-                                            :xt/valid-to (time/->zdt time/end-of-time)
-                                            :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
-                                           {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                                            :xt/system-from #xt/zoned-date-time "2022-01-01T00:00Z[UTC]",
-                                            :xt/valid-from #xt/zoned-date-time "2022-01-01T00:00Z[UTC]",
-                                            :xt/valid-to (time/->zdt time/end-of-time)
-                                            :op #xt/tagged [:put {:xt/id "foo", :v 1}]}]
+                      "r20230102.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                                          :xt/system-from (time/->zdt #inst "2021")
+                                          :xt/valid-from (time/->zdt #inst "2021")
+                                          :xt/valid-to (time/->zdt time/end-of-time)
+                                          :op #xt/tagged [:put {:v 1, :xt/id "bar"}]}
+                                         {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                                          :xt/system-from #xt/zoned-date-time "2022-01-01T00:00Z[UTC]",
+                                          :xt/valid-from #xt/zoned-date-time "2022-01-01T00:00Z[UTC]",
+                                          :xt/valid-to (time/->zdt time/end-of-time)
+                                          :op #xt/tagged [:put {:xt/id "foo", :v 1}]}]
 
-                        "rc.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
-                                     :xt/system-from (time/->zdt #inst "2023")
-                                     :xt/valid-from (time/->zdt #inst "2023")
-                                     :xt/valid-to (time/->zdt time/end-of-time)
-                                     :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
-                                    {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
-                                     :xt/system-from (time/->zdt #inst "2023")
-                                     :xt/valid-from (time/->zdt #inst "2023")
-                                     :xt/valid-to (time/->zdt time/end-of-time)
-                                     :op #xt/tagged [:put {:v 2, :xt/id "foo"}]}]}
+                      "rc.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
+                                   :xt/system-from (time/->zdt #inst "2023")
+                                   :xt/valid-from (time/->zdt #inst "2023")
+                                   :xt/valid-to (time/->zdt time/end-of-time)
+                                   :op #xt/tagged [:put {:v 2, :xt/id "bar"}]}
+                                  {:xt/iid #uuid "d9c7fae2-a04e-0471-6493-6265ba33cf80",
+                                   :xt/system-from (time/->zdt #inst "2023")
+                                   :xt/valid-from (time/->zdt #inst "2023")
+                                   :xt/valid-to (time/->zdt time/end-of-time)
+                                   :op #xt/tagged [:put {:v 2, :xt/id "foo"}]}]}
 
-                       (->> (for [^SegmentMerge$Result res results]
-                              [(str (.getFileName (.getPath$xtdb_core res)))
-                               (with-open [rel (.openAllAsRelation seg-merge res)]
-                                 (->> (.getAsMaps rel)
-                                      (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap)))))])
-                            (into {})))))))))))
+                     (->> (for [^SegmentMerge$Result res results]
+                            [(str (.getFileName (.getPath$xtdb_core res)))
+                             (with-open [rel (.openAllAsRelation seg-merge res)]
+                               (->> (.getAsMaps rel)
+                                    (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap)))))])
+                          (into {}))))))))))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1182,8 +1182,8 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (tct/defspec binary-overlay-len-default-is-len-of-placing-prop
   (tcp/for-all [[s1 s2 i] (overlay-args-gen tcg/bytes)]
-    (= (project1 '(overlay a b c d) {:a s1, :b s2, :c i, :d (project1 '(octet-length a) {:a s2})})
-       (project1 '(overlay a b c (default-overlay-length b)) {:a s1, :b s2, :c i}))))
+    (= (tu/->clj (project1 '(overlay a b c d) {:a s1, :b s2, :c i, :d (project1 '(octet-length a) {:a s2})}))
+       (tu/->clj (project1 '(overlay a b c (default-overlay-length b)) {:a s1, :b s2, :c i})))))
 
 (t/deftest test-math-functions
   (t/is (= [1.4142135623730951 1.8439088914585775 nil]

--- a/src/test/clojure/xtdb/operator/group_by_test.clj
+++ b/src/test/clojure/xtdb/operator/group_by_test.clj
@@ -449,25 +449,25 @@
                          array-agg [:list :i64],
                          array-agg-distinct [:list :i64]}}
 
-           (-> (tu/query-ra [:group-by '[k
-                                         {cnt (count v)}
-                                         {cnt-distinct (count-distinct v)}
-                                         {sum (sum v)}
-                                         {sum-distinct (sum-distinct v)}
-                                         {avg (avg v)}
-                                         {avg-distinct (avg-distinct v)}
-                                         {array-agg (array-agg v)}
-                                         {array-agg-distinct (array-agg-distinct v)}]
-                             [::tu/pages
-                              [[{:k :a, :v 10}
-                                {:k :b, :v 12}
-                                {:k :b, :v 15}
-                                {:k :b, :v 15}
-                                {:k :b, :v 10}]
-                               [{:k :a, :v 12}
-                                {:k :a, :v 10}]]]]
-                            {:with-col-types? true})
-               (update :res set)))))
+           (tu/->clj (-> (tu/query-ra [:group-by '[k
+                                                   {cnt (count v)}
+                                                   {cnt-distinct (count-distinct v)}
+                                                   {sum (sum v)}
+                                                   {sum-distinct (sum-distinct v)}
+                                                   {avg (avg v)}
+                                                   {avg-distinct (avg-distinct v)}
+                                                   {array-agg (array-agg v)}
+                                                   {array-agg-distinct (array-agg-distinct v)}]
+                                       [::tu/pages
+                                        [[{:k :a, :v 10}
+                                          {:k :b, :v 12}
+                                          {:k :b, :v 15}
+                                          {:k :b, :v 15}
+                                          {:k :b, :v 10}]
+                                         [{:k :a, :v 12}
+                                          {:k :a, :v 10}]]]]
+                                      {:with-col-types? true})
+                         (update :res set))))))
 
 (t/deftest test-group-by-with-nils-coerce-to-boolean-npe-regress
   (t/is (= {:res #{{:a 42} {}}

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -90,12 +90,12 @@
                          [:put-docs :xt_docs {:xt/id i :foo {:bar "forty-two"}}]))
 
     (t/is (= #{{:foo {:bar 42}} {:foo {:bar "forty-two"}}}
-             (set (tu/query-ra
-                   ;; the cross-join copies data from the underlying IndirectMultiVectorReader
-                   '[:apply :cross-join {}
-                     [:table [{}]]
-                     [:scan {:table #xt/table xt_docs} [foo]]]
-                   {:node node}))))))
+             (set (tu/->clj (tu/query-ra
+                             ;; the cross-join copies data from the underlying IndirectMultiVectorReader
+                             '[:apply :cross-join {}
+                               [:table [{}]]
+                               [:scan {:table #xt/table xt_docs} [foo]]]
+                             {:node node})))))))
 
 (t/deftest test-smaller-page-limit
   (util/with-open [node (xtn/start-node (merge tu/*node-opts* {:indexer {:page-limit 16}}))]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2257,13 +2257,13 @@ ORDER BY t.oid DESC LIMIT 1"
         (t/is (Arrays/equals ba ^bytes (:v (first (jdbc/execute! conn ["SELECT '00f0'::bytea AS v"]))))))
 
       (t/testing "nested varbinary"
-        (t/is (= [{:v {:ba (ByteBuffer/wrap (byte-array [0x00 0xf0]))}}]
-                 (q conn ["SELECT OBJECT(ba: X('00f0')) AS v"]))
+        (t/is (= (tu/->clj [{:v {:ba (byte-array [0x00 0xf0])}}])
+                 (tu/->clj (q conn ["SELECT OBJECT(ba: X('00f0')) AS v"])))
               "reading nested varbinary result")))
 
     (with-open [conn (jdbc-conn {"options" "-c fallback_output_format=transit"})]
       (let [res (:v (first  (q conn ["SELECT OBJECT(ba: X('00f0')) AS v"])))]
-        (t/is (Arrays/equals  ba (.array ^ByteBuffer (:ba res)))))))
+        (t/is (Arrays/equals ba ^bytes (:ba res))))))
 
   (t/testing "uri literals"
     (with-open [conn (jdbc-conn)]
@@ -2533,11 +2533,11 @@ ORDER BY 1,2;")
          (send (str sql ";\n"))
          (t/is (= [["depth" "op" "explain"]
                    ["->" "project"
-                    "{\"append?\":false,\"project\":\"[{_id foo.1\\/_id}]\"}"]
+                    "{\"project\":\"[{_id foo.1\\/_id}]\",\"append?\":false}"]
                    ["  ->" "rename"
                     "{\"prefix\":\"foo.1\"}"]
                    ["    ->" "scan"
-                    "{\"predicates\":[],\"columns\":[\"_id\"],\"table\":\"xtdb.public.foo\"}"]]
+                    "{\"columns\":[\"_id\"],\"table\":\"xtdb.public.foo\",\"predicates\":[]}"]]
 
                   (read))))))))
 

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/object-array.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/object-array.test
@@ -13,7 +13,7 @@ SELECT OBJECT(id: 1) FROM t1
 query T rowsort
 SELECT OBJECT (foo: 2, bar: OBJECT(baz: 'biff')) FROM t1
 ----
-{"bar" {"baz" "biff"}, "foo" 2}
+{"foo" 2, "bar" {"baz" "biff"}}
 
 query T rowsort
 SELECT OBJECT (foo: OBJECT(bibble: true),
@@ -21,7 +21,7 @@ SELECT OBJECT (foo: OBJECT(bibble: true),
                            flib: OBJECT(flob: false)))
 FROM t1
 ----
-{"bar" {"baz" -4113466, "flib" {"flob" false}}, "foo" {"bibble" true}}
+{"foo" {"bibble" true}, "bar" {"baz" -4113466, "flib" {"flob" false}}}
 
 query T rowsort
 SELECT ARRAY ['foo', 'bar'] FROM t1
@@ -41,7 +41,7 @@ SELECT ARRAY [true, FALSE, true, TRUE, false] FROM t1
 query T rowsort
 SELECT OBJECT (foo: 5, bar: OBJECT(baz: ARRAY [-45, 1, 24])) FROM t1
 ----
-{"bar" {"baz" [-45 1 24]}, "foo" 5}
+{"foo" 5, "bar" {"baz" [-45 1 24]}}
 
 query T rowsort
 SELECT ARRAY [OBJECT(foo: 5), OBJECT(foo: 5)] FROM t1
@@ -59,8 +59,8 @@ SELECT OBJECT (foo: OBJECT(bibble: true),
                            flib: OBJECT(flob: false)))
 FROM t1
 ----
-{"bar" {"baz" -4113466, "flib" {"flob" false}}, "foo" {"bibble" true}}
-{"bar" {"baz" -4113466, "flib" {"flob" false}}, "foo" {"bibble" true}}
+{"foo" {"bibble" true}, "bar" {"baz" -4113466, "flib" {"flob" false}}}
+{"foo" {"bibble" true}, "bar" {"baz" -4113466, "flib" {"flob" false}}}
 
 # testing field refs
 
@@ -96,8 +96,8 @@ VALUES(2, {foo: {bibble: true},
 query T rowsort
 SELECT t2.data FROM t2
 ----
-{"bar" {"baz" -4113466, "flib" {"flob" false}}, "foo" {"bibble" true}}
-{"bar" {"baz" 1001}, "foo" {"bibble" true}}
+{"foo" {"bibble" true}, "bar" {"baz" -4113466, "flib" {"flob" false}}}
+{"foo" {"bibble" true}, "bar" {"baz" 1001}}
 
 # SEE 440
 #query T rowsort


### PR DESCRIPTION
 This PR:

* migrates the EE to use new vecs
* migrates _nearly_ all the relational operators. 
  * The only one left is `:scan` - so the extent now is that there's a conversion from new -> old in the live-table snapshot, and then an old -> new in ScanCursor.
  * Then we can delete all the old vecs :relaxed: 