### PR TITLE
Hex encoding/decoding byte array strings within pg types.

### DIFF
--- a/src/main/clojure/xtdb/test_generators.clj
+++ b/src/main/clojure/xtdb/test_generators.clj
@@ -61,12 +61,11 @@
 (def duration-gen (gen/return #xt/duration "PT1S"))
 (def interval-gen (gen/return #xt/interval "P1YT1S"))
 
-;; Exclude varbinary generators due to issue #4793
 (def simple-type-gens
   [nil-gen bool-gen
    i8-gen i16-gen i32-gen i64-gen
    f64-gen decimal-gen
-   utf8-gen #_varbinary-gen
+   utf8-gen varbinary-gen
    keyword-gen uuid-gen uri-gen
    instant-gen local-date-gen local-time-gen
    local-datetime-gen offset-datetime-gen zoned-datetime-gen

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2283,6 +2283,11 @@ ORDER BY t.oid DESC LIMIT 1"
       (t/is (= [{:v "dollar $quoted$ string"}] (q conn ["SELECT $$dollar $quoted$ string$$ AS v"]))
             "dollar quoted string"))))
 
+(deftest test-varbinary-escaped-4793
+  (let [^bytes ba (byte-array [92])]
+    (with-open [conn (jdbc-conn)]
+      (t/is (Arrays/equals ba ^bytes (:v (first (jdbc/execute! conn ["SELECT X('5c') AS v"]))))
+            "reading varbinary result"))))
 
 (t/deftest test-patch
   (with-open [conn (jdbc-conn)]


### PR DESCRIPTION
Resolves #4793
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Abyte-buffer-ioobe-4793

Fixed ArrayIndexOutOfBoundsException errors when handling varbinary/bytea values containing backslash characters (byte 92). The PostgreSQL JDBC driver's PGbytea.toBytesOctalEscaped() method failed when trying to parse unencoded binary data that was returned in text format, causing queries with varbinary results to crash.


Changes

- Updated :bytea type handlers to use PostgreSQL's https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT (\x followed by hex digits) for text encoding/decoding
  - :write-text now encodes binary data as \x<hex> format before sending to clients
  - :read-text now decodes hex-encoded parameters sent by clients
- Re-enabled varbinary generation in test generators now that this bug is resolved
  - Can confirm that after re-enabling the varbinary generation, the property tests happily ran 500 iterations.