### PR TITLE
Update handling of tracing in pgwire to make passing down spans easier.

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1142,7 +1142,7 @@
 (defn unnamed-portal? [portal-name]
   (= "" portal-name))
 
-(defmethod handle-msg* :msg-bind [{:keys [conn-state] :as conn} {:keys [portal-name stmt-name] :as bind-msg}]
+(defmethod handle-msg* :msg-bind [{:keys [conn-state query-tracer] :as conn} {:keys [portal-name stmt-name] :as bind-msg}]
   (swap! conn-state assoc :protocol :extended)
   (let [stmt (into (or (get-in @conn-state [:prepared-statements stmt-name])
                        (throw (pgio/err-protocol-violation "no prepared statement")))
@@ -1152,6 +1152,11 @@
 
     (when (get-in @conn-state [:portals portal-name])
       (throw (pgio/err-protocol-violation "Named portals must be explicit closed before they can be redefined")))
+
+    ;; Create query span at bind time for query/show-variable statements and store in conn-state
+    (when (and query-tracer (#{:query :show-variable} (:statement-type stmt)))
+      (let [query-span (metrics/start-span query-tracer "pgwire.query" {:db.statement (:query stmt)})]
+        (swap! conn-state assoc :query-span query-span)))
 
     (let [bound-stmt (bind-stmt conn stmt)]
       (swap! conn-state
@@ -1384,11 +1389,13 @@
               (cmd-commit conn)
               (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "COMMIT"}))
 
-    (:query :show-variable) (let [query-tracer (:query-tracer conn)
-                                   query-str (:query portal)]
-                              (metrics/with-span query-tracer "pgwire.query"
-                                {:db.statement query-str}
-                                (metrics/record-callable! query-timer (cmd-exec-query conn portal))))
+    (:query :show-variable) (let [query-span (:query-span @conn-state)]
+                              (try
+                                (metrics/record-callable! query-timer (cmd-exec-query conn portal))
+                                (finally
+                                  (when query-span
+                                    (metrics/end-span query-span)
+                                    (swap! conn-state dissoc :query-span)))))
     :prepare (cmd-prepare conn portal)
     :dml (cmd-exec-dml conn portal)
 
@@ -1433,7 +1440,7 @@
     (execute-portal conn (cond-> portal
                            (not (zero? limit)) (assoc :limit limit)))))
 
-(defmethod handle-msg* :msg-simple-query [{:keys [conn-state] :as conn} {:keys [query]}]
+(defmethod handle-msg* :msg-simple-query [{:keys [conn-state query-tracer] :as conn} {:keys [query]}]
   (swap! conn-state assoc :protocol :simple)
 
   (close-portal conn "")
@@ -1449,7 +1456,10 @@
           (when (and (seq param-oids) (not= statement-type :show-variable))
             (throw (pgio/err-protocol-violation "Parameters not allowed in simple queries")))
 
-          (let [portal (bind-stmt conn prepared-stmt)]
+          (let [query-span (when (and query-tracer (#{:query :show-variable} statement-type))
+                             (metrics/start-span query-tracer "pgwire.query" {:db.statement (:query stmt)}))
+                _ (swap! conn-state assoc :query-span query-span)
+                portal (bind-stmt conn prepared-stmt)]
             (try
               (when (or (contains? #{:query :canned-response :show-variable} statement-type)
                         (and (= :execute statement-type)

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1155,7 +1155,7 @@
 
     ;; Create query span at bind time for query/show-variable statements and store in conn-state
     (when (and query-tracer (#{:query :show-variable} (:statement-type stmt)))
-      (let [query-span (metrics/start-span query-tracer "pgwire.query" {:db.statement (:query stmt)})]
+      (let [query-span (metrics/start-span query-tracer "pgwire.query" {:attributes {:db.statement (:query stmt)}})]
         (swap! conn-state assoc :query-span query-span)))
 
     (let [bound-stmt (bind-stmt conn stmt)]
@@ -1457,7 +1457,7 @@
             (throw (pgio/err-protocol-violation "Parameters not allowed in simple queries")))
 
           (let [query-span (when (and query-tracer (#{:query :show-variable} statement-type))
-                             (metrics/start-span query-tracer "pgwire.query" {:db.statement (:query stmt)}))
+                             (metrics/start-span query-tracer "pgwire.query" {:attributes {:db.statement (:query stmt)}}))
                 _ (swap! conn-state assoc :query-span query-span)
                 portal (bind-stmt conn prepared-stmt)]
             (try

--- a/src/test/clojure/xtdb/tracer_test.clj
+++ b/src/test/clojure/xtdb/tracer_test.clj
@@ -1,7 +1,8 @@
 (ns xtdb.tracer-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
-            [xtdb.node :as xtn])
+            [xtdb.node :as xtn]
+            [xtdb.pgwire-test :as pgw-test])
   (:import (io.opentelemetry.api.common Attributes AttributeKey)
            (io.opentelemetry.sdk.common CompletableResultCode)
            (io.opentelemetry.sdk.trace.data SpanData)
@@ -37,3 +38,28 @@
           (t/is (= 1 (count current-spans)))
           (t/is (= "pgwire.query" (.getName span))) 
           (t/is (= "SELECT 1" (.get span-attributes attribute-key))))))))
+
+(t/deftest ensure-pgwire-simple-query-behaves-with-traces
+  (let [!spans (atom [])
+        exporter (test-span-exporter !spans)
+        span-processor (SimpleSpanProcessor/create exporter)]
+    (with-open [node (xtn/start-node {:tracer {:enabled? true
+                                               :service-name "xtdb-test"
+                                               :span-processor span-processor}})]
+      (binding [pgw-test/*port* (.getServerPort node)
+                pgw-test/*server* node]
+        (with-open [conn (pgw-test/jdbc-conn {"preferQueryMode" "simple"})
+                    stmt (.createStatement conn)
+                    rs (.executeQuery stmt "SELECT 1 as a")]
+          (t/is (= [{"a" 1}] (pgw-test/rs->maps rs)))
+          
+          ;; Give spans a moment to be exported
+          (Thread/sleep 100)
+          
+          (let [current-spans @!spans
+                ^SpanData span (first current-spans)
+                ^Attributes span-attributes (.getAttributes span)
+                ^AttributeKey attribute-key (AttributeKey/stringKey "db.statement")]
+            (t/is (= 1 (count current-spans)))
+            (t/is (= "pgwire.query" (.getName span)))
+            (t/is (= "SELECT 1 as a" (.get span-attributes attribute-key)))))))))


### PR DESCRIPTION
Github actions runs here: https://github.com/danmason/xtdb/actions?query=branch%3Aupdates-to-pgwire-query++

- Starts the pgwire.query span and passes it through the connection, rather than wrapping a specific call with `with-span` - this should be useful for to be able to pass it around as a parent-span through the query.
- Adds ability to pass parent-span down through start-span/with-span helper functions.
- Adds a test against pgwire simple query to ensure tracing doesn't cause any issues.