### PR TITLE
Dump docker logs if lang xtdb service or lang test containers fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           services: "xtdb"
           cwd: "lang"
+          up-flags: "--wait"
+
+      - name: Dump XTDB logs on startup failure
+        if: failure()
+        working-directory: "lang"
+        run: docker compose logs xtdb
+
       - name: JS test
         working-directory: "lang"
         run: |
@@ -93,6 +100,11 @@ jobs:
         working-directory: "lang"
         run: |
           docker compose run elixir
+
+      - name: Dump all logs on test failure
+        if: failure()
+        working-directory: "lang"
+        run: docker compose logs
 
       - name: Post Slack Notification (On Fail)
         if: failure() && github.repository == 'xtdb/xtdb' && github.ref == 'refs/heads/main'

--- a/lang/docker-compose.yml
+++ b/lang/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     build:
       context: ../docker/standalone
     command: ["playground", "--port", "5439"]
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/5439'"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
 
   js:
     build:


### PR DESCRIPTION
Adds an explicit healthcheck for the postgres/playground port as this is what the test containers rely on. Previously container was inhereting the default healthz healthcheck which would always fail.