### PR TITLE
Add additional tests and test utils to compactor simulation test.

### DIFF
--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -246,6 +246,16 @@ private val L0TrieKeys = sequence {
     }
 }
 
+private val L1TrieKeys = sequence {
+    var blockIndex = 0
+    while (true) {
+        yield("l01-rc-b" + blockIndex.asLexHex)
+        blockIndex++
+    }
+}
+
+fun List<TrieKey>.prefix(levelPrefix: String) = this.filter { it.startsWith(levelPrefix) }
+
 @ExtendWith(DriverConfigExtension::class)
 class SimulationTest : SimulationTestBase() {
     var driverConfig: DriverConfig = DriverConfig()

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -205,7 +205,7 @@ private fun buildTrieDetails(tableName: String, trieKey: String, dataFileSize: L
 
 // Settings used by all tests in this class
 private const val logLevel = "DEBUG"
-private const val testIterations = 10
+private const val testIterations = 100
 
 // Clojure interop to get at internal functions
 private val setLogLevel = requiringResolve("xtdb.logging/set-log-level!")


### PR DESCRIPTION
#4998 
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Amore-tests-for-dst++

Adds some additional test helpers and tests to the compactor simulation test:
- Increases iteration count of the simulation test.
- Adds `prefix` and `l1TrieKeys` helpers.
- Simplifies some of the existing tests.
- Adds another more specific test with partial l2s based on one in compactor_test.
- Adds a test with a number of concurrent tables being compacted simultaneously. 