### PR TITLE
Pass dispatcher into general scope in compactor.

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -145,7 +145,7 @@ interface Compactor : AutoCloseable {
         private val jobCalculator: JobCalculator,
         private val ignoreSignalBlock: Boolean,
         threadCount: Int,
-        dispatcher: CoroutineDispatcher = Dispatchers.Default
+        private val dispatcher: CoroutineDispatcher = Dispatchers.Default
     ) : Compactor {
 
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
@@ -153,7 +153,7 @@ interface Compactor : AutoCloseable {
         override fun openForDatabase(db: IDatabase) = object : ForDatabase {
 
             private val dbJob = Job()
-            private val scope = CoroutineScope(dbJob)
+            private val scope = CoroutineScope(dbJob + dispatcher)
 
             private val trieCatalog = db.trieCatalog
 


### PR DESCRIPTION
The scope in openForDatabase is currently created without a dispatcher passed into it (CoroutineScope(dbJob)), which will default to `Dispatchers.Default` instead of using the test dispatcher - This means the outer loop runs on a real thread pool even when tests provided a DeterministicDispatcher.

We can see this within the logs (though the job should still be being dispatched by the test dispatcher)
```
15:54:34.013 [DefaultDispatcher-worker-1 @outer loop#16] DEBUG xtdb.compactor.Compactor - sending idle
15:54:34.014 [DefaultDispatcher-worker-1 @job: TableRef(dbName=xtdb, schemaName=public, tableName=docs) / l01-rc-b00#19] DEBUG xtdb.compactor.Compactor - compacting 'public/docs' ["l00-rc-b00"] -> l01-rc-b00
15:54:34.014 [DefaultDispatcher-worker-1 @job: TableRef(dbName=xtdb, schemaName=public, tableName=docs) / l01-rc-b00#19] DEBUG xtdb.compactor.Compactor - compacted 'public/docs' -> (l01-rc-b00)
15:54:34.015 [DefaultDispatcher-worker-1 @job: TableRef(dbName=xtdb, schemaName=public, tableName=docs) / l01-rc-b01#20] DEBUG xtdb.compactor.Compactor - compacting 'public/docs' ["l01-rc-b00" "l00-rc-b01"] -> l01-rc-b01
15:54:34.015 [DefaultDispatcher-worker-1 @job: TableRef(dbName=xtdb, schemaName=public, tableName=docs) / l01-rc-b01#20] DEBUG xtdb.compactor.Compactor - compacted 'public/docs' -> (l01-rc-b01)
```

With this, we've ran into some concurrency issues, specifically against compactAll() - this could complete before compaction jobs actually started:
- Outer loop sees no active/available jobs as it's just started, going into the `availableJobs.isEmpty() && queuedJobs.isEmpty() == true` conditional.
- Test calls compactAll(), creating a new promise.
- We're still inside the conditional, the `compactAllPromise` gets mutated, and we IMMEDIATELY complete the promise.
- compactAll() returns before any work is done.
- Test assertions fail since only L0 files present.

Switching this over is likely not the right thing to do - presumably, the above race would still a potential problem against the REAL compactor impl using the default dispatcher, so we would want to keep the split where the compactor impl runs on one thread, is driven by our dispatcher.
