### PR TITLE
Change scan/->path-pred to filter based on iid-set

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -158,12 +158,11 @@
 
 
 (defn ->path-pred [^SortedSet iid-set]
-  (when (and iid-set (= 1 (.size iid-set)))
-    ;; TODO use the whole set
-    (let [^bytes iid-bytes (first iid-set)]
+  (when (and iid-set (not (.isEmpty iid-set)))
+    (let [bucketer Bucketer/DEFAULT]
       (reify Predicate
         (test [_ path]
-          (zero? (.compareToPath Bucketer/DEFAULT iid-bytes ^bytes path)))))))
+          (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
 (defmethod ig/prep-key ::scan-emitter [_ opts]
   (merge opts

--- a/core/src/main/kotlin/xtdb/operator/scan/MultiIidSelector.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/MultiIidSelector.kt
@@ -52,9 +52,7 @@ class MultiIidSelector(private val iids: SortedSet<ByteArray>) : SelectionSpec {
     }
 
     fun select(allocator: BufferAllocator, readRelation: RelationReader, path: ByteArray): IntArray {
-        val iids =
-            bucketer.incrementPath(path)?.let { iids.subSet(bucketer.startIid(path), bucketer.startIid(it)) }
-                ?: iids.tailSet(bucketer.startIid(path))
+        val iids = bucketer.filterIidsForPath(this.iids, path)
 
         val res = IntArrayList()
         val iidReader = readRelation["_iid"]

--- a/core/src/main/kotlin/xtdb/trie/Bucketer.kt
+++ b/core/src/main/kotlin/xtdb/trie/Bucketer.kt
@@ -1,6 +1,7 @@
 package xtdb.trie
 
 import org.apache.arrow.memory.util.ArrowBufPointer
+import java.util.SortedSet
 
 
 const val DEFAULT_LEVEL_BITS = 2
@@ -84,6 +85,22 @@ data class Bucketer(val levelBits: Int = DEFAULT_LEVEL_BITS) {
         }
 
         return null
+    }
+
+    /**
+     * Filters a sorted set of IIDs to only those that could exist within the given path.
+     *
+     * Uses the path's bucket boundaries to create a subset of IIDs that fall within
+     * the range [startIid(path), startIid(nextPath)).
+     *
+     * @param iids The sorted set of IIDs to filter
+     * @param path The path to filter by
+     * @return A subset of the input containing only IIDs that could exist in this path
+     */
+    fun filterIidsForPath(iids: SortedSet<ByteArray>, path: ByteArray): SortedSet<ByteArray> {
+        return incrementPath(path)?.let { nextPath ->
+            iids.subSet(startIid(path), startIid(nextPath))
+        } ?: iids.tailSet(startIid(path))
     }
 
     companion object {


### PR DESCRIPTION
Opted not to include a limit, as suggested in the original issue, as the cost of obtaining the subset is negligible even at large N. Furthermore, the IID set is only populated for in-memory joins. Which have currently have a limit of 100K rows for the build side.

Provided a roughly 10x speedup to my yakbench read-urls locally. 