### PR TITLE
[bench] yakbench

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -631,6 +631,12 @@ fun createBench(benchName: String, properties: Map<String, String>) {
 
 createBench("tpch", mapOf("scaleFactor" to "--scale-factor"))
 
+createBench("yakbench", mapOf(
+    "scaleFactor" to "--scale-factor",
+    "noLoad" to "--no-load",
+    "nodeDir" to "--node-dir"
+))
+
 createBench(
     "auctionmark",
     mapOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,10 +155,10 @@ allprojects {
 
         tasks.register("property-test", Test::class) {
             jvmArgs(defaultJvmArgs + twelveGBJvmArgs)
-            
+
             val iterations = project.findProperty("iterations")?.toString() ?: "100"
             systemProperty("xtdb.property-test-iterations", iterations)
-            
+
             useJUnitPlatform {
                 includeTags("property")
             }
@@ -455,7 +455,7 @@ dependencies {
     testImplementation("clj-kondo", "clj-kondo", "2023.12.15")
     testImplementation("com.github.igrishaev", "pg2-core", "0.1.33")
     testImplementation(libs.hato)
-    
+
     // test check
     api(libs.clojure.test.check)
 
@@ -606,7 +606,14 @@ fun createBench(benchName: String, properties: Map<String, String>) {
         dependsOn(":modules:bench:assemble")
         classpath = sourceSets.dev.get().runtimeClasspath
         mainClass.set("clojure.main")
-        jvmArgs(defaultJvmArgs + sixGBJvmArgs + listOf("-Darrow.enable_unsafe_memory_access=true"))
+        // Choose JVM sizing for benches via project properties:
+        // -PtwelveGBJvm -> use twelveGBJvmArgs
+        // -PsixGBJvm    -> use sixGBJvmArgs (default)
+        val benchJvmArgs = when {
+            project.hasProperty("twelveGBJvm") -> twelveGBJvmArgs
+            else -> sixGBJvmArgs
+        }
+        jvmArgs(defaultJvmArgs + benchJvmArgs + listOf("-Darrow.enable_unsafe_memory_access=true"))
         val args = mutableListOf("-m", "xtdb.bench", benchName)
 
         val extraProps = properties + mapOf(

--- a/modules/bench/build.gradle.kts
+++ b/modules/bench/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     // bench
     api("com.github.oshi", "oshi-core", "6.3.0")
+    api("com.taoensso", "tufte", "2.6.3")
     api("pro.juxt.clojars-mirrors.hiccup", "hiccup", "2.0.0-alpha2")
     api("org.testcontainers", "testcontainers", "1.20.1")
 

--- a/modules/bench/build.gradle.kts
+++ b/modules/bench/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api("com.taoensso", "tufte", "2.6.3")
     api("pro.juxt.clojars-mirrors.hiccup", "hiccup", "2.0.0-alpha2")
     api("org.testcontainers", "testcontainers", "1.20.1")
+    api("kixi", "stats", "0.5.7")
 
     api("software.amazon.awssdk", "s3", "2.25.24")
     api("clj-http", "clj-http", "3.13.1")

--- a/modules/bench/cloud/helm/templates/NOTES.txt
+++ b/modules/bench/cloud/helm/templates/NOTES.txt
@@ -11,6 +11,9 @@ tpch:
 {{- else if eq .Values.benchType "auctionmark" }}
 auctionmark:
 {{ toYaml .Values.auctionmark | indent 2 }}
+{{- else if eq .Values.benchType "yakbench" }}
+yakbench:
+{{ toYaml .Values.yakbench | indent 2 }}
 {{- end }}
 
 To view the logs of the node, use:

--- a/modules/bench/cloud/helm/templates/benchmark-yakbench.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-yakbench.yaml
@@ -1,0 +1,79 @@
+{{- if eq .Values.benchType "yakbench" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: yakbench
+  namespace: {{ .Release.Namespace }}
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- $user := .Values.providerConfig.podLabels | default (dict) -}}
+        {{- $base := dict "app.kubernetes.io/name" "xtdb" "app.kubernetes.io/component" "benchmark" -}}
+        {{- $labels := merge (dict) $user $base -}}
+        {{- toYaml $labels | nindent 8 }}
+      annotations:
+        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
+      serviceAccountName: xtdb-service-account
+      restartPolicy: Never
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: local-disk-cache
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+      containers:
+        - name: xtdb-node
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: /var/lib/xtdb/buffers/
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          args:
+            - yakbench
+            - -f
+            - "/var/lib/xtdb-config/xtdbconfig.yaml"
+            - --scale-factor
+            - {{ .Values.yakbench.scaleFactor | quote }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+{{- end }}

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -21,6 +21,9 @@ readings:
   devices: 10000
   readings: 10000
 
+yakbench:
+  scaleFactor: 0.1
+
 xtdbConfig:
   # Core environment variables
   kafkaBootstrapServers: xtdb-benchmark-kafka.cloud-benchmark.svc.cluster.local:9092

--- a/modules/bench/cloud/run-bench.sh
+++ b/modules/bench/cloud/run-bench.sh
@@ -26,7 +26,7 @@ usage() {
 
 validate_inputs() {
   [[ "$CLOUD" =~ ^(aws|azure|google-cloud)$ ]] || error "Invalid cloud: $CLOUD"
-  [[ "$BENCH_TYPE" =~ ^(tpch|readings|auctionmark)$ ]] || error "Invalid bench type: $BENCH_TYPE"
+  [[ "$BENCH_TYPE" =~ ^(tpch|readings|auctionmark|yakbench)$ ]] || error "Invalid bench type: $BENCH_TYPE"
 }
 
 get_cloud_config() {

--- a/modules/bench/src/main/clojure/xtdb/bench/random.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/random.clj
@@ -1,0 +1,94 @@
+(ns xtdb.bench.random
+  (:import [java.time Instant LocalDate LocalTime ZoneOffset]
+           (java.util UUID)))
+
+(defn next-int
+  ([^java.util.Random random]
+   (next-int random Integer/MAX_VALUE))
+  ([^java.util.Random random bound]
+   (.nextInt random (min (max 1 bound) Integer/MAX_VALUE))))
+
+(defn uniform-nth
+  [^java.util.Random random coll]
+  (let [c (count coll)]
+    (when (pos? c)
+      (nth coll (next-int random c)))))
+
+(defn chance?
+  [^java.util.Random random ^double p]
+  (< (.nextDouble random) p))
+
+(defn weighted-nth
+  "Draw a single element from xs with non-negative weights.
+   Returns nil if xs empty. If all weights are zero, falls back to uniform."
+  [^java.util.Random rng weights xs]
+  (let [ws (mapv #(double (max 0.0 %)) weights)
+        xs (vec xs)
+        n  (count xs)]
+    (when (pos? n)
+      (let [s (reduce + 0.0 ws)]
+        (if (pos? s)
+          (let [target (* (.nextDouble rng) s)]
+            (loop [i 0 acc 0.0]
+              (let [acc' (+ acc (ws i))]
+                (if (or (>= acc' target) (= i (dec n)))
+                  (xs i)
+                  (recur (inc i) acc')))))
+          ;; uniform fallback
+          (xs (next-int rng n)))))))
+
+(defn next-uuid
+  "Generate a version-4 UUID using the supplied RNG, matching java.util.UUID/randomUUID idioms."
+  [^java.util.Random random]
+  (let [msb (.nextLong random)
+        lsb (.nextLong random)
+        msb (-> msb
+                (bit-and (bit-not (bit-shift-left 0xF 12)))
+                (bit-or  (bit-shift-left 0x4 12)))
+        lsb (-> lsb
+                (bit-and (bit-not (bit-shift-left 0x3 62)))
+                (bit-or  (bit-shift-left 0x2 62)))]
+    (UUID. msb lsb)))
+
+(def ^:private ^String charset "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+(defn next-string
+  ^String [^java.util.Random random ^long n]
+  (let [sb (StringBuilder. n)]
+    (loop [i 0]
+      (if (< i n)
+        (do (.append sb (.charAt charset (next-int random (.length charset))))
+            (recur (unchecked-inc i)))
+        (.toString sb)))))
+
+(defn next-instant
+  "Return a random instant between the beginning of `start-year` (inclusive)
+  and the beginning of `(inc end-year)` (exclusive).
+
+  Defaults to covering the last 10 calendar years."
+  ([^java.util.Random random]
+   (let [zone ZoneOffset/UTC
+         end-year (.getYear (LocalDate/now zone))
+         start-year (- end-year 10)]
+     (next-instant random start-year end-year)))
+  ([^java.util.Random random ^long start-year ^long end-year]
+   (let [[start-year end-year] (if (> start-year end-year)
+                                 [end-year start-year]
+                                 [start-year end-year])
+         zone ZoneOffset/UTC
+         ^Instant start (-> (LocalDate/of start-year 1 1)
+                            (.atStartOfDay zone)
+                            (.toInstant))
+         ^Instant end   (-> (LocalDate/of (inc end-year) 1 1)
+                            (.atStartOfDay zone)
+                            (.toInstant))
+         start-ms (.toEpochMilli start)
+         end-ms (.toEpochMilli end)
+         span (max 0 (- end-ms start-ms))
+         offset (if (pos? span)
+                  (long (Math/floor (* (.nextDouble random) (double span))))
+                  0)]
+     (Instant/ofEpochMilli (+ start-ms offset)))))
+
+(defn next-local-time [^java.util.Random random]
+  (LocalTime/of (next-int random 24) (next-int random 60) (next-int random 60)))

--- a/modules/bench/src/main/clojure/xtdb/bench/stats.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/stats.clj
@@ -1,0 +1,22 @@
+(ns xtdb.bench.stats)
+
+(defn round-down [x]
+  (long (Math/floor (double x))))
+
+(defn distribution-stats
+  "Compute summary statistics from a sequence of numeric counts."
+  [counts]
+  (let [counts (vec (map long counts))
+        n (count counts)
+        sorted (vec (sort counts))
+        mean (if (pos? n) (/ (reduce + 0 sorted) (double n)) 0.0)
+        mn (if (pos? n) (first sorted) 0)
+        mx (if (pos? n) (peek sorted) 0)
+        idx (fn [p]
+              (cond
+                (zero? n) 0
+                :else (-> (Math/floor (* p (dec n))) long (max 0) (min (dec n)))))
+        median (if (pos? n) (sorted (idx 0.5)) 0)
+        p90 (if (pos? n) (sorted (idx 0.90)) 0)
+        p99 (if (pos? n) (sorted (idx 0.99)) 0)]
+    {:mean mean :median median :p90 p90 :p99 p99 :min mn :max mx}))

--- a/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
@@ -1,0 +1,530 @@
+(ns xtdb.bench.yakbench
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [clojure.pprint :as pp]
+            [taoensso.tufte :as tufte :refer [p]]
+            [xtdb.api :as xt]
+            [xtdb.bench :as b]
+            [xtdb.datasets.yakbench :as yakbench]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]))
+
+(defn ?s [n]
+  (str "(" (str/join ", " (repeat n "?")) ")"))
+
+(defn get-conn ^java.sql.Connection [^xtdb.api.DataSource node]
+  (.build (.createConnectionBuilder node)))
+
+(def active-inst (.toInstant #inst "2025-01-01T00:00:00Z"))
+(def feed-sync-inst (.toInstant #inst "2025-09-29T00:00:00Z"))
+(def recent-inst (.toInstant #inst "2025-09-01T00:00:00Z"))
+(def recent-bookmarks-inst (.toInstant #inst "2024-09-01T00:00:00Z"))
+(def recent-ad-inst (.toInstant #inst "2025-01-01T00:00:00Z"))
+
+(defn benchmarks-queries
+  [{{:keys [user-id user-email]} :picked-user
+    :keys [active-user-ids biggest-feed]}]
+  (cond-> [{:id :get-user-by-email
+            :f #(xt/q % ["select * from users where user$email = ?" user-email])}
+           {:id :get-user-by-id
+            :f #(xt/q % ["select * from users where _id = ?" user-id])}
+           {:id :get-user-id-by-email
+            :f #(xt/q % ["select _id from users where user$email = ?" user-email])}
+           {:id :get-user-email-by-id
+            :f #(xt/q % ["select user$email from users where _id = ?" user-id])}
+           {:id :get-feeds
+            :f #(xt/q % [(str "select count(sub$feed$feed) from subs "
+                              "where sub$user = ? and sub$feed$feed is not null")
+                         user-id])}
+           {:id :get-items
+            :f #(xt/q % [(str "select count(i._id) "
+                              "from subs s "
+                              "join items i on i.item$feed$feed = s.sub$feed$feed "
+                              "where s.sub$user = ? "
+                              "and s.sub$feed$feed is not null")
+                         user-id])}
+           {:id :read-urls
+            :f #(xt/q % [(str "select distinct i.item$author_url "
+                              "from user_items ui "
+                              "join items i on i._id = ui.user_item$item "
+                              "where ui.user_item$user = ? "
+                              "and coalesce(ui.user_item$viewed_at, ui.user_item$favorited_at, ui.user_item$skipped_at) is not null "
+                              "and i.item$author_url is not null")
+                         user-id])}
+           {:id :email-items
+            :f #(xt/q % [(str "select s._id as sub_id, i._id as item_id "
+                              "from subs s "
+                              "join items i on i.item$email$sub = s._id "
+                              "where s.sub$user = ?")
+                         user-id])}
+           {:id :rss-items
+            :f #(xt/q % [(str "select s._id as sub_id, i._id as item_id "
+                              "from subs s "
+                              "join items i on i.item$feed$feed = s.sub$feed$feed "
+                              "where s.sub$user = ? and s.sub$feed$feed is not null")
+                         user-id])}
+           {:id :user-items
+            :f #(xt/q % [(str "select user_item$item, user_item$viewed_at, user_item$favorited_at, user_item$skipped_at "
+                              "from user_items where user_item$user = ?")
+                         user-id])}
+           {:id :active-users-by-joined-at
+            :f #(xt/q % ["select _id from users where user$joined_at > ?"
+                         active-inst])}
+           {:id :active-users-by-viewed-at
+            :f #(xt/q % ["select distinct user_item$user from user_items where user_item$viewed_at > ?"
+                         active-inst])}
+           {:id :active-users-by-ad-updated
+            :f #(xt/q % ["select ad$user from ads where ad$updated_at > ?"
+                         active-inst])}
+           {:id :active-users-by-ad-clicked
+            :f #(xt/q % ["select distinct ad.click$user from ad_clicks where ad.click$created_at > ?"
+                         active-inst])}
+           {:id :favorited-urls
+            :f #(xt/q % [(str "select item$url "
+                              "from items "
+                              "join user_items on user_item$item = items._id "
+                              "where user_item$favorited_at is not null")])}
+
+           {:id :direct-urls
+            :f #(xt/q % ["select item$url from items where item$doc_type = 'item/direct'"])}
+
+           {:id :recent-email-items
+            :f #(xt/q % [(str "select items._id, item$ingested_at "
+                              "from subs "
+                              "join items on subs._id = item$email$sub "
+                              "where sub$user = ? "
+                              "and item$ingested_at > ?")
+                         user-id
+                         recent-inst])}
+
+           {:id :recent-rss-items
+            :f #(xt/q % [(str "select items._id, item$ingested_at "
+                              "from subs "
+                              "join items on item$feed$feed = sub$feed$feed "
+                              "where sub$user = ? "
+                              "and sub$feed$feed is not null "
+                              "and item$ingested_at > ?")
+                         user-id
+                         recent-inst])}
+
+           {:id :recent-bookmarks
+            :f #(xt/q % [(str "select user_item$item, user_item$bookmarked_at "
+                              "from user_items "
+                              "where user_item$user = ? "
+                              "and user_item$bookmarked_at > ?")
+                         user-id
+                         recent-bookmarks-inst])}
+
+           {:id :subscription-status
+            :f #(xt/q % [(str "select _id, sub$email$unsubscribed_at "
+                              "from subs "
+                              "where sub$user = ?")
+                         user-id])}
+
+           {:id :latest-emails-received-at
+            :f #(xt/q % [(str "select subs._id, max(item$ingested_at) "
+                              "from subs "
+                              "join items on item$email$sub = subs._id "
+                              "where sub$user = ? "
+                              "group by subs._id")
+                         user-id])}
+
+           {:id :unique-ad-clicks
+            :f #(xt/q % [(str "select ad$click$ad, count(distinct ad$click$user) "
+                              "from ad_clicks "
+                              "group by ad$click$ad")])}
+
+           {:id :latest-ad-clicks
+            :f #(xt/q % [(str "select ad$click$ad, max(ad$click$created_at) "
+                              "from ad_clicks "
+                              "group by ad$click$ad")])}
+
+           {:id :charge-amounts-by-status
+            :f #(xt/q % [(str "select ad$credit$ad, ad$credit$charge_status, sum(ad$credit$amount) "
+                              "from ad_credits "
+                              "where ad$credit$charge_status is not null "
+                              "group by ad$credit$ad, ad$credit$charge_status")])}
+
+           {:id :candidate-statuses
+            :f #(xt/q % [(str "select item$direct$candidate_status, count(_id) "
+                              "from items "
+                              "where item$direct$candidate_status is not null "
+                              "group by item$direct$candidate_status")])}
+
+           {:id :feed-sub-urls
+            :f #(xt/q % [(str "select feed$url "
+                              "from feeds "
+                              "join subs on sub$feed$feed = feeds._id "
+                              "where sub$user = ?")
+                         user-id])}
+
+           {:id :favorites
+            :f #(xt/q % [(str "select user_item$user, user_item$item "
+                              "from user_items "
+                              "where user_item$favorited_at is not null")])}
+
+           {:id :approved-candidates
+            :f #(xt/q % [(str "select _id, item$url "
+                              "from items "
+                              "where item$direct$candidate_status = 'approved'")])}
+
+           {:id :ad-recent-cost
+            :f #(xt/q % [(str "select ad$click$ad, sum(ad$click$cost) "
+                              "from ad_clicks "
+                              "where ad$click$created_at > ? "
+                              "group by ad$click$ad")
+                         recent-ad-inst])}
+
+           {:id :ads-clicked-at
+            :f #(xt/q % [(str "select ad$click$ad, ad$click$user, max(ad$click$created_at) "
+                              "from ad_clicks "
+                              "group by ad$click$ad, ad$click$user")])}
+
+           {:id :all-n-likes
+            :f #(xt/q % [(str "select user_item$item, count(_id) "
+                              "from user_items "
+                              "where user_item$favorited_at is not null "
+                              "group by user_item$item")])}]
+
+    (seq active-user-ids)
+    (conj {:id :feeds-to-sync
+           :f #(xt/q %
+                     (vec (concat [(str "select distinct sub$feed$feed "
+                                        "from subs "
+                                        "join feeds on feeds._id = sub$feed$feed "
+                                        "where sub$user in " (?s (count active-user-ids))
+                                        " and (feed$synced_at is null or feed$synced_at < ?)")]
+                                  active-user-ids
+                                  [feed-sync-inst])))})
+
+    (and biggest-feed (seq (:titles biggest-feed)))
+    (conj {:id :existing-feed-titles
+           :f #(xt/q %
+                     (vec
+                      (concat [(str "select item$title "
+                                    "from items "
+                                    "where item$feed$feed = ? "
+                                    "and item$title in " (?s (count (:titles biggest-feed))))
+                               (:id biggest-feed)]
+                              (:titles biggest-feed))))})))
+
+(defn get-worst-case-user
+  [conn]
+  (let [row (first (xt/q conn [(str
+                                "select u._id, u.user$email, count(ui._id) as cnt "
+                                "from user_items ui "
+                                "join users u on u._id = ui.user_item$user "
+                                "group by u._id, u.user$email "
+                                "order by cnt desc "
+                                "limit 1")]))]
+    {:user-id (:xt/id row)
+     :user-email (:user/email row)}))
+
+(defn get-mean-user
+  [conn]
+  (let [row (first (xt/q conn [(str
+                                 "with per as ("
+                                 "  select u._id as _id, u.user$email as user_email, count(ui._id) as cnt "
+                                 "  from user_items ui "
+                                 "  join users u on u._id = ui.user_item$user "
+                                 "  group by u._id, u.user$email"
+                                 "), stats as (select avg(cnt) as avg_cnt from per) "
+                                 "select u._id, u.user$email, per.cnt "
+                                 "from per join users u on u._id = per._id, stats "
+                                 "order by (per.cnt - stats.avg_cnt)*(per.cnt - stats.avg_cnt) asc "
+                                 "limit 1")]))]
+    {:user-id (:xt/id row)
+     :user-email (:user/email row)}))
+
+(defn get-active-users
+  [conn ^java.util.Random random scale-factor]
+  (let [active-users (yakbench/round-down (* yakbench/active-user-baseline scale-factor))
+        joined (xt/q conn ["select u._id as _id from users u where u.user$joined_at > ?" active-inst])
+        viewed (xt/q conn ["select distinct ui.user_item$user as _id from user_items ui where ui.user_item$viewed_at > ?" active-inst])
+        ad-updated (xt/q conn ["select distinct a.ad$user as _id from ads a where a.ad$updated_at > ?" active-inst])
+        ids (->> (concat joined viewed ad-updated)
+                 (map :xt/id)
+                 (filter some?)
+                 distinct
+                 vec)
+        ids (let [al (java.util.ArrayList. ^java.util.Collection ids)]
+              (java.util.Collections/shuffle al random)
+              (vec al))]
+    (if (pos? active-users)
+      (vec (take active-users ids))
+      ids)))
+
+(defn get-biggest-feed
+  [conn random]
+  (let [feed (first (xt/q conn [(str
+                                 "select item$feed$feed as _id, count(*) as cnt "
+                                 "from items "
+                                 "group by item$feed$feed "
+                                 "order by cnt desc "
+                                 "limit 1")]))]
+    (when feed
+      (let [titles (map :item/title (xt/q conn ["select item$title from items where item$feed$feed = ? limit 10" (:xt/id feed)]))
+            random-titles (repeatedly (count titles) #(yakbench/next-string random (+ 10 (yakbench/next-int random 10))))
+            titles (concat titles random-titles)]
+        {:id (:xt/id feed)
+         :titles titles}))))
+
+(defn profile-data
+  [pstats]
+  (let [rows (for [[id {:keys [n min p50 p90 p95 p99 max mean mad sum]}]
+                   (get pstats :stats {})]
+               {:id id
+                :n n
+                :min min
+                :p50 p50
+                :p90 p90
+                :p95 p95
+                :p99 p99
+                :max max
+                :mean mean
+                :mad mad
+                :sum sum})]
+    (sort-by :sum > rows)))
+
+(defn profile
+  [node !state]
+  (with-open [conn (get-conn node)]
+    (let [iterations 10
+          suite (benchmarks-queries @!state)
+          _throwaway (doseq [{:keys [f]} suite]
+                       (f conn))
+          [_ pstats] (tufte/profiled
+                      {}
+                      (doseq [{:keys [id f]} suite
+                              _ (range iterations)]
+                        (p id (f conn))))]
+      (prn {:profile (profile-data @pstats)})
+      (println (tufte/format-pstats pstats))
+      (swap! !state assoc :pstats @pstats))))
+
+(defn distribution-stats
+  "Compute mean/median/p90/p99/min/max from a seq of numeric counts."
+  [counts]
+  (let [counts (vec (map long counts))
+        n (count counts)
+        sorted (vec (sort counts))
+        mean (if (pos? n) (/ (reduce + 0 sorted) (double n)) 0.0)
+        mn (if (pos? n) (first sorted) 0)
+        mx (if (pos? n) (peek sorted) 0)
+        idx (fn [p]
+              (cond
+                (zero? n) 0
+                :else (-> (Math/floor (* p (dec n))) long (max 0) (min (dec n)))))
+        median (if (pos? n) (sorted (idx 0.5)) 0)
+        p90 (if (pos? n) (sorted (idx 0.90)) 0)
+        p99 (if (pos? n) (sorted (idx 0.99)) 0)]
+    {:mean mean :median median :p90 p90 :p99 p99 :min mn :max mx}))
+
+(defn stats-from-sql
+  "Run a SQL that returns rows with a single count column (aliased as `cnt` by default)
+   and compute distribution stats over those counts. Provide `count-key` if alias differs."
+  ([conn sql]
+   (stats-from-sql conn sql :cnt))
+  ([conn sql count-key]
+   (let [rows (xt/q conn [sql])
+         counts (map count-key rows)]
+     (distribution-stats counts))))
+
+(defn get-user-items-stats
+  [conn]
+  (stats-from-sql conn
+                  (str "select count(*) as cnt "
+                       "from user_items ui "
+                       "group by ui.user_item$user")
+                  :cnt))
+
+(defn get-user-subs-stats
+  [conn]
+  (stats-from-sql conn
+                  (str "select count(*) as cnt "
+                       "from subs s "
+                       "group by s.sub$user")
+                  :cnt))
+
+(defn get-feed-items-stats
+  [conn]
+  (stats-from-sql conn
+                  (str "select count(*) as cnt "
+                       "from items i "
+                       "group by i.item$feed$feed")
+                  :cnt))
+
+(defn inspect
+  [node !state]
+  (with-open [conn (get-conn node)]
+    ;; Data
+    (let [tables ["users" "feeds" "subs"
+                  "items" "user_items" "ads"
+                  "ad_credits" "ad_clicks" "digests"
+                  "bulk_sends" "skips"]
+          rows (for [t tables]
+                 {:table t
+                  :count (:xt/column-1 (first (xt/q conn [(str "select count(*) from " t)])))})]
+      (println)
+      (println "Table counts")
+      (pp/print-table [:table :count] rows))
+      (println)
+
+    ;; User
+    (let [{{:keys [user-id]} :picked-user} @!state
+          queries [["subs" "select count(*) from subs where sub$user = ?" [user-id]]
+                   ["items" "select count(*) from items where item$feed$feed is not null and item$feed$feed in (select sub$feed$feed from subs where sub$user = ?)" [user-id]]
+                   ["user_items" "select count(*) from user_items where user_item$user = ?" [user-id]]
+                   ["ad_clicks" "select count(*) from ad_clicks where ad.click$user = ?" [user-id]]
+                   ["digests" "select count(*) from digests where digest$user = ?" [user-id]]
+                   ["skips" "select count(*) from skips where skip$user = ?" [user-id]]
+                   ["ads" "select count(*) from ads where ad$user = ?" [user-id]]
+                   ["ad_credits"
+                    (str "select count(c._id) \n"
+                         "from ad_credits c \n"
+                         "join ads a on c.ad.credit$ad = a._id \n"
+                         "where a.`ad$user` = ?")
+                    [user-id]]]]
+
+      (println "Picked User" (xt/q conn ["select * from users where _id = ?" user-id]))
+      (println)
+      (println "User Counts")
+      (let [rows (for [[label sql args] queries]
+                   {:table label
+                    :count (:xt/column-1 (first (xt/q conn (into [sql] args))))})]
+        (pp/print-table [:table :count] rows))
+      (println))
+
+    ;; Active Users
+    (println "Active Users" (count (:active-user-ids @!state)))
+    (println)
+
+    ;; User items stats
+    (println "User items stats")
+    (pp/print-table [(get-user-items-stats conn)])
+    (println)
+
+    ;; User subs stats
+    (println "User subs stats")
+    (pp/print-table [(get-user-subs-stats conn)])
+    (println)
+
+    ;; Feed items stats
+    (println "Feed items stats")
+    (pp/print-table [(get-feed-items-stats conn)])
+    (println)))
+
+(defn load-data!
+  "Load data in chunks if scale factor is greater than 0.1 under the assumption
+  that the whole dataset is roughly the same as an aggregation of chunk sized
+  datasets"
+  [node random scale-factor]
+  (with-open [conn (get-conn node)]
+    (let [scale (Double/parseDouble (str scale-factor))]
+      (when (pos? scale)
+        (let [chunk 0.1
+              n-full (long (Math/floor (/ scale chunk)))
+              rem (- scale (* n-full chunk))
+              sub-scales (cond
+                           (<= scale chunk) [scale]
+                           (pos? rem) (concat (repeat n-full chunk) [rem])
+                           :else (repeat n-full chunk))
+              v-sub-scales (vec sub-scales)
+              total (count v-sub-scales)]
+          (doseq [[idx sub-scale] (map-indexed vector v-sub-scales)]
+            (log/debug (format "Loading chunk %d/%d (scale %.3f)" (inc idx) total sub-scale))
+            (let [docs (yakbench/generate-data random sub-scale)]
+              (yakbench/load-generated! conn docs))))))))
+
+(defmethod b/cli-flags :yakbench [_]
+  [["-s" "--scale-factor SCALE_FACTOR" "Yakbench scale factor to use"
+    :parse-fn parse-double
+    :default 0.1]
+   ["-h" "--help"]])
+
+(defmethod b/->benchmark :yakbench [_ {:keys [scale-factor seed no-load?],
+                                       :or {scale-factor 0.1, seed 0}}]
+  (log/info {:scale-factor scale-factor :seed seed :no-load? no-load?})
+
+  {:title "Yakbench", :seed seed
+   :->state #(do {:!state (atom {})})
+   :tasks [{:t :do
+            :stage :ingest
+            :tasks (concat (when-not no-load?
+                             [{:t :call
+                               :stage :submit-docs
+                               :f (fn [{:keys [node random]}] (load-data! node random scale-factor))}])
+                           [{:t :do
+                             :stage :finish-block
+                             :tasks [{:t :call :f (fn [{:keys [node]}] (b/finish-block! node))}]}
+                            {:t :do
+                             :stage :compact
+                             :tasks [{:t :call :f (fn [{:keys [node]}] #_ (c/compact-all! node (Duration/ofSeconds 60)) (b/compact! node))}]}])}
+           {:t :do
+            :stage :get-query-data
+            :tasks [{:t :call
+                     :f (fn [{:keys [node !state]}]
+                          (with-open [conn (get-conn node)]
+                            (let [user (get-worst-case-user conn)]
+                              (swap! !state assoc :picked-user user))))}
+                    {:t :call
+                     :f (fn [{:keys [node !state random]}]
+                          (with-open [conn (get-conn node)]
+                            (let [active-users (get-active-users conn random scale-factor)]
+                              (swap! !state assoc :active-user-ids active-users))))}
+                    {:t :call
+                     :f (fn [{:keys [node !state random]}]
+                          (with-open [conn (get-conn node)]
+                            (let [biggest-feed (get-biggest-feed conn random)]
+                              (swap! !state assoc :biggest-feed biggest-feed))))}]}
+           {:t :do
+            :stage :profile
+            :tasks [{:t :call
+                     :f (fn [{:keys [node !state]}]
+                          (profile node !state))}
+                    #_
+                    {:t :call
+                     :f (fn [{:keys [node]}]
+                          (let [mean-user (get-mean-user (get-conn node))
+                                new-state (atom {:picked-user mean-user})]
+                            (profile node new-state)))}]}
+           {:t :do
+            :stage :inspect
+            :tasks [{:t :call
+                     :f (fn [{:keys [node !state]}]
+                          (inspect node !state))}]}]})
+
+(comment
+  (try
+    (let [rnd (java.util.Random. 0)
+          scale 1.0
+          !state (atom {})
+          dir (util/->path "/tmp/yakbench")
+          clear-dir (fn [^java.nio.file.Path path]
+                      (when (util/path-exists path)
+                        (log/info "Clearing directory" path)
+                        (util/delete-dir path)))]
+      (with-open [node (tu/->local-node {:node-dir dir})
+                  conn (get-conn node)]
+        (clear-dir dir)
+        (load-data! node rnd scale)
+        (b/finish-block! node)
+        (b/compact! node)
+        (swap! !state assoc :picked-user (get-worst-case-user conn))
+        (swap! !state assoc :active-user-ids (get-active-users conn rnd scale))
+        (swap! !state assoc :biggest-feed (get-biggest-feed conn rnd))
+        (profile node !state)
+        (inspect node !state)))
+      (catch Exception e
+        (log/error e)))
+
+  (try
+    (with-open [node (tu/->local-node {:node-dir (util/->path "/tmp/yakbench")})]
+      (b/finish-block! node))
+    (catch Exception e
+      (log/error e)))
+
+
+  (xtdb.logging/set-log-level! 'xtdb.bench :debug)
+
+  )

--- a/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
@@ -23,102 +23,98 @@
 (def recent-ad-inst (.toInstant #inst "2025-01-01T00:00:00Z"))
 
 (defn benchmarks-queries
-  [{:keys [active-user-ids biggest-feed]}]
-  (cond-> [{:id :active-users-by-joined-at
-            :f #(xt/q % ["select _id from users where user$joined_at > ?"
-                         active-inst])}
-           {:id :active-users-by-viewed-at
-            :f #(xt/q % ["select distinct user_item$user from user_items where user_item$viewed_at > ?"
-                         active-inst])}
-           {:id :active-users-by-ad-updated
-            :f #(xt/q % ["select ad$user from ads where ad$updated_at > ?"
-                         active-inst])}
-           {:id :active-users-by-ad-clicked
-            :f #(xt/q % ["select distinct ad.click$user from ad_clicks where ad.click$created_at > ?"
-                         active-inst])}
-           {:id :favorited-urls
-            :f #(xt/q % [(str "select item$url "
-                              "from items "
-                              "join user_items on user_item$item = items._id "
-                              "where user_item$favorited_at is not null")])}
+  [active-user-ids biggest-feed]
+  [{:id :active-users-by-joined-at
+    :f #(xt/q % ["select _id from users where user$joined_at > ?"
+                 active-inst])}
+   {:id :active-users-by-viewed-at
+    :f #(xt/q % ["select distinct user_item$user from user_items where user_item$viewed_at > ?"
+                 active-inst])}
+   {:id :active-users-by-ad-updated
+    :f #(xt/q % ["select ad$user from ads where ad$updated_at > ?"
+                 active-inst])}
+   {:id :active-users-by-ad-clicked
+    :f #(xt/q % ["select distinct ad.click$user from ad_clicks where ad.click$created_at > ?"
+                 active-inst])}
+   {:id :favorited-urls
+    :f #(xt/q % [(str "select item$url "
+                      "from items "
+                      "join user_items on user_item$item = items._id "
+                      "where user_item$favorited_at is not null")])}
 
-           {:id :direct-urls
-            :f #(xt/q % ["select item$url from items where item$doc_type = 'item/direct'"])}
+   {:id :direct-urls
+    :f #(xt/q % ["select item$url from items where item$doc_type = 'item/direct'"])}
 
-           {:id :unique-ad-clicks
-            :f #(xt/q % [(str "select ad$click$ad, count(distinct ad$click$user) "
-                              "from ad_clicks "
-                              "group by ad$click$ad")])}
+   {:id :unique-ad-clicks
+    :f #(xt/q % [(str "select ad$click$ad, count(distinct ad$click$user) "
+                      "from ad_clicks "
+                      "group by ad$click$ad")])}
 
-           {:id :latest-ad-clicks
-            :f #(xt/q % [(str "select ad$click$ad, max(ad$click$created_at) "
-                              "from ad_clicks "
-                              "group by ad$click$ad")])}
+   {:id :latest-ad-clicks
+    :f #(xt/q % [(str "select ad$click$ad, max(ad$click$created_at) "
+                      "from ad_clicks "
+                      "group by ad$click$ad")])}
 
-           {:id :charge-amounts-by-status
-            :f #(xt/q % [(str "select ad$credit$ad, ad$credit$charge_status, sum(ad$credit$amount) "
-                              "from ad_credits "
-                              "where ad$credit$charge_status is not null "
-                              "group by ad$credit$ad, ad$credit$charge_status")])}
+   {:id :charge-amounts-by-status
+    :f #(xt/q % [(str "select ad$credit$ad, ad$credit$charge_status, sum(ad$credit$amount) "
+                      "from ad_credits "
+                      "where ad$credit$charge_status is not null "
+                      "group by ad$credit$ad, ad$credit$charge_status")])}
 
-           {:id :candidate-statuses
-            :f #(xt/q % [(str "select item$direct$candidate_status, count(_id) "
-                              "from items "
-                              "where item$direct$candidate_status is not null "
-                              "group by item$direct$candidate_status")])}
+   {:id :candidate-statuses
+    :f #(xt/q % [(str "select item$direct$candidate_status, count(_id) "
+                      "from items "
+                      "where item$direct$candidate_status is not null "
+                      "group by item$direct$candidate_status")])}
 
-           {:id :favorites
-            :f #(xt/q % [(str "select user_item$user, user_item$item "
-                              "from user_items "
-                              "where user_item$favorited_at is not null")])}
+   {:id :favorites
+    :f #(xt/q % [(str "select user_item$user, user_item$item "
+                      "from user_items "
+                      "where user_item$favorited_at is not null")])}
 
-           {:id :approved-candidates
-            :f #(xt/q % [(str "select _id, item$url "
-                              "from items "
-                              "where item$direct$candidate_status = 'approved'")])}
+   {:id :approved-candidates
+    :f #(xt/q % [(str "select _id, item$url "
+                      "from items "
+                      "where item$direct$candidate_status = 'approved'")])}
 
-           {:id :ad-recent-cost
-            :f #(xt/q % [(str "select ad$click$ad, sum(ad$click$cost) "
-                              "from ad_clicks "
-                              "where ad$click$created_at > ? "
-                              "group by ad$click$ad")
-                         recent-ad-inst])}
+   {:id :ad-recent-cost
+    :f #(xt/q % [(str "select ad$click$ad, sum(ad$click$cost) "
+                      "from ad_clicks "
+                      "where ad$click$created_at > ? "
+                      "group by ad$click$ad")
+                 recent-ad-inst])}
 
-           {:id :ads-clicked-at
-            :f #(xt/q % [(str "select ad$click$ad, ad$click$user, max(ad$click$created_at) "
-                              "from ad_clicks "
-                              "group by ad$click$ad, ad$click$user")])}
+   {:id :ads-clicked-at
+    :f #(xt/q % [(str "select ad$click$ad, ad$click$user, max(ad$click$created_at) "
+                      "from ad_clicks "
+                      "group by ad$click$ad, ad$click$user")])}
 
-           {:id :all-n-likes
-            :f #(xt/q % [(str "select user_item$item, count(_id) "
-                              "from user_items "
-                              "where user_item$favorited_at is not null "
-                              "group by user_item$item")])}]
-
-    (seq active-user-ids)
-    (conj {:id :feeds-to-sync
-           :f #(xt/q %
-                     (vec (concat [(str "select distinct sub$feed$feed "
-                                        "from subs "
-                                        "join feeds on feeds._id = sub$feed$feed "
-                                        "where sub$user in " (?s (count active-user-ids))
-                                        " and (feed$synced_at is null or feed$synced_at < ?)")]
-                                  active-user-ids
-                                  [feed-sync-inst])))})
-
-    (and biggest-feed (seq (:titles biggest-feed)))
-    (conj {:id :existing-feed-titles
-           :f #(xt/q %
-                     (vec
-                      (concat [(str "select item$title "
-                                    "from items "
-                                    "where item$feed$feed = ? "
-                                    "and item$title in " (?s (count (:titles biggest-feed))))
-                               (:id biggest-feed)]
-                              (:titles biggest-feed))))})))
+   {:id :all-n-likes
+    :f #(xt/q % [(str "select user_item$item, count(_id) "
+                      "from user_items "
+                      "where user_item$favorited_at is not null "
+                      "group by user_item$item")])}
+   {:id :feeds-to-sync
+    :f #(xt/q %
+              (vec (concat [(str "select distinct sub$feed$feed "
+                                 "from subs "
+                                 "join feeds on feeds._id = sub$feed$feed "
+                                 "where sub$user in " (?s (count active-user-ids))
+                                 " and (feed$synced_at is null or feed$synced_at < ?)")]
+                           active-user-ids
+                           [feed-sync-inst])))}
+   {:id :existing-feed-titles
+    :f #(xt/q %
+              (vec
+               (concat [(str "select item$title "
+                             "from items "
+                             "where item$feed$feed = ? "
+                             "and item$title in " (?s (count (:titles biggest-feed))))
+                        (:id biggest-feed)]
+                       (:titles biggest-feed))))}])
 
 (defn user-specific-benchmarks-queries
-  [{{:keys [user-id user-email]} :picked-user}]
+  [{:keys [user-id user-email]}]
   [{:id :get-user-by-email
     :f #(xt/q % ["select * from users where user$email = ?" user-email])}
    {:id :get-user-by-id
@@ -204,7 +200,7 @@
                       "group by subs._id")
                  user-id])}])
 
-(defn get-worst-case-user
+(defn get-max-user
   [conn]
   (let [row (first (xt/q conn [(str
                                 "select u._id, u.user$email, count(ui._id) as cnt "
@@ -283,7 +279,7 @@
     (sort-by :sum > rows)))
 
 (defn profile
-  [node !state suite]
+  [node profile-id suite]
   (with-open [conn (get-conn node)]
     (let [iterations 10
           _throwaway (doseq [{:keys [f]} suite]
@@ -293,9 +289,8 @@
                       (doseq [{:keys [id f]} suite
                               _ (range iterations)]
                         (p id (f conn))))]
-      (prn {:profile (profile-data @pstats)})
-      (println (tufte/format-pstats pstats))
-      (swap! !state assoc :pstats @pstats))))
+      (prn {:profile-id profile-id :profile (profile-data @pstats)})
+      (println (tufte/format-pstats pstats)))))
 
 (defn distribution-stats
   "Compute mean/median/p90/p99/min/max from a seq of numeric counts."
@@ -350,9 +345,8 @@
                   :cnt))
 
 (defn inspect
-  [node !state]
+  [node {{:keys [user-id]} :max-user :keys [active-users]}]
   (with-open [conn (get-conn node)]
-    ;; Data
     (let [tables ["users" "feeds" "subs"
                   "items" "user_items" "ads"
                   "ad_credits" "ad_clicks" "digests"
@@ -362,12 +356,10 @@
                   :count (:xt/column-1 (first (xt/q conn [(str "select count(*) from " t)])))})]
       (println)
       (println "Table counts")
-      (pp/print-table [:table :count] rows))
-      (println)
+      (pp/print-table [:table :count] rows)
+      (println))
 
-    ;; User
-    (let [{{:keys [user-id]} :picked-user} @!state
-          queries [["subs" "select count(*) from subs where sub$user = ?" [user-id]]
+    (let [queries [["subs" "select count(*) from subs where sub$user = ?" [user-id]]
                    ["items" "select count(*) from items where item$feed$feed is not null and item$feed$feed in (select sub$feed$feed from subs where sub$user = ?)" [user-id]]
                    ["user_items" "select count(*) from user_items where user_item$user = ?" [user-id]]
                    ["ad_clicks" "select count(*) from ad_clicks where ad.click$user = ?" [user-id]]
@@ -383,28 +375,24 @@
 
       (println "Picked User" (xt/q conn ["select * from users where _id = ?" user-id]))
       (println)
-      (println "User Counts")
+      (println "Max User Counts")
       (let [rows (for [[label sql args] queries]
                    {:table label
                     :count (:xt/column-1 (first (xt/q conn (into [sql] args))))})]
         (pp/print-table [:table :count] rows))
       (println))
 
-    ;; Active Users
-    (println "Active Users" (count (:active-user-ids @!state)))
+    (println "Active Users" (count active-users))
     (println)
 
-    ;; User items stats
     (println "User items stats")
     (pp/print-table [(get-user-items-stats conn)])
     (println)
 
-    ;; User subs stats
     (println "User subs stats")
     (pp/print-table [(get-user-subs-stats conn)])
     (println)
 
-    ;; Feed items stats
     (println "Feed items stats")
     (pp/print-table [(get-feed-items-stats conn)])
     (println)))
@@ -450,50 +438,44 @@
                        :stage :submit-docs
                        :f (fn [{:keys [node random]}] (load-data! node random scale-factor))}
                       {:t :call
-                      :stage :await-transactions
-                      :f (fn [{:keys [node]}] (b/sync-node node))}
-                     {:t :call
-                      :stage :flush-block
-                      :f (fn [{:keys [node]}] (tu/flush-block! node))}
-                     {:t :call
-                      :stage :compact
-                      :f (fn [{:keys [node]}] (c/compact-all! node nil))}]})
-           {:t :do
+                       :stage :await-transactions
+                       :f (fn [{:keys [node]}] (b/sync-node node))}
+                      {:t :call
+                       :stage :flush-block
+                       :f (fn [{:keys [node]}] (tu/flush-block! node))}]})
+
+           {:t :call
+            :stage :compact
+            :f (fn [{:keys [node]}] (c/compact-all! node nil))}
+
+           {:t :call
             :stage :get-query-data
-            :tasks [{:t :call
-                     :f (fn [{:keys [node !state]}]
-                          (with-open [conn (get-conn node)]
-                            (let [user (get-worst-case-user conn)]
-                              (swap! !state assoc :picked-user user))))}
-                    {:t :call
-                     :f (fn [{:keys [node !state random]}]
-                          (with-open [conn (get-conn node)]
-                            (let [active-users (get-active-users conn random scale-factor)]
-                              (swap! !state assoc :active-user-ids active-users))))}
-                    {:t :call
-                     :f (fn [{:keys [node !state random]}]
-                          (with-open [conn (get-conn node)]
-                            (let [biggest-feed (get-biggest-feed conn random)]
-                              (swap! !state assoc :biggest-feed biggest-feed))))}]}
+            :f (fn [{:keys [node !state random]}]
+                 (with-open [conn (get-conn node)]
+                   (swap! !state merge {:max-user (get-max-user conn)
+                                        :mean-user (get-mean-user conn)
+                                        :active-users (get-active-users conn random scale-factor)
+                                        :biggest-feed (get-biggest-feed conn random)})))}
 
            {:t :call
             :stage :profile-global-queries
             :f (fn [{:keys [node !state]}]
-                 (profile node !state (benchmarks-queries @!state)))}
+                 (let [{:keys [active-users biggest-feed]} @!state]
+                   (profile node :global (benchmarks-queries active-users biggest-feed))))}
            {:t :call
             :stage :profile-max-user
             :f (fn [{:keys [node !state]}]
-                 (profile node !state (user-specific-benchmarks-queries @!state)))}
+                 (let [{:keys [max-user]} @!state]
+                   (profile node :max-user (user-specific-benchmarks-queries max-user))))}
            {:t :call
             :stage :profile-mean-user
-            :f (fn [{:keys [node]}]
-                 (let [state (atom {:picked-user (get-mean-user (get-conn node))})]
-                   (profile node state (user-specific-benchmarks-queries state))))}
-           #_
+            :f (fn [{:keys [node !state]}]
+                 (let [{:keys [mean-user]} @!state]
+                   (profile node :mean-user (user-specific-benchmarks-queries mean-user))))}
            {:t :call
             :stage :inspect
             :f (fn [{:keys [node !state]}]
-                 (inspect node !state))}]})
+                 (inspect node @!state))}]})
 
 (comment
   (try
@@ -504,10 +486,10 @@
                       (when (util/path-exists path)
                         (log/info "Clearing directory" path)
                         (util/delete-dir path)))]
+      (println "Clear dir")
+      (clear-dir dir)
       (with-open [node (tu/->local-node {:node-dir dir})
                   conn (get-conn node)]
-        (println "Clear dir")
-        (clear-dir dir)
         (println "Load data")
         (load-data! node rnd scale)
         (println "Flush block")
@@ -516,14 +498,20 @@
         (println "Compact")
         (c/compact-all! node nil)
         (println "Get Query Data")
-        (swap! !state assoc :picked-user (get-worst-case-user conn))
-        (swap! !state assoc :active-user-ids (get-active-users conn rnd scale))
-        (swap! !state assoc :biggest-feed (get-biggest-feed conn rnd))
-        (println "Profile")
-        (profile node !state)
-        (println "Inspect")
-        (inspect node !state)))
+        (let [max-user (get-max-user conn)
+              mean-user (get-mean-user conn)
+              active-users (get-active-users conn rnd scale)
+              biggest-feed (get-biggest-feed conn rnd)]
+          (println "Profile Global")
+          (profile node :global (benchmarks-queries active-users biggest-feed))
+          (println "Profile Max User")
+          (profile node :max-user (user-specific-benchmarks-queries max-user))
+          (println "Profile Mean User")
+          (profile node :mean-user (user-specific-benchmarks-queries mean-user))
+          (println "Inspect")
+          (inspect node {:max-user max-user
+                         :active-users active-users}))))
     (catch Exception e
       (log/error e)))
 
-  )
+)

--- a/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
@@ -5,6 +5,7 @@
             [taoensso.tufte :as tufte :refer [p]]
             [xtdb.api :as xt]
             [xtdb.bench :as b]
+            [xtdb.compactor :as c]
             [xtdb.datasets.yakbench :as yakbench]
             [xtdb.test-util :as tu]
             [xtdb.util :as util]))
@@ -448,21 +449,21 @@
 
   {:title "Yakbench", :seed seed
    :->state #(do {:!state (atom {})})
-   :tasks [{:t :do
-            :stage :ingest
-            :tasks (concat (when-not no-load?
-                             [{:t :call
-                               :stage :submit-docs
-                               :f (fn [{:keys [node random]}] (load-data! node random scale-factor))}])
-                           [{:t :call
-                             :stage :await-transactions
-                             :f (fn [{:keys [node]}] (b/sync-node node))}
-                            {:t :call
-                             :stage :flush-block
-                             :f (fn [{:keys [node]}] (tu/flush-block! node))}
-                            {:t :call
-                             :stage :compact
-                             :f (fn [{:keys [node]}] (b/compact! node))}])}
+   :tasks [(when-not no-load?
+             {:t :do
+              :stage :ingest
+              :tasks [{:t :call
+                       :stage :submit-docs
+                       :f (fn [{:keys [node random]}] (load-data! node random scale-factor))}
+                      {:t :call
+                      :stage :await-transactions
+                      :f (fn [{:keys [node]}] (b/sync-node node))}
+                     {:t :call
+                      :stage :flush-block
+                      :f (fn [{:keys [node]}] (tu/flush-block! node))}
+                     {:t :call
+                      :stage :compact
+                      :f (fn [{:keys [node]}] (c/compact-all! node nil))}]})
            {:t :do
             :stage :get-query-data
             :tasks [{:t :call
@@ -485,6 +486,12 @@
             :f (fn [{:keys [node !state]}]
                  (profile node !state))}
            {:t :call
+            :stage :profile-mean
+            :f (fn [{:keys [node]}]
+                 (let [state (atom {:picked-user (get-mean-user (get-conn node))})]
+                   (profile node state)))}
+           #_
+           {:t :call
             :stage :inspect
             :f (fn [{:keys [node !state]}]
                  (inspect node !state))}]})
@@ -493,7 +500,6 @@
   (try
     (let [rnd (java.util.Random. 0)
           scale 1.0
-          !state (atom {})
           dir (util/->path "/tmp/yakbench")
           clear-dir (fn [^java.nio.file.Path path]
                       (when (util/path-exists path)
@@ -509,7 +515,7 @@
         (b/sync-node node)
         (tu/flush-block! node)
         (println "Compact")
-        (b/compact! node)
+        (c/compact-all! node nil)
         (println "Get Query Data")
         (swap! !state assoc :picked-user (get-worst-case-user conn))
         (swap! !state assoc :active-user-ids (get-active-users conn rnd scale))

--- a/modules/datasets/src/main/clojure/xtdb/datasets/yakbench.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/yakbench.clj
@@ -133,7 +133,7 @@
   (into #{} (for [d weekdays :when (chance? random 0.5)] d)))
 
 (defn draw-poisson
-  "Knuth's algorithm for small λ; Normal approximation for large λ.
+  "Knuth's algorithm for small lambda, Normal approximation for large lambda.
    Returns a non-negative long."
   ^long [^java.util.Random random ^double lambda]
   (cond
@@ -151,7 +151,7 @@
       (max 0 k))))
 
 (defn lognormal-lambda
-  "Draw λ from LogNormal so E[λ]≈mean. sigma controls tail (1.0–2.0 typical)."
+  "Draw λ from LogNormal so E[λ]≈mean, sigma controls tail."
   ^double [^java.util.Random random ^double mean ^double sigma]
   (let [mu (- (Math/log (max mean 1e-9)) (/ (* sigma sigma) 2.0))]
     (Math/exp (+ mu (* sigma (.nextGaussian random))))))
@@ -248,8 +248,7 @@
                                      (let [raw-id (next-uuid random)
                                            email-sub (when (and (pos? sub-count) (chance? random 0.2))
                                                        (uniform-nth random sub-ids))
-                                           prefix (or feed-id email-sub #uuid "00000000-0000-0000-0000-000000000000")
-                                           id (uuid-with-prefix prefix raw-id)
+                                           id (uuid-with-prefix feed-id raw-id)
                                            categories (vec (repeatedly (next-int random 5) #(uniform-nth random cat-pool)))]
                                        (cond-> {:xt/id id
                                                 :item.feed/feed feed-id
@@ -265,8 +264,8 @@
                                                 :item/categories categories
                                                 :item/ingested-at (next-instant random)
                                                 :item/url (next-string random (+ 10 (next-int random 50)))}
-                                         (chance? random 0.01) (assoc :item/doc-type :item/direct
-                                                                      :item.direct/candidate-status (weighted-nth random [0.9 0.08 0.02] [:approved :failed :ingest-failed]))
+                                         (chance? random 0.001) (assoc :item/doc-type :item/direct
+                                                                       :item.direct/candidate-status (weighted-nth random [0.956 0.035 0.008] [:approved :failed :ingest-failed]))
                                          email-sub (assoc :item.email/sub email-sub))))
                                    (range k))))]
       (->> feeds

--- a/modules/datasets/src/main/clojure/xtdb/datasets/yakbench.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/yakbench.clj
@@ -1,0 +1,425 @@
+(ns xtdb.datasets.yakbench
+  (:require [clojure.string :as str]
+            [xtdb.api :as xt])
+  (:import [java.time Instant LocalTime LocalDate ZoneOffset]
+           [java.util UUID]))
+
+;; Scale-factor generation based on README proportions
+(def baseline-counts
+  {:users 4835
+   :feeds 24468
+   :subs 107597
+   :items 17460648
+   :user-items 236804
+   :ad-clicks 3341
+   :ad-credits 184
+   :ads 89
+   :bulk-sends 829
+   :digests 23091
+   :skips 4494})
+
+(def active-user-baseline 1768)
+
+(def user-items-stats
+  {:mean 27.2125948057918
+   :median 2
+   :p90 24
+   :p99 272
+   :min 1
+   :max 16708})
+
+(def user-subs-stats
+  {:mean 106.955268389662
+   :median 5
+   :p90 114
+   :p99 1865
+   :min 1
+   :max 13356})
+
+(def feed-items-stats
+  {:mean 736.407677681279
+   :median 25
+   :p90 589
+   :p99 12004
+   :min 1
+   :max 363444})
+
+(defn round-down [x]
+  (long (Math/floor (double x))))
+
+(defn next-int
+  ^long [^java.util.Random random ^long bound]
+  (.nextInt random (max 1 bound)))
+
+(defn uniform-nth
+  [^java.util.Random random coll]
+  (let [c (count coll)]
+    (when (pos? c)
+      (nth coll (next-int random c)))))
+
+(defn chance?
+  [^java.util.Random random ^double p]
+  (< (.nextDouble random) p))
+
+(defn weighted-nth
+  "Draw a single element from xs with non-negative weights.
+   Returns nil if xs empty. If all weights are zero, falls back to uniform."
+  [^java.util.Random rng weights xs]
+  (let [ws (mapv #(double (max 0.0 %)) weights)
+        xs (vec xs)
+        n  (count xs)]
+    (when (pos? n)
+      (let [s (reduce + 0.0 ws)]
+        (if (pos? s)
+          (let [target (* (.nextDouble rng) s)]
+            (loop [i 0 acc 0.0]
+              (let [acc' (+ acc (ws i))]
+                (if (or (>= acc' target) (= i (dec n)))
+                  (xs i)
+                  (recur (inc i) acc')))))
+          ;; uniform fallback
+          (xs (next-int rng n)))))))
+
+(defn next-uuid
+  [^java.util.Random random]
+  (let [msb (.nextLong random)
+        lsb (.nextLong random)
+        msb (-> msb
+                (bit-and (bit-not (bit-shift-left 0xF 12)))
+                (bit-or  (bit-shift-left 0x4 12)))
+        lsb (-> lsb
+                (bit-and (bit-not (bit-shift-left 0x3 62)))
+                (bit-or  (bit-shift-left 0x2 62)))]
+    (UUID. msb lsb)))
+
+(def ^:private ^String charset "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+(defn next-string
+  ^String [^java.util.Random random ^long n]
+  (let [sb (StringBuilder. n)]
+    (loop [i 0]
+      (if (< i n)
+        (do (.append sb (.charAt charset (next-int random (.length charset))))
+            (recur (unchecked-inc i)))
+        (.toString sb)))))
+
+(defn next-email [^java.util.Random random]
+  (str (next-string random 8) "@example.com"))
+
+(defn next-instant
+  ([^java.util.Random random] (next-instant random 2020 2025))
+  ([^java.util.Random random ^long start-year ^long end-year]
+   (let [^ZoneOffset zone ZoneOffset/UTC
+         ^Instant start (-> (LocalDate/of start-year 1 1)
+                            (.atStartOfDay zone)
+                            (.toInstant))
+         ^Instant end-excl (-> (LocalDate/of (inc end-year) 1 1)
+                               (.atStartOfDay zone)
+                               (.toInstant))
+         start-ms (.toEpochMilli start)
+         end-ms (.toEpochMilli end-excl)
+         span (max 0 (- end-ms start-ms))
+         n (if (pos? span)
+             (long (Math/floor (* (.nextDouble random) (double span))))
+             0)]
+     (Instant/ofEpochMilli (+ start-ms n)))))
+
+(defn next-local-time [^java.util.Random random]
+  (LocalTime/of (next-int random 24) (next-int random 60)))
+
+(def weekdays [:monday :tuesday :wednesday :thursday :friday :saturday :sunday])
+
+(defn next-weekday-set [^java.util.Random random]
+  (into #{} (for [d weekdays :when (chance? random 0.5)] d)))
+
+(defn draw-poisson
+  "Knuth's algorithm for small λ; Normal approximation for large λ.
+   Returns a non-negative long."
+  ^long [^java.util.Random random ^double lambda]
+  (cond
+    (<= lambda 0.0) 0
+    (<= lambda 50.0)
+    (let [L (Math/exp (- lambda))]
+      (loop [k 0, p 1.0]
+        (let [p (* p (.nextDouble random))]
+          (if (> p L)
+            (recur (inc k) p)
+            k))))
+    :else
+    (let [k (long (Math/round (+ lambda (* (Math/sqrt lambda)
+                                           (.nextGaussian random)))))]
+      (max 0 k))))
+
+(defn lognormal-lambda
+  "Draw λ from LogNormal so E[λ]≈mean. sigma controls tail (1.0–2.0 typical)."
+  ^double [^java.util.Random random ^double mean ^double sigma]
+  (let [mu (- (Math/log (max mean 1e-9)) (/ (* sigma sigma) 2.0))]
+    (Math/exp (+ mu (* sigma (.nextGaussian random))))))
+
+(defn sigma-from-stats
+  "Compute lognormal sigma from mean and median."
+  [{:keys [mean median]}]
+  (Math/sqrt (* 2.0 (Math/log (/ (double mean) (double median))))))
+
+(defn draw-lognormal-poisson
+  "Takes a map of :mean and :median and returns a poisson-distributed long."
+  [^java.util.Random random {:keys [mean median]}]
+  (let [sigma (sigma-from-stats {:mean mean :median median})]
+    (draw-poisson random (lognormal-lambda random mean sigma))))
+
+;; Match yakread behavior: take the first group (8 hex chars) from
+;; uuid-prefix and the remaining groups from uuid-rest.
+(defn uuid-with-prefix
+  [uuid-prefix uuid-rest]
+  (let [prefix-str (str uuid-prefix)
+        rest-str (str uuid-rest)
+        prefix (first (str/split prefix-str #"-"))
+        rest-groups (rest (str/split rest-str #"-"))]
+    (UUID/fromString (str/join "-" (cons prefix rest-groups)))))
+
+(defn gen-users
+  "For users we add an extra :user/k field that is a poisson-distributed long.
+  This is used to determine the number of items and subs a user has."
+  [random n]
+  (vec
+   (for [_ (range n)
+         :let [id (next-uuid random)
+               email (next-email random)
+               uname (subs email 0 (str/index-of email "@"))]]
+     {:xt/id id
+      :user/email email
+      :user/email-username uname
+      :user/digest-days (next-weekday-set random)
+      :user/send-digest-at (next-local-time random)
+      :user/joined-at (next-instant random)
+      :user/digest-last-sent (when (chance? random 0.8) (next-instant random))
+      :user/suppressed-at (when (chance? random 0.05) (Instant/parse "2025-01-01T00:00:00Z"))
+      :user/use-original-links (chance? random 0.5)
+      :user/k (draw-lognormal-poisson random user-items-stats)})))
+
+(defn gen-feeds
+  [random n]
+  (vec
+   (for [i (range n)
+         :let [id (next-uuid random)]]
+     {:xt/id id
+      :feed/url (str "https://example.com/feed/" i)
+      :feed/title (next-string random (+ 5 (next-int random 15)))
+      :feed/etag (next-string random (+ 10 (next-int random 20)))
+      :feed/last-modified (next-string random (+ 10 (next-int random 20)))
+      :feed/synced-at (next-instant random)
+      :feed/image-url (when (chance? random 0.3) (str "https://img.example/" (next-string random 16)))
+      :feed/description (next-string random (+ 20 (next-int random 80)))
+      :feed/failed-syncs (when (chance? random 0.1) (next-int random 1000))})))
+
+(defn gen-subs
+  [random users feeds]
+  (let [feed-ids (mapv :xt/id feeds)
+        n-feeds (count feed-ids)]
+    (->> users
+         (mapcat (fn [{user :xt/id
+                       user-k :user/k}]
+                   (let [k (min (long (* user-k 0.25)) n-feeds)
+                         chosen (->> (repeatedly #(next-int random n-feeds))
+                                     (distinct)
+                                     (take k)
+                                     (map feed-ids))]
+                     (for [f chosen]
+                       {:xt/id (uuid-with-prefix user (next-uuid random))
+                        :sub/user user
+                        :sub/created-at (next-instant random)
+                        :sub.feed/feed f
+                        :sub.email/from (when (chance? random 0.2) (next-string random (+ 5 (next-int random 15))))
+                        :sub.email/unsubscribed-at (when (chance? random 0.05) (next-instant random))}))))
+         vec)))
+
+(defn gen-items
+  [random feeds subs n-items]
+  (let [subs-by-feed (->> subs (group-by :sub.feed/feed))
+        langs ["EN" "ES" "DE" "FR" "IT" "PT" "PL" "NL"]
+        cat-pool (vec (repeatedly 64 #(next-string random (+ 3 (next-int random 10)))))
+        name-pool (vec (repeatedly 64 #(next-string random (+ 6 (next-int random 20)))))]
+    (letfn [(items-for-feed [{feed-id :xt/id}]
+                            (let [subs* (get subs-by-feed feed-id)
+                                  sub-ids (when (seq subs*) (mapv :xt/id subs*))
+                                  sub-count (count sub-ids)
+                                  k (min (draw-lognormal-poisson random feed-items-stats) n-items)]
+                              (map (fn [i]
+                                     (let [raw-id (next-uuid random)
+                                           email-sub (when (and (pos? sub-count) (chance? random 0.2))
+                                                       (uniform-nth random sub-ids))
+                                           prefix (or feed-id email-sub #uuid "00000000-0000-0000-0000-000000000000")
+                                           id (uuid-with-prefix prefix raw-id)
+                                           categories (vec (repeatedly (next-int random 5) #(uniform-nth random cat-pool)))]
+                                       (cond-> {:xt/id id
+                                                :item.feed/feed feed-id
+                                                :item/title (str "Item " feed-id "-" i)
+                                                :item/excerpt (next-string random (+ 40 (next-int random 120)))
+                                                :item/published-at (next-instant random)
+                                                :item/length (+ 100 (next-int random 2000))
+                                                :item/content-key (next-uuid random)
+                                                :item/lang (uniform-nth random langs)
+                                                :item/author-name (uniform-nth random name-pool)
+                                                :item/author-email (next-email random)
+                                                :item/author-url (str "https://example.com/author/" i)
+                                                :item/categories categories
+                                                :item/ingested-at (next-instant random)
+                                                :item/url (next-string random (+ 10 (next-int random 50)))}
+                                         (chance? random 0.01) (assoc :item/doc-type :item/direct
+                                                                      :item.direct/candidate-status (weighted-nth random [0.9 0.08 0.02] [:approved :failed :ingest-failed]))
+                                         email-sub (assoc :item.email/sub email-sub))))
+                                   (range k))))]
+      (->> feeds
+           cycle
+           (mapcat items-for-feed)
+           (take n-items)
+           vec))))
+
+(defn gen-user-items
+  [random users items]
+  (let [item-ids (mapv :xt/id items)
+        n-items (count item-ids)]
+    (->> users
+         (mapcat (fn [{user :xt/id
+                       user-k :user/k}]
+                   (let [k (min user-k n-items)
+                         chosen (->> (repeatedly #(next-int random n-items))
+                                     (distinct)
+                                     (take k)
+                                     (map item-ids))]
+                     (for [item chosen]
+                       (cond-> {:xt/id (uuid-with-prefix user (next-uuid random))
+                                :user-item/user user
+                                :user-item/item item}
+                         (chance? random 0.5) (assoc :user-item/viewed-at (next-instant random))
+                         (chance? random 0.2) (assoc :user-item/favorited-at (next-instant random))
+                         (chance? random 0.1) (assoc :user-item/bookmarked-at (next-instant random))
+                         (chance? random 0.1) (assoc :user-item/skipped-at (next-instant random)))))))
+         vec)))
+
+(defn gen-ads
+  [random users n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :ad/user (:xt/id (uniform-nth random users))
+      :ad/approve-state (uniform-nth random [:approved :pending :rejected])
+      :ad/paused (chance? random 0.2)
+      :ad/title (next-string random (+ 12 (next-int random 24)))
+      :ad/description (next-string random (+ 180 (next-int random 360)))
+      :ad/url (str "https://ads.example/" (next-string random 16))
+      :ad/image-url (str "https://img.example/" (next-string random 24))
+      :ad/payment-method (next-string random (+ 24 (next-int random 24)))
+      :ad/card-details {:brand (next-string random 6)
+                        :last4 (format "%04d" (mod (next-int random 10000) 10000))
+                        :exp-month (inc (next-int random 12))
+                        :exp-year (+ 2025 (next-int random 6))}
+      :ad/customer-id (next-string random (+ 18 (next-int random 10)))
+      :ad/payment-failed (chance? random 0.1)
+      :ad/budget (+ 100 (next-int random 2000))
+      :ad/balance (+ (next-int random 500) 0)
+      :ad/bid (max 1 (next-int random 200))
+      :ad/recent-cost (max 0 (next-int random 1000))
+      :ad/updated-at (next-instant random)})))
+
+(defn gen-ad-credits
+  [random ads n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :ad.credit/ad (:xt/id (uniform-nth random ads))
+      :ad.credit/cents (+ 100 (next-int random 10000))
+      :ad.credit/created-at (next-instant random)
+      :ad.credit/charge-status (if (chance? random 0.9) :confirmed :failed)
+      :ad.credit/source (if (chance? random 0.9) :charge :manual)
+      :ad.credit/amount (+ 100 (next-int random 1000))})))
+
+(defn gen-ad-clicks
+  [random ads users n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :ad.click/ad (:xt/id (uniform-nth random ads))
+      :ad.click/user (:xt/id (uniform-nth random users))
+      :ad.click/created-at (next-instant random)
+      :ad.click/url (str "https://clk.example/" (next-string random 12))
+      :ad.click/cost (next-int random 1000)})))
+
+(defn gen-digests
+  [random users n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :digest/user (:xt/id (uniform-nth random users))
+      :digest/sent-at (next-instant random)
+      :digest/subject (next-uuid random)
+      :digest/discover (next-uuid random)
+      :digest/count (+ 1 (next-int random 200))})))
+
+(defn gen-bulk-sends
+  [random digests n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :bulk-send/sent-at (next-instant random)
+      :bulk-send/digests (vec (repeatedly (next-int random 10) #(uniform-nth random digests)))
+      :bulk-send/mailersend-id (next-string random 24)
+      :bulk-send/num-users (+ 1 (next-int random 10000))
+      :bulk-send/payload-size (+ 1 (next-int random 10000))})))
+
+(defn gen-skips
+  [random users n]
+  (vec
+   (for [_ (range n)]
+     {:xt/id (next-uuid random)
+      :skip/user (:xt/id (uniform-nth random users))
+      :skip/created-at (next-instant random)})))
+
+(defn generate-data
+  "Generate synthetic data according to a scale factor and return a map of
+   table keyword -> vector of docs"
+  [random scale]
+  (let [{:keys [users feeds items ads ad-credits ad-clicks digests bulk-sends skips]} baseline-counts
+        n-users (round-down (* users scale))
+        n-feeds (round-down (* feeds scale))
+        n-items (round-down (* items scale))
+        n-ads (round-down (* ads scale))
+        n-ad-credits (round-down (* ad-credits scale))
+        n-ad-clicks (round-down (* ad-clicks scale))
+        n-digests (round-down (* digests scale))
+        n-bulk-sends (round-down (* bulk-sends scale))
+        n-skips (round-down (* skips scale))
+        users* (gen-users random n-users)
+        feeds* (gen-feeds random n-feeds)
+        subs* (gen-subs random users* feeds*)
+        items* (gen-items random feeds* subs* n-items)
+        user-items* (gen-user-items random users* items*)
+        ads* (gen-ads random users* n-ads)
+        ad-credits* (gen-ad-credits random ads* n-ad-credits)
+        ad-clicks* (gen-ad-clicks random ads* users* n-ad-clicks)
+        digests* (gen-digests random users* n-digests)
+        bulk-sends* (gen-bulk-sends random digests* n-bulk-sends)
+        skips* (gen-skips random users* n-skips)]
+    {:users users*
+     :feeds feeds*
+     :subs subs*
+     :items items*
+     :user_items user-items*
+     :ads ads*
+     :ad_credits ad-credits*
+     :ad_clicks ad-clicks*
+     :digests digests*
+     :bulk_sends bulk-sends*
+     :skips skips*}))
+
+(defn load-generated!
+  [conn docs-by-table]
+  (doseq [table [:users :feeds :subs :items :user_items :ads :ad_credits
+                 :ad_clicks :digests :bulk_sends :skips]
+          :let [docs (get docs-by-table table)]
+          :when (seq docs)]
+    (let [batches (partition-all 1000 docs)]
+      (loop [bs batches]
+        (when-let [batch (first bs)]
+          (xt/submit-tx conn [(into [:put-docs table] batch)])
+          (recur (rest bs)))))))


### PR DESCRIPTION
This PR implements the yakbench benchmark based on Jacob O'Bryants dataset for his product yakread.

It comprises generator functions for generating data as per the original dataset as closely as possible, and queries from Jacob.

Initially the benchmark generates data in memory forming joins between key records like user items, user subs and feed items. The dataset is quite large so in order to fit into memory the benchmark generates the data in chunks (0.1 scale factor chunks to be precise). It's an assumption that this doesn't have an impact on query performance.

In order to generate data suitably similar to the original dataset we distributed counts for key relationships like user items with a lognormal poisson distribution, this allows us to model the heavy tailed data as closely as possible.

You can see some stats/graphs on how closely the two datasets match [here](https://github.com/xtdb/xtdb/issues/4893#issuecomment-3432960182).

Closes #4893