### PR TITLE
Yakbench optimisations

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -97,7 +97,7 @@ interface Compactor : AutoCloseable {
                             try {
                                 LOGGER.debug("compacting '${job.table.sym}' '${job.trieKeys}' -> ${job.outputTrieKey}")
 
-                                job.trieKeys.safeMap { open(bp, mm, job.table, it) }.useAll { segs ->
+                                job.trieKeys.safeMap { open(al, bp, mm, job.table, it) }.useAll { segs ->
 
                                     val recencyPartitioning =
                                         if (job.partitionedByRecency) SegmentMerge.RecencyPartitioning.Partition

--- a/core/src/main/kotlin/xtdb/metadata/PageMetadata.kt
+++ b/core/src/main/kotlin/xtdb/metadata/PageMetadata.kt
@@ -84,6 +84,8 @@ class PageMetadata private constructor(private val rel: Relation, private val pa
 
     val metadataLeafReader: VectorReader = rel["nodes"]["leaf"]
 
+    val pageCount get() = metadataLeafReader.valueCount
+
     private val minReader: VectorReader?
     private val maxReader: VectorReader?
 

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -11,10 +11,12 @@ import xtdb.bloom.bloomHashes
 import xtdb.bloom.contains
 import xtdb.operator.SelectionSpec
 import xtdb.segment.MergeTask
+import xtdb.segment.Segment
 import xtdb.time.TEMPORAL_COL_NAMES
 import xtdb.trie.ColumnName
 import xtdb.trie.EventRowPointer
 import xtdb.util.TemporalBounds
+import xtdb.util.closeAll
 import xtdb.util.safeMap
 import xtdb.util.useAll
 import xtdb.vector.MultiVectorRelationFactory
@@ -28,6 +30,7 @@ class ScanCursor(
     private val colNames: Set<ColumnName>, private val colPreds: Map<ColumnName, SelectionSpec>,
     private val temporalBounds: TemporalBounds,
 
+    private val segments: List<Segment<*>>,
     private val mergeTasks: Iterator<MergeTask>,
 
     private val schema: Map<String, Any>, private val args: RelationReader,
@@ -131,5 +134,5 @@ class ScanCursor(
         return false
     }
 
-    override fun close() = Unit
+    override fun close() = segments.closeAll()
 }

--- a/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
@@ -1,15 +1,14 @@
 package xtdb.segment
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.types.pojo.Schema
-import xtdb.storage.BufferPool
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.compactor.resolveSameSystemTimeEvents
 import xtdb.log.proto.TemporalMetadata
 import xtdb.metadata.MetadataPredicate
 import xtdb.metadata.PageMetadata
+import xtdb.storage.BufferPool
 import xtdb.table.TableRef
 import xtdb.trie.ArrowHashTrie
 import xtdb.trie.Trie
@@ -39,7 +38,11 @@ class BufferPoolSegment private constructor(
         private val resolveSameSystemTimeEvents: Boolean
 
     ) : Segment.Page {
-        override fun testMetadata() = pageIdxPredicate?.test(pageIndex) ?: true
+
+        private var testMetadata: Boolean? = null
+
+        override fun testMetadata() =
+            testMetadata ?: (pageIdxPredicate?.test(pageIndex) ?: true).also { testMetadata = it }
 
         override fun openDataPage(al: BufferAllocator): RelationReader =
             bp.getRecordBatch(dataFilePath, pageIndex).use { rb ->
@@ -53,12 +56,18 @@ class BufferPoolSegment private constructor(
             }
     }
 
-    override fun page(leaf: ArrowHashTrie.Leaf) =
-        Page(
-            bp, dataFilePath, schema, leaf.dataPageIndex,
-            pageIdxPredicate, pageMetadata.temporalMetadata(leaf.dataPageIndex),
-            resolveSameSystemTimeEvents
-        )
+    private val pages = arrayOfNulls<Page>(pageMetadata.pageCount)
+
+    override fun page(leaf: ArrowHashTrie.Leaf): Page {
+        val dataPageIndex = leaf.dataPageIndex
+
+        return pages[dataPageIndex]
+            ?: Page(
+                bp, dataFilePath, schema, dataPageIndex,
+                pageIdxPredicate, pageMetadata.temporalMetadata(dataPageIndex),
+                resolveSameSystemTimeEvents
+            ).also { pages[dataPageIndex] = it }
+    }
 
     override fun close() = pageMetadata.close()
 

--- a/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
@@ -24,9 +24,7 @@ class MemorySegment(override val trie: MemoryHashTrie, val rel: RelationReader) 
 
         override val schema: Schema get() = this@MemorySegment.schema
 
-        private fun loadPage() = rel.select(leaf.mergeSort(trie))
-
-        override fun openDataPage(al: BufferAllocator) = loadPage().openSlice(al)
+        override fun loadDataPage(al: BufferAllocator) = rel.select(leaf.mergeSort(trie))
     }
 
     override fun page(leaf: MemoryHashTrie.Leaf) = Page(leaf)

--- a/core/src/main/kotlin/xtdb/segment/Segment.kt
+++ b/core/src/main/kotlin/xtdb/segment/Segment.kt
@@ -23,7 +23,7 @@ interface Segment<L> : AutoCloseable {
         fun testMetadata(): Boolean
         val temporalMetadata: TemporalMetadata
 
-        fun openDataPage(al: BufferAllocator): RelationReader
+        fun loadDataPage(al: BufferAllocator): RelationReader
     }
 
     fun page(leaf: L): Page

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -499,7 +499,7 @@
               ;; TODO this doseq seems to return nothing, so nothing gets tested?
               (doseq [{:keys [^String trie-key]} (map trie/parse-trie-file-path meta-files)]
                 (util/with-open [page-meta (.openPageMetadata meta-mgr (Trie/metaFilePath table-name trie-key))
-                                 seg (BufferPoolSegment/open bp meta-mgr table-name trie-key)]
+                                 seg (BufferPoolSegment/open tu/*allocator* bp meta-mgr table-name trie-key)]
                   (doseq [leaf (.getLeaves (.getTrie page-meta))
                           :let [page (.page seg leaf)]]
                     (with-open [rel (.openDataPage page tu/*allocator*)]


### PR DESCRIPTION
resolves xtdb/xtdb-devs#8

Three changes here to help out with OLTP performance on the Yakread benchmark ( :pray: @jacobobryant):

1. ensuring we don't re-calculate `testMetadata` calls for the same page within the same query. When we decide what pages from the various active segments to merge, we have to marry up all of the pages from each segment that contain events from the same IID space. Pages in shallower levels of the LSM are broader in IID space; deeper levels have more constrained IIDs (because that's our sharding key) - so pages in shallower levels may only have IIDs prefixed with 0231, deeper levels may have 023102, 023103, etc. We therefore repeat the 0231 page for each page from the deeper level - and previously, we were testing the metadata of that page for each repeat.
2. Similarly for loading the data relation of those pages - given that the pages from the shallow tree are repeated consecutively, we don't need to unload and reload those pages between merge tasks if it's the same page being loaded back in.
3. finally, we removed a whole load of `openSlice` calls in a hot path.

All in, a 6-7x speedup on the [get-items query](https://github.com/jacobobryant/benchmark/blob/d2eb1d56efc07f30153e9f9d0ca4e3f3bcc9b141/src/xtdb2.clj#L106-L110) :racehorse: we'll add the others shortly.