### PR TITLE
Clear entries in query plan cache on close.

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -427,6 +427,10 @@
     (when-not (.tryClose ref-ctr (Duration/ofMinutes 1))
       (log/warn "Failed to shut down after 60s due to outstanding queries"))
 
+    ;; Clear the plan cache itself
+    (.invalidateAll plan-cache)
+    (.cleanUp plan-cache)
+
     (util/close allocator)))
 
 (defmethod ig/prep-key ::query-source [_ opts]

--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -55,13 +55,9 @@
                         (= (tg/normalize-for-comparison (tu/remove-nils (last records)))
                            (tg/normalize-for-comparison (first (xt/q node "SELECT * FROM docs")))))))))))
 
-;; TODO: We've seen this namespace hang on a number of tests when increasing iterations to 1000
-;; This temporarily is used to limit iterations to 100
-(def tmp-max-iterations 100)
-
 (t/deftest ^:property mixed-records-flush-boundary
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+   {:num-tests tu/property-test-iterations}
    (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                   records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
                  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
@@ -81,7 +77,7 @@
 
 (t/deftest ^:property mixed-records-flush-and-compact-boundary
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+   {:num-tests tu/property-test-iterations}
    (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                   records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
                  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
@@ -103,7 +99,7 @@
 
 (t/deftest ^:property mixed-records-flush-and-live-boundary
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+   {:num-tests tu/property-test-iterations}
    (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                   records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
                  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
@@ -122,7 +118,7 @@
 
 (t/deftest ^:property mixed-records-live-boundary
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+   {:num-tests tu/property-test-iterations}
    (prop/for-all [records1 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)
                   records2 (gen/vector (tg/generate-record {:potential-doc-ids #{1 2 3 4 5}}) 1 10)]
                  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
@@ -188,7 +184,7 @@
 
 (t/deftest ^:property mixed-ops-across-boundaries
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations tmp-max-iterations)}
+   {:num-tests tu/property-test-iterations}
    (let [id-gen (gen/one-of [(gen/return 1) (gen/return "1")])]
      (prop/for-all [ops (gen/vector (gen/one-of [(gen/fmap (fn [id] [:erase id]) id-gen)
                                                  (gen/return [:compact])

--- a/src/test/clojure/xtdb/operator/patch_test.clj
+++ b/src/test/clojure/xtdb/operator/patch_test.clj
@@ -152,7 +152,7 @@
 
 (t/deftest ^:property multiple-patches-on-record
   (tu/run-property-test
-   {:num-tests (min tu/property-test-iterations 100)}
+   {:num-tests tu/property-test-iterations}
    (prop/for-all [records (gen/vector (tg/generate-record {:potential-doc-ids #{1}}) 1 20)]
                  (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                                    :compactor {:threads 0}})]


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aclearup-caches++

In practice, think I was mainly running into this as a potential problem in property tests where I was starting/closing a lot of in-memory nodes. Not sure it saves much memory/resources but seems like something we should do on node close anyway, as we do clear up the pinning cache's cache on close also. 

(Could separately look to close the relatively smaller "emit-cache" also, though perhaps that can be done separately)