### PR TITLE
use mmap in the MemoryCache (not actually caching anything now)

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -38,7 +38,9 @@
 
 (defmethod ig/init-key :xtdb/config [_ cfg] cfg)
 
-(defmethod ig/init-key :xtdb/allocator [_ _] (RootAllocator.))
+(defmethod ig/init-key :xtdb/allocator [_ _]
+  (RootAllocator. (long (* 0.9 (util/max-direct-memory)))))
+
 (defmethod ig/halt-key! :xtdb/allocator [_ ^BufferAllocator a]
   (util/close a))
 

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -8,6 +8,7 @@
             [xtdb.error :as err])
   (:import [clojure.lang Keyword MapEntry Symbol]
            (io.netty.buffer Unpooled)
+           io.netty.util.internal.PlatformDependent
            (java.io File)
            java.lang.AutoCloseable
            (java.net MalformedURLException ServerSocket URI URL)
@@ -494,6 +495,17 @@
                           (cons x (step (rest s) (conj seen v)))))))
                   xs seen)))]
      (step coll #{}))))
+
+(defn max-direct-memory
+  "Returns the maximum direct memory supposed to be used by the system.
+
+  Assumes the JVM option `io.netty.maxDirectMemory` is not set as otherwise that value is returned."
+  ^long []
+  (try
+    (PlatformDependent/maxDirectMemory)
+    (catch Throwable _t
+      ;; otherwise we use as much direct memory as there was heap specified
+      (.maxMemory (Runtime/getRuntime)))))
 
 (defn used-netty-memory []
   (io.netty.util.internal.PlatformDependent/usedDirectMemory))

--- a/core/src/main/kotlin/xtdb/IEvictBufferTest.kt
+++ b/core/src/main/kotlin/xtdb/IEvictBufferTest.kt
@@ -1,7 +1,4 @@
 package xtdb
 
-import java.nio.file.Path
-
 interface IEvictBufferTest {
-    fun evictCachedBuffer(key: Path)
 }

--- a/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
@@ -2,44 +2,37 @@
 
 package xtdb.cache
 
-import com.github.benmanes.caffeine.cache.Caffeine
-import com.github.benmanes.caffeine.cache.RemovalCause
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
-import io.netty.buffer.ByteBuf
-import io.netty.buffer.PooledByteBufAllocatorL
 import kotlinx.serialization.Serializable
 import org.apache.arrow.memory.ArrowBuf
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.ForeignAllocation
-import xtdb.cache.MemoryCache.PathSlice
-import xtdb.cache.PinningCache.IEntry
+import xtdb.util.closeOnCatch
 import xtdb.util.maxDirectMemory
 import xtdb.util.openReadableChannel
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
 import java.nio.channels.ClosedByInterruptException
+import java.nio.channels.FileChannel
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.io.path.fileSize
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
-
-private typealias PinningCacheMapEntry = Map.Entry<PathSlice, CompletableFuture<MemoryCache.Entry>>
-
-private val Path.isMetaFile: Boolean
-    get() {
-        val regex = Regex(""".*meta/.*\.arrow$""")
-        return regex.containsMatchIn(this.toString())
-    }
 
 /**
  * NOTE: the allocation count metrics in the provided `allocator` WILL NOT be accurate
  *   - we allocate a buffer in here for every _usage_, and don't take shared memory into account.
+ *
+ * This isn't *caching* much now (see #4831) - it's more to keep track of/limit how much we've mmap'd in.
  */
 class MemoryCache @JvmOverloads internal constructor(
     private val al: BufferAllocator,
-    maxSizeBytes: Long,
+    private val maxSizeBytes: Long,
     private val pathLoader: PathLoader = PathLoader()
 ) : AutoCloseable {
+
+    private val usedBytes = AtomicLong()
 
     data class Slice(val offset: Long, val length: Long) {
         companion object {
@@ -64,64 +57,24 @@ class MemoryCache @JvmOverloads internal constructor(
                 .also { meterRegistry?.registerMemoryCache(it) }
     }
 
-    internal val pinningCache = PinningCache<PathSlice, Entry>(maxSizeBytes)
+    internal data class Stats(val usedBytes: Long, val freeBytes: Long)
 
-    data class SectionStats(val sliceCount: Int, val weightBytes: Long, val pinned: Long, val unpinned: Long) {
-        internal companion object {
-            operator fun invoke(slices: List<PinningCacheMapEntry>): SectionStats {
-                val size = slices.size
-                val weightBytes = slices.sumOf { it.key.slice?.length ?: 0 }
-                val pinned = slices.sumOf { if (it.value.get().inner.refCount.get() > 0) 1L else 0L }
-                return SectionStats(size, weightBytes, pinned, size - pinned)
-            }
-        }
-    }
-
-    data class Stats(val metaStats: SectionStats, val dataStats: SectionStats)
-
-    private val stats0: Stats
-        get() {
-            val grouped = pinningCache.cache.asMap().entries.groupBy { it.key.path.isMetaFile }
-            return Stats(SectionStats(grouped[true].orEmpty()), SectionStats(grouped[false].orEmpty()))
-        }
-
-    private val statsCache =
-        Caffeine.newBuilder().expireAfterWrite(2.seconds.toJavaDuration())
-            .build<Unit, Stats> { stats0 }
-
-    val stats: Stats get() = statsCache[Unit]
+    internal val stats0 get() = usedBytes.get().let { used -> Stats(used, maxSizeBytes - used) }
 
     interface PathLoader {
-        fun load(path: Path, slice: Slice): ByteBuf
+        fun load(path: Path, slice: Slice, arena: Arena): MemorySegment
 
         companion object {
             operator fun invoke() = object : PathLoader {
-                private val pool = PooledByteBufAllocatorL()
-
-                override fun load(path: Path, slice: Slice) =
+                override fun load(path: Path, slice: Slice, arena: Arena): MemorySegment =
                     try {
                         path.openReadableChannel().use { ch ->
-                            val nettyBuf = pool.allocate(slice.length)
-                            val bbuf = nettyBuf.nioBuffer(0, slice.length.toInt())
-                            ch.position(slice.offset)
-                            ch.read(bbuf)
-                            nettyBuf
+                            ch.map(FileChannel.MapMode.READ_ONLY, slice.offset, slice.length, arena)
                         }
                     } catch (e: ClosedByInterruptException) {
                         throw InterruptedException(e.message)
                     }
             }
-        }
-    }
-
-    internal inner class Entry(
-        val inner: IEntry<PathSlice>,
-        val onEvict: AutoCloseable?,
-        val nettyBuf: ByteBuf
-    ) : IEntry<PathSlice> by inner {
-        override fun onEvict(k: PathSlice, reason: RemovalCause) {
-            nettyBuf.release()
-            onEvict?.close()
         }
     }
 
@@ -133,51 +86,60 @@ class MemoryCache @JvmOverloads internal constructor(
         operator fun invoke(k: Path): CompletableFuture<Pair<Path, AutoCloseable?>>
     }
 
+    private fun acquire(reqBytes: Long) {
+        while (true) {
+            val used = usedBytes.get()
+            val free = maxSizeBytes - used
+
+            if (reqBytes > free) throw OutOfMemoryError("out of memory. requested: $reqBytes, free: $free")
+
+            if (usedBytes.compareAndSet(used, used + reqBytes)) break
+        }
+    }
+
     @Suppress("NAME_SHADOWING")
-    fun get(key: Path, slice: Slice? = null, fetch: Fetch): ArrowBuf {
-        val cacheKey = PathSlice(key, slice)
-        val entry = pinningCache.get(cacheKey) { k ->
-            fetch(k.path).thenApplyAsync { (path, onEvict) ->
-                val nettyBuf = pathLoader.load(path, k.slice ?: Slice.from(path))
-                Entry(pinningCache.Entry(nettyBuf.capacity().toLong()), onEvict, nettyBuf)
+    fun get(key: Path, slice: Slice? = null, fetch: Fetch): ArrowBuf =
+        fetch(key).thenApplyAsync { (path, onEvict) ->
+            val slice = slice ?: Slice.from(path)
+            acquire(slice.length)
+            try {
+                // we open up a fine-grained arena here so that we can release the memory
+                // as soon as we're done with the ArrowBuf.
+                Arena.ofShared().closeOnCatch { arena ->
+                    val memSeg = pathLoader.load(path, slice, arena)
+
+                    al.wrapForeignAllocation(
+                        object : ForeignAllocation(memSeg.byteSize(), memSeg.address()) {
+                            override fun release0() {
+                                arena.close()
+                                usedBytes.addAndGet(-slice.length)
+                                onEvict?.close()
+                            }
+                        })
+                }
+            } catch (t: Throwable) {
+                usedBytes.addAndGet(-slice.length)
+                onEvict?.close()
+                throw t
             }
+
         }.get()!!
 
-        val nettyBuf = entry.nettyBuf
-
-        // create a new ArrowBuf for each request.
-        // when the ref-count drops to zero, we release a ref-count in the cache.
-        return al.wrapForeignAllocation(
-            object : ForeignAllocation(nettyBuf.capacity().toLong(), nettyBuf.memoryAddress()) {
-                override fun release0() = pinningCache.releaseEntry(cacheKey)
-            })
-    }
-
-    internal fun invalidate(key: Path, slice: Slice? = null) = pinningCache.invalidate(PathSlice(key, slice))
-
-    override fun close() {
-        pinningCache.close()
-    }
+    override fun close() = Unit
 
     companion object {
         @JvmStatic
         fun factory() = Factory()
 
         internal fun MeterRegistry.registerMemoryCache(cache: MemoryCache) {
-            cache.pinningCache.registerMetrics("memory-cache", this)
-
-            fun registerGauge(name: String, baseUnit: String? = null, f: SectionStats.() -> Double) {
-                Gauge.builder("memory-cache.metaFiles.$name", cache) { it.stats.metaStats.f() }
-                    .baseUnit(baseUnit).tag("type", "meta").register(this)
-
-                Gauge.builder("memory-cache.dataFiles.$name", cache) { it.stats.dataStats.f() }
-                    .baseUnit(baseUnit).tag("type", "data").register(this)
+            fun registerGauge(name: String, f: MemoryCache.() -> Long) {
+                Gauge.builder(name, cache) { cache.f().toDouble() }
+                    .baseUnit("bytes").register(this@registerMemoryCache)
             }
 
-            registerGauge("sliceCount") { sliceCount.toDouble() }
-            registerGauge("weightBytes", "bytes") { weightBytes.toDouble() }
-            registerGauge("pinned") { pinned.toDouble() }
-            registerGauge("unpinned") { unpinned.toDouble() }
+            registerGauge("memory-cache.pinnedBytes") { usedBytes.get() }
+            registerGauge("memory-cache.evictableBytes") { 0 }
+            registerGauge("memory-cache.freeBytes") { maxSizeBytes - usedBytes.get() }
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/cache/PinningCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/PinningCache.kt
@@ -95,15 +95,6 @@ class PinningCache<K : Any, V : PinningCache.IEntry<K>>(
                 }
         }!!
 
-    fun invalidate(k: K) {
-        cache.synchronous().run {
-            invalidate(k)
-            cleanUp()
-        }
-
-        ForkJoinPool.commonPool().awaitQuiescence(100, MILLISECONDS)
-    }
-
     override fun close() {
         cache.asMap().clear()
         cache.synchronous().cleanUp()

--- a/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
@@ -176,10 +176,6 @@ internal class LocalStorage(
         }
     }
 
-    override fun evictCachedBuffer(key: Path) {
-        memoryCache.invalidate(cacheRootPath.resolve(key))
-    }
-
     override fun close() {
         allocator.close()
     }

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -120,8 +120,6 @@ internal class MemoryStorage(
         }
     }
 
-    override fun evictCachedBuffer(key: Path) {}
-
     override fun close() {
         deleteAllObjects()
         allocator.close()

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -194,10 +194,6 @@ internal class RemoteBufferPool(
         objectStore.putObject(key, buffer).get()
     }
 
-    override fun evictCachedBuffer(key: Path) {
-        memoryCache.invalidate(key)
-    }
-
     override fun close() {
         objectStore.close()
         allocator.close()

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -1,5 +1,6 @@
 package xtdb.util
 
+import java.nio.channels.FileChannel
 import java.nio.channels.SeekableByteChannel
 import java.nio.channels.WritableByteChannel
 import java.nio.file.Files
@@ -11,7 +12,7 @@ import kotlin.contracts.contract
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteIfExists
 
-internal fun Path.openReadableChannel(): SeekableByteChannel = Files.newByteChannel(this, READ)
+internal fun Path.openReadableChannel(): FileChannel = FileChannel.open(this, READ)
 internal fun Path.openWritableChannel(): WritableByteChannel = Files.newByteChannel(this, WRITE, CREATE)
 
 internal fun <R> useTempFile(prefix: String, suffix: String, block: (Path) -> R): R =

--- a/core/src/test/kotlin/xtdb/cache/MemoryCacheTest.kt
+++ b/core/src/test/kotlin/xtdb/cache/MemoryCacheTest.kt
@@ -1,7 +1,5 @@
 package xtdb.cache
 
-import io.netty.buffer.ByteBuf
-import io.netty.buffer.Unpooled
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -9,8 +7,12 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.cache.MemoryCache.Slice
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout.JAVA_BYTE
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture.completedFuture
+import java.util.concurrent.ExecutionException
 
 class MemoryCacheTest {
 
@@ -29,15 +31,18 @@ class MemoryCacheTest {
     class PathLoader : MemoryCache.PathLoader {
         private var idx = 0
 
-        override fun load(path: Path, slice: Slice): ByteBuf =
-            Unpooled.directBuffer(slice.length.toInt())
-                .also { it.setByte(0, ++idx) }
+        override fun load(path: Path, slice: Slice, arena: Arena): MemorySegment =
+            arena.allocate(slice.length)
+                .also { it.set(JAVA_BYTE, 0, (++idx).toByte()) }
     }
 
     @Test
     fun `test memory cache`() {
         // just a starter-for-ten here, intent is that we go further down the property/deterministic testing route
         // significantly exercised E2E by the rest of the test-suite and benchmarks.
+
+        // this used to be more of a test when the memory cache actually cached entries.
+        // now, it's mostly a stats test.
 
         MemoryCache(allocator, 250, PathLoader()).use { cache ->
 
@@ -49,16 +54,16 @@ class MemoryCacheTest {
                 cache.get(Path.of("t1/100"), Slice(0, 100)) { completedFuture(it to onEvict) }.use { b1 ->
                     assertEquals(1, b1.getByte(0))
 
-                    assertEquals(PinningCache.Stats(100L, 0L, 150L), cache.pinningCache.stats0)
+                    assertEquals(MemoryCache.Stats(100L, 150L), cache.stats0)
                 }
 
                 cache.get(Path.of("t1/100"), Slice(0, 100)) { completedFuture(it to onEvict) }.use { b1 ->
-                    assertEquals(1, b1.getByte(0))
+                    assertEquals(2, b1.getByte(0))
                 }
 
                 Thread.sleep(50)
-                assertEquals(PinningCache.Stats(0L, 100L, 150L), cache.pinningCache.stats0)
-                assertFalse(t1Evicted)
+                assertEquals(MemoryCache.Stats(0, 250), cache.stats0)
+                assertTrue(t1Evicted)
             })
 
             var t2Evicted = false
@@ -68,34 +73,76 @@ class MemoryCacheTest {
 
                 val path = Path.of("t2/50")
                 cache.get(path, Slice(0, 50)) { completedFuture(it to onEvict) }.use { b1 ->
-                    assertEquals(2, b1.getByte(0))
+                    assertEquals(3, b1.getByte(0))
 
-                    assertEquals(PinningCache.Stats(50L, 100L, 100L), cache.pinningCache.stats0)
+                    assertEquals(MemoryCache.Stats(50, 200), cache.stats0)
                 }
 
                 Thread.sleep(100)
-                assertEquals(PinningCache.Stats(0L, 150L, 100L), cache.pinningCache.stats0)
+                assertEquals(MemoryCache.Stats(0L, 250L), cache.stats0)
             })
 
-            assertFalse(t1Evicted)
-            assertFalse(t2Evicted)
+            assertTrue(t1Evicted)
+            assertTrue(t2Evicted)
 
             assertAll("t3 evicts t2/t1", {
                 cache.get(Path.of("t3/170"), Slice(0, 170)) { completedFuture(it to null) }.use { b1 ->
-                    assertEquals(3, b1.getByte(0))
+                    assertEquals(4, b1.getByte(0))
                     assertTrue(t1Evicted)
 
                     // definitely needs to evict t1, may or may not evict t2
-                    val stats = cache.pinningCache.stats0
-                    assertEquals(170, stats.pinnedBytes)
-                    assertEquals(80, stats.evictableBytes + stats.freeBytes)
+                    val stats = cache.stats0
+                    assertEquals(170, stats.usedBytes)
+                    assertEquals(80, stats.freeBytes)
                 }
 
                 Thread.sleep(100)
-                val stats = cache.pinningCache.stats0
-                assertEquals(0, stats.pinnedBytes)
-                assertEquals(250, stats.evictableBytes + stats.freeBytes)
+                val stats = cache.stats0
+                assertEquals(0, stats.usedBytes)
+                assertEquals(250, stats.freeBytes)
             })
+        }
+    }
+
+    private inline fun <R> unwrapCause(f: () -> R) =
+        try {
+            f()
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
+
+    @Test
+    fun `ooms the mem-cache`() {
+        MemoryCache(allocator, 100, PathLoader()).use { cache ->
+            assertThrows(OutOfMemoryError::class.java) {
+                unwrapCause {
+                    cache.get(Path.of("t1/200"), Slice(0, 200)) { k -> completedFuture(k to null) }.use { }
+                }
+            }
+
+            assertAll(
+                "only takes a slice of a bigger file",
+                {
+                    cache.get(Path.of("t1/200"), Slice(0, 50)) { k -> completedFuture(k to null) }.use { b1 ->
+                        assertEquals(1, b1.getByte(0))
+                    }
+                }
+            )
+
+            assertAll(
+                "but too many slices OOMs too",
+                {
+                    cache.get(Path.of("t1/200"), Slice(0, 75)) { k -> completedFuture(k to null) }.use { b1 ->
+                        assertEquals(2, b1.getByte(0))
+
+                        assertThrows(OutOfMemoryError::class.java) {
+                            unwrapCause {
+                                cache.get(Path.of("t1/200"), Slice(75, 75)) { k -> completedFuture(k to null) }.use {}
+                            }
+                        }
+                    }
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
We're fully aware of and respect Crotty et al's ["Are you sure you want to use MMAP in your DBMS?"](https://db.cs.cmu.edu/papers/2022/cidr2022-p13-crotty.pdf) (sub-titled "MMAP = :hankey:") :sweat_smile:.

Our mitigations:
* XTDB has a read-only, LSM-tree buffer-pool - we don't write pages in-place, so many of the cautionary tales don't apply to us.
* We're not (yet) in a position where our memory cache was doing anything smarter than the kernel page cache does. Eventually, we'll want to use O_DIRECT or similar instead but, pragmatically, today is not that day.

Right, onto the PR:

The aim of this is to prevent double-accounting in our Docker images, which was causing Docker/Kubernetes to OOM-kill our containers. 

* We were reading pages through the kernel's page cache into an off-heap Netty buffer. This counts against us twice: once because of the Netty memory (obv), but we were also held responsible for the memory in the kernel page cache.
* With mmap'ing, we're no longer reading the memory into Netty, so we don't get charged for that. We do get charged for the open mmap - but, as soon as we close it, the memory goes into a global page cache. Bit cheeky, perhaps, but that's how it works.
* This does mean that we're relying on the kernel's page cache to keep the right pages warm. At the moment, compared to the memory caching we were doing, this is a reasonable trade-off - but, at some point, we'll want to make our memory caching more intelligent.

This replaces our existing memory cache with a 'cache' that essentially memory-maps the slice of the file and returns it. 

* Particularly, we are not doing any in-process memory caching here. Previously, we were caching reading the page into memory, but now that we're reading direct from mmap, the cache isn't doing any computation at the point of cache request.
* We use Java 22's new [FFI and Memory API](https://docs.oracle.com/en/java/javase/22/core/foreign-function-and-memory-api.html) so that we can deterministically close the mmap'd buffers as soon as we're done with them.
* We use the previously set limit for the memory cache. This is now effectively a 'pinned pages' limit - i.e. if we have more than this amount of pages in active use at once, we now throw our own OOME, cancelling the query. If it's thrown in the indexer, this may cause ingestion-stopped, which will cause the node to restart - but this will only be thrown when _active_ pages go over that limit, not evictable pages as is the case currently. Eventually, we may want to keep a separate pool for pages required by the indexer, but again, today is not that day.
