### PR TITLE
closing segment metadatas earlier to avoid them using memory for the entirety of the query

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -283,7 +283,7 @@
                                                                     (cat/current-tries)
                                                                     (cat/filter-tries temporal-bounds))]
                                (.add !segments
-                                     (BufferPoolSegment/open allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+                                     (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
 
                              (when live-table-snap
                                (.add !segments
@@ -294,10 +294,7 @@
                                      (let [[memory-rel trie] (info-schema/table-template info-schema table)]
                                        (MemorySegment. trie memory-rel))))
 
-                             (let [merge-tasks (->> (MergePlanner/plan !segments (->path-pred iid-set))
-                                                    (into [] (keep (fn [^MergeTask mt]
-                                                                     (when-let [pages (trie/filter-pages (.getPages mt) temporal-bounds)]
-                                                                       (MergeTask. pages (.getPath mt)))))))]
+                             (let [merge-tasks (MergePlanner/plan !segments (->path-pred iid-set) #(trie/filter-pages % temporal-bounds))]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds
                                                     temporal-bounds
                                                     !segments (.iterator ^Iterable merge-tasks)

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -8,8 +8,8 @@
            (java.time LocalDate)
            (java.util ArrayList)
            (xtdb.log.proto TrieDetails TrieMetadata TrieState)
-           xtdb.segment.Segment$Page
-           (xtdb.trie MemoryHashTrie MemoryHashTrie$Node MemoryHashTrie$Branch MemoryHashTrie$Leaf Trie Trie$Key)
+           (xtdb.segment Segment$PageMeta)
+           (xtdb.trie MemoryHashTrie MemoryHashTrie$Branch MemoryHashTrie$Leaf MemoryHashTrie$Node Trie Trie$Key)
            (xtdb.util Temporal TemporalBounds TemporalDimension)))
 
 (defn ->trie-details ^TrieDetails
@@ -95,7 +95,7 @@
   ([pages] (filter-pages pages (TemporalBounds.)))
   ([pages ^TemporalBounds query-bounds]
    (let [leaves (ArrayList.)]
-     (loop [[^Segment$Page page & more-pages] pages
+     (loop [[^Segment$PageMeta page & more-pages] pages
             smallest-valid-from Long/MAX_VALUE
             largest-valid-to Long/MIN_VALUE
             smallest-system-from Long/MAX_VALUE
@@ -123,7 +123,7 @@
 
          (when (seq leaves)
            (let [valid-time (TemporalDimension. smallest-valid-from largest-valid-to)]
-             (loop [[^Segment$Page page & more-pages] non-taken-pages]
+             (loop [[^Segment$PageMeta page & more-pages] non-taken-pages]
                (when page
                  (let [temporal-metadata (.getTemporalMetadata page)
                        obj-largest-system-from (.getMaxSystemFrom temporal-metadata)]

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -11,7 +11,7 @@
            [java.util.concurrent ConcurrentHashMap]
            org.roaringbitmap.buffer.ImmutableRoaringBitmap
            xtdb.catalog.BlockCatalog
-           xtdb.segment.Segment$Page
+           (xtdb.segment Segment$PageMeta)
            (xtdb.log.proto TemporalMetadata TrieDetails TrieMetadata)
            (xtdb.storage BufferPool)
            (xtdb.util TemporalBounds)))
@@ -264,7 +264,7 @@
       (.build)))
 
 (defrecord CatalogEntry [^LocalDate recency ^TrieMetadata trie-metadata ^TemporalBounds query-bounds]
-  Segment$Page
+  Segment$PageMeta
   (testMetadata [_]
     (let [min-query-recency (min (.getLower (.getValidTime query-bounds)) (.getLower (.getSystemTime query-bounds)))]
       (if-let [^long recency (and recency (time/instant->micros (time/->instant recency {:default-tz ZoneOffset/UTC})))]

--- a/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
@@ -5,9 +5,10 @@ import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.compactor.resolveSameSystemTimeEvents
-import xtdb.log.proto.TemporalMetadata
 import xtdb.metadata.MetadataPredicate
 import xtdb.metadata.PageMetadata
+import xtdb.segment.Segment.PageMeta
+import xtdb.segment.Segment.PageMeta.Companion.pageMeta
 import xtdb.storage.BufferPool
 import xtdb.table.TableRef
 import xtdb.trie.ArrowHashTrie
@@ -15,16 +16,12 @@ import xtdb.trie.Trie
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.TrieKey
-import xtdb.util.closeOnCatch
-import java.nio.file.Path
-import java.util.function.IntPredicate
 
-class BufferPoolSegment private constructor(
-    al: BufferAllocator, private val bp: BufferPool, override val pageMetadata: PageMetadata,
-    table: TableRef, trieKey: TrieKey, val pageIdxPredicate: IntPredicate?,
+class BufferPoolSegment(
+    al: BufferAllocator, private val bp: BufferPool, private val mm: PageMetadata.Factory,
+    val table: TableRef, val trieKey: TrieKey, val metadataPredicate: MetadataPredicate? = null,
 ) : Segment<ArrowHashTrie.Leaf> {
     val dataFilePath = table.dataFilePath(trieKey)
-    override val trie get() = pageMetadata.trie
     private val resolveSameSystemTimeEvents = Trie.parseKey(trieKey).level == 0L
 
     override val schema: Schema = bp.getFooter(dataFilePath).schema
@@ -32,67 +29,49 @@ class BufferPoolSegment private constructor(
     private val dataRel = Relation(al, schema)
     private var currentDataPageIndex: Int = -1
 
-    inner class Page(
-        private val bp: BufferPool,
-        val dataFilePath: Path, override val schema: Schema,
-        val pageIndex: Int,
-        val pageIdxPredicate: IntPredicate?,
-        override val temporalMetadata: TemporalMetadata,
-        private val resolveSameSystemTimeEvents: Boolean
-    ) : Segment.Page {
+    inner class Metadata(private val pageMetadata: PageMetadata) : Segment.Metadata<ArrowHashTrie.Leaf> {
 
-        private var testMetadata: Boolean? = null
+        override val trie get() = pageMetadata.trie
 
-        override fun testMetadata() =
-            testMetadata ?: (pageIdxPredicate?.test(pageIndex) ?: true).also { testMetadata = it }
+        private val pageIdxPredicate = metadataPredicate?.build(pageMetadata)
 
-        override fun loadDataPage(al: BufferAllocator): RelationReader =
-            if (currentDataPageIndex == pageIndex) dataRel
-            else {
-                currentDataPageIndex = pageIndex
-                bp.getRecordBatch(dataFilePath, pageIndex).use { rb ->
-                    if (resolveSameSystemTimeEvents) {
-                        dataRel.clear()
+        private val pages = arrayOfNulls<PageMeta<ArrowHashTrie.Leaf>>(pageMetadata.pageCount)
 
-                        Relation.fromRecordBatch(al, schema, rb).use { inRel ->
-                            resolveSameSystemTimeEvents(inRel, dataRel)
-                        }
-                    } else {
-                        dataRel.apply { load(rb) }
+        override fun page(leaf: ArrowHashTrie.Leaf): PageMeta<ArrowHashTrie.Leaf> {
+            val dataPageIndex = leaf.dataPageIndex
+
+            return pages[dataPageIndex]
+                ?: pageMeta(
+                    this@BufferPoolSegment, this, leaf,
+                    pageMetadata.temporalMetadata(dataPageIndex)
+                ).also { pages[dataPageIndex] = it }
+        }
+
+        override fun testPage(leaf: ArrowHashTrie.Leaf) = pageIdxPredicate?.test(leaf.dataPageIndex) ?: true
+
+        override fun close() = pageMetadata.close()
+    }
+
+    override fun openMetadata(): Metadata = Metadata(mm.openPageMetadata(table.metaFilePath(trieKey)))
+
+    override fun loadDataPage(al: BufferAllocator, leaf: ArrowHashTrie.Leaf): RelationReader =
+        if (currentDataPageIndex == leaf.dataPageIndex) dataRel
+        else {
+            currentDataPageIndex = leaf.dataPageIndex
+            bp.getRecordBatch(dataFilePath, leaf.dataPageIndex).use { rb ->
+                if (resolveSameSystemTimeEvents) {
+                    dataRel.clear()
+
+                    Relation.fromRecordBatch(al, schema, rb).use { inRel ->
+                        resolveSameSystemTimeEvents(inRel, dataRel)
                     }
+                } else {
+                    dataRel.apply { load(rb) }
                 }
             }
-    }
-
-    private val pages = arrayOfNulls<Page>(pageMetadata.pageCount)
-
-    override fun page(leaf: ArrowHashTrie.Leaf): Page {
-        val dataPageIndex = leaf.dataPageIndex
-
-        return pages[dataPageIndex]
-            ?: Page(
-                bp, dataFilePath, schema, dataPageIndex,
-                pageIdxPredicate, pageMetadata.temporalMetadata(dataPageIndex),
-                resolveSameSystemTimeEvents
-            ).also { pages[dataPageIndex] = it }
-    }
+        }
 
     override fun close() {
         dataRel.close()
-        pageMetadata.close()
-    }
-
-    companion object {
-
-        @JvmStatic
-        @JvmOverloads
-        fun open(
-            al: BufferAllocator, bp: BufferPool, mm: PageMetadata.Factory,
-            table: TableRef, trieKey: TrieKey,
-            metadataPredicate: MetadataPredicate? = null
-        ) =
-            mm.openPageMetadata(table.metaFilePath(trieKey)).closeOnCatch { pm ->
-                BufferPoolSegment(al, bp, pm, table, trieKey, metadataPredicate?.build(pm))
-            }
     }
 }

--- a/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
@@ -3,31 +3,31 @@ package xtdb.segment
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.RelationReader
-import xtdb.log.proto.TemporalMetadata
-import xtdb.metadata.PageMetadata
 import xtdb.metadata.UNBOUND_TEMPORAL_METADATA
+import xtdb.segment.Segment.PageMeta.Companion.pageMeta
+import xtdb.trie.HashTrie
 import xtdb.trie.MemoryHashTrie
 
 /**
  * @param rel NOTE: borrows `rel`, doesn't close it.
  */
-class MemorySegment(override val trie: MemoryHashTrie, val rel: RelationReader) : Segment<MemoryHashTrie.Leaf> {
+class MemorySegment(val trie: MemoryHashTrie, val rel: RelationReader) : Segment<MemoryHashTrie.Leaf> {
     override val schema: Schema get() = rel.schema
 
-    override val pageMetadata: PageMetadata? = null
+    inner class Metadata : Segment.Metadata<MemoryHashTrie.Leaf> {
+        override val trie: HashTrie<MemoryHashTrie.Leaf> get() = this@MemorySegment.trie
 
-    // this one is the exception to the rule - nothing in the Memory class that needs closing,
-    // so DataPage can be an inner object.
-    inner class Page(val leaf: MemoryHashTrie.Leaf) : Segment.Page {
-        override fun testMetadata() = true
-        override val temporalMetadata: TemporalMetadata get() = UNBOUND_TEMPORAL_METADATA
+        override fun page(leaf: MemoryHashTrie.Leaf) =
+            pageMeta(this@MemorySegment, this, leaf, UNBOUND_TEMPORAL_METADATA)
 
-        override val schema: Schema get() = this@MemorySegment.schema
+        override fun testPage(leaf: MemoryHashTrie.Leaf) = true
 
-        override fun loadDataPage(al: BufferAllocator) = rel.select(leaf.mergeSort(trie))
+        override fun close() = Unit
     }
 
-    override fun page(leaf: MemoryHashTrie.Leaf) = Page(leaf)
+    override fun openMetadata(): Metadata = Metadata()
+
+    override fun loadDataPage(al: BufferAllocator, leaf: MemoryHashTrie.Leaf) = rel.select(leaf.mergeSort(trie))
 
     override fun close() = Unit
 }

--- a/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
+++ b/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
@@ -1,57 +1,79 @@
 package xtdb.segment
 
 import com.carrotsearch.hppc.ObjectStack
+import xtdb.segment.Segment.Page
+import xtdb.segment.Segment.PageMeta
 import xtdb.trie.DEFAULT_LEVEL_WIDTH
 import xtdb.trie.HashTrie
 import xtdb.trie.conjPath
+import xtdb.util.safeMap
+import xtdb.util.useAll
 import java.util.function.Predicate
 
 object MergePlanner {
-    private data class SegmentNode<L>(val segment: Segment<L>, val node: HashTrie.Node<L>) {
+    private data class SegmentNode<L>(
+        val segMeta: Segment.Metadata<L>, val node: HashTrie.Node<L>
+    ) {
         val children: List<SegmentNode<L>?>?
-            get() = node.hashChildren?.map { it?.let { SegmentNode(segment, it) } }
+            get() = node.hashChildren?.map { it?.let { SegmentNode(segMeta, it) } }
 
         @Suppress("UNCHECKED_CAST")
-        val page get() = segment.page(node as L)
+        val page get() = segMeta.page(node as L)
     }
 
-    private fun <L> Segment<L>.toSegmentNode() = trie.rootNode?.let { node -> SegmentNode(this, node) }
+    private fun <L> Segment.Metadata<L>.toSegmentNode() = trie.rootNode?.let { node -> SegmentNode(this, node) }
 
     private class WorkTask(val segNodes: List<SegmentNode<*>>, val path: ByteArray)
 
+    @FunctionalInterface
+    fun interface PagesFilter {
+        fun filterPages(pages: List<PageMeta<*>>): List<PageMeta<*>>?
+    }
+
     // IMPORTANT - Tries (i.e. segments) and nodes need to be returned in system time order
     @JvmStatic
-    fun plan(segments: List<Segment<*>>, pathPred: Predicate<ByteArray>?): List<MergeTask> {
-        val result = mutableListOf<MergeTask>()
+    @JvmOverloads
+    fun plan(
+        segments: List<Segment<*>>,
+        pathPred: Predicate<ByteArray>?,
+        filterPages: PagesFilter = PagesFilter { it }
+    ): List<MergeTask> {
+        segments.safeMap { it.openMetadata() }.useAll { segMetas ->
+            val result = mutableListOf<MergeTask>()
 
-        val initialSegNodes = segments.mapNotNull { it.toSegmentNode() }
-        if (initialSegNodes.isEmpty()) return emptyList()
+            val initialSegNodes = segMetas.mapNotNull { it.toSegmentNode() }
+            if (initialSegNodes.isEmpty()) return emptyList()
 
-        val stack = ObjectStack<WorkTask>()
+            val stack = ObjectStack<WorkTask>()
 
-        stack.push(WorkTask(initialSegNodes, ByteArray(0)))
+            stack.push(WorkTask(initialSegNodes, ByteArray(0)))
 
-        while (!stack.isEmpty) {
-            val workTask = stack.pop()
-            val segNodes = workTask.segNodes
-            if (pathPred != null && !pathPred.test(workTask.path)) continue
+            while (!stack.isEmpty) {
+                val workTask = stack.pop()
+                val segNodes = workTask.segNodes
+                if (pathPred != null && !pathPred.test(workTask.path)) continue
 
-            val nodeChildren = segNodes.map { it to it.children }
-            if (nodeChildren.any { (_, children) -> children != null }) {
-                // do these in reverse order so that they're on the stack in path-prefix order
-                for (bucketIdx in (0..<DEFAULT_LEVEL_WIDTH).reversed()) {
-                    val newSegNodes = nodeChildren.mapNotNull { (segNode, children) ->
-                        // children == null iff this is a leaf
-                        // children[bucketIdx] is null iff this is a branch but without any values in this bucket.
-                        if (children != null) children[bucketIdx] else segNode
+                val nodeChildren = segNodes.map { it to it.children }
+                if (nodeChildren.any { (_, children) -> children != null }) {
+                    // do these in reverse order so that they're on the stack in path-prefix order
+                    for (bucketIdx in (0..<DEFAULT_LEVEL_WIDTH).reversed()) {
+                        val newSegNodes = nodeChildren.mapNotNull { (segNode, children) ->
+                            // children == null iff this is a leaf
+                            // children[bucketIdx] is null iff this is a branch but without any values in this bucket.
+                            if (children != null) children[bucketIdx] else segNode
+                        }
+
+                        if (newSegNodes.isNotEmpty())
+                            stack.push(WorkTask(newSegNodes, conjPath(workTask.path, bucketIdx.toByte())))
                     }
-
-                    if (newSegNodes.isNotEmpty())
-                        stack.push(WorkTask(newSegNodes, conjPath(workTask.path, bucketIdx.toByte())))
+                } else {
+                    filterPages.filterPages(segNodes.map { it.page })
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.let { filteredPages -> result += MergeTask(filteredPages.map { it.page }, workTask.path) }
                 }
-            } else result += MergeTask(segNodes.map { it.page }, workTask.path)
-        }
+            }
 
-        return result
+            return result
+        }
     }
 }

--- a/core/src/main/kotlin/xtdb/segment/MergeTask.kt
+++ b/core/src/main/kotlin/xtdb/segment/MergeTask.kt
@@ -1,3 +1,3 @@
 package xtdb.segment
 
-class MergeTask(val pages: List<Segment.Page>, val path: ByteArray)
+class MergeTask(val pages: List<Segment.Page<*>>, val path: ByteArray)

--- a/core/src/main/kotlin/xtdb/segment/Segment.kt
+++ b/core/src/main/kotlin/xtdb/segment/Segment.kt
@@ -4,28 +4,51 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.RelationReader
 import xtdb.log.proto.TemporalMetadata
-import xtdb.metadata.PageMetadata
+import xtdb.segment.Segment.Page.Companion.page
 import xtdb.trie.HashTrie
 
 interface Segment<L> : AutoCloseable {
-    val trie: HashTrie<L>
-
     val schema: Schema
 
-    val pageMetadata: PageMetadata?
+    fun openMetadata(): Metadata<L>
 
-    /**
-     * Implementations of DataPage should be able to out-live the related Segment
-     */
-    interface Page {
-        val schema: Schema
+    interface Metadata<L> : AutoCloseable {
+        val trie: HashTrie<L>
 
-        fun testMetadata(): Boolean
-        val temporalMetadata: TemporalMetadata
-
-        fun loadDataPage(al: BufferAllocator): RelationReader
+        fun page(leaf: L): PageMeta<L>
+        fun testPage(leaf: L): Boolean
     }
 
-    fun page(leaf: L): Page
+    interface Page<L> {
 
+        fun loadDataPage(al: BufferAllocator): RelationReader
+
+        companion object {
+            fun <L> page(segment: Segment<L>, leaf: L) = object : Page<L> {
+                override fun loadDataPage(al: BufferAllocator) = segment.loadDataPage(al, leaf)
+            }
+        }
+    }
+
+    interface PageMeta<L> {
+        val page: Page<L>
+        val temporalMetadata: TemporalMetadata
+
+        fun testMetadata(): Boolean
+
+        companion object {
+            fun <L> pageMeta(seg: Segment<L>, meta: Metadata<L>, leaf: L, temporalMetadata: TemporalMetadata) =
+                object : PageMeta<L> {
+                    override val page get() = page(seg, leaf)
+                    override val temporalMetadata get() = temporalMetadata
+
+                    private var testMetadata: Boolean? = null
+
+                    override fun testMetadata() =
+                        testMetadata ?: meta.testPage(leaf).also { testMetadata = it }
+                }
+        }
+    }
+
+    fun loadDataPage(al: BufferAllocator, leaf: L): RelationReader
 }

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -498,12 +498,12 @@
 
               ;; TODO this doseq seems to return nothing, so nothing gets tested?
               (doseq [{:keys [^String trie-key]} (map trie/parse-trie-file-path meta-files)]
-                (util/with-open [page-meta (.openPageMetadata meta-mgr (Trie/metaFilePath table-name trie-key))
-                                 seg (BufferPoolSegment/open tu/*allocator* bp meta-mgr table-name trie-key)]
-                  (doseq [leaf (.getLeaves (.getTrie page-meta))
-                          :let [page (.page seg leaf)]]
-                    (with-open [rel (.loadDataPage page tu/*allocator*)]
-                      (t/is (pos? (.getRowCount rel))))))))))))))
+                (util/with-open [seg (BufferPoolSegment. tu/*allocator* bp meta-mgr table-name trie-key nil)
+                                 seg-meta (.openMetadata seg)]
+                  (doseq [leaf (.getLeaves (.getTrie seg-meta))
+                          :let [page (.page seg-meta leaf)
+                                rel (.loadDataPage (.getPage page) tu/*allocator*)]]
+                    (t/is (pos? (.getRowCount rel)))))))))))))
 
 (t/deftest test-l2-compaction-badly-distributed
   (let [node-dir (util/->path "target/compactor/test-l2-compaction-badly-distributed")]


### PR DESCRIPTION
Previously, we were opening the metadata files for a scan at the start of a query and only closing them with the cursor at the end. When tables have significant metadata, this was leading to higher-than-necessary memory usage.

This was introduced in `c1db9edd1065973c5ff5038c16d9fae28928f3f1` - but we extended the lifetime of both the data rels (intended) and the metadata (unintended), because the two were unnecessarily coupled.

This PR decouples the two, extracting metadata into a separate object that can be closed sooner. Now, metadata is closed as soon as the merge tasks for that scan have been calculated.

We still bring all of the active metadata for a given table into memory at once, which may still lead to memory pressure - we can subsequently investigate only opening metadata files at the point in the IID trie traversal where they're required.