### PR TITLE
add LPAD and RPAD

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1135,6 +1135,7 @@
 
 ;; stringy
 (def-sql-fns [str] 1 Long/MAX_VALUE)
+(def-sql-fns [lpad rpad] 2 3)
 (def-sql-fns [namespace local_name] 1 1)
 
 (defrecord ExprPlanVisitor [env scope]

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -160,6 +160,41 @@
   (t/is (= '(length "abc") (plan-expr-with-foo "LENGTH('abc')")))
   (t/is (= '(length [1 2 3]) (plan-expr-with-foo "LENGTH([1, 2, 3])"))))
 
+(t/deftest test-lpad-rpad
+  (t/testing "LPAD with 2 args"
+    (t/is (= [{:res "     hello"}]
+             (xt/q tu/*node* "SELECT LPAD('hello', 10) AS res"))))
+
+  (t/testing "LPAD with 3 args"
+    (t/is (= [{:res "xxxxxhello"}]
+             (xt/q tu/*node* "SELECT LPAD('hello', 10, 'x') AS res")))
+    (t/is (= [{:res "ababahello"}]
+             (xt/q tu/*node* "SELECT LPAD('hello', 10, 'ab') AS res"))))
+
+  (t/testing "LPAD truncates when target length is less than string length"
+    (t/is (= [{:res "hel"}]
+             (xt/q tu/*node* "SELECT LPAD('hello', 3) AS res"))))
+
+  (t/testing "RPAD with 2 args"
+    (t/is (= [{:res "hello     "}]
+             (xt/q tu/*node* "SELECT RPAD('hello', 10) AS res"))))
+
+  (t/testing "RPAD with 3 args"
+    (t/is (= [{:res "helloxxxxx"}]
+             (xt/q tu/*node* "SELECT RPAD('hello', 10, 'x') AS res")))
+    (t/is (= [{:res "helloababa"}]
+             (xt/q tu/*node* "SELECT RPAD('hello', 10, 'ab') AS res"))))
+
+  (t/testing "RPAD truncates when target length is less than string length"
+    (t/is (= [{:res "hel"}]
+             (xt/q tu/*node* "SELECT RPAD('hello', 3) AS res"))))
+
+  (t/testing "LPAD/RPAD with zero or negative length"
+    (t/is (= [{:res ""}]
+             (xt/q tu/*node* "SELECT LPAD('hello', 0) AS res")))
+    (t/is (= [{:res ""}]
+             (xt/q tu/*node* "SELECT RPAD('hello', -1) AS res")))))
+
 (t/deftest test-length-query
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1
                                              :string "abcdef"


### PR DESCRIPTION
e.g. often used for displaying data:
```
SELECT relname table_name,
       lpad(to_char(reltuples, 'FM9,999,999,999'), 13) row_count
FROM pg_class
LEFT JOIN pg_namespace
    ON (pg_namespace.oid = pg_class.relnamespace)
WHERE nspname NOT IN ('pg_catalog', 'information_schema')
AND relkind = 'r'
ORDER BY reltuples DESC;
```
=>
```
              table_name               |   row_count
---------------------------------------+---------------
 trips                                 | 1,120,559,744
 uber_trips_2015                       |    14,270,497
 spatial_ref_sys                       |         3,911
 central_park_weather_observations_raw |         2,372
 nyct2010                              |         2,167
 uber_taxi_zone_lookups                |           265
 yellow_tripdata_staging               |             0
 cab_types                             |             0
 uber_trips_staging                    |             0
 green_tripdata_staging                |             0
```
(overview of approximate counts, from https://tech.marksblogg.com/billion-nyc-taxi-rides-redshift.html)