### PR TITLE
ADBC implementation

### DIFF
--- a/modules/adbc/build.gradle.kts
+++ b/modules/adbc/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `java-library`
+    alias(libs.plugins.clojurephant)
+    `maven-publish`
+    signing
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.dokka)
+}
+
+ext {
+    set("labs", true)
+}
+
+publishing {
+    publications.create("maven", MavenPublication::class) {
+        pom {
+            name.set("XTDB ADBC Driver")
+            description.set("In-process ADBC driver for XTDB")
+        }
+    }
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    api(project(":xtdb-api"))
+    api(project(":xtdb-core"))
+
+    api("org.apache.arrow", "arrow-vector", "15.0.2")
+    api(libs.arrow.adbc)
+
+    api(kotlin("stdlib"))
+
+    testImplementation(testFixtures(project(":")))
+}

--- a/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -1,0 +1,26 @@
+package xtdb.adbc
+
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcException
+import org.apache.arrow.adbc.core.AdbcStatement
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.ipc.ArrowReader
+import xtdb.api.Xtdb
+
+class XtdbConnection(
+    private val allocator: BufferAllocator,
+    private val node: Xtdb
+) : AdbcConnection {
+
+    override fun createStatement(): AdbcStatement {
+        return XtdbStatement(allocator, node)
+    }
+
+    override fun getInfo(infoCodes: IntArray?): ArrowReader {
+        throw AdbcException.notImplemented("getInfo")
+    }
+
+    override fun close() {
+        // Connection lifecycle is managed externally
+    }
+}

--- a/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbDatabase.kt
+++ b/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbDatabase.kt
@@ -1,0 +1,22 @@
+package xtdb.adbc
+
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.adbc.core.AdbcException
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.Xtdb
+
+class XtdbDatabase(
+    private val allocator: BufferAllocator,
+    private val node: Xtdb
+) : AdbcDatabase {
+
+    override fun connect(): AdbcConnection {
+        return XtdbConnection(allocator, node)
+    }
+
+    override fun close() {
+        // Database lifecycle is managed externally
+        // The node should not be closed by the ADBC driver
+    }
+}

--- a/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbDriver.kt
+++ b/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbDriver.kt
@@ -1,0 +1,21 @@
+package xtdb.adbc
+
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.adbc.core.AdbcDriver
+import org.apache.arrow.adbc.core.AdbcException
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.Xtdb
+
+class XtdbDriver(private val allocator: BufferAllocator) : AdbcDriver {
+
+    companion object {
+        const val PARAM_XTDB_NODE = "xtdb.node"
+    }
+
+    override fun open(parameters: MutableMap<String, Any>?): AdbcDatabase {
+        val node = parameters?.get(PARAM_XTDB_NODE) as? Xtdb
+            ?: throw IllegalArgumentException("Missing required parameter: $PARAM_XTDB_NODE")
+
+        return XtdbDatabase(allocator, node)
+    }
+}

--- a/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbStatement.kt
+++ b/modules/adbc/src/main/kotlin/xtdb/adbc/XtdbStatement.kt
@@ -1,0 +1,158 @@
+package xtdb.adbc
+
+import clojure.lang.ILookup
+import org.apache.arrow.adbc.core.AdbcStatement
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.VectorLoader
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.types.pojo.Schema
+import xtdb.IResultCursor
+import xtdb.api.Xtdb
+import xtdb.arrow.Relation
+import xtdb.arrow.RelationReader
+import xtdb.database.Database
+import xtdb.query.IQuerySource
+import xtdb.query.PreparedQuery
+
+class XtdbStatement(
+    private val allocator: BufferAllocator,
+    private val node: Xtdb
+) : AdbcStatement {
+
+    private var sqlQuery: String? = null
+    private var preparedQuery: PreparedQuery? = null
+    private var nodeAllocator: BufferAllocator? = null
+    private var boundParams: RelationReader? = null
+
+    override fun setSqlQuery(query: String?) {
+        this.sqlQuery = query
+        this.preparedQuery = null
+    }
+
+    override fun prepare() {
+        val sql = sqlQuery ?: throw IllegalStateException("No SQL query set")
+
+        val nodeMap = node as? ILookup ?: throw IllegalStateException("Node does not support field access")
+
+        nodeAllocator = nodeMap.valAt(clojure.lang.Keyword.intern("allocator")) as? BufferAllocator
+            ?: throw IllegalStateException("Cannot access allocator from node")
+
+        val qSrc = nodeMap.valAt(clojure.lang.Keyword.intern("q-src")) as? IQuerySource
+            ?: throw IllegalStateException("Cannot access query source from node")
+
+        val dbCat = nodeMap.valAt(clojure.lang.Keyword.intern("db-cat")) as? Database.Catalog
+            ?: throw IllegalStateException("Cannot access database catalog from node")
+
+        val opts = clojure.lang.PersistentHashMap.create(
+            clojure.lang.Keyword.intern("default-db"), "xtdb"
+        )
+
+        preparedQuery = qSrc.prepareQuery(sql, dbCat, opts)
+    }
+
+    override fun bind(root: VectorSchemaRoot?) {
+        if (root == null) {
+            boundParams = null
+            return
+        }
+
+        val alloc = nodeAllocator ?: throw IllegalStateException("Statement not prepared")
+
+        // Convert VectorSchemaRoot to a Relation for parameter binding
+        // Note: Relation.fromRoot shares buffers with the root, so we shouldn't close it
+        val paramRel = Relation.fromRoot(alloc, root)
+        boundParams = paramRel
+    }
+
+    override fun executeQuery(): AdbcStatement.QueryResult {
+        val alloc = nodeAllocator ?: run {
+            // If not prepared, prepare now
+            prepare()
+            nodeAllocator!!
+        }
+
+        val pq = preparedQuery ?: run {
+            // If not prepared, do it now
+            prepare()
+            preparedQuery!!
+        }
+
+        // Build options map with parameters if bound
+        val opts = if (boundParams != null) {
+            clojure.lang.PersistentHashMap.create(
+                clojure.lang.Keyword.intern("args"), boundParams
+            )
+        } else {
+            emptyMap<Any, Any>()
+        }
+
+        val cursor: IResultCursor = pq.openQuery(opts)
+        val reader = XtdbArrowReader(alloc, cursor)
+
+        return AdbcStatement.QueryResult(-1, reader)
+    }
+
+    override fun executeUpdate(): AdbcStatement.UpdateResult {
+        executeQuery().use { result ->
+            return AdbcStatement.UpdateResult(-1)
+        }
+    }
+
+    override fun close() {
+        // Don't close boundParams - it shares buffers with the caller's VectorSchemaRoot
+        // which will be closed by the caller
+        preparedQuery = null
+        boundParams = null
+    }
+
+    private class XtdbArrowReader(
+        allocator: BufferAllocator,
+        private val cursor: IResultCursor
+    ) : ArrowReader(allocator) {
+
+        private val vsr: VectorSchemaRoot = VectorSchemaRoot.create(
+            Schema(cursor.resultFields),
+            allocator
+        )
+        private val loader = VectorLoader(vsr)
+
+        override fun loadNextBatch(): Boolean {
+            // Clear vectors from previous batch to prepare for new data
+            vsr.fieldVectors.forEach { it.clear() }
+
+            val loaded = booleanArrayOf(false)
+
+            cursor.tryAdvance { rel ->
+                // Open direct slice with our allocator (shares memory with node)
+                val directSlice = rel.openDirectSlice(allocator)
+                directSlice.use {
+                    val recordBatch = directSlice.openArrowRecordBatch()
+                    recordBatch.use {
+                        // Load batch into VectorSchemaRoot
+                        // This is still a copy, but it's the minimum required
+                        // for ADBC's API which expects VectorSchemaRoot
+                        loader.load(recordBatch)
+                        loaded[0] = true
+                    }
+                }
+            }
+
+            return loaded[0]
+        }
+
+        override fun closeReadSource() {
+            try {
+                vsr.close()
+            } finally {
+                cursor.close()
+            }
+        }
+
+        override fun getVectorSchemaRoot(): VectorSchemaRoot = vsr
+
+        override fun bytesRead(): Long = 0
+
+        override fun readSchema(): Schema = vsr.schema
+    }
+}

--- a/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcPreparedStatementTest.kt
+++ b/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcPreparedStatementTest.kt
@@ -1,0 +1,149 @@
+package xtdb.adbc
+
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import xtdb.api.Xtdb
+import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
+import xtdb.arrow.Relation
+
+class AdbcPreparedStatementTest {
+
+    private lateinit var xtdb: Xtdb
+    private lateinit var al: BufferAllocator
+    private lateinit var db: AdbcDatabase
+    private lateinit var conn: AdbcConnection
+
+    @BeforeEach
+    fun setUp() {
+        xtdb = Xtdb.openNode()
+
+        al = RootAllocator()
+        db = XtdbDriver(al).open(mutableMapOf(
+            XtdbDriver.PARAM_XTDB_NODE to xtdb
+        ))
+        conn = db.connect()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        conn.close()
+        db.close()
+        al.close()
+        xtdb.close()
+    }
+
+    @Test
+    fun `test prepared statement with parameters`() {
+        conn.createStatement().use { stmt ->
+            // Set up a parameterized query
+            stmt.setSqlQuery("SELECT ? AS x, ? AS y")
+
+            // Prepare the statement
+            stmt.prepare()
+
+            // Create parameter values
+            val paramSchema = Schema(listOf(
+                Field("?_0", FieldType.nullable(ArrowType.Int(64, true)), null),
+                Field("?_1", FieldType.nullable(ArrowType.Utf8()), null)
+            ))
+
+            VectorSchemaRoot.create(paramSchema, al).use { paramRoot ->
+                val xVec = paramRoot.getVector("?_0") as BigIntVector
+                val yVec = paramRoot.getVector("?_1") as VarCharVector
+
+                // Set parameter values: 42, "hello"
+                xVec.allocateNew(1)
+                yVec.allocateNew(1)
+
+                xVec.setSafe(0, 42L)
+                yVec.setSafe(0, "hello".toByteArray())
+
+                paramRoot.rowCount = 1
+
+                // Bind parameters
+                stmt.bind(paramRoot)
+
+                // Execute query
+                stmt.executeQuery().reader.use { rdr ->
+                    val root = rdr.vectorSchemaRoot
+                    assertTrue(rdr.loadNextBatch())
+
+                    Relation.fromRoot(al, root).use { rel ->
+                        val results = rel.toMaps(SNAKE_CASE_STRING)
+                        assertEquals(1, results.size)
+
+                        val row = results[0]
+                        assertEquals(42L, row["x"])
+                        assertEquals("hello", row["y"])
+                    }
+
+                    assertFalse(rdr.loadNextBatch())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test prepared statement reuse with different parameters`() {
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT ? + 10 AS result")
+            stmt.prepare()
+
+            val paramSchema = Schema(listOf(
+                Field("?_0", FieldType.nullable(ArrowType.Int(64, true)), null)
+            ))
+
+            // Execute with first parameter value: 5
+            VectorSchemaRoot.create(paramSchema, al).use { paramRoot ->
+                val vec = paramRoot.getVector("?_0") as BigIntVector
+                vec.allocateNew(1)
+                vec.setSafe(0, 5L)
+                paramRoot.rowCount = 1
+
+                stmt.bind(paramRoot)
+                stmt.executeQuery().reader.use { rdr ->
+                    val root = rdr.vectorSchemaRoot
+                    assertTrue(rdr.loadNextBatch())
+
+                    Relation.fromRoot(al, root).use { rel ->
+                        val results = rel.toMaps(SNAKE_CASE_STRING)
+                        assertEquals(15L, results[0]["result"])
+                    }
+                }
+            }
+
+            // Execute with second parameter value: 20
+            VectorSchemaRoot.create(paramSchema, al).use { paramRoot ->
+                val vec = paramRoot.getVector("?_0") as BigIntVector
+                vec.allocateNew(1)
+                vec.setSafe(0, 20L)
+                paramRoot.rowCount = 1
+
+                stmt.bind(paramRoot)
+                stmt.executeQuery().reader.use { rdr ->
+                    val root = rdr.vectorSchemaRoot
+                    assertTrue(rdr.loadNextBatch())
+
+                    Relation.fromRoot(al, root).use { rel ->
+                        val results = rel.toMaps(SNAKE_CASE_STRING)
+                        assertEquals(30L, results[0]["result"])
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcSimpleTest.kt
+++ b/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcSimpleTest.kt
@@ -1,0 +1,59 @@
+package xtdb.adbc
+
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import xtdb.api.Xtdb
+
+class AdbcSimpleTest {
+
+    private lateinit var xtdb: Xtdb
+
+    private lateinit var al: BufferAllocator
+    private lateinit var db: AdbcDatabase
+    private lateinit var conn: AdbcConnection
+
+    @BeforeEach
+    fun setUp() {
+        xtdb = Xtdb.openNode()
+
+        al = RootAllocator()
+        db = XtdbDriver(al).open(mutableMapOf(
+            XtdbDriver.PARAM_XTDB_NODE to xtdb
+        ))
+        conn = db.connect()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        conn.close()
+        db.close()
+        al.close()
+
+        xtdb.close()
+    }
+
+    @Test
+    fun `test simple select`() {
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT 1 AS x, 'hello' AS y")
+            stmt.executeQuery().reader.use { rdr ->
+                val root = rdr.vectorSchemaRoot
+                println("Schema: ${root.schema}")
+                println("Loading batch...")
+                val hasData = rdr.loadNextBatch()
+                println("Has data: $hasData")
+                if (hasData) {
+                    println("Row count: ${root.rowCount}")
+                }
+                assertTrue(hasData)
+            }
+        }
+    }
+}

--- a/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcTest.kt
+++ b/modules/adbc/src/test/kotlin/xtdb/adbc/AdbcTest.kt
@@ -1,0 +1,87 @@
+package xtdb.adbc
+
+import clojure.java.api.Clojure
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import xtdb.api.Xtdb
+import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
+import xtdb.arrow.Relation
+import java.time.ZonedDateTime
+import java.util.*
+
+class AdbcTest {
+
+    private lateinit var xtdb: Xtdb
+
+    private lateinit var al: BufferAllocator
+    private lateinit var db: AdbcDatabase
+    private lateinit var conn: AdbcConnection
+
+    @BeforeEach
+    fun setUp() {
+        xtdb = Xtdb.openNode()
+
+        al = RootAllocator()
+        db = XtdbDriver(al).open(mutableMapOf(
+            XtdbDriver.PARAM_XTDB_NODE to xtdb
+        ))
+        conn = db.connect()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        conn.close()
+        db.close()
+        al.close()
+
+        xtdb.close()
+    }
+
+    @Test
+    fun `test simple round-trip`() {
+        // Use execute-tx to ensure transaction is committed and indexed
+        val require = Clojure.`var`("clojure.core", "require")
+        require.invoke(Clojure.read("xtdb.api"))
+        val executeTx = Clojure.`var`("xtdb.api", "execute-tx")
+
+        executeTx.invoke(xtdb, Clojure.read("""
+            [[:sql "INSERT INTO foo RECORDS
+            {
+              _id: UUID 'b82ae7b2-13cf-4828-858d-cd992fec9aa7',
+              name: 'foo',
+              created_at: TIMESTAMP '2020-01-01T12:34:00Z'
+            }"]]
+        """.trimIndent()))
+
+        // Now query the data back via ADBC
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT * FROM foo")
+            stmt.executeQuery().reader.use { rdr ->
+                val root = rdr.vectorSchemaRoot
+                assertTrue(rdr.loadNextBatch())
+
+                Relation.fromRoot(al, root).use { rel ->
+                    assertEquals(
+                        listOf(
+                            mapOf(
+                                "_id" to UUID.fromString("b82ae7b2-13cf-4828-858d-cd992fec9aa7"),
+                                "name" to "foo",
+                                "created_at" to ZonedDateTime.parse("2020-01-01T12:34:00Z")
+                            )
+                        ),
+                        rel.toMaps(SNAKE_CASE_STRING)
+                    )
+                }
+
+                assertFalse(rdr.loadNextBatch())
+            }
+        }
+    }
+}

--- a/modules/bench/build.gradle.kts
+++ b/modules/bench/build.gradle.kts
@@ -3,10 +3,15 @@ import xtdb.DataReaderTransformer
 plugins {
     `java-library`
     alias(libs.plugins.clojurephant)
+    alias(libs.plugins.kotlin.jvm)
     id("com.gradleup.shadow")
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+configurations.testRuntimeClasspath {
+    exclude(group = "io.grpc", module = "grpc-xds")
+}
 
 dependencies {
     api(project(":"))
@@ -35,8 +40,20 @@ dependencies {
 
     api("software.amazon.awssdk", "s3", "2.25.24")
     api("clj-http", "clj-http", "3.13.1")
+
+    // Driver benchmarks
+    testImplementation(project(":modules:xtdb-adbc"))
+    testImplementation(project(":modules:xtdb-flight-sql"))
+    testImplementation(libs.arrow.adbc.fsql)
+    testImplementation(kotlin("stdlib"))
 }
 
+
+tasks.test {
+    testLogging {
+        showStandardStreams = true
+    }
+}
 
 tasks.shadowJar {
     transform(DataReaderTransformer())

--- a/modules/bench/src/test/kotlin/xtdb/bench/DriverBench.kt
+++ b/modules/bench/src/test/kotlin/xtdb/bench/DriverBench.kt
@@ -1,0 +1,385 @@
+package xtdb.bench
+
+import clojure.java.api.Clojure
+import clojure.lang.IFn
+import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.AdbcDatabase
+import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.adbc.XtdbDriver
+import xtdb.api.FlightSqlServer
+import xtdb.api.Xtdb
+import xtdb.api.flightSqlServer
+import xtdb.api.module
+import java.sql.Connection
+import java.sql.DriverManager
+import kotlin.system.measureNanoTime
+
+/**
+ * TPC-H Benchmark comparing three access methods:
+ * 1. In-Process ADBC (direct Arrow access, zero TCP overhead)
+ * 2. FlightSQL/ADBC over TCP (Arrow over network with serialization)
+ * 3. JDBC over PgWire (traditional row-oriented protocol)
+ *
+ * This demonstrates the performance characteristics of:
+ * - Zero-copy in-process Arrow access (ADBC)
+ * - Columnar network protocol (FlightSQL)
+ * - Row-oriented network protocol (PgWire/JDBC)
+ */
+class DriverBench {
+
+    private lateinit var xtdb: Xtdb
+    private lateinit var allocator: BufferAllocator
+
+    // ADBC connections
+    private lateinit var adbcDb: AdbcDatabase
+    private lateinit var adbcConn: AdbcConnection
+    private lateinit var flightDb: AdbcDatabase
+    private lateinit var flightConn: AdbcConnection
+
+    // JDBC connection (PgWire)
+    private lateinit var jdbcConn: Connection
+
+    private var flightSqlPort: Int = 0
+    private var pgwirePort: Int = 0
+
+    companion object {
+        // Simple TPC-H queries that work well for comparison
+        val QUERIES = mapOf(
+            "Q6" to """
+                SELECT SUM(l_extendedprice * l_discount) AS revenue
+                FROM lineitem
+                WHERE l_shipdate >= DATE '1994-01-01'
+                  AND l_shipdate < DATE '1995-01-01'
+                  AND l_discount BETWEEN 0.05 AND 0.07
+                  AND l_quantity < 24
+            """.trimIndent(),
+
+            "Q1-simple" to """
+                SELECT
+                    l_returnflag,
+                    l_linestatus,
+                    COUNT(*) AS count_order
+                FROM lineitem
+                WHERE l_shipdate <= DATE '1998-09-02'
+                GROUP BY l_returnflag, l_linestatus
+                ORDER BY l_returnflag, l_linestatus
+            """.trimIndent(),
+
+            "Point-Query" to """
+                SELECT * FROM customer WHERE c_custkey = 1
+            """.trimIndent(),
+
+            "Small-Agg" to """
+                SELECT COUNT(*) AS cnt FROM orders WHERE o_orderdate >= DATE '1995-01-01'
+            """.trimIndent(),
+
+            "Wide-Projection" to """
+                SELECT * FROM lineitem LIMIT 100
+            """.trimIndent(),
+
+            "Medium-Result" to """
+                SELECT * FROM lineitem LIMIT 1000
+            """.trimIndent(),
+
+            "Large-Result" to """
+                SELECT * FROM orders
+            """.trimIndent(),
+
+            "Join-Query" to """
+                SELECT o.o_orderkey, o.o_orderdate, c.c_name
+                FROM orders o
+                JOIN customer c ON o.o_custkey = c.c_custkey
+                LIMIT 500
+            """.trimIndent()
+        )
+
+        const val WARMUP_ITERATIONS = 3
+        const val BENCHMARK_ITERATIONS = 10
+    }
+
+    @BeforeEach
+    fun setUp() {
+        println("\n=== Setting up TPC-H Benchmark ===")
+
+        // Start XTDB node with FlightSQL server
+        xtdb = Xtdb.openNode {
+            flightSqlServer { port = 0 }
+        }
+
+        // Get FlightSQL port
+        flightSqlPort = xtdb.module<FlightSqlServer>()!!.port
+        println("FlightSQL server started on port: $flightSqlPort")
+
+        // Get PgWire port
+        pgwirePort = xtdb.serverPort
+        println("PgWire server started on port: $pgwirePort")
+
+        // Load TPC-H data (scale factor 0.01)
+        loadTpchData(0.01)
+
+        // Setup allocator
+        allocator = RootAllocator()
+
+        // Setup In-Process ADBC
+        adbcDb = XtdbDriver(allocator).open(mutableMapOf(
+            XtdbDriver.PARAM_XTDB_NODE to xtdb
+        ))
+        adbcConn = adbcDb.connect()
+        println("✓ In-Process ADBC connected")
+
+        // Setup FlightSQL ADBC
+        flightDb = FlightSqlDriver(allocator).open(mapOf(
+            "uri" to "grpc+tcp://127.0.0.1:$flightSqlPort"
+        ))
+        flightConn = flightDb.connect()
+        println("✓ FlightSQL ADBC connected")
+
+        // Setup JDBC (PgWire)
+        jdbcConn = DriverManager.getConnection(
+            "jdbc:xtdb://localhost:$pgwirePort/xtdb",
+            "xtdb",
+            "xtdb"
+        )
+        println("✓ JDBC (PgWire) connected")
+
+        println("=== Setup Complete ===\n")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        jdbcConn.close()
+        flightConn.close()
+        flightDb.close()
+        adbcConn.close()
+        adbcDb.close()
+        allocator.close()
+        xtdb.close()
+    }
+
+    private fun loadTpchData(scaleFactor: Double) {
+        println("Loading TPC-H data (scale factor: $scaleFactor)...")
+
+        val require = Clojure.`var`("clojure.core", "require")
+        require.invoke(Clojure.read("xtdb.datasets.tpch"))
+
+        val submitDocs: IFn = Clojure.`var`("xtdb.datasets.tpch", "submit-docs!")
+        submitDocs.invoke(xtdb, scaleFactor)
+
+        // Wait for indexing
+        val sync = Clojure.`var`("xtdb.log", "sync-node")
+        sync.invoke(xtdb)
+
+        println("✓ TPC-H data loaded and indexed")
+    }
+
+    data class QueryResult(
+        val queryName: String,
+        val method: String,
+        val avgTimeMs: Double,
+        val minTimeMs: Double,
+        val maxTimeMs: Double,
+        val rowCount: Long,
+        val iterations: Int
+    )
+
+    private fun benchmarkQuery(
+        queryName: String,
+        sql: String,
+        iterations: Int = BENCHMARK_ITERATIONS
+    ): List<QueryResult> {
+        println("\n--- Benchmarking: $queryName ---")
+
+        val results = mutableListOf<QueryResult>()
+
+        // 1. In-Process ADBC
+        val adbcTimes = mutableListOf<Long>()
+        var adbcRowCount = 0L
+
+        repeat(WARMUP_ITERATIONS) {
+            adbcConn.createStatement().use { stmt ->
+                stmt.setSqlQuery(sql)
+                stmt.executeQuery().reader.use { reader ->
+                    while (reader.loadNextBatch()) { /* consume */ }
+                }
+            }
+        }
+
+        repeat(iterations) {
+            val time = measureNanoTime {
+                adbcConn.createStatement().use { stmt ->
+                    stmt.setSqlQuery(sql)
+                    stmt.executeQuery().reader.use { reader ->
+                        var count = 0L
+                        while (reader.loadNextBatch()) {
+                            count += reader.vectorSchemaRoot.rowCount
+                        }
+                        adbcRowCount = count
+                    }
+                }
+            }
+            adbcTimes.add(time)
+        }
+
+        results.add(QueryResult(
+            queryName = queryName,
+            method = "In-Process ADBC",
+            avgTimeMs = adbcTimes.average() / 1_000_000.0,
+            minTimeMs = adbcTimes.minOrNull()!! / 1_000_000.0,
+            maxTimeMs = adbcTimes.maxOrNull()!! / 1_000_000.0,
+            rowCount = adbcRowCount,
+            iterations = iterations
+        ))
+
+        // 2. FlightSQL ADBC
+        val flightTimes = mutableListOf<Long>()
+        var flightRowCount = 0L
+
+        repeat(WARMUP_ITERATIONS) {
+            flightConn.createStatement().use { stmt ->
+                stmt.setSqlQuery(sql)
+                stmt.executeQuery().reader.use { reader ->
+                    while (reader.loadNextBatch()) { /* consume */ }
+                }
+            }
+        }
+
+        repeat(iterations) {
+            val time = measureNanoTime {
+                flightConn.createStatement().use { stmt ->
+                    stmt.setSqlQuery(sql)
+                    stmt.executeQuery().reader.use { reader ->
+                        var count = 0L
+                        while (reader.loadNextBatch()) {
+                            count += reader.vectorSchemaRoot.rowCount
+                        }
+                        flightRowCount = count
+                    }
+                }
+            }
+            flightTimes.add(time)
+        }
+
+        results.add(QueryResult(
+            queryName = queryName,
+            method = "FlightSQL/TCP",
+            avgTimeMs = flightTimes.average() / 1_000_000.0,
+            minTimeMs = flightTimes.minOrNull()!! / 1_000_000.0,
+            maxTimeMs = flightTimes.maxOrNull()!! / 1_000_000.0,
+            rowCount = flightRowCount,
+            iterations = iterations
+        ))
+
+        // 3. JDBC (PgWire)
+        val jdbcTimes = mutableListOf<Long>()
+        var jdbcRowCount = 0L
+
+        repeat(WARMUP_ITERATIONS) {
+            jdbcConn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    while (rs.next()) { /* consume */ }
+                }
+            }
+        }
+
+        repeat(iterations) {
+            val time = measureNanoTime {
+                jdbcConn.createStatement().use { stmt ->
+                    stmt.executeQuery(sql).use { rs ->
+                        var count = 0L
+                        while (rs.next()) {
+                            count++
+                        }
+                        jdbcRowCount = count
+                    }
+                }
+            }
+            jdbcTimes.add(time)
+        }
+
+        results.add(QueryResult(
+            queryName = queryName,
+            method = "JDBC/PgWire",
+            avgTimeMs = jdbcTimes.average() / 1_000_000.0,
+            minTimeMs = jdbcTimes.minOrNull()!! / 1_000_000.0,
+            maxTimeMs = jdbcTimes.maxOrNull()!! / 1_000_000.0,
+            rowCount = jdbcRowCount,
+            iterations = iterations
+        ))
+
+        return results
+    }
+
+    private fun printResults(allResults: List<QueryResult>) {
+        println("\n" + "=".repeat(100))
+        println("TPC-H Benchmark Results (Scale Factor: 0.01)")
+        println("=".repeat(100))
+        println()
+
+        val grouped = allResults.groupBy { it.queryName }
+
+        for ((queryName, results) in grouped) {
+            println("Query: $queryName (${results[0].rowCount} rows)")
+            println("-".repeat(100))
+            println(String.format("%-20s | %12s | %12s | %12s | %10s",
+                "Method", "Avg (ms)", "Min (ms)", "Max (ms)", "Speedup"))
+            println("-".repeat(100))
+
+            val baseline = results.find { it.method == "JDBC/PgWire" }?.avgTimeMs ?: 1.0
+
+            for (result in results) {
+                val speedup = baseline / result.avgTimeMs
+                println(String.format("%-20s | %12.3f | %12.3f | %12.3f | %10.2fx",
+                    result.method,
+                    result.avgTimeMs,
+                    result.minTimeMs,
+                    result.maxTimeMs,
+                    speedup
+                ))
+            }
+            println()
+        }
+
+        // Summary statistics
+        println("=".repeat(100))
+        println("Summary")
+        println("=".repeat(100))
+
+        val adbcResults = allResults.filter { it.method == "In-Process ADBC" }
+        val flightResults = allResults.filter { it.method == "FlightSQL/TCP" }
+        val jdbcResults = allResults.filter { it.method == "JDBC/PgWire" }
+
+        println(String.format("In-Process ADBC avg: %.3f ms", adbcResults.map { it.avgTimeMs }.average()))
+        println(String.format("FlightSQL/TCP avg:   %.3f ms", flightResults.map { it.avgTimeMs }.average()))
+        println(String.format("JDBC/PgWire avg:     %.3f ms", jdbcResults.map { it.avgTimeMs }.average()))
+        println()
+
+        val adbcVsJdbc = jdbcResults.map { it.avgTimeMs }.average() / adbcResults.map { it.avgTimeMs }.average()
+        val flightVsJdbc = jdbcResults.map { it.avgTimeMs }.average() / flightResults.map { it.avgTimeMs }.average()
+
+        println(String.format("In-Process ADBC is %.2fx faster than JDBC/PgWire", adbcVsJdbc))
+        println(String.format("FlightSQL/TCP is %.2fx faster than JDBC/PgWire", flightVsJdbc))
+        println()
+        println("Protocol Comparison:")
+        println("  • In-Process ADBC: Zero network overhead, direct Arrow buffer access")
+        println("  • FlightSQL/TCP: Columnar Arrow over network, batch-oriented")
+        println("  • JDBC/PgWire: Row-oriented protocol, row-by-row iteration")
+        println("=".repeat(100))
+    }
+
+    @Test
+    fun `benchmark TPC-H queries`() {
+        val allResults = mutableListOf<QueryResult>()
+
+        for ((queryName, sql) in QUERIES) {
+            val results = benchmarkQuery(queryName, sql)
+            allResults.addAll(results)
+        }
+
+        printResults(allResults)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,9 @@ project(":modules:aws").name = "xtdb-aws"
 project(":modules:azure").name = "xtdb-azure"
 project(":modules:google-cloud").name = "xtdb-google-cloud"
 
-include("modules:flight-sql")
+include("modules:flight-sql", "modules:adbc")
 project(":modules:flight-sql").name = "xtdb-flight-sql"
+project(":modules:adbc").name = "xtdb-adbc"
 
 include("modules:bench", "modules:datasets")
 project(":modules:datasets").name = "xtdb-datasets"


### PR DESCRIPTION
`./gradlew :modules:bench:test --tests "xtdb.bench.DriverBench"`

```
=== Setting up TPC-H Benchmark ===
17:44:46.405 [Test worker] INFO  xtdb.metrics - tagging all metrics with node-id: 0af066be
17:44:47.238 [Test worker] INFO  xtdb.pgwire - Server started at postgres://127.0.0.1:36579
17:44:47.867 [Test worker] INFO  xtdb.flight-sql - Flight SQL server started, port 42783
FlightSQL server started on port: 42783
PgWire server started on port: 36579
Loading TPC-H data (scale factor: 0.01)...
17:44:47.960 [Test worker] INFO  xtdb.datasets.tpch - Transacting TPC-H tables...
17:45:10.101 [Test worker] INFO  xtdb.datasets.tpch - Transacted TPC-H tables...
✓ TPC-H data loaded and indexed
✓ In-Process ADBC connected
✓ FlightSQL ADBC connected
✓ JDBC (PgWire) connected
=== Setup Complete ===


--- Benchmarking: Q6 ---

--- Benchmarking: Q1-simple ---

--- Benchmarking: Point-Query ---

--- Benchmarking: Small-Agg ---

--- Benchmarking: Wide-Projection ---

--- Benchmarking: Medium-Result ---

--- Benchmarking: Large-Result ---

--- Benchmarking: Join-Query ---

====================================================================================================
TPC-H Benchmark Results (Scale Factor: 0.01)
====================================================================================================

Query: Q6 (1 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |      153.727 |      128.790 |      203.940 |       0.75x
FlightSQL/TCP        |      131.819 |      111.031 |      167.958 |       0.88x
JDBC/PgWire          |      115.804 |       85.290 |      156.188 |       1.00x

Query: Q1-simple (4 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |      191.736 |      153.868 |      230.768 |       0.81x
FlightSQL/TCP        |      168.951 |      142.041 |      240.533 |       0.92x
JDBC/PgWire          |      155.040 |      134.690 |      189.798 |       1.00x

Query: Point-Query (0 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |        4.423 |        2.989 |        6.286 |       1.50x
FlightSQL/TCP        |       12.777 |       11.567 |       14.824 |       0.52x
JDBC/PgWire          |        6.647 |        6.046 |        7.188 |       1.00x

Query: Small-Agg (1 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |       19.974 |       17.110 |       35.037 |       1.20x
FlightSQL/TCP        |       29.310 |       25.347 |       39.360 |       0.82x
JDBC/PgWire          |       23.981 |       19.443 |       31.263 |       1.00x

Query: Wide-Projection (100 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |        5.041 |        3.756 |        6.315 |       2.35x
FlightSQL/TCP        |       14.588 |       13.145 |       17.289 |       0.81x
JDBC/PgWire          |       11.842 |       10.521 |       13.110 |       1.00x

Query: Medium-Result (1000 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |        8.375 |        7.857 |        9.711 |       5.70x
FlightSQL/TCP        |       20.256 |       17.277 |       24.066 |       2.36x
JDBC/PgWire          |       47.719 |       42.085 |       52.845 |       1.00x

Query: Large-Result (15000 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |       36.748 |       32.630 |       46.691 |       8.53x
FlightSQL/TCP        |       57.823 |       48.820 |       70.312 |       5.42x
JDBC/PgWire          |      313.276 |      272.990 |      372.486 |       1.00x

Query: Join-Query (500 rows)
----------------------------------------------------------------------------------------------------
Method               |     Avg (ms) |     Min (ms) |     Max (ms) |    Speedup
----------------------------------------------------------------------------------------------------
In-Process ADBC      |       68.802 |       60.300 |       81.801 |       1.93x
FlightSQL/TCP        |       80.987 |       60.399 |       94.119 |       1.64x
JDBC/PgWire          |      132.839 |       98.914 |      231.958 |       1.00x

====================================================================================================
Summary
====================================================================================================
In-Process ADBC avg: 61.103 ms
FlightSQL/TCP avg:   64.564 ms
JDBC/PgWire avg:     100.893 ms

In-Process ADBC is 1.65x faster than JDBC/PgWire
FlightSQL/TCP is 1.56x faster than JDBC/PgWire

Protocol Comparison:
  • In-Process ADBC: Zero network overhead, direct Arrow buffer access
  • FlightSQL/TCP: Columnar Arrow over network, batch-oriented
  • JDBC/PgWire: Row-oriented protocol, row-by-row iteration
====================================================================================================
17:45:37.024 [Test worker] INFO  xtdb.flight-sql - Flight SQL server stopped
17:45:37.094 [Test worker] INFO  xtdb.pgwire - Server stopped.
```