### PR TITLE
Add max-block-idx to partitions, fixes #4946

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -76,10 +76,7 @@
         p (range cat/branch-factor)
         :let [out-level (inc level)
               out-part (conj part p)
-              {level-above-live :live level-above-nascent :nascent} (get table-tries [out-level recency out-part])
-              {lnp1-live-block-idx :block-idx} (first level-above-live)
-              {lnp1-nascent-block-idx :block-idx} (first level-above-nascent)
-              lnp1-block-idx (or lnp1-nascent-block-idx lnp1-live-block-idx)
+              {lnp1-block-idx :max-block-idx} (get table-tries [out-level recency out-part])
 
               in-files (-> live-files
                            (cond->> lnp1-block-idx (drop-while #(<= (:block-idx %) lnp1-block-idx)))

--- a/core/src/main/proto/xtdb/meta/block/proto/block.proto
+++ b/core/src/main/proto/xtdb/meta/block/proto/block.proto
@@ -13,6 +13,7 @@ message Partition {
   int64 recency = 2;
   bytes part = 3;
   repeated xtdb.log.proto.TrieDetails tries = 4;
+  int64 max_block_index = 5;
 }
 
 message TableBlock {

--- a/src/test/clojure/xtdb/table_catalog_test.clj
+++ b/src/test/clojure/xtdb/table_catalog_test.clj
@@ -48,8 +48,8 @@
         (xt/execute-tx node [[:put-docs :foo {:xt/id 2}]])
         (tu/finish-block! node)
 
-        (t/is (= [(os/->StoredObject "tables/public$foo/blocks/b00.binpb" 4425)
-                  (os/->StoredObject "tables/public$foo/blocks/b01.binpb" 4579)]
+        (t/is (= [(os/->StoredObject "tables/public$foo/blocks/b00.binpb" 4427)
+                  (os/->StoredObject "tables/public$foo/blocks/b01.binpb" 4581)]
                  (.listAllObjects bp (table-cat/->table-block-dir #xt/table foo))))
 
         (let [{hlls1 :hlls :as _table-block1} (->> (.getByteArray bp (util/->path "tables/public$foo/blocks/b00.binpb"))
@@ -59,14 +59,18 @@
                                                   TableBlock/parseFrom
                                                   table-cat/<-table-block)
 
-              current-tries (->> table-block2
-                                 :partitions
+              partitions (:partitions table-block2)
+
+              current-tries (->> partitions
                                  (mapcat :tries)
                                  (map trie-details->edn)
                                  ;; they are sorted by block index descending
                                  reverse)
               trie-metas (map :trie-metadata current-tries)
               [trie1-bloom _trie2-bloom] (map :iid-bloom trie-metas)]
+
+          (t/is (= 1 (-> partitions first :max-block-idx)))
+
           (t/is (= [{:table #xt/table foo,
                      :trie-key "l00-rc-b00",
                      :data-file-size 1966}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b00.binpb.edn
@@ -15,4 +15,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [-2050569905 5]}}]}]}
+      :iid-bloom [-2050569905 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b01.binpb.edn
@@ -18,7 +18,8 @@
       :iid-bloom [314116840 5]}}
     {:trie-key "l00-rc-b00",
      :data-file-size 1966,
-     :trie-metadata nil}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}
   {:level 1,
    :part [],
    :tries
@@ -33,10 +34,12 @@
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
       :iid-bloom [-2050569905 5]}}],
+   :max-block-idx 0,
    :recency #xt/date "2011-01-03"}
   {:level 1,
    :part [],
    :tries
    [{:trie-key "l01-rc-b00",
      :data-file-size 1382,
-     :trie-metadata nil}]}]}
+     :trie-metadata nil}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b02.binpb.edn
@@ -8,7 +8,8 @@
    [{:trie-key "l00-rc-b01", :data-file-size 1966, :trie-metadata nil}
     {:trie-key "l00-rc-b00",
      :data-file-size 1966,
-     :trie-metadata nil}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}
   {:level 1,
    :part [],
    :tries
@@ -23,6 +24,7 @@
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
       :iid-bloom [-2050569905 5]}}],
+   :max-block-idx 0,
    :recency #xt/date "2011-01-03"}
   {:level 1,
    :part [],
@@ -30,7 +32,8 @@
    [{:trie-key "l01-rc-b01", :data-file-size 1382, :trie-metadata nil}
     {:trie-key "l01-rc-b00",
      :data-file-size 1382,
-     :trie-metadata nil}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}
   {:level 1,
    :part [],
    :tries
@@ -45,4 +48,5 @@
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 1,
       :iid-bloom [314116840 5]}}],
+   :max-block-idx 1,
    :recency #xt/date "2016-01-04"}]}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
@@ -26,7 +26,8 @@
       :iid-bloom [1432977773 5]}}
     {:trie-key "l00-rc-b00",
      :data-file-size 2798,
-     :trie-metadata nil}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}
   {:level 1,
    :part [],
    :tries
@@ -40,4 +41,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
@@ -16,7 +16,8 @@
    [{:trie-key "l00-rc-b01", :data-file-size 2798, :trie-metadata nil}
     {:trie-key "l00-rc-b00",
      :data-file-size 2798,
-     :trie-metadata nil}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}
   {:level 1,
    :part [],
    :tries
@@ -33,4 +34,5 @@
       :iid-bloom [-2083310006 10]}}
     {:trie-key "l01-rc-b00",
      :data-file-size 2806,
-     :trie-metadata nil}]}]}
+     :trie-metadata nil}],
+   :max-block-idx 1}]}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/public$device_info/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/public$device_info/blocks/b00.binpb.edn
@@ -25,4 +25,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 2,
-      :iid-bloom [218706493 10]}}]}]}
+      :iid-bloom [218706493 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/public$device_readings/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/public$device_readings/blocks/b00.binpb.edn
@@ -43,4 +43,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 2,
-      :iid-bloom [769566549 10]}}]}]}
+      :iid-bloom [769566549 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 2,
-      :iid-bloom [1087039858 10]}}]}]}
+      :iid-bloom [1087039858 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/public$xt_docs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/public$xt_docs/blocks/b00.binpb.edn
@@ -24,4 +24,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 6,
-      :iid-bloom [-484615358 30]}}]}]}
+      :iid-bloom [-484615358 30]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/tables/public$table/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/tables/public$table/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 2,
-      :iid-bloom [1099369295 10]}}]}]}
+      :iid-bloom [1099369295 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/public$foo/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/public$foo/blocks/b00.binpb.edn
@@ -17,4 +17,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 2,
-      :iid-bloom [1320799995 10]}}]}]}
+      :iid-bloom [1320799995 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/public$foo/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/public$foo/blocks/b01.binpb.edn
@@ -28,4 +28,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 2,
-      :iid-bloom [1320799995 10]}}]}]}
+      :iid-bloom [1320799995 10]}}],
+   :max-block-idx 1}]}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b01.binpb.edn
@@ -34,4 +34,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-01T00:00:00Z",
       :row-count 1,
-      :iid-bloom [341758827 5]}}]}]}
+      :iid-bloom [341758827 5]}}],
+   :max-block-idx 1}]}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
@@ -24,4 +24,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 6,
-      :iid-bloom [788818467 30]}}]}]}
+      :iid-bloom [788818467 30]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 2,
-      :iid-bloom [746386279 10]}}]}]}
+      :iid-bloom [746386279 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
@@ -18,4 +18,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-03T00:00:00Z",
       :row-count 4,
-      :iid-bloom [-1757454886 10]}}]}]}
+      :iid-bloom [-1757454886 10]}}],
+   :max-block-idx 0}]}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -23,4 +23,5 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-03T00:00:00Z",
       :row-count 3,
-      :iid-bloom [1421692163 15]}}]}]}
+      :iid-bloom [1421692163 15]}}],
+   :max-block-idx 0}]}


### PR DESCRIPTION
We are adding a max-block-idx to the partition proto. This is the largest block idx the partition has ever seen (including live, nascent and garbage). We use this twofold:
- Decide on stale messages (#4946)
- Decide on what to compact next (making sure we don't compact a file twice)

