### PR TITLE
Add per-cursor level query tracing.

### DIFF
--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -99,8 +99,7 @@
                                                                          (.accept c (vr/rel-reader [match-vec]))))))
 
                                            (close [_] (.close dep-cursor)))
-                                   explain-analyze? (ICursor/wrapExplainAnalyze) 
-                                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))))
+                                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))
 
                            [:otherwise _] ->dependent-cursor)]
 
@@ -117,5 +116,4 @@
                                                                                                                          (.select (int-array [idx]))
                                                                                                                          (.withName (str dk)))))
                                                                                                            1))))))))
-                         explain-analyze? (ICursor/wrapExplainAnalyze)
-                         (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -47,11 +47,11 @@
                        loader (path->loader al path)]
              (->> (.getFields (.getSchema loader))
                   (into {} (map (juxt #(symbol (.getName ^Field %)) identity)))))
-   :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze?]}]
+   :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze? tracer query-span]}]
                (util/with-close-on-catch [loader (path->loader allocator path)
                                           rel (Relation. allocator (.getSchema loader))]
                  (cond-> (ArrowCursor. rel loader on-close-fn)
-                   explain-analyze? (ICursor/wrapExplainAnalyze))))})
+                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))})
 
 (defmethod lp/emit-expr :arrow [{:keys [^URL url]} _args]
   ;; TODO: should we make it possible to disable local files?

--- a/core/src/main/clojure/xtdb/operator/csv.clj
+++ b/core/src/main/clojure/xtdb/operator/csv.clj
@@ -85,7 +85,7 @@
     {:op :csv
      :children []
      :fields fields
-     :->cursor (fn [{:keys [^BufferAllocator allocator, explain-analyze?]}]
+     :->cursor (fn [{:keys [^BufferAllocator allocator, explain-analyze?, tracer, query-span]}]
                  (cond-> (let [rdr (Files/newBufferedReader path)
                                rows (rest (csv/read-csv rdr))
                                schema (Schema. (vals fields))]
@@ -94,4 +94,4 @@
                                        (->> fields (into {} (map (juxt (comp name key)
                                                                        (comp col-parsers types/field->col-type val)))))
                                        (.iterator ^Iterable (partition-all batch-size rows))))
-                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))
+                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -86,5 +86,4 @@
                                                                          {:build-fields inner-fields
                                                                           :key-col-names (set (keys inner-fields))
                                                                           :nil-keys-equal? true}))
-                                  explain-analyze? (ICursor/wrapExplainAnalyze)
-                                  (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
+                                  (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -80,10 +80,11 @@
                    {:op :distinct
                     :children [inner-rel]
                     :fields inner-fields
-                    :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                    :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                                 (cond-> (DistinctCursor. allocator in-cursor
                                                          (->relation-map allocator
                                                                          {:build-fields inner-fields
                                                                           :key-col-names (set (keys inner-fields))
                                                                           :nil-keys-equal? true}))
-                                  explain-analyze? (ICursor/wrapExplainAnalyze)))})))
+                                  explain-analyze? (ICursor/wrapExplainAnalyze)
+                                  (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -626,7 +626,7 @@
                               (into {} (map (comp (juxt #(symbol (.getName ^Field %)) identity)
                                                   #(.getField ^IAggregateSpecFactory %))))))
 
-           :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+           :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (util/with-close-on-catch [agg-specs (LinkedList.)]
                                  (doseq [^IAggregateSpecFactory factory agg-factories]
                                    (.add agg-specs (.build factory allocator)))
@@ -635,4 +635,5 @@
                                                  (->group-mapper allocator (select-keys fields group-cols))
                                                  (vec agg-specs)
                                                  false))
-                         explain-analyze? (ICursor/wrapExplainAnalyze)))})))))
+                         explain-analyze? (ICursor/wrapExplainAnalyze)
+                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -635,5 +635,4 @@
                                                  (->group-mapper allocator (select-keys fields group-cols))
                                                  (vec agg-specs)
                                                  false))
-                         explain-analyze? (ICursor/wrapExplainAnalyze)
-                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -153,8 +153,7 @@
        :fields (merge left-fields right-fields)
        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                    (cond-> (CrossJoinCursor. allocator left-cursor right-cursor (ArrayList.) nil nil)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)
-                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))
 
 (defmethod lp/emit-expr :cross-join [join-expr args]
   (emit-cross-join (emit-join-children join-expr args)))
@@ -424,8 +423,7 @@
                                                                           ::semi-join JoinType/SEMI
                                                                           ::anti-semi-join JoinType/ANTI
                                                                           ::single-join JoinType/SINGLE)))
-                                                   explain-analyze? (ICursor/wrapExplainAnalyze)
-                                                   (and tracer query-span) (ICursor/wrapTracing tracer query-span))
+                                                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))
                                                  output-projections)))))}))
 
 (defn emit-join-expr-and-children {:style/indent 2} [join-expr args join-impl]

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -151,9 +151,10 @@
       {:op :cross-join
        :children [left-rel right-rel]
        :fields (merge left-fields right-fields)
-       :->cursor (fn [{:keys [allocator explain-analyze?]} left-cursor right-cursor]
+       :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                    (cond-> (CrossJoinCursor. allocator left-cursor right-cursor (ArrayList.) nil nil)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)))})))
+                     explain-analyze? (ICursor/wrapExplainAnalyze)
+                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
 
 (defmethod lp/emit-expr :cross-join [join-expr args]
   (emit-cross-join (emit-join-children join-expr args)))
@@ -379,7 +380,7 @@
 
      :fields (projection-specs->fields output-projections)
 
-     :->cursor (fn [{:keys [allocator explain-analyze? args] :as opts}]
+     :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span args] :as opts}]
                  (util/with-close-on-catch [build-cursor (->build-cursor opts)
                                             build-side (->build-side allocator {:fields build-fields
                                                                                 :key-col-names build-key-col-names
@@ -423,7 +424,8 @@
                                                                           ::semi-join JoinType/SEMI
                                                                           ::anti-semi-join JoinType/ANTI
                                                                           ::single-join JoinType/SINGLE)))
-                                                   explain-analyze? (ICursor/wrapExplainAnalyze))
+                                                   explain-analyze? (ICursor/wrapExplainAnalyze)
+                                                   (and tracer query-span) (ICursor/wrapTracing tracer query-span))
                                                  output-projections)))))}))
 
 (defn emit-join-expr-and-children {:style/indent 2} [join-expr args join-impl]

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -20,12 +20,13 @@
      :children [emitted-bound-rel emitted-body-rel]
      :fields (:fields emitted-body-rel)
      :stats (:stats emitted-body-rel)
-     :->cursor (fn [{:keys [allocator explain-analyze?] :as opts}]
+     :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (util/with-close-on-catch [bound-cursor (->bound-cursor opts)
                                                     factory (LetCursorFactory. allocator bound-cursor)
                                                     body-cursor (->body-cursor (assoc-in opts [:let-bindings binding] factory))]
                            (.wrapBodyCursor factory body-cursor))
-                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))
+                   explain-analyze? (ICursor/wrapExplainAnalyze)
+                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))
 
 (s/def ::relation simple-symbol?)
 (s/def ::col-names (s/coll-of ::lp/column :kind vector?))
@@ -47,7 +48,7 @@
     {:op :relation
      :children []
      :fields fields, :stats stats
-     :->cursor (fn [{:keys [explain-analyze?] :as opts}]
+     :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts}]
                  (let [^ICursor$Factory cursor-factory (or (get-in opts [:let-bindings relation])
                                                            (let [available (set (keys (:let-bindings opts)))]
                                                              (throw (err/fault ::missing-relation
@@ -57,4 +58,5 @@
                                                                                 :available available}))))]
 
                    (cond-> (.open cursor-factory)
-                     explain-analyze? (ICursor/wrapExplainAnalyze))))}))
+                     explain-analyze? (ICursor/wrapExplainAnalyze)
+                     (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -25,8 +25,7 @@
                                                     factory (LetCursorFactory. allocator bound-cursor)
                                                     body-cursor (->body-cursor (assoc-in opts [:let-bindings binding] factory))]
                            (.wrapBodyCursor factory body-cursor))
-                   explain-analyze? (ICursor/wrapExplainAnalyze)
-                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))
+                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))
 
 (s/def ::relation simple-symbol?)
 (s/def ::col-names (s/coll-of ::lp/column :kind vector?))
@@ -58,5 +57,4 @@
                                                                                 :available available}))))]
 
                    (cond-> (.open cursor-factory)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)
-                     (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -60,7 +60,8 @@
     {:op :list
      :children []
      :fields (restrict-cols fields list-expr)
-     :->cursor (fn [{:keys [allocator ^RelationReader args explain-analyze?]}]
+     :->cursor (fn [{:keys [allocator ^RelationReader args explain-analyze? tracer query-span]}]
                  (cond-> (ListCursor. allocator (->list-expr schema args) named-field
                                       *batch-size* 0)
-                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))
+                   explain-analyze? (ICursor/wrapExplainAnalyze)
+                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -63,5 +63,4 @@
      :->cursor (fn [{:keys [allocator ^RelationReader args explain-analyze? tracer query-span]}]
                  (cond-> (ListCursor. allocator (->list-expr schema args) named-field
                                       *batch-size* 0)
-                   explain-analyze? (ICursor/wrapExplainAnalyze)
-                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))
+                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -271,6 +271,7 @@
        :children [rel]
        :explain {:order-specs (pr-str order-specs)}
        :fields fields
-       :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+       :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                    (cond-> (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)))})))
+                     explain-analyze? (ICursor/wrapExplainAnalyze)
+                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -273,5 +273,4 @@
        :fields fields
        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                    (cond-> (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)
-                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/patch.clj
+++ b/core/src/main/clojure/xtdb/operator/patch.clj
@@ -56,5 +56,4 @@
                                                                          (types/field-with-name field (str nm)))))
                                                    valid-from
                                                    valid-to)
-                           explain-analyze? (ICursor/wrapExplainAnalyze)
-                           (and tracer query-span) (ICursor/wrapTracing tracer query-span)))))}))))
+                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))}))))

--- a/core/src/main/clojure/xtdb/operator/patch.clj
+++ b/core/src/main/clojure/xtdb/operator/patch.clj
@@ -42,7 +42,7 @@
          :explain {:valid-from (pr-str valid-from)
                    :valid-to (pr-str valid-to)}
          :fields fields
-         :->cursor (fn [{:keys [^BufferAllocator allocator current-time explain-analyze?] :as qopts} inner]
+         :->cursor (fn [{:keys [^BufferAllocator allocator current-time explain-analyze? tracer query-span] :as qopts} inner]
                      (let [valid-from (time/instant->micros (->instant (or valid-from [:literal current-time]) qopts))
                            valid-to (or (some-> valid-to (->instant qopts) time/instant->micros) Long/MAX_VALUE)]
                        (if (> valid-from valid-to)
@@ -56,4 +56,5 @@
                                                                          (types/field-with-name field (str nm)))))
                                                    valid-from
                                                    valid-to)
-                           explain-analyze? (ICursor/wrapExplainAnalyze)))))}))))
+                           explain-analyze? (ICursor/wrapExplainAnalyze)
+                           (and tracer query-span) (ICursor/wrapTracing tracer query-span)))))}))))

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -85,8 +85,7 @@
            :stats (:stats emitted-child-relation)
            :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts} in-cursor]
                        (cond-> (->project-cursor opts in-cursor projection-specs)
-                         explain-analyze? (ICursor/wrapExplainAnalyze)
-                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))
 
 (defmethod lp/emit-expr :map [op args]
   (lp/emit-expr (assoc op :op :project :opts {:append-columns? true}) args))

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -83,9 +83,10 @@
                         (into {} (map (comp (juxt #(symbol (.getName ^Field %)) identity)
                                             #(.getField ^ProjectionSpec %)))))
            :stats (:stats emitted-child-relation)
-           :->cursor (fn [{:keys [explain-analyze?] :as opts} in-cursor]
+           :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts} in-cursor]
                        (cond-> (->project-cursor opts in-cursor projection-specs)
-                         explain-analyze? (ICursor/wrapExplainAnalyze)))})))))
+                         explain-analyze? (ICursor/wrapExplainAnalyze)
+                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))
 
 (defmethod lp/emit-expr :map [op args]
   (lp/emit-expr (assoc op :op :project :opts {:append-columns? true}) args))

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -57,10 +57,11 @@
                                                (types/field-with-name (str (col-name-mapping (symbol (.getName field)))))))
                                          val)))))
      :stats (:stats emitted-child-relation)
-     :->cursor (fn [{:keys [explain-analyze?] :as opts}]
+     :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts}]
                  (let [opts (-> opts
                                 (update :pushdown-blooms update-keys #(get col-name-reverse-mapping %))
                                 (update :pushdown-iids update-keys #(get col-name-reverse-mapping %)))]
                    (cond-> (util/with-close-on-catch [in-cursor (->inner-cursor opts)]
                              (RenameCursor. in-cursor col-name-mapping))
-                     explain-analyze? (ICursor/wrapExplainAnalyze))))}))
+                     explain-analyze? (ICursor/wrapExplainAnalyze)
+                     (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -63,5 +63,4 @@
                                 (update :pushdown-iids update-keys #(get col-name-reverse-mapping %)))]
                    (cond-> (util/with-close-on-catch [in-cursor (->inner-cursor opts)]
                              (RenameCursor. in-cursor col-name-mapping))
-                     explain-analyze? (ICursor/wrapExplainAnalyze)
-                     (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -299,8 +299,7 @@
                                                     temporal-bounds
                                                     !segments (.iterator ^Iterable merge-tasks)
                                                     schema args)
-                                 explain-analyze? (ICursor/wrapExplainAnalyze)
-                                 (and tracer query-span) (ICursor/wrapTracing tracer query-span))))))))}))))
+                                 (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-fields, param-fields]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -9,6 +9,7 @@
             [xtdb.information-schema :as info-schema]
             [xtdb.logical-plan :as lp]
             [xtdb.metadata :as meta]
+            [xtdb.metrics :as metrics]
             xtdb.object-store
             [xtdb.table :as table]
             [xtdb.time :as time]
@@ -240,7 +241,7 @@
 
          :fields fields
          :stats {:row-count row-count}
-         :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze?]}]
+         :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^Snapshot snapshot (get snaps db-name)
                            derived-table-schema (info-schema/derived-table table)
                            template-table? (boolean (info-schema/template-table table))]
@@ -298,7 +299,8 @@
                                                     temporal-bounds
                                                     !segments (.iterator ^Iterable merge-tasks)
                                                     schema args)
-                                 explain-analyze? (ICursor/wrapExplainAnalyze))))))))}))))
+                                 explain-analyze? (ICursor/wrapExplainAnalyze)
+                                 (and tracer query-span) (ICursor/wrapTracing tracer query-span))))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-fields, param-fields]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -25,7 +25,8 @@
          :children [inner-rel]
          :explain  {:predicate (pr-str predicate)}
          :fields inner-fields
-         :->cursor (fn [{:keys [allocator args schema explain-analyze?]} in-cursor]
+         :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor] 
                      (cond-> (-> (SelectCursor. allocator in-cursor selector schema args)
                                  (coalesce/->coalescing-cursor allocator))
-                       explain-analyze? (ICursor/wrapExplainAnalyze)))}))))
+                       explain-analyze? (ICursor/wrapExplainAnalyze)
+                       (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))))

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -25,8 +25,7 @@
          :children [inner-rel]
          :explain  {:predicate (pr-str predicate)}
          :fields inner-fields
-         :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor] 
+         :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor]
                      (cond-> (-> (SelectCursor. allocator in-cursor selector schema args)
                                  (coalesce/->coalescing-cursor allocator))
-                       explain-analyze? (ICursor/wrapExplainAnalyze)
-                       (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))))
+                       (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -73,8 +73,7 @@
                      :fields (union-fields left-fields right-fields)
                      :->cursor (fn [{:keys [explain-analyze? tracer query-span]} left-cursor right-cursor]
                                  (cond-> (UnionAllCursor. left-cursor right-cursor)
-                                   explain-analyze? (ICursor/wrapExplainAnalyze)
-                                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
+                                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))
 
 (deftype IntersectionCursor [^ICursor left-cursor, ^ICursor right-cursor
                              ^BuildSide build-side, key-col-names
@@ -139,8 +138,7 @@
                                                                   (join/->cmp-factory {:fields right-fields
                                                                                        :key-col-names key-col-names})
                                                                   false false)
-                                       explain-analyze? (ICursor/wrapExplainAnalyze)
-                                       (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))))
+                                       (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))
 
 (defmethod lp/emit-expr :difference [{:keys [left right]} args]
   (lp/binary-expr (lp/emit-expr left args) (lp/emit-expr right args)
@@ -160,5 +158,4 @@
                                                                   (join/->cmp-factory {:fields right-fields
                                                                                        :key-col-names key-col-names})
                                                                   true false)
-                                       explain-analyze? (ICursor/wrapExplainAnalyze)
-                                       (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))))
+                                       (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -71,9 +71,10 @@
                     {:op :union-all
                      :children [left-rel right-rel]
                      :fields (union-fields left-fields right-fields)
-                     :->cursor (fn [{:keys [explain-analyze?]} left-cursor right-cursor]
+                     :->cursor (fn [{:keys [explain-analyze? tracer query-span]} left-cursor right-cursor]
                                  (cond-> (UnionAllCursor. left-cursor right-cursor)
-                                   explain-analyze? (ICursor/wrapExplainAnalyze)))})))
+                                   explain-analyze? (ICursor/wrapExplainAnalyze)
+                                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
 
 (deftype IntersectionCursor [^ICursor left-cursor, ^ICursor right-cursor
                              ^BuildSide build-side, key-col-names
@@ -128,7 +129,7 @@
                       {:op :intersect
                        :children [left-rel right-rel]
                        :fields fields
-                       :->cursor (fn [{:keys [allocator explain-analyze?]} left-cursor right-cursor]
+                       :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                                    (let [build-side (join/->build-side allocator
                                                                        {:fields left-fields
                                                                         :key-col-names key-col-names})]
@@ -138,7 +139,8 @@
                                                                   (join/->cmp-factory {:fields right-fields
                                                                                        :key-col-names key-col-names})
                                                                   false false)
-                                       explain-analyze? (ICursor/wrapExplainAnalyze))))}))))
+                                       explain-analyze? (ICursor/wrapExplainAnalyze)
+                                       (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))))
 
 (defmethod lp/emit-expr :difference [{:keys [left right]} args]
   (lp/binary-expr (lp/emit-expr left args) (lp/emit-expr right args)
@@ -148,7 +150,7 @@
                       {:op :difference
                        :children [left-rel right-rel]
                        :fields fields
-                       :->cursor (fn [{:keys [allocator explain-analyze?]} left-cursor right-cursor]
+                       :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                                    (let [build-side (join/->build-side allocator
                                                                        {:fields left-fields
                                                                         :key-col-names key-col-names})]
@@ -158,4 +160,5 @@
                                                                   (join/->cmp-factory {:fields right-fields
                                                                                        :key-col-names key-col-names})
                                                                   true false)
-                                       explain-analyze? (ICursor/wrapExplainAnalyze))))}))))
+                                       explain-analyze? (ICursor/wrapExplainAnalyze)
+                                       (and tracer query-span) (ICursor/wrapTracing tracer query-span))))}))))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -199,6 +199,7 @@
      :children []
      :fields   fields
      :stats    (when row-count {:row-count row-count})
-     :->cursor (fn [{:keys [allocator explain-analyze?] :as opts}]
+     :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (TableCursor. allocator (->out-rel opts))
-                   explain-analyze? (ICursor/wrapExplainAnalyze)))}))
+                   explain-analyze? (ICursor/wrapExplainAnalyze)
+                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -201,5 +201,4 @@
      :stats    (when row-count {:row-count row-count})
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (TableCursor. allocator (->out-rel opts))
-                   explain-analyze? (ICursor/wrapExplainAnalyze)
-                   (and tracer query-span) (ICursor/wrapTracing tracer query-span)))}))
+                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -69,7 +69,7 @@
                       :limit (some-> limit-arg pr-str)}
                      (into {} (filter val)))
        :fields fields
-       :->cursor (fn [{:keys [args explain-analyze?]} in-cursor]
+       :->cursor (fn [{:keys [args explain-analyze? tracer query-span]} in-cursor]
                    (cond-> (TopCursor. in-cursor
                                        (case skip-tag
                                          :literal skip-arg
@@ -80,4 +80,5 @@
                                          :param (read-param args limit-arg)
                                          nil Long/MAX_VALUE)
                                        0)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)))})))
+                     explain-analyze? (ICursor/wrapExplainAnalyze)
+                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -80,5 +80,4 @@
                                          :param (read-param args limit-arg)
                                          nil Long/MAX_VALUE)
                                        0)
-                     explain-analyze? (ICursor/wrapExplainAnalyze)
-                     (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -111,8 +111,9 @@
                         :fields (-> fields
                                     (assoc to-col (types/field-with-name unnest-field (str to-col)))
                                     (cond-> ordinality-column (assoc ordinality-column (types/col-type->field ordinality-column :i32))))
-                        :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+                        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                                     (cond-> (UnnestCursor. allocator in-cursor
                                                            (str from-col) (types/field-with-name unnest-field (str to-col))
                                                            (some-> ordinality-column str))
-                                      explain-analyze? (ICursor/wrapExplainAnalyze)))})))))
+                                      explain-analyze? (ICursor/wrapExplainAnalyze)
+                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -115,5 +115,4 @@
                                     (cond-> (UnnestCursor. allocator in-cursor
                                                            (str from-col) (types/field-with-name unnest-field (str to-col))
                                                            (some-> ordinality-column str))
-                                      explain-analyze? (ICursor/wrapExplainAnalyze)
-                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))
+                                      (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -173,5 +173,4 @@
                                                   order-specs
                                                   (vec window-fn-specs)
                                                   false))
-                         explain-analyze? (ICursor/wrapExplainAnalyze)
-                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -163,7 +163,7 @@
                                                      [to-column (pr-str window-agg)]))))}
            :fields out-fields
 
-           :->cursor (fn [{:keys [allocator explain-analyze?]} in-cursor]
+           :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
                                  (doseq [^IWindowFnSpecFactory factory window-fn-factories]
                                    (.add window-fn-specs (.build factory allocator)))
@@ -173,4 +173,5 @@
                                                   order-specs
                                                   (vec window-fn-specs)
                                                   false))
-                         explain-analyze? (ICursor/wrapExplainAnalyze)))})))))
+                         explain-analyze? (ICursor/wrapExplainAnalyze)
+                         (and tracer query-span) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1036,8 +1036,8 @@
           pg-types
           result-formats)))
 
-(defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
-  (let [{:keys [session transaction await-token]} @conn-state
+(defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator query-tracer] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
+  (let [{:keys [session transaction await-token query-span]} @conn-state
         {:keys [^Clock clock], session-params :parameters} session
         await-token (:await-token transaction await-token)
 
@@ -1047,7 +1047,9 @@
                                       (:current-time transaction)
                                       (.instant clock))
                     :default-tz (or (:default-tz transaction) (.getZone clock))
-                    :await-token await-token}
+                    :await-token await-token
+                    :tracer query-tracer
+                    :query-span query-span}
 
         xt-args (xtify-args conn args stmt)]
 

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -353,7 +353,7 @@
 
             (getWarnings [_] (:warnings (plan-query* @!table-info)))
 
-            (openQuery [_ {:keys [args current-time snapshot-token snapshot-time default-tz close-args? await-token]
+            (openQuery [_ {:keys [args current-time snapshot-token snapshot-time default-tz close-args? await-token tracer query-span]
                            :or {default-tz default-tz
                                 close-args? true}}]
               (util/with-close-on-catch [^BufferAllocator allocator (if allocator
@@ -408,7 +408,9 @@
                                                     :current-time current-time
                                                     :args args, :schema table-info
                                                     :default-tz default-tz
-                                                    :explain-analyze? (:explain-analyze? planned-query)})
+                                                    :explain-analyze? (:explain-analyze? planned-query)
+                                                    :tracer tracer
+                                                    :query-span query-span})
 
                                          (wrap-result-fields fields)
                                          (wrap-dynvars current-time expr/*snapshot-token* default-tz ref-ctr))]

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -91,6 +91,7 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
             private var rowCount: Long = 0;
             private var started = false
             private var startTime = clock.instant()
+            private var endTime = clock.instant()
             private var timeToFirstPage: Duration? = null
             private var totalTime: Duration = Duration.ZERO
             private var span: Span? = null
@@ -115,7 +116,9 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
                     pageCount++
                     c.accept(rel)
                 }.also {
-                    totalTime += Duration.between(pageStart, clock.instant())
+                    val pageEnd = clock.instant()
+                    totalTime += Duration.between(pageStart, pageEnd)
+                    endTime = pageEnd
                 }
             }
 
@@ -128,7 +131,6 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
                     }
                     s.tag("cursor.page_count", pageCount.toString())
                     s.tag("cursor.row_count", rowCount.toString())
-                    val endTime = startTime.plus(totalTime)
                     s.end(endTime.asMicros, java.util.concurrent.TimeUnit.MICROSECONDS)
                 }
             }

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -1,11 +1,15 @@
 package xtdb
 
+import io.micrometer.tracing.Tracer
+import io.micrometer.tracing.Span
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.query.IKeyFn
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.RelationReader
+import xtdb.time.InstantUtil.asMicros
 import java.lang.AutoCloseable
 import java.time.Duration
+import java.time.Instant
 import java.time.InstantSource
 import java.util.*
 import java.util.function.Consumer
@@ -77,7 +81,65 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
             override fun getComparator(): Comparator<in RelationReader>? = inner.comparator
         }
 
+        private class TracingCursor(
+            private val inner: ICursor,
+            private val tracer: Tracer,
+            private val parentSpan: Span,
+            private val clock: InstantSource = InstantSource.system()
+        ) : ICursor by inner {
+            private var pageCount: Int = 0;
+            private var rowCount: Long = 0;
+            private var started = false
+            private var startTime = clock.instant()
+            private var timeToFirstPage: Duration? = null
+            private var totalTime: Duration = Duration.ZERO
+            private var span: Span? = null
+
+            override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
+                if (!started) {
+                    started = true
+                    startTime = clock.instant()
+                    span = tracer.nextSpan(parentSpan)!!
+                        .name("query.cursor.${inner.cursorType}")
+                        .tag("cursor.type", inner.cursorType)
+                        .start()
+                }
+                val pageStart = clock.instant()
+
+                return inner.tryAdvance { rel ->
+                    val pageTime = Duration.between(pageStart, clock.instant())
+                    timeToFirstPage = timeToFirstPage ?: pageTime
+                    rowCount += rel.rowCount
+                    pageCount++
+                    c.accept(rel)
+                }.also {
+                    totalTime += Duration.between(pageStart, clock.instant())
+                }
+            }
+
+            override fun close() {
+                span!!.tag("cursor.total_time_ms", totalTime.toMillis().toString())
+                timeToFirstPage?.let { ttfp ->
+                    span!!.tag("cursor.time_to_first_page_ms", ttfp.toMillis().toString())
+                }
+                span!!.tag("cursor.page_count", pageCount.toString())
+                span!!.tag("cursor.row_count", rowCount.toString())
+                inner.close()
+                val endTime = startTime.plus(totalTime)
+                span!!.end(endTime.asMicros, java.util.concurrent.TimeUnit.MICROSECONDS)
+            }
+
+            @Suppress("RedundantOverride")
+            override fun forEachRemaining(action: Consumer<in RelationReader>?) = super.forEachRemaining(action)
+            override fun getExactSizeIfKnown(): Long = inner.exactSizeIfKnown
+            override fun hasCharacteristics(characteristics: Int): Boolean = inner.hasCharacteristics(characteristics)
+            override fun getComparator(): Comparator<in RelationReader>? = inner.comparator
+        }
+
         @JvmStatic
         fun ICursor.wrapExplainAnalyze(): ICursor = ExplainAnalyzeCursor(this)
+
+        @JvmStatic
+        fun ICursor.wrapTracing(tracer: Tracer, span: Span): ICursor = TracingCursor(this, tracer, span)
     }
 }


### PR DESCRIPTION
Resolves #4985 
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Atracing-scan-cursor

- Passes the query tracer and `pgwire.query` span down as query-opts from pgwire.
  - This allows us to create spans with pgwire.query as the parent, so they're all nested under there.
- Add TracingCursor/wrapTracing to ICursor.
  - This is where the bulk of the tracing implementation lives. 
  - TracingCursor wraps another ICursor and creates a child span under the provided parent (e.g. `pgwire.query`). 
  - The span is started when the cursor is first advanced and records metrics such as total execution time, time to first block, number of blocks, and total rows processed. These metrics are attached as span tags on close. 
- Calling TracingCursor/wrapTracing from all of our operators - essentially, similar to how we call wrapExplainAnalyze.
- Updated the tracer tests to verify full span hierarchy rather than just top-level spans - building a tree of nested spans, ensuring children appear in start-time order, and filtering out time-related attributes for deterministic comparison.

<img width="1814" height="1318" alt="image" src="https://github.com/user-attachments/assets/d20e3966-1574-487e-b9e4-9f4a18f5cbe8" />

