### PR TITLE
azure/helm: add ability to supply envFrom

### DIFF
--- a/azure/helm/templates/statefulset.yaml
+++ b/azure/helm/templates/statefulset.yaml
@@ -51,6 +51,10 @@ spec:
               mountPath: "/var/lib/xtdb/buffers/"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.xtdbConfig.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: JDK_JAVA_OPTIONS
               value: {{ .Values.xtdbConfig.jdkOptions }}

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -96,6 +96,9 @@ xtdbConfig:
     # (ENV_VAR_NAME: Value)
     XTDB_LOGGING_LEVEL: "info" # See https://docs.xtdb.com/ops/troubleshooting/overview.html
 
+  # Extra EnvFrom sources
+  envFrom: []
+
 startupProbe:
   httpGet:
     path: /healthz/started


### PR DESCRIPTION
This allows some additional environment variables to be mapped in from a secret for secure values:

```yaml
xtdbConfig:
  envFrom:
    - secretRef:
        name: xtdb-secret-envs
```