### PR TITLE
Make simulation test iterations configurable by system property.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,7 @@ allprojects {
             testRuntimeOnly(libs.slf4j.jpl)
 
             testImplementation(libs.junit.jupiter.api)
+            testImplementation(libs.junit.jupiter.params)
             testRuntimeOnly(libs.junit.jupiter.engine)
             testRuntimeOnly(libs.junit.platform.launcher)
 
@@ -485,6 +486,7 @@ dependencies {
     testImplementation(kotlin("test-junit5"))
     testImplementation(libs.kotest)
     testImplementation(libs.kotest.props)
+    testImplementation(libs.junit.jupiter.params)
 
     // For Healthz Test
     testImplementation("clj-http", "clj-http","3.12.3")

--- a/core/src/test/kotlin/xtdb/SimulationTestBase.kt
+++ b/core/src/test/kotlin/xtdb/SimulationTestBase.kt
@@ -2,12 +2,17 @@ package xtdb
 
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import xtdb.util.logger
 import xtdb.util.warn
+import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 @Target(AnnotationTarget.FUNCTION)
@@ -58,5 +63,18 @@ abstract class SimulationTestBase {
     @AfterEach
     open fun tearDownSimulation() {
         explicitSeed = null
+    }
+
+    companion object SimulationIterations {
+        /**
+         * Returns iteration numbers for simulation tests.
+         * Override using:
+         *   -Dxtdb.simulation-test-iterations=N
+         */
+        private val testIterations: Int =
+            System.getProperty("xtdb.simulation-test-iterations", "100").toInt()
+
+        @JvmStatic
+        fun iterationSource(): List<Arguments> = (1..testIterations).map { Arguments.of(it) }
     }
 }

--- a/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/SimulationTest.kt
@@ -646,7 +646,7 @@ class MultiDbSimulationTest : SimulationTestBase() {
     }
 
     @RepeatedTest(10)
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @WithDriverConfig(temporalSplitting = BOTH)
     fun biggerMultiCompactorRun() {
         val docsTable = TableRef("xtdb", "public", "docs")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ integrant = { group = "integrant", name = "integrant", version = "1.0.1" }
 buddy-hashers = { group = "buddy", name = "buddy-hashers", version = "2.0.167" }
 
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-launcher" }
 


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Aconfigurable-sim-test-iterations++ 

Required a replacement of RepeatedTest in most places as this cannot have non-compile time values - making use of ParameterizedTest and a MethodSource for the iterations instead. 