### PR TITLE
fix TsTzRangeVector promotion #4379

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
@@ -76,8 +76,14 @@ class FixedSizeListVector private constructor(
             elVector is NullVector && elVector.valueCount == 0 ->
                 Field("\$data\$", fieldType, emptyList()).openVector(al).also { elVector = it }
 
-            else -> TODO("promote elVector")
+            else -> elVector.maybePromote(al, fieldType).also { elVector = it }
         }
+
+    fun maybePromoteElement(targetFieldType: FieldType) {
+        if (elVector.field.fieldType != targetFieldType) {
+            elVector = elVector.maybePromote(al, targetFieldType)
+        }
+    }
 
     override fun getListCount(idx: Int) = listSize
     override fun getListStartIndex(idx: Int) = idx * listSize

--- a/core/src/main/kotlin/xtdb/arrow/TsTzRangeVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/TsTzRangeVector.kt
@@ -29,10 +29,15 @@ class TsTzRangeVector(override val inner: FixedSizeListVector) : ExtensionVector
 
     override fun writeObject0(value: Any) = when (value) {
         is ZonedDateTimeRange -> {
-            inner.getListElements(FieldType.notNullable(Timestamp(MICROSECOND, "UTC"))).let { elVec ->
-                if (value.from != null) elVec.writeObject(value.from) else elVec.writeLong(Long.MIN_VALUE)
-                if (value.to != null) elVec.writeObject(value.to) else elVec.writeLong(Long.MAX_VALUE)
-            }
+            val from = value.from
+            if (from != null) inner.maybePromoteElement(from.toFieldType())
+
+            val to = value.to
+            if (to != null) inner.maybePromoteElement(to.toFieldType())
+
+            val elVec = inner.listElements
+            if (from != null) elVec.writeObject(from) else elVec.writeLong(Long.MIN_VALUE)
+            if (to != null) elVec.writeObject(to) else elVec.writeLong(Long.MAX_VALUE)
             inner.endList()
         }
 


### PR DESCRIPTION
Re-requesting review on this as it seems the implementation we paired on could benefit from some changes to FixedSizeListVector also.

What we paired on looked like:
```
        is ZonedDateTimeRange -> {
            val from = value.from
            if (from != null) inner.maybePromote(inner.al, from.toFieldType())

            val to = value.to
            if (to != null) inner.maybePromote(inner.al, to.toFieldType())

            val elVec = inner.listElements
            if (from != null) elVec.writeObject(from) else elVec.writeLong(Long.MIN_VALUE)
            if (to != null) elVec.writeObject(to) else elVec.writeLong(Long.MAX_VALUE)
            inner.endList()
        }
```

I imagine the implementation proposed here is preferable to exposing the private `al` field from FixedSizeListVector...?