### PR TITLE
bump -> Java 24 s.t. we can start to use finalised native memory support in the JDK

### DIFF
--- a/.github/workflows/bench-docker.yml
+++ b/.github/workflows/bench-docker.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Set up QEMU

--- a/.github/workflows/build-connect.yml
+++ b/.github/workflows/build-connect.yml
@@ -16,10 +16,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
           sudo dpkg-reconfigure -f noninteractive tzdata
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
@@ -63,10 +63,10 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
@@ -113,10 +113,10 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -148,10 +148,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
@@ -167,10 +167,10 @@ jobs:
 
   #   steps:
   #     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-  #     - name: Set up JDK 21
+  #     - name: Set up JDK 24
   #       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
   #       with:
-  #         java-version: '21'
+  #         java-version: '24'
   #         distribution: 'temurin'
   #     - name: Setup Gradle
   #       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Run Readings benchmark

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -41,10 +41,10 @@ jobs:
           CLUSTER_ID: q1Sh-9_ISia_zwGINzRvyQ
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - id: 'google-cloud-auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/property-test.yml
+++ b/.github/workflows/property-test.yml
@@ -18,10 +18,10 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/slt.yml
+++ b/.github/workflows/slt.yml
@@ -26,10 +26,10 @@ jobs:
                   {dir: "index/random/", failure: 5}]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v3
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
       - name: SLT Test Dir
         uses: gradle/gradle-build-action@915a66c096a03101667f9df2e56c9efef558b165 # v2.6.1

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     testImplementation(libs.next.jdbc)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 tasks.javadoc {
     exclude("xtdb/util/*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,8 @@ val defaultJvmArgs = listOf(
     "-XX:-OmitStackTraceInFastThrow",
     "-Dlogback.configurationFile=${rootDir.resolve("src/main/resources/logback-test.xml")}",
     "-Dxtdb.rootDir=$rootDir",
-    "-Djunit.jupiter.extensions.autodetection.enabled=true"
+    "-Djunit.jupiter.extensions.autodetection.enabled=true",
+    "--enable-native-access=ALL-UNNAMED", // netty
 )
 
 val sixGBJvmArgs = listOf(
@@ -51,7 +52,7 @@ val twelveGBJvmArgs = listOf(
     "-XX:MaxMetaspaceSize=1g"
 )
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 application {
     applicationName = "xtdb"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.20")
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 tasks.shadowJar {
     isZip64 = true

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     api(libs.arrow.vector)
     api(libs.arrow.memory.netty)
     api(libs.netty.common)
+    api(libs.netty.buffer)
 
     api(libs.roaring.bitmap)
 
@@ -93,14 +94,12 @@ dependencies {
     testImplementation(project(":modules:xtdb-flight-sql"))
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 tasks.javadoc.get().enabled = false
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
-
         java {
             freeCompilerArgs.add("-Xjvm-default=all")
         }

--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -12,7 +12,7 @@ All of the below commands should be run in the *root* of the XT2 repo.
 
 == Prerequisites
 
-You will need at least JDK 21 installed.
+You will need at least JDK 24 installed.
 
 == Getting started
 

--- a/dev/RELEASING.adoc
+++ b/dev/RELEASING.adoc
@@ -25,7 +25,7 @@ To build the XTDB release artifacts locally and deploy them to Maven Central, ru
 
 Build and deploy release jars:
 
-. `java -version` -> java-21-openjdk
+. `java -version` -> java-24-openjdk
 . `git clean -dXf`
 . `export XTDB_VERSION=2.0.0` (`set -x XTDB_VERSION=2.0.0` for the fish people)
 . `./gradlew clean jreleaserDeploy`
@@ -79,7 +79,7 @@ NOTE: we could do a fair bit of this through JReleaser too, but for now I prefer
 == Building locally and releasing JAR snapshots:
 
 .  (none of the above sections are required)
-.  `java -version` → java-21-openjdk
+.  `java -version` → java-24-openjdk
 .  `git clean -dXf`
 .  `./gradlew clean jreleaserDeploy`
 .  (nothing to be done in Sonatype!)

--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:24
 
 LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
 LABEL org.opencontainers.image.description="XTDB 2.x"

--- a/docker/aws/build.gradle.kts
+++ b/docker/aws/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     runtimeOnly(libs.slf4j.jpl)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 application {
     mainClass.set("clojure.main")

--- a/docker/azure/Dockerfile
+++ b/docker/azure/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:24
 
 LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
 LABEL org.opencontainers.image.description="XTDB 2.x"

--- a/docker/azure/build.gradle.kts
+++ b/docker/azure/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     runtimeOnly(libs.slf4j.jpl)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 application {
     mainClass.set("clojure.main")

--- a/docker/google-cloud/Dockerfile
+++ b/docker/google-cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:24
 
 LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
 LABEL org.opencontainers.image.description="XTDB 2.x"

--- a/docker/google-cloud/build.gradle.kts
+++ b/docker/google-cloud/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     runtimeOnly(libs.slf4j.jpl)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 application {
     mainClass.set("clojure.main")

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:24
 
 LABEL org.opencontainers.image.source=https://github.com/xtdb/xtdb
 LABEL org.opencontainers.image.description="XTDB 2.x"

--- a/docker/standalone/build.gradle.kts
+++ b/docker/standalone/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     runtimeOnly(libs.slf4j.jpl)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 application {
     mainClass.set("clojure.main")

--- a/docs/src/content/docs/drivers/clojure.adoc
+++ b/docs/src/content/docs/drivers/clojure.adoc
@@ -62,7 +62,7 @@ You can run XTDB nodes either in-process, or connect to a remote XTDB server via
 ----
 {:deps {org.clojure/clojure {:mvn/version "1.12.0"} ; minimum reqmt
 
-        ;; minimum JDK: 21
+        ;; minimum JDK: 24
 
         ;; xtdb-api for the main public API, for both remote and in-process nodes
         com.xtdb/xtdb-api {:mvn/version "XTDB_VERSION"}
@@ -84,7 +84,7 @@ From here, check out the link:/drivers/clojure/codox/xtdb.api.html[`xtdb.api` AP
 If you're running a JVM, you can also use XTDB directly, in-process.
 In-process XTDB is particularly useful for testing and interactive development - you can start an in-memory node quickly and with little hassle, which makes it a great tool for unit tests and REPL experimentation.
 
-1. First, ensure you are running JDK 21+ and then add the `xtdb-core` library to your dependency manager.
+1. First, ensure you are running JDK 24+ and then add the `xtdb-core` library to your dependency manager.
 2. You'll also need to add the following JVM arguments to run Apache Arrow (included in the `:xtdb` deps.edn alias above):
 +
 --

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ shadow = "8.3.6"
 freefair-javadoc = "8.13.1"
 junit = "5.13.0"
 junit-launcher = "1.12.2"
-netty = "4.2.2.Final"
+netty = "4.2.6.Final"
 protobuf = "4.31.1"
 protobuf-plugin = "0.9.5"
 reitit = "0.9.1"
@@ -32,6 +32,7 @@ arrow-vector = { group = "org.apache.arrow", name = "arrow-vector", version.ref 
 arrow-adbc = { group = "org.apache.arrow.adbc", name = "adbc-core", version.ref = "arrow-adbc" }
 arrow-adbc-fsql = { group = "org.apache.arrow.adbc", name = "adbc-driver-flight-sql", version.ref = "arrow-adbc" }
 netty-common = { group = "io.netty", name = "netty-common", version.ref = "netty" }
+netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 
 roaring-bitmap = { group = "org.roaringbitmap", name = "RoaringBitmap", version = "1.3.0" }
 hppc = { group = "com.carrotsearch", name = "hppc", version = "0.10.0" }

--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -19,7 +19,7 @@ publishing {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":xtdb-api"))

--- a/modules/azure/build.gradle.kts
+++ b/modules/azure/build.gradle.kts
@@ -19,7 +19,7 @@ publishing {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":xtdb-api"))

--- a/modules/bench/Dockerfile
+++ b/modules/bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:24
 
 WORKDIR /opt/xtdb
 ENTRYPOINT [ \

--- a/modules/bench/build.gradle.kts
+++ b/modules/bench/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.gradleup.shadow")
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":"))

--- a/modules/datasets/build.gradle.kts
+++ b/modules/datasets/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     signing
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":"))

--- a/modules/flight-sql/build.gradle.kts
+++ b/modules/flight-sql/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":xtdb-api"))

--- a/modules/google-cloud/build.gradle.kts
+++ b/modules/google-cloud/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.protobuf)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 publishing {
     publications.create("maven", MavenPublication::class) {

--- a/modules/kafka-connect/build.gradle.kts
+++ b/modules/kafka-connect/build.gradle.kts
@@ -13,7 +13,7 @@ ext {
     set("labs", true)
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":xtdb-api"))

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(24))
 
 dependencies {
     api(project(":xtdb-api"))


### PR DESCRIPTION
* You'll obviously need a JDK 24+ locally to run it, or if users are running XT in-process.
* There's a few warnings still - Netty ([issue](https://github.com/netty/netty/issues/14942)) and protobuf ([issue](https://github.com/protocolbuffers/protobuf/issues/20760)) being the main culprits.