### PR TITLE
Fixing clojure printing of specific kotlin created anomalies

### DIFF
--- a/api/src/main/kotlin/xtdb/error/Anomaly.kt
+++ b/api/src/main/kotlin/xtdb/error/Anomaly.kt
@@ -19,6 +19,10 @@ sealed class Anomaly(
         internal val CATEGORY = Keyword.intern("cognitect.anomalies", "category")
         internal val ERROR_CODE = Keyword.intern("xtdb.error", "code")
 
+        internal fun ensureCategory(data: IPersistentMap, category: Keyword): IPersistentMap {
+            return if (data.containsKey(CATEGORY)) data else data.assoc(CATEGORY, category)
+        }
+
         internal fun dataFromMap(category: Keyword, errorCode: String?, data: Map<String, *>?) =
             PersistentHashMap.create(data.orEmpty().mapKeys { (k, _) -> Keyword.intern(k) })
                 .assoc(CATEGORY, category)

--- a/api/src/main/kotlin/xtdb/error/Busy.kt
+++ b/api/src/main/kotlin/xtdb/error/Busy.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Busy(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly(message, data, cause) {
+) : Anomaly(message, Anomaly.ensureCategory(data, BUSY), cause) {
     companion object {
         internal val BUSY = Keyword.intern("cognitect.anomalies", "busy")
     }

--- a/api/src/main/kotlin/xtdb/error/Conflict.kt
+++ b/api/src/main/kotlin/xtdb/error/Conflict.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Conflict(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly.Caller(message, data, cause) {
+) : Anomaly.Caller(message, Anomaly.ensureCategory(data, CONFLICT), cause) {
 
     companion object {
         internal val CONFLICT = Keyword.intern("cognitect.anomalies", "conflict")

--- a/api/src/main/kotlin/xtdb/error/Fault.kt
+++ b/api/src/main/kotlin/xtdb/error/Fault.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Fault(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly(message, data, cause) {
+) : Anomaly(message, Anomaly.ensureCategory(data, FAULT), cause) {
     companion object {
         internal val FAULT = Keyword.intern("cognitect.anomalies", "fault")
     }

--- a/api/src/main/kotlin/xtdb/error/Forbidden.kt
+++ b/api/src/main/kotlin/xtdb/error/Forbidden.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Forbidden(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly.Caller(message, data, cause) {
+) : Anomaly.Caller(message, Anomaly.ensureCategory(data, FORBIDDEN), cause) {
     companion object {
         internal val FORBIDDEN = Keyword.intern("cognitect.anomalies", "forbidden")
     }

--- a/api/src/main/kotlin/xtdb/error/Incorrect.kt
+++ b/api/src/main/kotlin/xtdb/error/Incorrect.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Incorrect(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly.Caller(message, data, cause) {
+) : Anomaly.Caller(message, Anomaly.ensureCategory(data, INCORRECT), cause) {
 
     companion object {
         internal val INCORRECT = Keyword.intern("cognitect.anomalies/incorrect")

--- a/api/src/main/kotlin/xtdb/error/Interrupted.kt
+++ b/api/src/main/kotlin/xtdb/error/Interrupted.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Interrupted(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly(message, data, cause){
+) : Anomaly(message, Anomaly.ensureCategory(data, INTERRUPTED), cause){
     companion object {
         internal val INTERRUPTED = Keyword.intern("cognitect.anomalies", "interrupted")
     }

--- a/api/src/main/kotlin/xtdb/error/NotFound.kt
+++ b/api/src/main/kotlin/xtdb/error/NotFound.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class NotFound(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly.Caller(message, data, cause) {
+) : Anomaly.Caller(message, Anomaly.ensureCategory(data, NOT_FOUND), cause) {
     companion object {
         internal val NOT_FOUND = Keyword.intern("cognitect.anomalies", "not-found")
     }

--- a/api/src/main/kotlin/xtdb/error/Unavailable.kt
+++ b/api/src/main/kotlin/xtdb/error/Unavailable.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Unavailable(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly(message, data, cause) {
+) : Anomaly(message, Anomaly.ensureCategory(data, UNAVAILABLE), cause) {
 
     companion object {
         internal val UNAVAILABLE = Keyword.intern("cognitect.anomalies", "unavailable")

--- a/api/src/main/kotlin/xtdb/error/Unsupported.kt
+++ b/api/src/main/kotlin/xtdb/error/Unsupported.kt
@@ -6,7 +6,7 @@ import clojure.lang.PersistentHashMap
 
 class Unsupported(
     message: String?, data: IPersistentMap = PersistentHashMap.EMPTY, cause: Throwable? = null
-) : Anomaly.Caller(message, data, cause) {
+) : Anomaly.Caller(message, Anomaly.ensureCategory(data, UNSUPPORTED), cause) {
     companion object {
         internal val UNSUPPORTED = Keyword.intern("cognitect.anomalies", "unsupported")
     }

--- a/api/src/test/clojure/xtdb/error_test.clj
+++ b/api/src/test/clojure/xtdb/error_test.clj
@@ -1,0 +1,13 @@
+(ns xtdb.error-test
+  (:require [clojure.test :as t]
+            [clojure.pprint :as pprint])
+  (:import [xtdb.error Busy]))
+
+(t/deftest test-anomaly-pretty-printing
+  (t/testing "Busy anomaly pretty-prints correctly"
+    (let [ex (Busy. "System is busy" "BUSY" {"retry-after" 5000} nil)
+          ex-2 (Busy. "System is busy" {"retry-after" 5000} nil)
+          ex-3 (Busy. "System is busy" {"retry-after" 5000} (Exception. "Foo"))]
+      (t/is (nil? (pprint/pprint ex)))
+      (t/is (nil? (pprint/pprint ex-2)))
+      (t/is (nil? (pprint/pprint ex-3))))))


### PR DESCRIPTION
Issue initially found in #4874 - for certain arities of Anomaly constructors, we were not defaulting/ensuring the presence of a `cognitect.anomalies/category` key. In the test below. ex-2 and ex-3 would throw an error due to category not being present on `main`:

```
(t/deftest test-anomaly-pretty-printing
  (t/testing "Busy anomaly pretty-prints correctly"
    (let [ex (Busy. "System is busy" "BUSY" {"retry-after" 5000} nil)
          ex-2 (Busy. "System is busy" {"retry-after" 5000} nil)
          ex-3 (Busy. "System is busy" {"retry-after" 5000} (Exception. "Foo"))]
      (t/is (nil? (pprint/pprint ex)))
      (t/is (nil? (pprint/pprint ex-2)))
      (t/is (nil? (pprint/pprint ex-3)))))
```