### PR TITLE
Flattening multiple indirections

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -106,6 +106,12 @@ class DenseUnionVector private constructor(
                 }
         })
 
+        override fun select(idxs: IntArray): VectorReader =
+            inner.select(IntArray(idxs.size) { selIdx -> getOffset(selIdx) })
+
+        override fun select(startIdx: Int, len: Int): VectorReader =
+            select(IntArray(len) { startIdx + it })
+
         override fun openSlice(al: BufferAllocator): VectorReader =
             typeBuffer.openSlice(al).closeOnCatch { typeBuffer ->
                 offsetBuffer.openSlice(al).closeOnCatch { offsetBuffer ->

--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -107,7 +107,7 @@ class DenseUnionVector private constructor(
         })
 
         override fun select(idxs: IntArray): VectorReader =
-            inner.select(IntArray(idxs.size) { selIdx -> getOffset(selIdx) })
+            inner.select(IntArray(idxs.size) { selIdx -> getOffset(idxs[selIdx]) })
 
         override fun select(startIdx: Int, len: Int): VectorReader =
             select(IntArray(len) { startIdx + it })

--- a/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
@@ -25,7 +25,7 @@ sealed class FixedWidthVector : Vector() {
     internal abstract val validityBuffer: BitBuffer
     internal abstract val dataBuffer: ExtensibleBuffer
 
-    final override fun isNull(idx: Int) = !validityBuffer.getBit(idx)
+    final override fun isNull(idx: Int) = nullable && !validityBuffer.getBit(idx)
 
     final override fun writeUndefined() {
         validityBuffer.writeBit(valueCount++, 0)

--- a/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.memory.util.ArrowBufPointer
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.FieldType
 import xtdb.api.query.IKeyFn
+import xtdb.arrow.VectorIndirection.Companion.selection
 import xtdb.util.Hasher
 import java.nio.ByteBuffer
 
@@ -43,6 +44,12 @@ class IndirectVector(private val inner: VectorReader, private val sel: VectorInd
     override fun hashCode(idx: Int, hasher: Hasher) = inner.hashCode(sel[idx], hasher)
 
     override fun openSlice(al: BufferAllocator) = IndirectVector(inner.openSlice(al), sel)
+
+    override fun select(idxs: IntArray): VectorReader =
+        IndirectVector(inner, selection(sel.select(idxs)))
+
+    override fun select(startIdx: Int, len: Int): VectorReader =
+        IndirectVector(inner, selection(sel.select(startIdx, len)))
 
     override fun rowCopier(dest: VectorWriter): RowCopier {
         val innerCopier = inner.rowCopier(dest)

--- a/core/src/main/kotlin/xtdb/arrow/VariableWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VariableWidthVector.kt
@@ -59,7 +59,7 @@ abstract class VariableWidthVector : Vector() {
         return ByteArray(buf.remaining()).also { buf.duplicate().get(it) }
     }
 
-    override fun hashCode0(idx: Int, hasher: Hasher) = hasher.hash(getByteArray(idx))
+    override fun hashCode0(idx: Int, hasher: Hasher) = hasher.hash(getBytes(idx))
 
     override fun rowCopier0(src: VectorReader): RowCopier {
         check(src is VariableWidthVector)

--- a/core/src/main/kotlin/xtdb/arrow/VectorIndirection.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorIndirection.kt
@@ -7,23 +7,19 @@ interface VectorIndirection {
 
     operator fun get(idx: Int): Int = getIndex(idx)
 
+    fun select(idxs: IntArray) = IntArray(idxs.size) { getIndex(idxs[it]) }
+    fun select(startIdx: Int, len: Int) = IntArray(len) { getIndex(startIdx + it) }
+
     companion object {
         @JvmStatic
         fun selection(idxs: IntArray): VectorIndirection = Selection(idxs)
 
         internal data class Selection(val idxs: IntArray) : VectorIndirection {
-            override fun valueCount(): Int {
-                return idxs.size
-            }
+            override fun valueCount(): Int = idxs.size
 
-            override fun getIndex(idx: Int): Int {
-                return idxs[idx]
-            }
+            override fun getIndex(idx: Int): Int = idxs[idx]
 
-            override fun toString(): String {
-                val idxs = idxs.contentToString()
-                return "(Selection {idxs=$idxs})"
-            }
+            override fun toString(): String = "(Selection {idxs=${this.idxs.contentToString()}})"
 
             override fun equals(other: Any?) = when {
                 this === other -> true
@@ -35,16 +31,11 @@ interface VectorIndirection {
         }
 
         @JvmStatic
-        fun slice(startIdx: Int, len: Int) : VectorIndirection = Slice(startIdx, len)
+        fun slice(startIdx: Int, len: Int): VectorIndirection = Slice(startIdx, len)
 
         internal data class Slice(val startIdx: Int, val len: Int) : VectorIndirection {
-            override fun valueCount(): Int {
-                return len
-            }
-
-            override fun getIndex(idx: Int): Int {
-                return startIdx + idx
-            }
+            override fun valueCount(): Int = len
+            override fun getIndex(idx: Int): Int = startIdx + idx
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/expression/map/IndexHasher.kt
+++ b/core/src/main/kotlin/xtdb/expression/map/IndexHasher.kt
@@ -10,13 +10,14 @@ import xtdb.util.Hasher
 class IndexHasher(private val rel: RelationReader, private val hashCols: List<VectorReader>) {
     private val hasher = Hasher.Xx()
 
-    fun hashCode(index: Int): Int =
-        hashCols.foldRight(0) { col, acc ->
-            MurmurHasher.combineHashCode(
-                acc,
-                col.hashCode(index, hasher)
-            )
-        }
+    fun hashCode(index: Int): Int {
+        var acc = 0
+
+        for (col in hashCols)
+            acc = MurmurHasher.combineHashCode(acc, col.hashCode(index, hasher))
+
+        return acc
+    }
 
     fun writeAllHashes(hashCol: VectorWriter) {
         hashCol.clear()


### PR DESCRIPTION
Again, guided by the profile, we're spending a lot of time resolving indirections on a row-by-row basis.

This PR:
- removes the initial DUV indirection that comes from pulling the 'put' vector - as soon as we select on that leg, we know that it's only put values, and so we can jump out of the DUV indirection
- ensures that when we call 'select' on an indirect vector, we eagerly resolve the two indirections s.t. we've only got one.