### PR TITLE
Remove outdated system time ordering comment from MergePlanner.plan

### DIFF
--- a/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
+++ b/core/src/main/kotlin/xtdb/segment/MergePlanner.kt
@@ -37,7 +37,6 @@ object MergePlanner {
         filterPages: PagesFilter = PagesFilter { it }
     ) = runBlocking { plan(segments, pathPred, filterPages) }
 
-    // IMPORTANT - Tries (i.e. segments) and nodes need to be returned in system time order
     suspend fun plan(
         segments: List<Segment<*>>,
         pathPred: Predicate<ByteArray>?,


### PR DESCRIPTION
6fd8c09 removed the requirement for pages/tries to be ordered by system time in filter-pages. Reinforced by the removal of block-idx sorting in trie_catalog in 4d30fd6.

Consumers of MergeTasks also do not depend on the system time ordering of MergeTasks or the pages within. Instead they use EventRowPointer.comparator to ensure system time ordering.