### PR TITLE
Handle string escaping within vectors.

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire/types.clj
+++ b/core/src/main/clojure/xtdb/pgwire/types.clj
@@ -99,19 +99,11 @@
 
 (defn- read-utf8 [^bytes barr] (String. barr StandardCharsets/UTF_8))
 
-(defn- escape-pg-array-element
-  "Escapes a string element for PostgreSQL array format.
-  Wraps in quotes if it contains special characters or would otherwise be misparsed."
-  [^String s]
-  (let [needs-quotes? (or (str/blank? s)
-                          (#{"NULL"} s)
-                          (re-find #"[\"\\,\{\}\s]" s))]
-    (if needs-quotes?
-      (format "\"%s\""
-              (-> s
-                  (str/replace "\\" "\\\\")
-                  (str/replace "\"" "\\\"")))
-      s)))
+(defn- escape-pg-array-element [^String s]
+  (format "\"%s\""
+          (-> s
+              (str/replace "\\" "\\\\")
+              (str/replace "\"" "\\\""))))
 
 (defn utf8
   "Returns the utf8 byte-array for the given string"


### PR DESCRIPTION
resolves #4858, resolves #4859

Github action runs: https://github.com/danmason/xtdb/actions?query=branch%3Astring-escaping-in-vectors

Handles a number of cases where we were not properly escaping strings stored within vectors when returning the results from pgwire/storing them within a PgArray, leading to numerous incorrect results and errors.

## Comparison with `main`

The test covers the various cases which were causing issues - running this on main reveals multiple issues with how vector string values are decoded from Postgres:

**Indexing / type errors:**
- Curly braces → Index -1 out of bounds for length 0
- Question mark + curly brace → PgArrayList cannot be cast to String

**Escaping inconsistencies:**
- Commas are being treated as delimiters instead of literal characters (["hello" "hello" "world"] instead of ["," ",hello" "hello,world"]).
- Spaces are stripped (["a" "b" "c" "helloworld"] instead of ["a " "b " " c " "hello world"]).
- Quotes are unescaped (["quoted"] instead of ["\"quoted\"\"]).
- Backslashes are lost (["abc"] instead of ["a\\b\\c"]).
- Empty strings are dropped entirely ([] instead of [""]).
- Literal "NULL" strings are decoded as SQL nulls ([nil] instead of ["NULL"]).