### PR TITLE
Fix and test against log off-by-one error on restart.

### DIFF
--- a/src/main/clojure/xtdb/test_util.clj
+++ b/src/main/clojure/xtdb/test_util.clj
@@ -12,6 +12,7 @@
             [xtdb.log :as xt-log]
             [xtdb.logical-plan :as lp]
             [xtdb.node :as xtn]
+            [xtdb.object-store :as os]
             [xtdb.protocols :as xtp]
             [xtdb.query :as q]
             [xtdb.serde :as serde]
@@ -431,3 +432,7 @@
 
 (defn remove-nils [m]
   (into {} (remove (comp nil? val) m)))
+
+(defn read-files-from-bp-path [node ^Path path]
+  (->> (.listAllObjects (.getBufferPool (db/primary-db node)) (util/->path path))
+       (mapv (comp str #(.getFileName ^Path %) :key os/<-StoredObject))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -313,72 +313,72 @@
 (t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-block-cut
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
     (util/with-tmp-dirs #{local-disk-path}
-      ;; Start a node, write a number of transactions to the topic - ensure block is cut
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
-                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
-                                        :storage [:local {:path local-disk-path}]
-                                        :indexer {:rows-per-block 20}
-                                        :compactor {:threads 0}})]
+      (t/testing "Start a node, write a number of transactions to the topic - ensure block is cut"
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :indexer {:rows-per-block 20}
+                                          :compactor {:threads 0}})]
 
-        (doseq [batch (->> (range 100) (partition-all 10))]
-          (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
-        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
-        (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
-        (t/testing "ensure blocks have been written"
-          (Thread/sleep 1000)
-          (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
-                   (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
-
-      ;; Restart the node, ensure it picks up from the correct position in the log
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
-                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
-                                        :storage [:local {:path local-disk-path}]
-                                        :indexer {:rows-per-block 20}
-                                        :compactor {:threads 0}})]
-
-        (t/testing "shouldn't reindex any transactions when starting up"
-          (Thread/sleep 1000)
+          (doseq [batch (->> (range 100) (partition-all 10))]
+            (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
           (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
-          (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+          (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+          (t/testing "ensure blocks have been written"
+            (Thread/sleep 1000)
+            (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                     (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))
 
-        (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off"
-          (xt/execute-tx node (for [i (range 101 111)] [:put-docs :docs {:xt/id i}]))
-          (t/is (= 110 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
-          (t/is (= 11 (count (xt/q node "SELECT *  FROM xt.txs"))))
-          (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
-                   (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))
+      (t/testing "Restart the node, ensure it picks up from the correct position in the log"
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :indexer {:rows-per-block 20}
+                                          :compactor {:threads 0}})]
+
+          (t/testing "shouldn't reindex any transactions when starting up"
+            (Thread/sleep 1000)
+            (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+            (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+          (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off"
+            (xt/execute-tx node (for [i (range 101 111)] [:put-docs :docs {:xt/id i}]))
+            (t/is (= 110 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+            (t/is (= 11 (count (xt/q node "SELECT *  FROM xt.txs"))))
+            (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                     (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))))))
 
 (t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-flush-block
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
     (util/with-tmp-dirs #{local-disk-path}
-      ;; Start a node, write a number of transactions to the log - ensure block is cut
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
-                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
-                                        :storage [:local {:path local-disk-path}]
-                                        :compactor {:threads 0}})]
+      (t/testing "Start a node, write a number of transactions to the log - ensure block is cut"
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :compactor {:threads 0}})]
 
-        (doseq [batch (->> (range 100) (partition-all 10))]
-          (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
-        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
-        (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
-        (tu/finish-block! node)
-        (t/testing "ensure block has been written"
-          (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
-
-      ;; Restart the node, ensure it picks up from the correct position in the log
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
-                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
-                                        :storage [:local {:path local-disk-path}]
-                                        :compactor {:threads 0}})]
-
-        (t/testing "shouldn't reindex any transactions when starting up"
-          (Thread/sleep 1000)
+          (doseq [batch (->> (range 100) (partition-all 10))]
+            (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
           (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
-          (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+          (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+          (tu/finish-block! node)
+          (t/testing "ensure block has been written"
+            (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))
 
-        (t/testing "shouldn't have flushed another block / re-read the flush block"
-          (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))
+      (t/testing "Restart the node, ensure it picks up from the correct position in the log"
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :compactor {:threads 0}})]
+
+          (t/testing "shouldn't reindex any transactions when starting up"
+            (Thread/sleep 1000)
+            (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+            (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+          (t/testing "shouldn't have flushed another block / re-read the flush block"
+            (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -53,18 +53,18 @@
            topic: xtdb.kafka-test-secondary.%s
          $$" test-uuid)])
       (with-open [secondary-conn (.build (-> (.createConnectionBuilder node)
-                                   (.database "secondary")))]
+                                             (.database "secondary")))]
 
-       (t/is (xt/submit-tx xtdb-conn [[:put-docs :docs {:xt/id :primary}]]))
-       (t/is (xt/submit-tx secondary-conn [[:put-docs :docs {:xt/id :secondary}]]))
+        (t/is (xt/submit-tx xtdb-conn [[:put-docs :docs {:xt/id :primary}]]))
+        (t/is (xt/submit-tx secondary-conn [[:put-docs :docs {:xt/id :secondary}]]))
 
-       (t/is (= [{:xt/id :primary}] (xt/q xtdb-conn "SELECT _id FROM docs")))
-       (t/is (= [{:xt/id :secondary}] (xt/q secondary-conn "SELECT _id FROM docs")))
+        (t/is (= [{:xt/id :primary}] (xt/q xtdb-conn "SELECT _id FROM docs")))
+        (t/is (= [{:xt/id :secondary}] (xt/q secondary-conn "SELECT _id FROM docs")))
 
-       (tu/flush-block! node)
+        (tu/flush-block! node)
 
-       (t/is (= [{:xt/id :primary}] (xt/q xtdb-conn "SELECT _id FROM docs")))
-       (t/is (= [{:xt/id :secondary}] (xt/q secondary-conn "SELECT _id FROM docs")))))))
+        (t/is (= [{:xt/id :primary}] (xt/q xtdb-conn "SELECT _id FROM docs")))
+        (t/is (= [{:xt/id :secondary}] (xt/q secondary-conn "SELECT _id FROM docs")))))))
 
 (t/deftest ^:integration test-kafka-setup-with-provided-opts
   (let [test-uuid (random-uuid)]
@@ -191,7 +191,7 @@
           (t/is (= (set [{:xt/id :foo}
                          {:xt/id :bar}
                          {:xt/id :new}
-                         {:xt/id :new2} ])
+                         {:xt/id :new2}])
                    (set (xt/q node "SELECT _id FROM xt_docs")))))
 
         (t/testing "can continue to index/query new transactions"
@@ -277,6 +277,37 @@
                    (set (xt/q node "SELECT _id FROM xt_docs")))))
 
         (t/testing "can finish the block"
+          (t/is (nil? (tu/finish-block! node)))))
+
+
+      ;; Restarting the node again with the same new log path and epoch 1
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"
+                                                                          :properties-map {}
+                                                                          :properties-file nil}]}
+                                        :log [:kafka {:cluster :my-kafka
+                                                      :topic empty-topic
+                                                      :epoch 1}]
+                                        :storage [:local {:path local-disk-path}]})]
+        (t/testing "can query same transactions + nothing has been re-indexed"
+          (t/is (= (set [{:xt/id :foo}
+                         {:xt/id :bar}
+                         {:xt/id :baz}
+                         {:xt/id :new}
+                         {:xt/id :new2}])
+                   (set (xt/q node "SELECT _id FROM xt_docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL")))))
+
+        (t/testing "can index/query new transactions"
+          (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :new3}]]))
+          (t/is (= (set [{:xt/id :foo}
+                         {:xt/id :bar}
+                         {:xt/id :baz}
+                         {:xt/id :new}
+                         {:xt/id :new2}
+                         {:xt/id :new3}])
+                   (set (xt/q node "SELECT _id FROM xt_docs")))))
+
+        (t/testing "can finish another block"
           (t/is (nil? (tu/finish-block! node))))))))
 
 (t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-block-cut
@@ -309,16 +340,15 @@
 
         (t/testing "shouldn't reindex any transactions when starting up"
           (Thread/sleep 1000)
-          (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL")))) 
+          (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
           (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
 
-        (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off" 
+        (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off"
           (xt/execute-tx node (for [i (range 101 111)] [:put-docs :docs {:xt/id i}]))
           (t/is (= 110 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
           (t/is (= 11 (count (xt/q node "SELECT *  FROM xt.txs"))))
           (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
                    (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))
-
 
 (t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-flush-block
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
@@ -327,7 +357,7 @@
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
                                                                           :poll-duration "PT2S"}]}
                                         :log [:kafka {:cluster :my-kafka, :topic topic}]
-                                        :storage [:local {:path local-disk-path}] 
+                                        :storage [:local {:path local-disk-path}]
                                         :compactor {:threads 0}})]
 
         (doseq [batch (->> (range 100) (partition-all 10))]

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -3,7 +3,7 @@
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
             [xtdb.db-catalog :as db]
-            [xtdb.node :as xtn]
+            [xtdb.node :as xtn] 
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import org.apache.kafka.common.KafkaException
@@ -278,3 +278,77 @@
 
         (t/testing "can finish the block"
           (t/is (nil? (tu/finish-block! node))))))))
+
+(t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-block-cut
+  (let [topic (str "xtdb.kafka-test." (random-uuid))]
+    (util/with-tmp-dirs #{local-disk-path}
+      ;; Start a node, write a number of transactions to the topic - ensure block is cut
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                        :storage [:local {:path local-disk-path}]
+                                        :indexer {:rows-per-block 20}
+                                        :compactor {:threads 0}})]
+
+        (doseq [batch (->> (range 100) (partition-all 10))]
+          (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
+        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+        (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+        (t/testing "ensure blocks have been written"
+          (Thread/sleep 1000)
+          (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                   (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
+
+      ;; Restart the node, ensure it picks up from the correct position in the log
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                        :storage [:local {:path local-disk-path}]
+                                        :indexer {:rows-per-block 20}
+                                        :compactor {:threads 0}})]
+
+        (t/testing "shouldn't reindex any transactions when starting up"
+          (Thread/sleep 1000)
+          (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL")))) 
+          (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+        (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off" 
+          (xt/execute-tx node (for [i (range 101 111)] [:put-docs :docs {:xt/id i}]))
+          (t/is (= 110 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+          (t/is (= 11 (count (xt/q node "SELECT *  FROM xt.txs"))))
+          (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                   (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))
+
+
+(t/deftest ^:integration test-kafka-log-starts-at-correct-point-after-flush-block
+  (let [topic (str "xtdb.kafka-test." (random-uuid))]
+    (util/with-tmp-dirs #{local-disk-path}
+      ;; Start a node, write a number of transactions to the log - ensure block is cut
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                        :storage [:local {:path local-disk-path}] 
+                                        :compactor {:threads 0}})]
+
+        (doseq [batch (->> (range 100) (partition-all 10))]
+          (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
+        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+        (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+        (tu/finish-block! node)
+        (t/testing "ensure block has been written"
+          (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
+
+      ;; Restart the node, ensure it picks up from the correct position in the log
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                          :poll-duration "PT2S"}]}
+                                        :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                        :storage [:local {:path local-disk-path}]
+                                        :compactor {:threads 0}})]
+
+        (t/testing "shouldn't reindex any transactions when starting up"
+          (Thread/sleep 1000)
+          (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+          (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+        (t/testing "shouldn't have flushed another block / re-read the flush block"
+          (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -1,11 +1,10 @@
 (ns xtdb.log-test
-  (:require [clojure.java.io :as io]
-            [clojure.pprint :as pp]
+  (:require [clojure.java.io :as io] 
             [clojure.test :as t]
             [xtdb.api :as xt]
-            [xtdb.arrow-edn-test :as aet]
+            [xtdb.arrow-edn-test :as aet] 
             [xtdb.log :as log]
-            [xtdb.node :as xtn]
+            [xtdb.node :as xtn] 
             [xtdb.serde :as serde]
             [xtdb.test-util :as tu]
             [xtdb.time :as time]
@@ -205,7 +204,7 @@
   (util/with-tmp-dirs #{node-dir}
     ;; Node with local storage and local directory log 
     (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
-                                       :storage [:local {:path (.resolve node-dir "objects")}]})]
+                                      :storage [:local {:path (.resolve node-dir "objects")}]})]
       ;; Submit a few transactions
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
       (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]])
@@ -250,3 +249,66 @@
 
       (t/testing "can finish the block"
         (t/is (nil? (tu/finish-block! node)))))))
+
+(t/deftest test-local-log-starts-at-correct-point-after-block-cut
+  (util/with-tmp-dirs #{node-dir}
+    ;; Start a node, write a number of transactions to the log - ensure block is cut
+    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                      :storage [:local {:path (.resolve node-dir "objects")}]
+                                      :indexer {:rows-per-block 20}
+                                      :compactor {:threads 0}})]
+
+      (doseq [batch (->> (range 100) (partition-all 10))]
+        (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
+      (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+      (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+      (t/testing "ensure blocks have been written"
+        (Thread/sleep 1000)
+        (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                 (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
+
+    ;; Restart the node, ensure it picks up from the correct position in the log
+    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                      :storage [:local {:path (.resolve node-dir "objects")}]
+                                      :indexer {:rows-per-block 20}
+                                      :compactor {:threads 0}})]
+
+      (t/testing "shouldn't reindex any transactions when starting up"
+        (Thread/sleep 1000)
+        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+        (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+      (t/testing "sending a new transaction shouldnt cut a block yet - still ten blocks off"
+        (xt/execute-tx node (for [i (range 101 111)] [:put-docs :docs {:xt/id i}]))
+        (t/is (= 110 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+        (t/is (= 11 (count (xt/q node "SELECT *  FROM xt.txs"))))
+        (t/is (= ["l00-rc-b00.arrow" "l00-rc-b01.arrow" "l00-rc-b02.arrow" "l00-rc-b03.arrow" "l00-rc-b04.arrow"]
+                 (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))))
+
+(t/deftest test-local-log-starts-at-correct-point-after-flush-block
+  (util/with-tmp-dirs #{node-dir}
+    ;; Start a node, write a number of transactions to the log - ensure block is cut
+    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                      :storage [:local {:path (.resolve node-dir "objects")}] 
+                                      :compactor {:threads 0}})]
+
+      (doseq [batch (->> (range 100) (partition-all 10))]
+        (xt/execute-tx node (for [i batch] [:put-docs :docs {:xt/id i}])))
+      (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+      (t/is (= 10 (count (xt/q node "SELECT * FROM xt.txs"))))
+      (tu/finish-block! node)
+      (t/testing "ensure block has been written" 
+        (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))
+
+    ;; Restart the node, ensure it picks up from the correct position in the log
+    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                      :storage [:local {:path (.resolve node-dir "objects")}]
+                                      :compactor {:threads 0}})]
+
+      (t/testing "shouldn't reindex any transactions when starting up"
+        (Thread/sleep 1000)
+        (t/is (= 100 (count (xt/q node "SELECT *, _valid_from, _system_from FROM docs FOR VALID_TIME ALL FOR SYSTEM_TIME ALL"))))
+        (t/is (= 10 (count (xt/q node "SELECT *  FROM xt.txs")))))
+
+      (t/testing "shouldn't have flushed another block / re-read the flush block"
+        (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))))

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
- :latest-processed-msg-id 0,
+ :latest-processed-msg-id 2265,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 1,
  :latest-completed-tx
  {:tx-id 3021, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 3021,
+ :latest-processed-msg-id 5286,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 2,
  :latest-completed-tx
  {:tx-id 3021, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 5867,
+ :latest-processed-msg-id 6084,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
@@ -1,7 +1,7 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 4769, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 4769,
+ :latest-processed-msg-id 9546,
  :table-names
  #{"xt/txs" "public/device_info" "public/device_readings"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 12549, :system-time #xt/instant "2020-01-06T00:00:00Z"},
- :latest-processed-msg-id 12549,
+ :latest-processed-msg-id 14542,
  :table-names #{"xt/txs" "public/foo" "public/world" "public/hello"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
- :latest-processed-msg-id 0,
+ :latest-processed-msg-id 4401,
  :table-names #{"xt/txs" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
- :latest-processed-msg-id 0,
+ :latest-processed-msg-id 2649,
  :table-names #{"xt/txs" "public/table"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
- :latest-processed-msg-id 0,
+ :latest-processed-msg-id 2169,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 1,
  :latest-completed-tx
  {:tx-id 2993, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 2993,
+ :latest-processed-msg-id 5154,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 3849, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 3849,
+ :latest-processed-msg-id 6858,
  :table-names #{"xt/txs" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 3849, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 3849,
+ :latest-processed-msg-id 6858,
  :table-names #{"xt/txs" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-completed-tx
  {:tx-id 4050, :system-time #xt/instant "2020-01-03T00:00:00Z"},
- :latest-processed-msg-id 4050,
+ :latest-processed-msg-id 7451,
  :table-names #{"xt/txs" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,5 +1,5 @@
 {:block-idx 0,
- :latest-processed-msg-id 0,
+ :latest-processed-msg-id 114,
  :table-names #{"xt/txs"},
  :secondary-dbs
  {"new_db"


### PR DESCRIPTION
Github action runs here: https://github.com/danmason/xtdb/actions?query=branch%3Alog-off-by-one

This should incidentally fix #4856 as it was caused by different nodes writing out data/meta files and running into problems caused by this specifically.

In essence - this fixes an issue where we would re-read the message on the log that prompted us to flush a block (ie, either a flush-block message OR the last transaction that filled the live index) upon restarting a node. As an explainer:

Looking at `LogProcessor`, lets say we're one transaction away from flushBlock:
- Next transaction is `msgId` = 1000
- `latestProcessedMsgId` will be the one before this = 999.
- We index the transaction, and then called `finishBlock` when the `liveIndex` is full:
  - We pass the `latestProcessedMsgId` to `finishBlock`
  - The block will be written with it's `latestProcessedMsgId` at 999.
- We THEN incremented `latestProcessedMsgId` = 1000.

Then when we started a node:
- The `LogProcessor` will fetch the `latestProcessedMsgId` from the block catalog = 999.
- It will convert this to `latestProcessedOffset`  (epoch = 0, so this will also equal 999)
- The kafka consumer will start and seek to `latestProcessedOffset + 1` , so it will seek to offset 1000.
(Ie, The offset of the transaction). 
- We would re-read the message at offset 1000.

This PR adds some tests that confirm the above behaviour was taking place in both the local and kafka logs, and then fixes it by ensuring that finishBlock is called only AFTER latestProcessedMsgId is incremented.