### PR TITLE
Add cancellation handling to LocalLog subscriber

### DIFF
--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -1,0 +1,41 @@
+package xtdb.api.log
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.io.TempDir
+import xtdb.api.log.Log.Message
+import xtdb.api.log.Log.Record
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+class LocalLogTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Tag("integration")
+    @RepeatedTest(5000)
+    fun `close should cancel all subscription coroutines without leaking`() = runTest(timeout = 10.seconds) {
+        val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
+
+        // Create a subscription
+        val records = mutableListOf<Record>()
+        val subscription = log.subscribe(
+            object : Log.Subscriber {
+                override val latestProcessedMsgId: Long = -1
+                override val latestSubmittedMsgId: Long = -1
+                override fun processRecords(recs: List<Record>) {
+                    recs.forEach { records.add(it) }
+                }
+            },
+            -1
+        )
+
+        log.appendMessage(Message.FlushBlock(1))
+
+        subscription.close()
+
+        log.close()
+    }
+}


### PR DESCRIPTION
Optimistically resolves #4914
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Aintermittent-log-close-error++

Intermittent failures in the integration and nightly test suites were traced back to `LocalLog.subscribe()`. Although many of the failing tests (e.g. blob-storage tests) didn't actually USE `LocalLog`. It appears that errors thrown within node close() on previous tests were causing issues in later tests.

The underlying issue was that LocalLog.subscribe() was not handle coroutine cancellation robustly. Subscription coroutines could encounter `ClosedByInterruptException` or attempt to read from a closed channel during shutdown, and these cases were not being caught or handled. As a result, we would throw unhandled errors which would cause issues in subsequent tests.

This PR improves cancellation handling within LocalLog.subscribe() by:
- Catching ClosedByInterruptException and InterruptedException and cancelling the subscription coroutine cleanly.
- Using receiveCatching() to gracefully handle channel closure without throwing.
  - Similar to what we are doing within the InMemoryLog.