### PR TITLE
chore: upgrade integrant 0.13.0 -> 1.0.1

### DIFF
--- a/core/src/main/clojure/xtdb/authn.clj
+++ b/core/src/main/clojure/xtdb/authn.clj
@@ -86,10 +86,10 @@
 (defn ->user-table-authn [^Authenticator$Factory$UserTable cfg, q-src, db-cat]
   (->UserTableAuthn (<-rules-cfg (.getRules cfg)) q-src db-cat))
 
-(defmethod ig/prep-key :xtdb/authn [_ opts]
-  (into {:q-src (ig/ref :xtdb.query/query-source)
-         :db-cat (ig/ref :xtdb/db-catalog)}
-        opts))
+(defmethod ig/expand-key :xtdb/authn [k opts]
+  {k (into {:q-src (ig/ref :xtdb.query/query-source)
+            :db-cat (ig/ref :xtdb/db-catalog)}
+           opts)})
 
 (defn- validate-oidc-config [config discovery-url]
   (let [{:keys [token_endpoint userinfo_endpoint]} config]

--- a/core/src/main/clojure/xtdb/block_catalog.clj
+++ b/core/src/main/clojure/xtdb/block_catalog.clj
@@ -6,9 +6,9 @@
   (:import (xtdb.block.proto Block TxKey)
            xtdb.catalog.BlockCatalog))
 
-(defmethod ig/prep-key :xtdb/block-catalog [_ {:keys [db-name]}]
-  {:db-name db-name
-   :buffer-pool (ig/ref :xtdb/buffer-pool)})
+(defmethod ig/expand-key :xtdb/block-catalog [k {:keys [db-name]}]
+  {k {:db-name db-name
+      :buffer-pool (ig/ref :xtdb/buffer-pool)}})
 
 (defmethod ig/init-key :xtdb/block-catalog [_ {:keys [db-name buffer-pool]}]
   (BlockCatalog. db-name buffer-pool))

--- a/core/src/main/clojure/xtdb/buffer_pool.clj
+++ b/core/src/main/clojure/xtdb/buffer_pool.clj
@@ -47,9 +47,9 @@
                        :remote ::remote)
                      opts))
 
-(defmethod ig/prep-key :xtdb/buffer-pool [_ {:keys [base db-name factory]}]
-  {:base base, :factory factory, :db-name db-name
-   :allocator (ig/ref :xtdb.db-catalog/allocator)})
+(defmethod ig/expand-key :xtdb/buffer-pool [k {:keys [base db-name factory]}]
+  {k {:base base, :factory factory, :db-name db-name
+      :allocator (ig/ref :xtdb.db-catalog/allocator)}})
 
 (defmethod ig/init-key :xtdb/buffer-pool [_ {{:keys [meter-registry mem-cache disk-cache]} :base, :keys [allocator ^Storage$Factory factory, db-name]}]
   (.open factory allocator mem-cache disk-cache db-name meter-registry Storage/VERSION))

--- a/core/src/main/clojure/xtdb/cache.clj
+++ b/core/src/main/clojure/xtdb/cache.clj
@@ -10,10 +10,10 @@
     max-cache-bytes (.maxSizeBytes max-cache-bytes)
     max-cache-ratio (.maxSizeRatio max-cache-ratio)))
 
-(defmethod ig/prep-key ::memory [_ factory]
-  {:allocator (ig/ref :xtdb/allocator)
-   :factory factory
-   :metrics-registry (ig/ref :xtdb.metrics/registry)})
+(defmethod ig/expand-key ::memory [k factory]
+  {k {:allocator (ig/ref :xtdb/allocator)
+      :factory factory
+      :metrics-registry (ig/ref :xtdb.metrics/registry)}})
 
 (defmethod ig/init-key ::memory [_ {:keys [allocator ^MemoryCache$Factory factory metrics-registry]}]
   (.open factory allocator metrics-registry))
@@ -27,9 +27,9 @@
                 max-cache-bytes (.maxSizeBytes max-cache-bytes)
                 max-cache-ratio (.maxSizeRatio max-cache-ratio))))
 
-(defmethod ig/prep-key ::disk [_ factory]
-  {:factory factory
-   :metrics-registry (ig/ref :xtdb.metrics/registry)})
+(defmethod ig/expand-key ::disk [k factory]
+  {k {:factory factory
+      :metrics-registry (ig/ref :xtdb.metrics/registry)}})
 
 (defmethod ig/init-key ::disk [_ {:keys [^DiskCache$Factory factory metrics-registry]}]
   (some-> factory (.build metrics-registry)))

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -100,9 +100,9 @@
           (l2h-compaction-jobs table table-tries opts)
           (tiering-compaction-jobs table table-tries opts)))
 
-(defmethod ig/prep-key :xtdb/compactor [_ ^CompactorConfig config]
-  {:threads (.getThreads config)
-   :metrics-registry (ig/ref :xtdb.metrics/registry)})
+(defmethod ig/expand-key :xtdb/compactor [k ^CompactorConfig config]
+  {k {:threads (.getThreads config)
+      :metrics-registry (ig/ref :xtdb.metrics/registry)}})
 
 (def ^:dynamic *page-size* 1024)
 
@@ -127,9 +127,9 @@
 (defmethod ig/halt-key! :xtdb/compactor [_ compactor]
   (util/close compactor))
 
-(defmethod ig/prep-key ::for-db [_ {:keys [base]}]
-  {:base base
-   :query-db (ig/ref :xtdb.db-catalog/for-query)})
+(defmethod ig/expand-key ::for-db [k {:keys [base]}]
+  {k {:base base
+      :query-db (ig/ref :xtdb.db-catalog/for-query)}})
 
 (defmethod ig/init-key ::for-db [_ {{:keys [^Compactor compactor]} :base, :keys [query-db]}]
   (.openForDatabase compactor query-db))

--- a/core/src/main/clojure/xtdb/garbage_collector.clj
+++ b/core/src/main/clojure/xtdb/garbage_collector.clj
@@ -15,12 +15,12 @@
                        garbage-lifetime (.garbageLifetime garbage-lifetime)
                        approx-run-interval (.approxRunInterval approx-run-interval))))
 
-(defmethod ig/prep-key :xtdb/garbage-collector [_ ^GarbageCollectorConfig config]
-  {:db-cat (ig/ref :xtdb/db-catalog)
-   :enabled? (.getEnabled config)
-   :blocks-to-keep (.getBlocksToKeep config)
-   :garbage-lifetime (.getGarbageLifetime config)
-   :approx-run-interval (.getApproxRunInterval config)})
+(defmethod ig/expand-key :xtdb/garbage-collector [k ^GarbageCollectorConfig config]
+  {k {:db-cat (ig/ref :xtdb/db-catalog)
+      :enabled? (.getEnabled config)
+      :blocks-to-keep (.getBlocksToKeep config)
+      :garbage-lifetime (.getGarbageLifetime config)
+      :approx-run-interval (.getApproxRunInterval config)}})
 
 (defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [^Database$Catalog db-cat, enabled? blocks-to-keep garbage-lifetime approx-run-interval]}]
   ;; TODO multi-db

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -115,12 +115,12 @@
                                               (InetAddress/getByName host)))
                 (not= ::absent port) (.port port)))))
 
-(defmethod ig/prep-key :xtdb/healthz [_ ^HealthzConfig config]
-  {:host (.getHost config)
-   :port (.getPort config)
-   :meter-registry (ig/ref :xtdb.metrics/registry)
-   :db-cat (ig/ref :xtdb/db-catalog)
-   :node (ig/ref :xtdb/node)})
+(defmethod ig/expand-key :xtdb/healthz [k ^HealthzConfig config]
+  {k {:host (.getHost config)
+      :port (.getPort config)
+      :meter-registry (ig/ref :xtdb.metrics/registry)
+      :db-cat (ig/ref :xtdb/db-catalog)
+      :node (ig/ref :xtdb/node)}})
 
 (defmethod ig/init-key :xtdb/healthz [_ {:keys [node, ^InetAddress host, ^long port, meter-registry, ^Database$Catalog db-cat]}]
   (let [db (.getPrimary db-cat)

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -613,11 +613,11 @@
 
                (.endStruct doc-writer)))))
 
-(defmethod ig/prep-key :xtdb/indexer [_ opts]
-  (merge {:config (ig/ref :xtdb/config)
-          :q-src (ig/ref ::q/query-source)
-          :metrics-registry (ig/ref :xtdb.metrics/registry)}
-         opts))
+(defmethod ig/expand-key :xtdb/indexer [k opts]
+  {k (merge {:config (ig/ref :xtdb/config)
+             :q-src (ig/ref ::q/query-source)
+             :metrics-registry (ig/ref :xtdb.metrics/registry)}
+            opts)})
 
 (defrecord IndexerForDatabase [^BufferAllocator allocator, node-id, ^IQuerySource q-src
                                ^Database db, ^LiveIndex live-index, table-catalog
@@ -753,9 +753,9 @@
 (defmethod ig/halt-key! :xtdb/indexer [_ indexer]
   (util/close indexer))
 
-(defmethod ig/prep-key ::for-db [_ {:keys [base]}]
-  {:base base
-   :query-db (ig/ref :xtdb.db-catalog/for-query)})
+(defmethod ig/expand-key ::for-db [k {:keys [base]}]
+  {k {:base base
+      :query-db (ig/ref :xtdb.db-catalog/for-query)}})
 
 (defmethod ig/init-key ::for-db [_ {{:keys [^Indexer indexer]} :base,
                                     :keys [query-db]}]

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -204,21 +204,21 @@
       (log/warn "Failed to shut down live-index after 60s due to outstanding watermarks.")
       (util/close allocator))))
 
-(defmethod ig/prep-key :xtdb.indexer/live-index [_ {:keys [base, db-name, ^IndexerConfig indexer-conf]}]
-  {:base base
-   :db-name db-name
+(defmethod ig/expand-key :xtdb.indexer/live-index [k {:keys [base, db-name, ^IndexerConfig indexer-conf]}]
+  {k {:base base
+      :db-name db-name
 
-   :allocator (ig/ref :xtdb.db-catalog/allocator)
-   :buffer-pool (ig/ref :xtdb/buffer-pool)
-   :block-cat (ig/ref :xtdb/block-catalog)
-   :table-cat (ig/ref :xtdb/table-catalog)
-   :log (ig/ref :xtdb/log)
-   :trie-cat (ig/ref :xtdb/trie-catalog)
+      :allocator (ig/ref :xtdb.db-catalog/allocator)
+      :buffer-pool (ig/ref :xtdb/buffer-pool)
+      :block-cat (ig/ref :xtdb/block-catalog)
+      :table-cat (ig/ref :xtdb/table-catalog)
+      :log (ig/ref :xtdb/log)
+      :trie-cat (ig/ref :xtdb/trie-catalog)
 
-   :rows-per-block (.getRowsPerBlock indexer-conf)
-   :log-limit (.getLogLimit indexer-conf)
-   :page-limit (.getPageLimit indexer-conf)
-   :skip-txs (.getSkipTxs indexer-conf)})
+      :rows-per-block (.getRowsPerBlock indexer-conf)
+      :log-limit (.getLogLimit indexer-conf)
+      :page-limit (.getPageLimit indexer-conf)
+      :skip-txs (.getSkipTxs indexer-conf)}})
 
 (defmethod ig/init-key :xtdb.indexer/live-index [_ {{:keys [meter-registry]} :base,
                                                     :keys [allocator, db-name, ^BlockCatalog block-cat, buffer-pool log trie-cat table-cat

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -471,10 +471,10 @@
 
   (table-template [info-schema table-ref]))
 
-(defmethod ig/prep-key :xtdb/information-schema [_ opts]
-  (into {:allocator (ig/ref :xtdb/allocator)
-         :metrics-registry (ig/ref :xtdb.metrics/registry)}
-        opts))
+(defmethod ig/expand-key :xtdb/information-schema [k opts]
+  {k (into {:allocator (ig/ref :xtdb/allocator)
+            :metrics-registry (ig/ref :xtdb.metrics/registry)}
+           opts)})
 
 (defmethod ig/init-key :xtdb/information-schema [_ {:keys [allocator metrics-registry]}]
   (let [pg-user (pg-user-template-page+trie allocator)]

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -280,10 +280,10 @@
 (defmethod xtn/apply-config! :xtdb/log [^Xtdb$Config config _ [tag opts]]
   (.log config (->log-factory tag opts)))
 
-(defmethod ig/prep-key :xtdb/log [_ {:keys [base factory]}]
-  {:base base
-   :block-cat (ig/ref :xtdb/block-catalog)
-   :factory factory})
+(defmethod ig/expand-key :xtdb/log [k {:keys [base factory]}]
+  {k {:base base
+      :block-cat (ig/ref :xtdb/block-catalog)
+      :factory factory}})
 
 (def out-of-sync-log-message
   "Node failed to start due to an invalid transaction log state (%s) that does not correspond with the latest indexed transaction (epoch=%s and offset=%s).
@@ -340,15 +340,15 @@
                                                                                                              :system-time (some-> system-time time/expect-instant))))))]
         (MsgIdUtil/offsetToMsgId (.getEpoch log) (.getLogOffset message-meta))))))
 
-(defmethod ig/prep-key :xtdb.log/processor [_ {:keys [base ^IndexerConfig indexer-conf]}]
-  {:base base
-   :allocator (ig/ref :xtdb.db-catalog/allocator)
-   :db (ig/ref :xtdb.db-catalog/for-query)
-   :indexer (ig/ref :xtdb.indexer/for-db)
-   :compactor (ig/ref :xtdb.compactor/for-db)
-   :block-flush-duration (.getFlushDuration indexer-conf)
-   :skip-txs (.getSkipTxs indexer-conf)
-   :enabled? (.getEnabled indexer-conf)})
+(defmethod ig/expand-key :xtdb.log/processor [k {:keys [base ^IndexerConfig indexer-conf]}]
+  {k {:base base
+      :allocator (ig/ref :xtdb.db-catalog/allocator)
+      :db (ig/ref :xtdb.db-catalog/for-query)
+      :indexer (ig/ref :xtdb.indexer/for-db)
+      :compactor (ig/ref :xtdb.compactor/for-db)
+      :block-flush-duration (.getFlushDuration indexer-conf)
+      :skip-txs (.getSkipTxs indexer-conf)
+      :enabled? (.getEnabled indexer-conf)}})
 
 (defmethod ig/init-key :xtdb.log/processor [_ {{:keys [meter-registry db-catalog]} :base
                                                :keys [allocator db indexer compactor block-flush-duration skip-txs enabled?]}]

--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -4,9 +4,9 @@
   (:import xtdb.storage.BufferPool
            (xtdb.metadata PageMetadata)))
 
-(defmethod ig/prep-key ::metadata-manager [_ _]
-  {:allocator (ig/ref :xtdb.db-catalog/allocator)
-   :buffer-pool (ig/ref :xtdb/buffer-pool)})
+(defmethod ig/expand-key ::metadata-manager [k _]
+  {k {:allocator (ig/ref :xtdb.db-catalog/allocator)
+      :buffer-pool (ig/ref :xtdb/buffer-pool)}})
 
 (defmethod ig/init-key ::metadata-manager [_ {:keys [allocator, ^BufferPool buffer-pool, cache-size], :or {cache-size 128}}]
   (PageMetadata/factory allocator buffer-pool cache-size))

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -58,8 +58,8 @@
   (->> (java.lang.management.ManagementFactory/getPlatformMXBeans java.lang.management.BufferPoolMXBean)
        (some #(when (= (.getName ^java.lang.management.BufferPoolMXBean %) "direct") %))))
 
-(defmethod ig/prep-key ::registry [_ _]
-  {:config (ig/ref :xtdb/config)})
+(defmethod ig/expand-key ::registry [k _]
+  {k {:config (ig/ref :xtdb/config)}})
 
 (defmethod ig/init-key ::registry [_ {{:keys [node-id]} :config}]
   (let [reg (PrometheusMeterRegistry. PrometheusConfig/DEFAULT)]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -164,10 +164,10 @@
         (test [_ path]
           (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
-(defmethod ig/prep-key ::scan-emitter [_ opts]
-  (merge opts
-         {:allocator (ig/ref :xtdb/allocator)
-          :info-schema (ig/ref :xtdb/information-schema)}))
+(defmethod ig/expand-key ::scan-emitter [k opts]
+  {k (merge opts
+            {:allocator (ig/ref :xtdb/allocator)
+             :info-schema (ig/ref :xtdb/information-schema)})})
 
 (defn scan-fields [^Database$Catalog db-catalog, snaps, scan-cols]
   (letfn [(->field [[^TableRef table col-name]]

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1818,11 +1818,11 @@
    :ssl-ctx (when-let [ssl (.getSsl config)]
               (->ssl-ctx (.getKeyStore ssl) (.getKeyStorePassword ssl)))})
 
-(defmethod ig/prep-key ::server [_ config]
-  (into {:node (ig/ref :xtdb/node)
-         :allocator (ig/ref :xtdb/allocator)
-         :metrics-registry (ig/ref :xtdb.metrics/registry)}
-        (<-config config)))
+(defmethod ig/expand-key ::server [k config]
+  {k (into {:node (ig/ref :xtdb/node)
+            :allocator (ig/ref :xtdb/allocator)
+            :metrics-registry (ig/ref :xtdb.metrics/registry)}
+           (<-config config))})
 
 (defmethod ig/init-key ::server [_ {:keys [host node allocator port ro-port] :as opts}]
   (let [opts (dissoc opts :port :ro-port)]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -440,11 +440,11 @@
 
     (util/close allocator)))
 
-(defmethod ig/prep-key ::query-source [_ opts]
-  (merge opts
-         {:allocator (ig/ref :xtdb/allocator)
-          :metrics-registry (ig/ref :xtdb.metrics/registry)
-          :scan-emitter (ig/ref :xtdb.operator.scan/scan-emitter)}))
+(defmethod ig/expand-key ::query-source [k opts]
+  {k (merge opts
+            {:allocator (ig/ref :xtdb/allocator)
+             :metrics-registry (ig/ref :xtdb.metrics/registry)
+             :scan-emitter (ig/ref :xtdb.operator.scan/scan-emitter)})})
 
 (defn ->query-source [{:keys [allocator metrics-registry] :as deps}]
   (let [ref-ctr (RefCounter.)

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -128,9 +128,9 @@
   (getFields [_ table] (get-in table->metadata [table :fields]))
   (getFields [_] (update-vals table->metadata :fields)))
 
-(defmethod ig/prep-key :xtdb/table-catalog [_ _]
-  {:buffer-pool (ig/ref :xtdb/buffer-pool)
-   :block-cat (ig/ref :xtdb/block-catalog)})
+(defmethod ig/expand-key :xtdb/table-catalog [k _]
+  {k {:buffer-pool (ig/ref :xtdb/buffer-pool)
+      :block-cat (ig/ref :xtdb/block-catalog)}})
 
 (defmethod ig/init-key :xtdb/table-catalog [_ {:keys [buffer-pool block-cat]}]
   (let [[block-idx table->table-block] (load-tables-to-metadata buffer-pool block-cat)]

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -356,11 +356,11 @@
                 (fn [_table table-cat]
                   (reset->l0 table-cat))))))
 
-(defmethod ig/prep-key :xtdb/trie-catalog [_ opts]
-  (into {:buffer-pool (ig/ref :xtdb/buffer-pool)
-         :block-cat (ig/ref :xtdb/block-catalog)
-         :table-cat (ig/ref :xtdb/table-catalog)}
-        opts))
+(defmethod ig/expand-key :xtdb/trie-catalog [k opts]
+  {k (into {:buffer-pool (ig/ref :xtdb/buffer-pool)
+            :block-cat (ig/ref :xtdb/block-catalog)
+            :table-cat (ig/ref :xtdb/table-catalog)}
+           opts)})
 
 (defn new-trie-details? [^TrieDetails trie-details]
   (.hasTrieState trie-details))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ transit-clj = { group = "com.cognitect", name = "transit-clj", version.ref = "tr
 transit-java = { group = "com.cognitect", name = "transit-java", version.ref = "transit" }
 next-jdbc = { group = "com.github.seancorfield", name = "next.jdbc", version = "1.3.1048" }
 honeysql = { group = "com.github.seancorfield", name = "honeysql", version = "2.7.1310" }
-integrant = { group = "integrant", name = "integrant", version = "0.13.1" }
+integrant = { group = "integrant", name = "integrant", version = "1.0.1" }
 buddy-hashers = { group = "buddy", name = "buddy-hashers", version = "2.0.167" }
 
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }


### PR DESCRIPTION
Claude did a nice job here, just gave it the changlog and off it went.

Major change is the removal of `ig/prep-key` in favour of `ig/expand-key` which is [recommended in the README](https://github.com/weavejester/integrant?tab=readme-ov-file#replacing-prep)