### PR TITLE
Fix: close portals when the connection loop ends unexpectedly.

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1678,6 +1678,7 @@
       (catch InterruptedException _)
 
       (finally
+        (close-all-portals conn)
         (util/close conn)
 
         ;; can be used to co-ordinate waiting for close


### PR DESCRIPTION
Please review test.

While working on #4861 I noticed a warning log message after 1 minute when a node is shut down:
```
Failed to shut down after 60s due to outstanding queries
```
This is caused by connection portals not being freed. Could this cause cursors being leaked when connections are closed abruptly (for example, by an exception or socket closed)? This has been solved by calling `close-portals` whenever the connection loop is finished. (However, there isn't a way right now for tests to check that portals are not leaking).