### PR TITLE
add `export-snapshot` CLI tool to export a snapshot of an XT object-store

### DIFF
--- a/core/src/main/clojure/xtdb/export.clj
+++ b/core/src/main/clojure/xtdb/export.clj
@@ -1,0 +1,111 @@
+(ns xtdb.export
+  (:require [clojure.tools.logging :as log]
+            [xtdb.db-catalog :as db]
+            [xtdb.error :as err]
+            [xtdb.node :as xtn]
+            [xtdb.table-catalog :as table-cat]
+            [xtdb.trie-catalog :as trie-cat]
+            [xtdb.util :as util])
+  (:import [java.nio.file Path]
+           (java.time Duration Instant ZoneId)
+           (java.time.format DateTimeFormatter)
+           java.time.temporal.ChronoUnit
+           xtdb.catalog.BlockCatalog
+           (xtdb.database Database)
+           xtdb.api.storage.Storage
+           xtdb.table.TableRef
+           (xtdb.trie Trie)))
+
+(defn- export-dir-path ^java.nio.file.Path [block-idx ^Instant now]
+  (-> (util/->path "exports")
+      (.resolve (format "b%s_%s"
+                        (util/->lex-hex-string block-idx)
+                        (.format (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'")
+                                 (.atZone now (ZoneId/of "UTC")))))))
+
+(defn- all-trie-keys [trie-cat ^TableRef table]
+  (->> (trie-cat/all-tries
+        (trie-cat/trie-state trie-cat table))
+       (into []
+             (comp (filter (comp #{:live :nascent} :state))
+                   (map :trie-key)))))
+
+(defn export-snapshot!
+  ([node-opts db-name] (export-snapshot! node-opts db-name {}))
+
+  ([node-opts db-name {:keys [dry-run?]}]
+   (let [config (doto (xtn/->config node-opts)
+                  (-> (.getCompactor) (.threads 0))
+                  (-> (.getIndexer) (.enabled false))
+                  (.setServer nil))]
+
+     (log/info (str "Starting minimal node to export snapshot of database: " db-name))
+
+     (with-open [node (.open config)]
+       (let [^Database db (or (.databaseOrNull (db/<-node node) db-name)
+                              (throw (err/incorrect ::db-not-found
+                                                    (format "Database not found: '%s'" db-name)
+                                                    {:db-name db-name})))
+             buffer-pool (.getBufferPool db)
+             block-cat (.getBlockCatalog db)
+             trie-cat (.getTrieCatalog db)
+             
+             start-time (Instant/now)]
+
+         (when-let [block-idx (or (.getCurrentBlockIndex block-cat)
+                                  (log/warn "No completed blocks found - aborting."))]
+
+           (let [export-dir (export-dir-path block-idx start-time)
+                 export-root (.resolve export-dir (Storage/storageRoot Storage/VERSION 0))
+                 tables (.getTables trie-cat)]
+
+             (log/infof "Export directory: %s" export-dir)
+             (log/infof "Found %d tables to export" (count tables))
+
+             (let [block-files [(BlockCatalog/blockFilePath block-idx)]
+                   table-block-files (for [^TableRef table tables]
+                                       (-> (Trie/getTablePath table)
+                                           (table-cat/->table-block-metadata-obj-key block-idx)))
+                   trie-files (for [^TableRef table tables
+                                    :let [trie-keys (all-trie-keys trie-cat table)
+                                          _ (log/infof "Table %s: %d active trie files" (pr-str table) (count trie-keys))]
+                                    ^String trie-key trie-keys
+                                    path [(Trie/metaFilePath table trie-key)
+                                          (Trie/dataFilePath table trie-key)]]
+                                path)
+                   files-to-copy (vec (concat block-files table-block-files trie-files))]
+
+               (log/infof "Copying %d block files, %d table-block files, %d trie files (total: %d)"
+                          (count block-files) (count table-block-files) (count trie-files) (count files-to-copy))
+
+               (if dry-run?
+                 (do
+                   (println "DRY RUN: No files will be copied")
+                   (println "Files that would be copied:")
+                   (doseq [src-path files-to-copy]
+                     (println (str src-path))))
+
+                 (do
+                   (log/info "Starting file copy...")
+
+                   (doseq [^Path path files-to-copy]
+                     (try
+                       (let [dest-path (.resolve export-root path)]
+                         (log/debugf "Copying %s -> %s" path dest-path)
+                         (.copyObject buffer-pool path dest-path))
+                       (catch Exception e
+                         (log/errorf e "Failed to copy %s" path)
+                         (throw e))))
+
+                   (log/infof "Export complete! Copied %d files in %s"
+                              (count files-to-copy) (-> (Duration/between start-time (Instant/now))
+                                                        (.truncatedTo ChronoUnit/MILLIS)))
+
+                   (log/infof "Snapshot saved to: %s" export-dir)))
+
+               {:block-idx block-idx
+                :export-time start-time
+                :export-dir export-dir
+                :tables (count tables)
+                :file-count (count files-to-copy)
+                :dry-run? dry-run?}))))))))

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -28,8 +28,9 @@
       (.resolve block-table-metadata-path)))
 
 (defn ->table-block-metadata-obj-key ^java.nio.file.Path [^Path table-path block-idx]
-  (.resolve (.resolve table-path block-table-metadata-path)
-            (format "b%s.binpb" (util/->lex-hex-string block-idx))))
+  (-> table-path
+      (.resolve block-table-metadata-path)
+      (.resolve (format "b%s.binpb" (util/->lex-hex-string block-idx)))))
 
 (defn write-table-block-data ^java.nio.ByteBuffer [^Schema table-schema ^long row-count
                                                    table-tries hlls]

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -27,6 +27,10 @@ class BlockCatalog(private val dbName: DatabaseName, private val bp: BufferPool)
 
     companion object {
         private val blocksPath = "blocks".asPath
+
+        @JvmStatic
+        fun blockFilePath(blockIndex: BlockIndex): Path =
+            blocksPath.resolve("b${blockIndex.asLexHex}.binpb")
     }
 
     private val allBlockFiles get() = bp.listAllObjects(blocksPath).filter { it.key.fileName.extension == "binpb" }
@@ -65,7 +69,7 @@ class BlockCatalog(private val dbName: DatabaseName, private val bp: BufferPool)
             secondaryDatabases?.let { this.secondaryDatabases.putAll(it) }
         }
 
-        bp.putObject(blocksPath.resolve("b${blockIndex.asLexHex}.binpb"), ByteBuffer.wrap(newBlock.toByteArray()))
+        bp.putObject(blockFilePath(blockIndex), ByteBuffer.wrap(newBlock.toByteArray()))
 
         this.latestBlock = newBlock
     }

--- a/docs/src/content/docs/ops/config.md
+++ b/docs/src/content/docs/ops/config.md
@@ -109,31 +109,29 @@ v2.1: top-level commands
 
   Previously, the playground and compact-only nodes were activated using optional flags - `--playground-port` and `--compact-only` respectively.
 
-  `reset-compactor` was also added in v2.1.
+  `reset-compactor` and `export-snapshot` were also added in v2.1.
     
 </details>
 
 You can run various tools by passing arguments - either directly to the CLI or via Docker's arguments:
 
 `node` (default, can be omitted)
-: - `-f <file>`, `--file <file>`: specifies the configuration file
-    to use.
+
+: - `-f <file>`, `--file <file>`: specifies the configuration file to use.
 
 `playground`
-: Starts a playground - an in-memory server that will accept any
-    database name, creating it if required.
 
-    - `-p <port>`, `--port <port>` (default 5432): specifies the port to run the playground server on.
+: Starts a playground - an in-memory server that will accept any database name, creating it if required.
+  - `-p <port>`, `--port <port>` (default 5432): specifies the port to run the playground server on.
 
 `compactor`
-: Starts a compactor-only node - useful for giving the compaction
-    process more compute resources.
 
-    - `-f <file>`, `--file <file>`: specifies the configuration file to use.
+: Starts a compactor-only node - useful for giving the compaction process more compute resources.
+  - `-f <file>`, `--file <file>`: specifies the configuration file to use.
 
-`reset-compactor`
-: Resets the compaction back to L0, deleting any L1+ files - use this
-    if you've encountered a compaction bug and need to reset its state.
+`reset-compactor <db-name>`
+
+: Resets the compaction back to L0, deleting any L1+ files - use this if you've encountered a compaction bug and need to reset its state.
 
     1. Spin down all of your XT nodes
     2. Using your container orchestration tool (e.g.
@@ -147,11 +145,33 @@ You can run various tools by passing arguments - either directly to the CLI or v
 
     At the moment, this can only reset all the way back to L0 -
     finer-grained reset will be added in a later release.
+    
+`export-snapshot <db-name>`
+
+: - `-f <file>`, `--file <file>`: specifies the configuration file to use.
+
+  This exports a snapshot of the object-store into a sibling directory within the object store.
+  e.g. if your storage is at `s3://my-bucket/`, this will export to a directory under `s3://my-bucket/exports/...` - the exact directory will be given in the logs.
+  
+  You can then start another node against this storage directory - you will need to start a new log, and increase the log epoch in your configuration: 
+  
+  ```yaml
+  log: !Kafka
+    ...
+    topic: new-topic
+    epoch: 1
+  storage: !Remote
+    objectStore: !S3
+      bucket: my-bucket
+      prefix: exports/...
+  ```
 
 `read-arrow-file <file>`
+
 : reads an Arrow file and emits it as EDN
 
 `read-arrow-stream-file <file>`
+
 : reads an Arrow 'stream IPC format' file and emits it as EDN
 
 e.g.

--- a/src/test/clojure/xtdb/export_test.clj
+++ b/src/test/clojure/xtdb/export_test.clj
@@ -1,0 +1,76 @@
+(ns xtdb.export-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.compactor :as c]
+            [xtdb.export :as export]
+            [xtdb.node :as xtn]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import [java.nio.file Path]
+           [xtdb.api Xtdb$Config]
+           xtdb.api.log.Log
+           xtdb.api.storage.Storage))
+
+(t/deftest test-export-snapshot
+  (let [node-dir (util/->path "target/export-test")]
+    (util/delete-dir node-dir)
+    (with-open [node (tu/->local-node {:node-dir node-dir
+                                       :rows-per-block 10})]
+      (xt/execute-tx node [[:put-docs :foo {:xt/id 1, :name "Alice", :age 30}]
+                           [:put-docs :foo {:xt/id 2, :name "Bob", :age 25}]
+                           [:put-docs :foo {:xt/id 3, :name "Charlie", :age 35}]
+                           [:put-docs :bar {:xt/id 1, :category "A"}]
+                           [:put-docs :bar {:xt/id 2, :category "B"}]])
+
+      (t/is (= 3 (count (xt/q node "SELECT * FROM foo"))))
+      (t/is (= 2 (count (xt/q node "SELECT * FROM bar"))))
+
+      (tu/flush-block! node))
+
+    ;; compacted files won't be copied because they're not in the block
+    ;; this is to inject some chaos :) 
+    (with-open [node (tu/->local-node {:node-dir node-dir})]
+      (c/compact-all! node #xt/duration "PT1M"))
+
+    (let [{:keys [^Path export-dir tables file-count]} (export/export-snapshot! (doto (Xtdb$Config.)
+                                                                                  (.log (Log/localLog (.resolve node-dir "log")))
+                                                                                  (.storage (Storage/local (.resolve node-dir "objects"))))
+                                                                                "xtdb")]
+
+      (t/is (= 3 tables))
+      (t/is (= 10 file-count))
+
+      (let [export-dir (-> node-dir
+                           (.resolve "objects")
+                           (.resolve (Storage/storageRoot Storage/VERSION 0))
+                           (.resolve export-dir))
+            export-root (-> export-dir
+                            (.resolve (Storage/storageRoot Storage/VERSION 0)))]
+
+        (t/is (.exists (.toFile export-root)))
+        (t/is (.exists (.toFile (.resolve export-root "tables"))))
+        (t/is (.exists (.toFile (.resolve export-root "blocks"))))
+
+        (with-open [export-node (xtn/start-node {:log [:in-memory {:epoch 1}]
+                                                 :storage [:local {:path export-dir}]})]
+
+          (let [foo-results (xt/q export-node "SELECT _id, name, age FROM foo ORDER BY _id")
+                bar-results (xt/q export-node "SELECT _id, category FROM bar ORDER BY _id")]
+
+            (t/is (= [{:xt/id 1, :name "Alice", :age 30}
+                      {:xt/id 2, :name "Bob", :age 25}
+                      {:xt/id 3, :name "Charlie", :age 35}]
+                     foo-results))
+
+            (t/is (= [{:xt/id 1, :category "A"}
+                      {:xt/id 2, :category "B"}]
+                     bar-results))
+
+            (t/is (= [{:xt/id 1, :name "Alice", :category "A"}
+                      {:xt/id 2, :name "Bob", :category "B"}]
+                     (xt/q export-node "SELECT f._id, f.name, b.category
+                                        FROM foo f
+                                        JOIN bar b ON f._id = b._id
+                                        ORDER BY f._id")))))))))
+
+


### PR DESCRIPTION
Quick CLI tool to export a snapshot of an XTDB database out to a sibling directory in its own object store - this directory can then be moved elsewhere and new nodes started.

Similarly to compactor-reset, set the CMD to `export-snapshot -f node-config.yaml <db-name>`, then you should get an `exports/b00_20251031T170000Z` directory in your object store (exact name given in the logs).

Then, start a new log topic on your destination node, and increase the log epoch:

```yaml
log: !Kafka
  ...
  topic: new-topic
  epoch: 1
storage: !Remote
  objectStore: !S3
    bucket: my-bucket
    prefix: exports/...
```