### PR TITLE
Batching contiguous copies

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/Buffers.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Buffers.kt
@@ -78,9 +78,13 @@ internal class ExtensibleBuffer private constructor(private val allocator: Buffe
 
     operator fun set(idx: Int, v: Int) = buf.setInt(idx.toLong() * Int.SIZE_BYTES, v)
 
+    fun unsafeWriteInt(value: Int) {
+        buf.writeInt(value)
+    }
+
     fun writeInt(value: Int) {
         ensureWritable(Int.SIZE_BYTES.toLong())
-        buf.writeInt(value)
+        unsafeWriteInt(value)
     }
 
     fun getLong(idx: Int) = buf.getLong((idx * Long.SIZE_BYTES).toLong())

--- a/core/src/main/kotlin/xtdb/arrow/ConcatVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ConcatVector.kt
@@ -115,7 +115,7 @@ class ConcatVector private constructor(
     override fun rowCopier(dest: VectorWriter): RowCopier {
         val rowCopiers = readers.map { it.rowCopier(dest) }
         return object : RowCopier {
-            override fun copyRow(sourceIdx: Int) = rowCopiers[readerIdx(sourceIdx)].copyRow(sourceIdx)
+            override fun copyRow(srcIdx: Int) = rowCopiers[readerIdx(srcIdx)].copyRow(srcIdx)
 
             override fun copyRange(startIdx: Int, len: Int) {
                 val endIdx = startIdx + len - 1

--- a/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
@@ -47,7 +47,7 @@ class IndirectVector(private val inner: VectorReader, private val sel: VectorInd
     override fun rowCopier(dest: VectorWriter): RowCopier {
         val innerCopier = inner.rowCopier(dest)
         return object : RowCopier {
-            override fun copyRow(sourceIdx: Int) = innerCopier.copyRow(sel[sourceIdx])
+            override fun copyRow(srcIdx: Int) = innerCopier.copyRow(sel[srcIdx])
 
             override fun copyRows(sel: IntArray) {
                 val translatedSel = IntArray(sel.size) { this@IndirectVector.sel[sel[it]] }

--- a/core/src/main/kotlin/xtdb/arrow/RowCopier.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RowCopier.kt
@@ -1,7 +1,7 @@
 package xtdb.arrow
 
 fun interface RowCopier {
-    fun copyRow(sourceIdx: Int)
+    fun copyRow(srcIdx: Int)
 
     fun copyRows(sel: IntArray) = sel.forEach { copyRow(it) }
     fun copyRange(startIdx: Int, len: Int) = repeat(len) { copyRow(startIdx + it) }

--- a/core/src/test/kotlin/xtdb/arrow/BitBufferTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/BitBufferTest.kt
@@ -21,7 +21,7 @@ class BitBufferTest {
     internal fun BitBuffer.writeBoolean(bit: Boolean) = writeBit(if (bit) 1 else 0)
 
     @Test
-    fun testUnsafeCopyFromProps(al: BufferAllocator) = runTest {
+    fun testUnsafeWriteBitsProps(al: BufferAllocator) = runTest {
         data class TestCase(val srcBits: List<Boolean>, val offset: Int, val length: Int, val destBits: List<Boolean>)
 
         checkAll(
@@ -41,7 +41,7 @@ class BitBufferTest {
                 BitBuffer(al, 64).use { dest ->
                     destBits.forEach { dest.writeBoolean(it) }
 
-                    dest.unsafeCopyFrom(srcBuf, offset, len)
+                    dest.unsafeWriteBits(srcBuf, offset, len)
 
                     dest.asBooleans shouldBe (destBits + srcBits.subList(offset, offset + len)).toBooleanArray()
                 }

--- a/core/src/test/kotlin/xtdb/arrow/VariableWidthVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/VariableWidthVectorTest.kt
@@ -1,5 +1,18 @@
 package xtdb.arrow
 
+import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.PropTestConfig
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.nonNegativeInt
+import io.kotest.property.arbitrary.positiveInt
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.internal.decodeStringToJsonTree
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -7,7 +20,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import xtdb.test.AllocatorResolver
+import xtdb.types.Type
+import xtdb.types.Type.Companion.ofType
+import kotlin.random.Random
 
+@ExtendWith(AllocatorResolver::class)
 class VariableWidthVectorTest {
     private lateinit var allocator: BufferAllocator
 
@@ -33,6 +52,42 @@ class VariableWidthVectorTest {
 
                 assertEquals(3, copy.valueCount)
                 assertNull(copy.getObject(1))
+            }
+        }
+    }
+
+    @Test
+    fun `copy rows in batch`(al: BufferAllocator) = runTest {
+        checkAll(Arb.list(Arb.string(), 0..12), Arb.int()) { strs, seed ->
+            val rand = Random(seed)
+            val idxs = (0..<strs.size).shuffled(rand).toIntArray()
+
+            Vector.fromList(al, "foo" ofType Type.UTF8, strs).use { src ->
+                Vector.open(al, src.field).use { dest ->
+                    val copier = src.rowCopier(dest)
+                    copier.copyRows(idxs)
+
+                    dest.asList shouldBe idxs.map { src[it] }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `copy range`(al: BufferAllocator) = runTest {
+        checkAll(arbitrary {
+            val strs = Arb.list(Arb.string(), 1..12).bind()
+            val offset = Arb.nonNegativeInt(strs.size - 1).bind()
+            val len = Arb.nonNegativeInt(strs.size - 1 - offset).bind()
+            Triple(strs, offset, len)
+        }) { (strs, offset, len) ->
+            Vector.fromList(al, "foo" ofType Type.UTF8, strs).use { src ->
+                Vector.open(al, src.field).use { dest ->
+                    val copier = src.rowCopier(dest)
+                    copier.copyRange(offset, len)
+
+                    dest.asList shouldBe (offset..<(offset + len)).map { src[it] }
+                }
             }
         }
     }


### PR DESCRIPTION
see #4931.

This PR extends copyRange and copyRows implementations to FixedWidthVector, VariableWidthVector and RelationReader. Landing this separately from the rest of #4931 because this already makes a significant difference on copy-heavy queries - ~40% on TPC-H Q5 SF1.

There's still more we can do in this area: BitBuffer/unsafeWriteBits, for example, has a relatively slow slow-path - we can likely copy at least a byte at a time here. Even if the bits aren't contiguous in the source, we can pull them all into a byte before we write them, which should reduce the reading/writing by a reasonable margin.