### PR TITLE
MemoryCache.get → suspend

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -294,7 +294,7 @@
                                      (let [[memory-rel trie] (info-schema/table-template info-schema table)]
                                        (MemorySegment. trie memory-rel))))
 
-                             (let [merge-tasks (MergePlanner/plan !segments (->path-pred iid-set) #(trie/filter-pages % temporal-bounds))]
+                             (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % temporal-bounds))]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds
                                                     temporal-bounds
                                                     !segments (.iterator ^Iterable merge-tasks)

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -52,7 +52,7 @@ interface Compactor : AutoCloseable {
     fun openForDatabase(db: IDatabase): ForDatabase
 
     interface Driver : AutoCloseable {
-        fun executeJob(job: Job): TriesAdded
+        suspend fun executeJob(job: Job): TriesAdded
         suspend fun appendMessage(triesAdded: TriesAdded): Log.MessageMetadata
 
         interface Factory {
@@ -86,7 +86,7 @@ interface Compactor : AutoCloseable {
                                 .setTrieMetadata(trieMetadata)
                                 .build()
 
-                        override fun executeJob(job: Job): TriesAdded =
+                        override suspend fun executeJob(job: Job): TriesAdded =
                             try {
                                 job.trieKeys.map { BufferPoolSegment(al, bp, mm, job.table, it) }.useAll { segs ->
                                     val recencyPartitioning =

--- a/core/src/main/kotlin/xtdb/metadata/PageMetadata.kt
+++ b/core/src/main/kotlin/xtdb/metadata/PageMetadata.kt
@@ -4,6 +4,7 @@ import com.carrotsearch.hppc.ObjectIntHashMap
 import com.carrotsearch.hppc.ObjectIntMap
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.storage.BufferPool
 import xtdb.arrow.Relation
@@ -133,7 +134,9 @@ class PageMetadata private constructor(private val rel: Relation, private val pa
 
         private val al = al.openChildAllocator("metadata-mgr")
 
-        fun openPageMetadata(metaFilePath: Path): PageMetadata =
+        fun openPageMetadataSync(metaFilePath: Path): PageMetadata = runBlocking { openPageMetadata(metaFilePath) }
+
+        suspend fun openPageMetadata(metaFilePath: Path): PageMetadata =
             bp.getRecordBatch(metaFilePath, 0).use { rb ->
                 val footer = bp.getFooter(metaFilePath)
                 Relation.fromRecordBatch(al, footer.schema, rb).closeOnCatch { rel ->

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -1,5 +1,6 @@
 package xtdb.operator.scan
 
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.util.ArrowBufPointer
 import xtdb.ICursor
@@ -49,7 +50,8 @@ class ScanCursor(
             val mergeQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.comparator()))
             val polygonCalculator = PolygonCalculator(temporalBounds)
 
-            val loadedPages = task.pages.map { it.loadDataPage(al) }
+            // we're not in coroutine land here, so it's a good boundary for runBlocking
+            val loadedPages = runBlocking { task.pages.map { it.loadDataPage(al) } }
 
             val leafReaders = loadedPages.map { it.maybeSelect(iidPred, taskPath) }
 

--- a/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
@@ -55,9 +55,9 @@ class BufferPoolSegment(
         override fun close() = pageMetadata.close()
     }
 
-    override fun openMetadata(): Metadata = Metadata(mm.openPageMetadata(table.metaFilePath(trieKey)))
+    override suspend fun openMetadata(): Metadata = Metadata(mm.openPageMetadata(table.metaFilePath(trieKey)))
 
-    override fun loadDataPage(al: BufferAllocator, leaf: ArrowHashTrie.Leaf): RelationReader =
+    override suspend fun loadDataPage(al: BufferAllocator, leaf: ArrowHashTrie.Leaf): RelationReader =
         if (currentDataPageIndex == leaf.dataPageIndex) dataRel
         else {
             currentDataPageIndex = leaf.dataPageIndex

--- a/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
@@ -27,9 +27,9 @@ class MemorySegment(val trie: MemoryHashTrie, val rel: RelationReader) : Segment
         override fun close() = Unit
     }
 
-    override fun openMetadata(): Metadata = Metadata()
+    override suspend fun openMetadata(): Metadata = Metadata()
 
-    override fun loadDataPage(al: BufferAllocator, leaf: MemoryHashTrie.Leaf) = rel.select(leaf.mergeSort(trie))
+    override suspend fun loadDataPage(al: BufferAllocator, leaf: MemoryHashTrie.Leaf) = rel.select(leaf.mergeSort(trie))
 
     override fun close() = Unit
 }

--- a/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
+++ b/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
@@ -1,6 +1,7 @@
 package xtdb.segment
 
 import com.carrotsearch.hppc.ObjectStack
+import kotlinx.coroutines.runBlocking
 import xtdb.segment.Segment.PageMeta
 import xtdb.trie.DEFAULT_LEVEL_WIDTH
 import xtdb.trie.HashTrie
@@ -29,10 +30,15 @@ object MergePlanner {
         fun filterPages(pages: List<PageMeta<*>>): List<PageMeta<*>>?
     }
 
-    // IMPORTANT - Tries (i.e. segments) and nodes need to be returned in system time order
     @JvmStatic
-    @JvmOverloads
-    fun plan(
+    fun planSync(
+        segments: List<Segment<*>>,
+        pathPred: Predicate<ByteArray>?,
+        filterPages: PagesFilter = PagesFilter { it }
+    ) = runBlocking { plan(segments, pathPred, filterPages) }
+
+    // IMPORTANT - Tries (i.e. segments) and nodes need to be returned in system time order
+    suspend fun plan(
         segments: List<Segment<*>>,
         pathPred: Predicate<ByteArray>?,
         filterPages: PagesFilter = PagesFilter { it }

--- a/core/src/main/kotlin/xtdb/segment/Segment.kt
+++ b/core/src/main/kotlin/xtdb/segment/Segment.kt
@@ -1,5 +1,6 @@
 package xtdb.segment
 
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.RelationReader
@@ -12,7 +13,8 @@ interface Segment<L> : AutoCloseable {
 
     val schema: Schema
 
-    fun openMetadata(): Metadata<L>
+    fun openMetadataSync(): Metadata<L> = runBlocking { openMetadata() }
+    suspend fun openMetadata(): Metadata<L>
 
     interface Metadata<L> : AutoCloseable {
         val trie: HashTrie<L>
@@ -23,11 +25,11 @@ interface Segment<L> : AutoCloseable {
 
     interface Page<L> {
 
-        fun loadDataPage(al: BufferAllocator): RelationReader
+        suspend fun loadDataPage(al: BufferAllocator): RelationReader
 
         companion object {
             fun <L> page(segment: Segment<L>, leaf: L) = object : Page<L> {
-                override fun loadDataPage(al: BufferAllocator) = segment.loadDataPage(al, leaf)
+                override suspend fun loadDataPage(al: BufferAllocator) = segment.loadDataPage(al, leaf)
             }
         }
     }
@@ -52,5 +54,5 @@ interface Segment<L> : AutoCloseable {
         }
     }
 
-    fun loadDataPage(al: BufferAllocator, leaf: L): RelationReader
+    suspend fun loadDataPage(al: BufferAllocator, leaf: L): RelationReader
 }

--- a/core/src/main/kotlin/xtdb/storage/BufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/BufferPool.kt
@@ -1,6 +1,7 @@
 package xtdb.storage
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.vector.ipc.message.ArrowFooter
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import xtdb.ArrowWriter
@@ -39,7 +40,9 @@ sealed interface BufferPool : AutoCloseable {
      *
      * Throws if not an arrow file or the record batch is out of bounds.
      */
-    fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch
+    fun getRecordBatchSync(key: Path, idx: Int): ArrowRecordBatch = runBlocking { getRecordBatch(key, idx) }
+
+    suspend fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch
 
     fun putObject(key: Path, buffer: ByteBuffer)
 
@@ -71,7 +74,7 @@ sealed interface BufferPool : AutoCloseable {
             override val epoch: StorageEpoch get() = unsupported("epoch")
             override fun getByteArray(key: Path) = unsupported("getByteArray")
             override fun getFooter(key: Path) = unsupported("getFooter")
-            override fun getRecordBatch(key: Path, idx: Int) = unsupported("getRecordBatch")
+            override suspend fun getRecordBatch(key: Path, idx: Int) = unsupported("getRecordBatch")
             override fun putObject(key: Path, buffer: ByteBuffer) = unsupported("putObject")
             override fun listAllObjects() = unsupported("listAllObjects")
             override fun listAllObjects(dir: Path) = unsupported("listAllObjects")

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -46,7 +46,7 @@ internal class MemoryStorage(
     override fun getFooter(key: Path): ArrowFooter =
         (memoryStore.lockAndGet(key) ?: throw objectMissingException(key)).readArrowFooter()
 
-    override fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch {
+    override suspend fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch {
         try {
             val arrowBuf = memoryStore.lockAndGet(key) ?: throw objectMissingException(key)
 

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -117,7 +117,7 @@ class MockDriver(
             return Pair(size * part1 / 100, size * part2 / 100)
         }
 
-        override fun executeJob(job: Job): TriesAdded {
+        override suspend fun executeJob(job: Job): TriesAdded {
             val trieKey = job.outputTrieKey
             val trieDetailsBuilder = TrieDetails.newBuilder()
                 .setTableName(job.table.tableName)

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -1,5 +1,6 @@
 package xtdb.storage
 
+import kotlinx.coroutines.test.runTest
 import com.google.protobuf.Any as ProtoAny
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Field
@@ -60,7 +61,7 @@ class RemoteStorageTest : StorageTest() {
 
 
     @Test
-    fun arrowIpcTest(al: BufferAllocator) {
+    fun arrowIpcTest(al: BufferAllocator) = runTest {
         val path = Path.of("aw")
         Relation(al, "a" ofType Type.I32).use { relation ->
             remoteBufferPool.openArrowWriter(path, relation).use { writer ->

--- a/src/test/clojure/xtdb/compactor/segment_merge_test.clj
+++ b/src/test/clojure/xtdb/compactor/segment_merge_test.clj
@@ -36,7 +36,7 @@
                       (MemorySegment. (.compactLogs (.getLiveTrie lt1)) live-rel1)]]
 
         (t/testing "merge segments"
-          (util/with-open [results (.mergeSegments seg-merge segments nil (SegmentMerge$RecencyPartitioning$Preserve. nil))]
+          (util/with-open [results (.mergeSegmentsSync seg-merge segments nil (SegmentMerge$RecencyPartitioning$Preserve. nil))]
             (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
                         :xt/system-from #xt/zdt "2023-01-01Z[UTC]"
                         :xt/valid-from #xt/zdt "2023-01-01Z[UTC]"
@@ -74,7 +74,7 @@
                               (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
 
         (t/testing "merge segments with path predicate"
-          (util/with-open [results (.mergeSegments seg-merge segments (byte-array [2]) (SegmentMerge$RecencyPartitioning$Preserve. nil))]
+          (util/with-open [results (.mergeSegmentsSync seg-merge segments (byte-array [2]) (SegmentMerge$RecencyPartitioning$Preserve. nil))]
             (t/is (= [[{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
                         :xt/system-from (time/->zdt #inst "2023")
                         :xt/valid-from (time/->zdt #inst "2023")
@@ -97,7 +97,7 @@
                               (mapv #(update % :xt/iid (comp util/byte-buffer->uuid ByteBuffer/wrap))))))))))
 
         (t/testing "merge segments partitioning by recency"
-          (util/with-open [results (.mergeSegments seg-merge segments nil SegmentMerge$RecencyPartitioning$Partition/INSTANCE)]
+          (util/with-open [results (.mergeSegmentsSync seg-merge segments nil SegmentMerge$RecencyPartitioning$Partition/INSTANCE)]
             (t/is (= {"r20210104.arrow" [{:xt/iid #uuid "9e3f856e-6899-8313-827f-f18dd4d88e78",
                                           :xt/system-from (time/->zdt #inst "2020")
                                           :xt/valid-from (time/->zdt #inst "2020")

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -525,7 +525,7 @@
               ;; TODO this doseq seems to return nothing, so nothing gets tested?
               (doseq [{:keys [^String trie-key]} (map trie/parse-trie-file-path meta-files)]
                 (util/with-open [seg (BufferPoolSegment. tu/*allocator* bp meta-mgr table-name trie-key nil)
-                                 seg-meta (.openMetadata seg)]
+                                 seg-meta (.openMetadataSync seg)]
                   (doseq [leaf (.getLeaves (.getTrie seg-meta))
                           :let [page (.page seg-meta leaf)
                                 rel (.loadDataPage (.getPage page) tu/*allocator*)]]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -652,7 +652,7 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
 
           (let [live-table-tx-path (util/->path (format "crashes/%s/1970-01-01T00:00:00Z/live-table-tx.arrow" node-id))
                 footer (.getFooter bp live-table-tx-path)]
-            (with-open [rb (.getRecordBatch bp live-table-tx-path 0)
+            (with-open [rb (.getRecordBatchSync bp live-table-tx-path 0)
                         rel (Relation/fromRecordBatch al (.getSchema footer) rb)]
               (t/is (= [{:xt/system-from (time/->zdt #inst "2020"),
                          :xt/valid-from (time/->zdt #inst "2020"),
@@ -667,7 +667,7 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
 
           (let [query-rel-path (util/->path (format "crashes/%s/1970-01-01T00:00:00Z/query-rel.arrow" node-id))
                 footer (.getFooter bp query-rel-path)]
-            (with-open [rb (.getRecordBatch bp query-rel-path 0)
+            (with-open [rb (.getRecordBatchSync bp query-rel-path 0)
                         rel (Relation/fromRecordBatch al (.getSchema footer) rb)]
               (t/is (= [{:foo "bar", :baz 32}, {:foo "baz", :baz 64}]
                        (->> (.getAsMaps rel)
@@ -675,7 +675,7 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
 
           (let [tx-ops-path (util/->path (format "crashes/%s/1970-01-01T00:00:00Z/tx-ops.arrow" node-id))
                 footer (.getFooter bp tx-ops-path)]
-            (with-open [rb (.getRecordBatch bp tx-ops-path 0)
+            (with-open [rb (.getRecordBatchSync bp tx-ops-path 0)
                         rel (Relation/fromRecordBatch al (.getSchema footer) rb)]
               (t/is (= [[{"_id" 3, "version" 0}] [{"_id" 4, "version" 0}]]
                        (-> (.vectorFor rel "$data$")

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -133,7 +133,7 @@
 
         (t/testing "L0"
           (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
-            (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+            (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
               (t/is (= 4 (.rowIndex page-metadata "_id" 0)))
 
               (let [page-idx-pred (.build literal-selector page-metadata)]
@@ -142,7 +142,7 @@
 
         (t/testing "L1"
           (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
-            (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+            (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
               (let [page-idx-pred (.build literal-selector page-metadata)]
                 (doseq [page-idx relevant-pages]
                   (t/is (true? (.test page-idx-pred page-idx))
@@ -156,7 +156,7 @@
 
   (let [metadata-mgr (.getMetadataManager (db/primary-db tu/*node*))
         meta-file-path (Trie/metaFilePath "public$xt_docs" ^String (trie/->l0-trie-key 0))]
-    (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+    (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
       (let [sys-time-micros (time/instant->micros #xt/instant "2020-01-01T00:00:00.000000Z")
             temporal-metadata (tu/->temporal-metadata sys-time-micros Long/MAX_VALUE sys-time-micros sys-time-micros)]
         (t/is (= temporal-metadata (.temporalMetadata page-metadata 0)))))))
@@ -170,7 +170,7 @@
 
     (t/testing "L0"
       (let [meta-file-path (Trie/metaFilePath "public$xt_docs" ^String (trie/->l0-trie-key 0))]
-        (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+        (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
           (let [page-idx-pred (.build true-selector page-metadata)]
             (t/is (= 5 (.rowIndex page-metadata "boolean_or_int" 0)))
 
@@ -180,7 +180,7 @@
 
     (t/testing "L1"
       (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
-        (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+        (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
           (let [page-idx-pred (.build true-selector page-metadata)]
             (t/is (= 5 (.rowIndex page-metadata "boolean_or_int" 0)))
 
@@ -205,12 +205,12 @@
         (let [metadata-mgr (.getMetadataManager (db/primary-db node))]
           (t/testing "L0"
             (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
-              (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+              (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                 (t/is (= 6 (.rowIndex page-metadata "colours" 0))))))
 
           (t/testing "L1"
             (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
-              (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+              (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                 (t/is (= 6 (.rowIndex page-metadata "colours" 0)))))))))))
 
 (t/deftest test-duration-metadata-4198
@@ -234,7 +234,7 @@
                                  #"l01.*")
 
         (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
-          (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+          (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
             (t/is (= 5 (.rowIndex page-metadata "duration" 0)))))))))
 
 (t/deftest test-missing-type-metadata-4665
@@ -270,7 +270,7 @@
 
             (t/testing "L0 metadata pred"
               (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
-                (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+                (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                   (let [page-idx-pred (.build not-null-selector page-metadata)]
                     ;; Pages with user1 and user2 (nulls) should be filtered out
                     (t/is (false? (.test page-idx-pred 0)))

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -20,7 +20,7 @@
 
 (defn with-page-metadata [node meta-file-path f]
   (let [metadata-mgr (.getMetadataManager (db/primary-db node))]
-    (util/with-open [page-metadata (.openPageMetadata metadata-mgr meta-file-path)]
+    (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
       (f page-metadata))))
 
 (t/deftest test-find-gt-ivan

--- a/src/test/kotlin/xtdb/segment/MergePlannerTest.kt
+++ b/src/test/kotlin/xtdb/segment/MergePlannerTest.kt
@@ -3,6 +3,7 @@ package xtdb.segment
 import com.carrotsearch.hppc.ByteArrayList
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import xtdb.segment.MergePlannerTest.RenderedMergeTask.Companion.page
 import xtdb.segment.MergePlannerTest.RenderedMergeTask.Companion.path
@@ -36,7 +37,7 @@ class MergePlannerTest {
     }
 
     @Test
-    fun `test merge plan with null nodes #2700`() {
+    fun `test merge plan with null nodes #2700`() = runTest {
         withClue("part 1") {
             val t1 = seg("t1", b(b(null, l(0), null, l(1)), l(2), null, l(3)))
             val log = seg("log", l(0))

--- a/src/test/kotlin/xtdb/segment/TestSegment.kt
+++ b/src/test/kotlin/xtdb/segment/TestSegment.kt
@@ -8,23 +8,22 @@ class TestSegment(val name: String, val trie: TestTrie) : Segment<TestTrie.Leaf>
     override val schema: Schema get() = error("schema")
 
     class Page(val name: String, val pageIdx: Int) : Segment.Page<TestTrie.Leaf>, Segment.PageMeta<TestTrie.Leaf> {
-        override fun loadDataPage(al: BufferAllocator) = error("loadDataPage")
+        override suspend fun loadDataPage(al: BufferAllocator) = error("loadDataPage")
         override val page: Segment.Page<TestTrie.Leaf> get() = this
         override val temporalMetadata get() = error("temporalMetadata")
         override fun testMetadata() = error("testMetadata")
     }
 
-    override fun openMetadata() = object : Segment.Metadata<TestTrie.Leaf> {
+    override suspend fun openMetadata() = object : Segment.Metadata<TestTrie.Leaf> {
         override val trie = this@TestSegment.trie
 
         override fun page(leaf: TestTrie.Leaf) = Page(name, leaf.pageIdx)
 
         override fun testPage(leaf: TestTrie.Leaf) = error("testPage")
         override fun close() = Unit
-
     }
 
-    override fun loadDataPage(al: BufferAllocator, leaf: TestTrie.Leaf) = error("loadDataPage")
+    override suspend fun loadDataPage(al: BufferAllocator, leaf: TestTrie.Leaf) = error("loadDataPage")
     override fun close() = Unit
 
     companion object {


### PR DESCRIPTION
so that we can DST it.

related to #4938 - subsequent PR will fix that one.

tl;dr here is that this change then propagates out through the codebase:

- In Kotlin, generally fine - because we add `suspend` to most of the callers.
- I've used `runBlocking` in the ScanCursor because that never runs in a coroutine (the query engine doesn't use them)
- Where Clojure code was calling these functions (in tests) I've added `fooSync` calls - so `suspend fun foo(...)`, then `fun fooSync(...) = runBlocking { foo() }`.