### PR TITLE
Update property tests to only spin up one node each.

### DIFF
--- a/src/main/clojure/xtdb/test_generators.clj
+++ b/src/main/clojure/xtdb/test_generators.clj
@@ -279,3 +279,12 @@
                     (mapv (fn [{:keys [column-name data-type]}]
                             (types/col-type->field column-name (read-string data-type)))))]
     (field->value-generator (apply types/->field "docs" #xt.arrow/type :struct false fields))))
+
+(defn unique-table "Generate a unique table name and keyword for property tests."
+  ([]
+   (unique-table "docs"))
+  ([prefix]
+   (gen/let [table-suffix uuid-gen]
+     (let [table-name (str prefix "_" (str/replace (str table-suffix) #"-" "_"))]
+       {:table-name table-name
+        :table-kw (keyword table-name)}))))

--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -10,198 +10,191 @@
             [xtdb.test-util :as tu]))
 
 (t/deftest ^:property multiple-writes-to-doc
-  (tu/run-property-test
-   {:num-tests tu/property-test-iterations}
-   (prop/for-all [records (gen/vector (tg/generate-record {:potential-doc-ids #{1}}) 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests tu/property-test-iterations}
+     (prop/for-all [records (gen/vector (tg/generate-record {:potential-doc-ids #{1}}) 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
                    (doseq [record records]
-                     (xt/execute-tx node [[:put-docs :docs record]]))
+                     (xt/execute-tx node [[:put-docs table-kw record]]))
 
                    (and
-                    (t/testing "multiple transaction recorded"
-                      (= (count records) (count (xt/q node "FROM xt.txs"))))
                     (t/testing "all entries in history"
-                      (let [res (xt/q node "SELECT * FROM docs FOR VALID_TIME ALL")]
+                      (let [res (xt/q node (str "SELECT * FROM " table-name " FOR VALID_TIME ALL"))]
                         (= (count records) (count res))))
                     (t/testing "only one document present at valid time"
-                      (let [res (xt/q node "SELECT * FROM docs")]
+                      (let [res (xt/q node (str "SELECT * FROM " table-name))]
                         (= 1 (count res))))
                     (t/testing "document is equal to last entry"
                       (= (tg/normalize-for-comparison (tu/remove-nils (last records)))
-                         (tg/normalize-for-comparison (first (xt/q node "SELECT * FROM docs"))))))))))
+                         (tg/normalize-for-comparison (first (xt/q node (str "SELECT * FROM " table-name)))))))))))
 
 (t/deftest ^:property multiple-writes-to-doc-in-same-tx
-  (tu/run-property-test
-   {:num-tests tu/property-test-iterations}
-   (prop/for-all [records (gen/vector (tg/generate-record {:potential-doc-ids #{1}}) 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests tu/property-test-iterations}
+     (prop/for-all [records (gen/vector (tg/generate-record {:potential-doc-ids #{1}}) 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
                    (let [vts (take (count records) (tu/->instants :day 1 #inst "2019-01-01"))
                          docs-with-time (mapv (fn [record valid-from]
-                                                [:put-docs {:into :docs :valid-from valid-from} record])
+                                                [:put-docs {:into table-kw :valid-from valid-from} record])
                                               records vts)]
                      (xt/execute-tx node docs-with-time)
                      (and
-                      (t/testing "one transaction recorded"
-                        (= 1 (count (xt/q node "FROM xt.txs"))))
                       (t/testing "all entries in history"
-                        (let [res (xt/q node "SELECT * FROM docs FOR VALID_TIME ALL")]
+                        (let [res (xt/q node (str "SELECT * FROM " table-name " FOR VALID_TIME ALL"))]
                           (= (count records) (count res))))
                       (t/testing "only one document present at valid time"
-                        (let [res (xt/q node "SELECT * FROM docs")] 
+                        (let [res (xt/q node (str "SELECT * FROM " table-name))]
                           (= 1 (count res))))
                       (t/testing "document is equal to last entry"
                         (= (tg/normalize-for-comparison (tu/remove-nils (last records)))
-                           (tg/normalize-for-comparison (first (xt/q node "SELECT * FROM docs")))))))))))
+                           (tg/normalize-for-comparison (first (xt/q node (str "SELECT * FROM " table-name))))))))))))
 
 ;; TODO: We've seen this namespace hang on a number of tests when increasing iterations to 1000
 ;; This temporarily is used to limit iterations to 100
 (def tmp-max-iterations 100)
 
 (t/deftest ^:property mixed-records-flush-boundary
-  (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
-   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
-                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
-                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
+                   (xt/execute-tx node [(into [:put-docs table-kw] records1)])
                    (tu/flush-block! node)
-
-                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                   
+                   (xt/execute-tx node [(into [:put-docs table-kw] records2)])
                    (tu/flush-block! node)
-
-                   (and (t/testing "two transactions recorded"
-                          (= 2 (count (xt/q node "FROM xt.txs"))))
-                        (t/testing "all expected document IDs present"
-                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                            (= expected-ids (into #{} (map :xt/id res))))))))))
+                   
+                   (t/testing "all expected document IDs present"
+                     (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                           expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                       (= expected-ids (into #{} (map :xt/id res)))))))))
 
 (t/deftest ^:property mixed-records-flush-and-compact-boundary
-  (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
-   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
-                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
-                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
+                   (xt/execute-tx node [(into [:put-docs table-kw] records1)])
                    (tu/flush-block! node)
-
-                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                   
+                   (xt/execute-tx node [(into [:put-docs table-kw] records2)])
                    (tu/flush-block! node)
-
+                   
                    (c/compact-all! node #xt/duration "PT1S")
-
-                   (and (t/testing "two transactions recorded"
-                          (= 2 (count (xt/q node "FROM xt.txs"))))
-                        (t/testing "all expected document IDs present"
-                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                            (= expected-ids (into #{} (map :xt/id res))))))))))
+                   
+                   (t/testing "all expected document IDs present"
+                     (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                           expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                       (= expected-ids (into #{} (map :xt/id res)))))))))
 
 (t/deftest ^:property mixed-records-flush-and-live-boundary
-  (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
-   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
-                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
-                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
+                   (xt/execute-tx node [(into [:put-docs table-kw] records1)])
                    (tu/flush-block! node)
-
-                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
-
-                   (and (t/testing "two transactions recorded"
-                          (= 2 (count (xt/q node "FROM xt.txs"))))
-                        (t/testing "all expected document IDs present"
-                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                            (= expected-ids (into #{} (map :xt/id res))))))))))
+                   
+                   (xt/execute-tx node [(into [:put-docs table-kw] records2)])
+                   
+                   (t/testing "all expected document IDs present"
+                     (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                           expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                       (= expected-ids (into #{} (map :xt/id res)))))))))
 
 (t/deftest ^:property mixed-records-live-boundary
-  (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
-   (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
-                  records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
-                   (xt/execute-tx node [(into [:put-docs :docs] records1)])
-                   (xt/execute-tx node [(into [:put-docs :docs] records2)])
-
-                   (and (t/testing "two transactions recorded"
-                          (= 2 (count (xt/q node "FROM xt.txs"))))
-                        (t/testing "all expected document IDs present"
-                          (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                            (= expected-ids (into #{} (map :xt/id res))))))))))
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
+                   (xt/execute-tx node [(into [:put-docs table-kw] records1)])
+                   (xt/execute-tx node [(into [:put-docs table-kw] records2)])
+                   
+                   (t/testing "all expected document IDs present"
+                     (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                           expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                       (= expected-ids (into #{} (map :xt/id res)))))))))
 
 (t/deftest ^:property type-change-across-blocks
-  (tu/run-property-test
-   {:num-tests tu/property-test-iterations}
-   (prop/for-all [[vec1 vec2] tg/two-distinct-single-type-vecs-gen]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests tu/property-test-iterations}
+     (prop/for-all [[vec1 vec2] tg/two-distinct-single-type-vecs-gen
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
                    (let [values1 (:vs vec1)
                          values2 (:vs vec2)
                          records1 (map-indexed (fn [i v] {:xt/id (+ 1000 i) :field v}) values1)
                          records2 (map-indexed (fn [i v] {:xt/id (+ 2000 i) :field v}) values2)]
-                     (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                     (xt/execute-tx node [(into [:put-docs table-kw] records1)])
                      (tu/flush-block! node)
 
-                     (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                     (xt/execute-tx node [(into [:put-docs table-kw] records2)])
                      (tu/flush-block! node)
 
                      (c/compact-all! node #xt/duration "PT1S")
 
-                     (and (t/testing "two transactions recorded"
-                            (= 2 (count (xt/q node "FROM xt.txs"))))
-                          (t/testing "all expected document IDs present"
-                            (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                  expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                              (= expected-ids (into #{} (map :xt/id res)))))))))))
+                     (t/testing "all expected document IDs present"
+                       (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                             expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                         (= expected-ids (into #{} (map :xt/id res))))))))))
 
 (t/deftest ^:property single-typed-value-to-nils-across-blocks
-  (tu/run-property-test
-   {:num-tests tu/property-test-iterations}
-   (prop/for-all [single-type-vec (tg/single-type-vector-vs-gen 1 100)]
-                 (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                                   :compactor {:threads 0}})]
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests tu/property-test-iterations}
+     (prop/for-all [single-type-vec (tg/single-type-vector-vs-gen 1 100)
+                    {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
                    (let [values (:vs single-type-vec)
                          records1 (map-indexed (fn [i v] {:xt/id (+ 1000 i) :field v}) values)
                          records2 (map-indexed (fn [i _] {:xt/id (+ 2000 i)}) values)]
-                     (xt/execute-tx node [(into [:put-docs :docs] records1)])
+                     (xt/execute-tx node [(into [:put-docs table-kw] records1)])
                      (tu/flush-block! node)
 
-                     (xt/execute-tx node [(into [:put-docs :docs] records2)])
+                     (xt/execute-tx node [(into [:put-docs table-kw] records2)])
                      (tu/flush-block! node)
 
                      (c/compact-all! node #xt/duration "PT1S")
 
-                     (and (t/testing "two transactions recorded"
-                            (= 2 (count (xt/q node "FROM xt.txs"))))
-                          (t/testing "all expected document IDs present"
-                            (let [res (xt/q node "SELECT * FROM docs ORDER BY _id")
-                                  expected-ids (into #{} (map :xt/id (concat records1 records2)))]
-                              (= expected-ids (into #{} (map :xt/id res)))))))))))
+                     (t/testing "all expected document IDs present"
+                       (let [res (xt/q node (str "SELECT * FROM " table-name " ORDER BY _id"))
+                             expected-ids (into #{} (map :xt/id (concat records1 records2)))]
+                         (= expected-ids (into #{} (map :xt/id res))))))))))
 
 (t/deftest ^:property mixed-ops-across-boundaries
-  (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
-   (let [id-gen (gen/one-of [(gen/return 1) (gen/return "1")])]
-     (prop/for-all [ops (gen/vector (gen/one-of [(gen/fmap (fn [id] [:erase id]) id-gen)
-                                                 (gen/return [:compact])
-                                                 (gen/return [:flush])
-                                                 (gen/fmap (fn [value] [:put value])
-                                                           (tg/generate-record {:potential-doc-ids #{1 "1"}}))])
-                                    1 20)]
-       (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
-                                         :compactor {:threads 0}})]
-         (doseq [[op value] ops]
-           (case op
-             :put     (xt/execute-tx node [[:put-docs :docs value]])
-             :erase   (xt/execute-tx node [[:erase-docs :docs value]])
-             :compact (c/compact-all! node #xt/duration "PT1S")
-             :flush   (tu/flush-block! node)))
-         (xt/q node "FROM docs WHERE _id = 1"))))))
+  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
+                                    :compactor {:threads 0}})]
+    (tu/run-property-test
+     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     (let [id-gen (gen/one-of [(gen/return 1) (gen/return "1")])]
+       (prop/for-all [ops (gen/vector (gen/one-of [(gen/fmap (fn [id] [:erase id]) id-gen)
+                                                   (gen/return [:compact])
+                                                   (gen/return [:flush])
+                                                   (gen/fmap (fn [value] [:put value])
+                                                             (tg/generate-record {:potential-doc-ids #{1 "1"}}))])
+                                      1 20)
+                      {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
+                     (doseq [[op value] ops]
+                       (case op
+                         :put     (xt/execute-tx node [[:put-docs table-kw value]])
+                         :erase   (xt/execute-tx node [[:erase-docs table-kw value]])
+                         :compact (c/compact-all! node #xt/duration "PT1S")
+                         :flush   (tu/flush-block! node)))
+                     (xt/q node (str "FROM " table-name " WHERE _id = 1")))))))

--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -53,15 +53,11 @@
                         (= (tg/normalize-for-comparison (tu/remove-nils (last records)))
                            (tg/normalize-for-comparison (first (xt/q node (str "SELECT * FROM " table-name))))))))))))
 
-;; TODO: We've seen this namespace hang on a number of tests when increasing iterations to 1000
-;; This temporarily is used to limit iterations to 100
-(def tmp-max-iterations 100)
-
 (t/deftest ^:property mixed-records-flush-boundary
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                     :compactor {:threads 0}})]
     (tu/run-property-test
-     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     {:num-tests tu/property-test-iterations}
      (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
@@ -80,7 +76,7 @@
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                     :compactor {:threads 0}})]
     (tu/run-property-test
-     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     {:num-tests tu/property-test-iterations}
      (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
@@ -101,7 +97,7 @@
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                     :compactor {:threads 0}})]
     (tu/run-property-test
-     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     {:num-tests tu/property-test-iterations}
      (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
@@ -119,7 +115,7 @@
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                     :compactor {:threads 0}})]
     (tu/run-property-test
-     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     {:num-tests tu/property-test-iterations}
      (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                     {:keys [table-name table-kw]} (tg/unique-table "bb_test")]
@@ -182,7 +178,7 @@
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                     :compactor {:threads 0}})]
     (tu/run-property-test
-     {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+     {:num-tests tu/property-test-iterations}
      (let [id-gen (gen/one-of [(gen/return 1) (gen/return "1")])]
        (prop/for-all [ops (gen/vector (gen/one-of [(gen/fmap (fn [id] [:erase id]) id-gen)
                                                    (gen/return [:compact])


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Ainvestigate-hanging-prop-tests++

Spinning up thousands of memory nodes seemed to cause problems, primarily that the memory usage would get eaten into quite a bit and eventually the run would slow to a crawl when running with a higher iteration count.

Have moved the property tests to spin up a single node each - a local storage/log based node which should have predictable memory usage/performance and scale better on iteration counts. Should be less overhead of starting/stopping nodes, also.

## Issues with reusing memory nodes.

Unfortunately, this now means we run out of memory with 1000 iterations instead! Wondering if there's a middle ground, ie, "restart node every 100 iterations", something like that. Perhaps points me back towards attempting to fix whatever issue we run into when restarting lots of in memory nodes. 

## Issues with local nodes

I then tried this with local nodes instead - this was predictably slower than the above, though ALSO had a number of errors with it - this would get stuck again, and a fair few of the tests seemed to fail. Not entirely sure on their full errors here, yet. This would also run out of tmp space, interestingly enough.