### PR TITLE
Add MultiDbSimulationTest

### DIFF
--- a/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
+++ b/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
@@ -2,14 +2,16 @@ package xtdb
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Runnable
+import org.testcontainers.shaded.org.bouncycastle.asn1.cmp.Challenge
 import kotlin.coroutines.CoroutineContext
 import kotlin.random.Random
 
-class DeterministicDispatcher(seed: Int) : CoroutineDispatcher() {
+class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() {
+
+    constructor(seed: Int) : this(Random(seed))
 
     private data class DispatchJob(val context: CoroutineContext, val block: Runnable)
 
-    private val rand = Random(seed)
 
     private val jobs = mutableSetOf<DispatchJob>()
 

--- a/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
+++ b/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
@@ -2,7 +2,6 @@ package xtdb
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Runnable
-import org.testcontainers.shaded.org.bouncycastle.asn1.cmp.Challenge
 import kotlin.coroutines.CoroutineContext
 import kotlin.random.Random
 

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -594,8 +594,8 @@ class MultiDbSimulationTest {
             createTrieCatalog.invoke(mutableMapOf<Any, Any>(), 100 * 1024 * 1024) as TrieCatalog
         }
 
-        dbs = List(numberOfSystems) {
-            MockDb("xtdb", trieCatalogs[it] )
+        dbs = List(numberOfSystems) { i ->
+            MockDb("xtdb-$i", trieCatalogs[i] )
         }
     }
 

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -540,6 +540,24 @@ class SimulationTest : SimulationTestBase() {
     }
 }
 
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WithNumberOfSystems(val numberOfSystems: Int)
+
+class NumberOfSystemsExtension : BeforeEachCallback {
+    override fun beforeEach(context: ExtensionContext) {
+        val annotation = context.requiredTestMethod.getAnnotation(WithNumberOfSystems::class.java)
+            ?: return
+
+        val testInstance = context.requiredTestInstance
+        if (testInstance !is MultiDbSimulationTest) return
+
+        testInstance.numberOfSystems = annotation.numberOfSystems
+    }
+}
+
+@ExtendWith(SeedExceptionWrapper::class, SeedExtension::class, DriverConfigExtension::class, NumberOfSystemsExtension::class)
 class MultiDbSimulationTest {
     var currentSeed: Int = 0
     var explicitSeed: Int? = null

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -273,9 +273,6 @@ class SimulationTest : SimulationTestBase() {
     override fun setUpSimulation() {
         super.setUpSimulation()
         setLogLevel.invoke("xtdb.compactor".symbol, logLevel)
-        currentSeed = explicitSeed ?: Random.nextInt()
-        rand = Random(currentSeed)
-        dispatcher = DeterministicDispatcher(rand)
         mockDriver = MockDriver(dispatcher, currentSeed, driverConfig)
         jobCalculator = createJobCalculator.invoke() as Compactor.JobCalculator
         compactor = Compactor.Impl(mockDriver, null, jobCalculator, false, 2, dispatcher)

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -70,7 +70,7 @@ enum class TemporalSplitting {
 data class DriverConfig(
     val temporalSplitting: TemporalSplitting = CURRENT,
     val baseTime: Instant = Instant.parse("2020-01-01T00:00:00Z"),
-    val blocksPerWeek: Long = 14
+    val blocksPerWeek: Long = 140
 )
 
 class MockDriver(

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import xtdb.DeterministicDispatcher
+import xtdb.SeedExceptionWrapper
+import xtdb.SeedExtension
 import xtdb.SimulationTestBase
 import xtdb.WithSeed
 import xtdb.api.log.Log
@@ -269,6 +271,9 @@ class SimulationTest : SimulationTestBase() {
     override fun setUpSimulation() {
         super.setUpSimulation()
         setLogLevel.invoke("xtdb.compactor".symbol, logLevel)
+        currentSeed = explicitSeed ?: Random.nextInt()
+        rand = Random(currentSeed)
+        dispatcher = DeterministicDispatcher(rand)
         mockDriver = MockDriver(dispatcher, currentSeed, driverConfig)
         jobCalculator = createJobCalculator.invoke() as Compactor.JobCalculator
         compactor = Compactor.Impl(mockDriver, null, jobCalculator, false, 2, dispatcher)
@@ -563,6 +568,7 @@ class MultiDbSimulationTest {
     var explicitSeed: Int? = null
     var driverConfig: DriverConfig = DriverConfig()
     var numberOfSystems: Int = 2
+    private lateinit var rand: Random
     private lateinit var mockDriver: MockDriver
     private lateinit var jobCalculator: Compactor.JobCalculator
     private lateinit var compactors: List<Compactor.Impl>
@@ -574,7 +580,8 @@ class MultiDbSimulationTest {
     fun setUp() {
         setLogLevel.invoke("xtdb.compactor".symbol, logLevel)
         currentSeed = explicitSeed ?: Random.nextInt()
-        dispatcher = DeterministicDispatcher(currentSeed)
+        rand = Random(currentSeed)
+        dispatcher = DeterministicDispatcher(rand)
         mockDriver = MockDriver(dispatcher, currentSeed, driverConfig)
         jobCalculator = createJobCalculator.invoke() as Compactor.JobCalculator
 


### PR DESCRIPTION
This adds a couple of things (I likely squash it into one commit at the end):
- Adding a MultiDbSimulationTest
- Switching from `Channel` to `SharedFlow` in MockDriver
- A `@WithNumberOfSystems` annotation for tests
- Adds a  `startCompaction` method to the `Compactor.ForDatabase` interface to start compactors without waiting for everything to be compacted.