### PR TITLE
Add type-strict equality (`===`) to the expression engine

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -747,16 +747,16 @@
   (defmethod codegen-call [f-kw :any :any] [_]
     {:return-type :bool, :->call-code #(cmp `(compare ~@%))}))
 
-(defmethod codegen-call [:= :num :num] [_]
+(defmethod codegen-call [:== :num :num] [_]
   {:return-type :bool
    :->call-code #(do `(== ~@%))})
 
-(defmethod codegen-call [:= :any :any] [_]
+(defmethod codegen-call [:== :any :any] [_]
   {:return-type :bool
    :->call-code #(do `(= ~@%))})
 
 (doseq [col-type #{:varbinary :utf8 :uuid}]
-  (defmethod codegen-call [:= col-type col-type] [_]
+  (defmethod codegen-call [:== col-type col-type] [_]
     {:return-type :bool,
      :->call-code #(do `(.equals ~@%))}))
 
@@ -1608,11 +1608,11 @@
 (defmethod codegen-call [:get_field :any] [_]
   {:return-type :null, :->call-code (constantly nil)})
 
-(doseq [[op return-code] [[:= 1] [:<> -1]]]
+(doseq [[op return-code] [[:== 1] [:<> -1]]]
   (defmethod codegen-call [op :struct :struct] [{[[_ l-field-types] [_ r-field-types]] :arg-types}]
     (let [fields (set (keys l-field-types))]
       (if-not (= fields (set (keys r-field-types)))
-        {:return-type :bool, :->call-code (constantly (if (= := op) false true))}
+        {:return-type :bool, :->call-code (constantly (if (= :== op) false true))}
 
         (let [inner-calls (->> (for [field fields]
                                  (MapEntry/create field
@@ -1621,7 +1621,7 @@
                                                          (MapEntry/create [l-val-type r-val-type]
                                                                           (if (or (= :null l-val-type) (= :null r-val-type))
                                                                             {:return-type :null, :->call-code (constantly nil)}
-                                                                            (codegen-call {:f :=, :arg-types [l-val-type r-val-type]}))))
+                                                                            (codegen-call {:f :==, :arg-types [l-val-type r-val-type]}))))
                                                        (into {}))))
                                (into {}))
               l-sym (gensym 'l-struct)
@@ -1828,7 +1828,7 @@
                              ~(f return-type (-> `(trim-array-view ~n-sym ~list-sym)
                                                  (with-tag ListValueReader)))))))}))
 
-(doseq [[op return-code] [[:= 1] [:<> -1]]]
+(doseq [[op return-code] [[:== 1] [:<> -1]]]
   (defmethod codegen-call [op :list :list] [{[[_ l-el-type] [_ r-el-type]] :arg-types}]
     (let [n-sym (gensym 'n)
           len-sym (gensym 'len)
@@ -1838,7 +1838,7 @@
                              (MapEntry/create [l-el-type r-el-type]
                                               (if (or (= :null l-el-type) (= :null r-el-type))
                                                 {:return-type :null, :->call-code (constantly nil)}
-                                                (codegen-call {:f :=, :arg-types [l-el-type r-el-type]}))))
+                                                (codegen-call {:f :==, :arg-types [l-el-type r-el-type]}))))
                            (into {}))]
 
       {:return-type [:union #{:bool :null}]
@@ -1890,8 +1890,8 @@
    :->call-code (fn [[start end step]]
                   `(series (long ~start) (long ~end) (long ~step)))})
 
-(defmethod codegen-call [:= :set :set] [{[[_ _l-el-type] [_ _r-el-type]] :arg-types}]
-  (throw (UnsupportedOperationException. "TODO: `=` on sets")))
+(defmethod codegen-call [:== :set :set] [{[[_ _l-el-type] [_ _r-el-type]] :arg-types}]
+  (throw (UnsupportedOperationException. "TODO: `==` on sets")))
 
 (defmethod codegen-call [:<> :set :set] [{[[_ _l-el-type] [_ _r-el-type]] :arg-types}]
   (throw (UnsupportedOperationException. "TODO: `<>` on sets")))

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -612,7 +612,7 @@
 
 (def ^:private shortcut-null-args?
   (complement (comp #{:is_true :is_false :is_null :true? :false? :nil? :boolean
-                      :null_eq :compare_nulls_first :compare_nulls_last
+                      :=== :null_eq :compare_nulls_first :compare_nulls_last
                       :period :str :_patch}
                     normalise-fn-name)))
 
@@ -751,12 +751,31 @@
   {:return-type :bool
    :->call-code #(do `(== ~@%))})
 
-(defmethod codegen-call [:== :any :any] [_]
+(defmethod codegen-call [:== :any :any] [expr]
+  (codegen-call (assoc expr :f :===)))
+
+(defmethod codegen-call [:=== :any :any] [_]
   {:return-type :bool
    :->call-code #(do `(= ~@%))})
 
+(defmethod codegen-call [:=== :null :null] [_]
+  {:return-type :bool
+   :->call-code (constantly true)})
+
+(defmethod codegen-call [:=== :int :int] [_]
+  {:return-type :bool
+   :->call-code #(do `(== ~@%))})
+
+(defmethod codegen-call [:=== :float :float] [_]
+  {:return-type :bool
+   :->call-code #(do `(== ~@%))})
+
+(defmethod codegen-call [:=== :decimal :decimal] [_]
+  {:return-type :bool
+   :->call-code #(do `(== ~@%))})
+
 (doseq [col-type #{:varbinary :utf8 :uuid}]
-  (defmethod codegen-call [:== col-type col-type] [_]
+  (defmethod codegen-call [:=== col-type col-type] [_]
     {:return-type :bool,
      :->call-code #(do `(.equals ~@%))}))
 

--- a/core/src/main/clojure/xtdb/expression/comparator.clj
+++ b/core/src/main/clojure/xtdb/expression/comparator.clj
@@ -10,7 +10,7 @@
 ;; null-eq is an internal function used in situations where two nulls should compare equal,
 ;; e.g when grouping rows in group-by.
 (defmethod expr/codegen-call [:null_eq :any :any] [call]
-  (expr/codegen-call (assoc call :f :=)))
+  (expr/codegen-call (assoc call :f :==)))
 
 (defmethod expr/codegen-call [:null_eq :null :any] [_]
   {:return-type :bool, :->call-code (constantly false)})

--- a/core/src/main/clojure/xtdb/expression/macro.clj
+++ b/core/src/main/clojure/xtdb/expression/macro.clj
@@ -67,7 +67,7 @@
       2 expr
       (macroexpand1r-call expr))))
 
-(doseq [f #{:< :<= := :!= :>= :>}]
+(doseq [f #{:< :<= :== :!= :>= :>}]
   (defmethod macroexpand1-call f [{:keys [args] :as expr}]
     (case (count args)
       (0 1) {:op :literal, :literal (not= f :!=)}
@@ -101,7 +101,7 @@
             :args (->> (for [[test expr] (partition-all 2 clauses)]
                          (if-not expr
                            [test] ; default case
-                           [{:op :call, :f :=,
+                           [{:op :call, :f :==,
                              :args [{:op :local, :local local} test]}
                             expr]))
                        (mapcat identity))}}))
@@ -124,7 +124,7 @@
      :expr x
      :body {:op :if
             :pred {:op :call, :f :true?
-                   :args [{:op :call, :f :=,
+                   :args [{:op :call, :f :==,
                            :args [{:op :local, :local local} y]}]}
             :then nil-literal
             :else {:op :local, :local local}}}))

--- a/core/src/main/clojure/xtdb/expression/map.clj
+++ b/core/src/main/clojure/xtdb/expression/map.clj
@@ -46,7 +46,7 @@
 
 (defn ->equi-comparator [^VectorReader left-col, ^VectorReader right-col, params
                          {:keys [nil-keys-equal? param-fields]}]
-  (let [f (build-comparator {:op :call, :f (if nil-keys-equal? :null-eq :=)
+  (let [f (build-comparator {:op :call, :f (if nil-keys-equal? :null-eq :==)
                              :args [{:op :variable, :variable left-vec, :rel left-rel, :idx left-idx}
                                     {:op :variable, :variable right-vec, :rel right-rel, :idx right-idx}]}
                             {:vec-fields {left-vec (.getField left-col)

--- a/core/src/main/clojure/xtdb/expression/metadata.clj
+++ b/core/src/main/clojure/xtdb/expression/metadata.clj
@@ -102,7 +102,7 @@
                          {:op :test-not-null
                           :col (:variable nil-arg)}))))
 
-            (:< :<= :> :>= :=)
+            (:< :<= :> :>= :==)
             (when-let [[field-val-tag col-expr val-expr] (normalise-bool-args args)]
               (case field-val-tag
                 :constant expr
@@ -111,22 +111,22 @@
                            :<= (minmax-expr :<= :min col-expr val-expr)
                            :> (minmax-expr :> :max col-expr val-expr)
                            :>= (minmax-expr :>= :max col-expr val-expr)
-                           := {:op :call, :f :and
-                               :args [(minmax-expr :<= :min col-expr val-expr)
-                                      (minmax-expr :>= :max col-expr val-expr)
+                           :== {:op :call, :f :and
+                                :args [(minmax-expr :<= :min col-expr val-expr)
+                                       (minmax-expr :>= :max col-expr val-expr)
 
-                                      (bloom-expr col-expr val-expr)
-                                      (presence-expr col-expr val-expr)]})
+                                       (bloom-expr col-expr val-expr)
+                                       (presence-expr col-expr val-expr)]})
 
                 :val-col (case f
                            :< (minmax-expr :> :max col-expr val-expr)
                            :<= (minmax-expr :>= :max col-expr val-expr)
                            :> (minmax-expr :< :min col-expr val-expr)
                            :>= (minmax-expr :<= :min col-expr val-expr)
-                           := {:op :call, :f :and
-                               :args [(minmax-expr :<= :min col-expr val-expr)
-                                      (minmax-expr :>= :max col-expr val-expr)
-                                      (bloom-expr col-expr val-expr)]})))
+                           :== {:op :call, :f :and
+                                :args [(minmax-expr :<= :min col-expr val-expr)
+                                       (minmax-expr :>= :max col-expr val-expr)
+                                       (bloom-expr col-expr val-expr)]})))
 
             nil)
 

--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -940,7 +940,7 @@
                   (= x-unit :month-day-nano) (fn [[x y]] `(compare-md*-intervals ~x ~y))
                   (= x-unit :month-day-micro) (fn [[x y]] `(compare-md*-intervals ~x ~y)))})
 
-(doseq [[f cmp] [[:= #(do `(zero? ~%))]
+(doseq [[f cmp] [[:== #(do `(zero? ~%))]
                  [:< #(do `(neg? ~%))]
                  [:<= #(do `(not (pos? ~%)))]
                  [:> #(do `(pos? ~%))]
@@ -962,7 +962,7 @@
 
 ;;;; Periods
 
-(defmethod expr/codegen-call [:= :tstz-range :tstz-range] [_]
+(defmethod expr/codegen-call [:== :tstz-range :tstz-range] [_]
   {:return-type :bool
    :->call-code (fn [[x y]]
                   (let [x-sym (gensym 'x)

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -327,7 +327,7 @@
 (defn equals-predicate? [predicate]
   (and (sequential? predicate)
        (= 3 (count predicate))
-       (= '= (first predicate))))
+       (= '== (first predicate))))
 
 (defn all-columns-in-relation?
   "Returns true if all columns referenced by the expression are present in the given relation.

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -128,7 +128,7 @@
 
 (defn selects->iid-bytes ^bytes [selects ^RelationReader args-rel]
   (when-let [eid-select (get selects "_id")]
-    (when (= '= (first eid-select))
+    (when (= '== (first eid-select))
       (when-let [eid (eid-select->eid eid-select)]
         (cond
           (and (s/valid? ::lp/value eid) (util/valid-iid? eid))

--- a/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
@@ -32,7 +32,7 @@
                           [:rename {_id n_nationkey}
                            [:scan {:table #xt/table nation} [_id n_name n_regionkey]]]
                           [:rename {_id r_regionkey}
-                           [:scan {:table #xt/table region} [_id {r_name (= r_name ?region)}]]]]
+                           [:scan {:table #xt/table region} [_id {r_name (== r_name ?region)}]]]]
                          [:rename {_id s_suppkey}
                           [:scan {:table #xt/table supplier} [_id s_nationkey s_acctbal s_name s_address s_phone s_comment]]]]
                         [:scan {:table #xt/table partsupp} [ps_suppkey ps_partkey ps_supplycost]]]]
@@ -43,7 +43,7 @@
             [:join [{ps_partkey p_partkey}]
              [:relation PartSupp {:col-names [ps_partkey ps_supplycost]}]
              [:rename {_id p_partkey}
-              [:scan {:table #xt/table part} [_id p_mfgr {p_size (= p_size ?size)} {p_type (like p_type "%BRASS")}]]]]
+              [:scan {:table #xt/table part} [_id p_mfgr {p_size (== p_size ?size)} {p_type (like p_type "%BRASS")}]]]]
             [:group-by [ps_partkey {min_ps_supplycost (min ps_supplycost)}]
              [:relation PartSupp {:col-names [ps_partkey ps_supplycost]}]]]]]]]
       (with-args {:region "EUROPE"
@@ -63,7 +63,7 @@
             [:join [{c_custkey o_custkey}]
              [:rename {_id c_custkey}
               [:scan {:table #xt/table customer}
-               [_id {c_mktsegment (= c_mktsegment ?segment)}]]]
+               [_id {c_mktsegment (== c_mktsegment ?segment)}]]]
              [:rename {_id o_orderkey}
               [:scan {:table #xt/table orders}
                [_id o_custkey o_shippriority
@@ -99,7 +99,7 @@
              [:join [{r_regionkey n_regionkey}]
               [:rename {_id r_regionkey}
                [:scan {:table #xt/table region}
-                [_id {r_name (= r_name "ASIA")}]]]
+                [_id {r_name (== r_name "ASIA")}]]]
               [:rename {_id n_nationkey}
                [:scan {:table #xt/table nation}
                 [_id n_name n_regionkey]]]]
@@ -140,15 +140,15 @@
                     {volume (* l_extendedprice (- 1 l_discount))}]
           [:rename {n1/n_name supp_nation, n2/n_name cust_nation}
            [:join [{c_nationkey n2/n_nationkey}
-                   (or (and (= n1/n_name ?nation1)
-                            (= n2/n_name ?nation2))
-                       (and (= n1/n_name ?nation2)
-                            (= n2/n_name ?nation1)))]
+                   (or (and (== n1/n_name ?nation1)
+                            (== n2/n_name ?nation2))
+                       (and (== n1/n_name ?nation2)
+                            (== n2/n_name ?nation1)))]
             [:join [{o_custkey c_custkey}]
              [:join [{n1/n_nationkey s_nationkey}]
               [:rename n1
                [:rename {_id n_nationkey}
-                [:scan {:table #xt/table nation} [_id {n_name (or (= n_name ?nation1) (= n_name ?nation2))}]]]]
+                [:scan {:table #xt/table nation} [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]]]]
               [:join [{o_orderkey l_orderkey}]
                [:rename {_id o_orderkey}
                 [:scan {:table #xt/table orders} [_id o_custkey]]]
@@ -163,7 +163,7 @@
               [:scan {:table #xt/table customer} [_id c_nationkey]]]]
             [:rename n2
              [:rename {_id n_nationkey}
-              [:scan {:table #xt/table nation} [_id {n_name (or (= n_name ?nation1) (= n_name ?nation2))}]]]]]]]]]
+              [:scan {:table #xt/table nation} [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]]]]]]]]]
       (with-args {:nation1 "FRANCE"
                   :nation2 "GERMANY"
                   :start-date (LocalDate/parse "1995-01-01")
@@ -174,7 +174,7 @@
         [:project [o_year {mkt_share (/ brazil_revenue revenue)}]
          [:group-by [o_year {brazil_revenue (sum brazil_volume)} {revenue (sum volume)}]
           [:project [{o_year (extract "YEAR" o_orderdate)}
-                     {brazil_volume (if (= nation ?nation)
+                     {brazil_volume (if (== nation ?nation)
                                       (* l_extendedprice (- 1 l_discount))
                                       0.0)}
                      {volume (* l_extendedprice (- 1 l_discount))}
@@ -187,7 +187,7 @@
                 [:join [{l_suppkey s_suppkey}]
                  [:join [{p_partkey l_partkey}]
                   [:rename {_id p_partkey}
-                   [:scan {:table #xt/table part} [_id {p_type (= p_type ?type)}]]]
+                   [:scan {:table #xt/table part} [_id {p_type (== p_type ?type)}]]]
                   [:scan {:table #xt/table lineitem} [l_orderkey l_extendedprice l_discount l_suppkey l_partkey]]]
                  [:rename {_id s_suppkey}
                   [:scan {:table #xt/table supplier} [_id s_nationkey]]]]
@@ -200,7 +200,7 @@
                 [:scan {:table #xt/table customer} [_id c_nationkey]]]]
               [:join [{r_regionkey n1/n_regionkey}]
                [:rename {_id r_regionkey}
-                [:scan {:table #xt/table region} [_id {r_name (= r_name ?region)}]]]
+                [:scan {:table #xt/table region} [_id {r_name (== r_name ?region)}]]]
                [:rename n1
                 [:rename {_id n_nationkey}
                  [:scan {:table #xt/table nation} [_id n_name n_regionkey]]]]]]
@@ -257,7 +257,7 @@
                  {o_orderdate (and (>= o_orderdate ?start_date)
                                    (< o_orderdate ?end_date))}]]]]
              [:scan {:table #xt/table lineitem}
-              [l_orderkey {l_returnflag (= l_returnflag "R")} l_extendedprice l_discount]]]
+              [l_orderkey {l_returnflag (== l_returnflag "R")} l_extendedprice l_discount]]]
             [:rename {_id n_nationkey}
              [:scan {:table #xt/table nation} [_id n_name]]]]]]]]
       (with-args {:start-date (LocalDate/parse "1993-10-01")
@@ -268,7 +268,7 @@
                         [:join [{s_suppkey ps_suppkey}]
                          [:join [{n_nationkey s_nationkey}]
                           [:rename {_id n_nationkey}
-                           [:scan {:table #xt/table nation} [_id {n_name (= n_name ?nation)}]]]
+                           [:scan {:table #xt/table nation} [_id {n_name (== n_name ?nation)}]]]
                           [:rename {_id s_suppkey}
                            [:scan {:table #xt/table supplier} [_id s_nationkey]]]]
                          [:scan {:table #xt/table partsupp} [ps_partkey ps_suppkey ps_supplycost ps_availqty]]]]]
@@ -289,8 +289,8 @@
                     {high_line_count (sum high_line)}
                     {low_line_count (sum low_line)}]
          [:project [l_shipmode
-                    {high_line (if (or (= o_orderpriority "1-URGENT")
-                                       (= o_orderpriority "2-HIGH"))
+                    {high_line (if (or (== o_orderpriority "1-URGENT")
+                                       (== o_orderpriority "2-HIGH"))
                                  1
                                  0)}
                     {low_line (if (and (<> o_orderpriority "1-URGENT")
@@ -304,8 +304,8 @@
                          (< l_shipdate l_commitdate))
             [:scan {:table #xt/table lineitem}
              [l_orderkey l_commitdate l_shipdate
-              {l_shipmode (or (= l_shipmode ?ship_mode1)
-                              (= l_shipmode ?ship_mode2))}
+              {l_shipmode (or (== l_shipmode ?ship_mode1)
+                              (== l_shipmode ?ship_mode2))}
               {l_receiptdate (and (>= l_receiptdate ?start_date)
                                   (< l_receiptdate ?end_date))}]]]]]]]
       (with-args {:ship-mode1 "MAIL"
@@ -395,7 +395,7 @@
          [:join [{p_partkey l_partkey} (< l_quantity small_avg_qty)]
           [:rename {_id p_partkey}
            [:scan {:table #xt/table part}
-            [_id {p_brand (= p_brand ?brand)} {p_container (= p_container ?container)}]]]
+            [_id {p_brand (== p_brand ?brand)} {p_container (== p_container ?container)}]]]
           [:join [{l_partkey l_partkey}]
            [:project [l_partkey {small_avg_qty (* 0.2 avg_qty)}]
             [:group-by [l_partkey {avg_qty (avg l_quantity)}]
@@ -424,29 +424,29 @@
 (def q19-discounted-revenue
   (-> '[:group-by [{revenue (sum disc_price)}]
         [:project [{disc_price (* l_extendedprice (- 1 l_discount))}]
-         [:select (or (and (= p_brand ?brand1)
-                           (or (= p_container "SM CASE")
-                               (= p_container "SM BOX")
-                               (= p_container "SM PACK")
-                               (= p_container "SM PKG"))
+         [:select (or (and (== p_brand ?brand1)
+                           (or (== p_container "SM CASE")
+                               (== p_container "SM BOX")
+                               (== p_container "SM PACK")
+                               (== p_container "SM PKG"))
                            (>= l_quantity ?qty1)
                            (<= l_quantity (+ ?qty1 10))
                            (>= p_size 1)
                            (<= p_size 5))
-                      (and (= p_brand ?brand2)
-                           (or (= p_container "MED CASE")
-                               (= p_container "MED BOX")
-                               (= p_container "MED PACK")
-                               (= p_container "MED PKG"))
+                      (and (== p_brand ?brand2)
+                           (or (== p_container "MED CASE")
+                               (== p_container "MED BOX")
+                               (== p_container "MED PACK")
+                               (== p_container "MED PKG"))
                            (>= l_quantity ?qty2)
                            (<= l_quantity (+ ?qty2 10))
                            (>= p_size 1)
                            (<= p_size 10))
-                      (and (= p_brand ?brand3)
-                           (or (= p_container "LG CASE")
-                               (= p_container "LG BOX")
-                               (= p_container "LG PACK")
-                               (= p_container "LG PKG"))
+                      (and (== p_brand ?brand3)
+                           (or (== p_container "LG CASE")
+                               (== p_container "LG BOX")
+                               (== p_container "LG PACK")
+                               (== p_container "LG PKG"))
                            (>= l_quantity ?qty3)
                            (<= l_quantity (+ ?qty3 10))
                            (>= p_size 1)
@@ -456,8 +456,8 @@
             [:scan {:table #xt/table part} [_id p_brand p_container p_size]]]
            [:scan {:table #xt/table lineitem}
             [l_partkey l_extendedprice l_discount l_quantity
-             {l_shipmode (or (= l_shipmode "AIR") (= l_shipmode "AIR REG"))}
-             {l_shipinstruct (= l_shipinstruct "DELIVER IN PERSON")}]]]]]]
+             {l_shipmode (or (== l_shipmode "AIR") (== l_shipmode "AIR REG"))}
+             {l_shipinstruct (== l_shipinstruct "DELIVER IN PERSON")}]]]]]]
       (with-args {:qty1 1, :qty2 10, :qty3 20
                   :brand1 "Brand#12", :brand2 "Brand23", :brand3 "Brand#34"})))
 
@@ -467,7 +467,7 @@
          [:semi-join [{s_suppkey ps_suppkey}]
           [:join [{n_nationkey s_nationkey}]
            [:rename {_id n_nationkey}
-            [:scan {:table #xt/table nation} [_id {n_name (= n_name ?nation)}]]]
+            [:scan {:table #xt/table nation} [_id {n_name (== n_name ?nation)}]]]
            [:rename {_id s_suppkey}
             [:scan {:table #xt/table supplier} [_id s_name s_address s_nationkey]]]]
           [:join [{ps_partkey l_partkey} {ps_suppkey l_suppkey} (> ps_availqty sum_qty)]
@@ -496,14 +496,14 @@
                        [l_orderkey l_suppkey l_receiptdate l_commitdate]]]]
                     [:rename {_id o_orderkey}
                      [:scan {:for-valid-time [:at :now], :table #xt/table orders}
-                      [_id {o_orderstatus (= o_orderstatus "F")}]]]]
+                      [_id {o_orderstatus (== o_orderstatus "F")}]]]]
                    [:semi-join [{s_nationkey n_nationkey}]
                     [:rename {_id s_suppkey}
                      [:scan {:for-valid-time [:at :now], :table #xt/table supplier}
                       [_id s_nationkey s_name]]]
                     [:rename {_id n_nationkey}
                      [:scan {:for-valid-time [:at :now], :table #xt/table nation}
-                      [_id {n_name (= n_name ?nation)}]]]]]
+                      [_id {n_name (== n_name ?nation)}]]]]]
                   [:rename l2
                    [:scan {:for-valid-time [:at :now], :table #xt/table lineitem}
                     [l_orderkey l_suppkey]]]]]

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -456,7 +456,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
              {:depth "  ->", :op :scan,
               :explain {:table "xtdb.public.people",
                         :columns ["_valid_from" "age" "name" "_valid_to" "_id"],
-                        :predicates ["(= _id ?_0)"]}}]
+                        :predicates ["(== _id ?_0)"]}}]
            (xt/q tu/*node*
                  [(format "EXPLAIN XTQL ($$ %s $$, ?)"
                           (pr-str '#(from :people [{:xt/id %} name age xt/valid-from xt/valid-to])))
@@ -468,7 +468,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
              {:depth "    ->", :op :scan,
               :explain {:table "xtdb.public.people"
                         :columns ["_valid_from" "age" "name" "_valid_to" "_id"]
-                        :predicates ["(= _id ?_0)"]}}]
+                        :predicates ["(== _id ?_0)"]}}]
            (xt/q tu/*node*
                  ["EXPLAIN SELECT name, age, _valid_from, _valid_to FROM people WHERE _id = ?"
                   "dummy-arg-because-pgjdbc-expects-one"]))))

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -1835,3 +1835,30 @@
   (t/is (= #xt/duration "PT13M56.12345678S" (time/alter-duration-precision 8 #xt/duration "PT13M56.123456789S")))
   (t/is (= #xt/duration "PT13M56.123456S" (time/alter-duration-precision 6 #xt/duration "PT13M56.123456789S")))
   (t/is (= #xt/duration "PT13M56.123S" (time/alter-duration-precision 3 #xt/duration "PT13M56.123456789S"))))
+
+(deftest test-type-strict-equality-temporal
+  (t/is (true? (et/project1 '(=== #xt/instant "2020-01-01T00:00:00Z"
+                                  #xt/instant "2020-01-01T00:00:00Z") {}))
+        "timestamp-tz === same TZ")
+
+  (t/is (false? (et/project1 '(=== #xt/zdt "2020-01-01T00:00:00Z"
+                                   #xt/zdt "2020-01-01T01:00:00+01:00") {}))
+        "timestamp-tz !== different TZ (same instant)")
+
+  (t/is (true? (et/project1 '(== #xt/zdt "2020-01-01T00:00:00Z"
+                                 #xt/zdt "2020-01-01T01:00:00+01:00") {}))
+        "timestamp-tz == different TZ (same instant)")
+
+  (t/is (true? (et/project1 '(=== #xt/ldt "2020-01-01T00:00:00"
+                                  #xt/ldt "2020-01-01T00:00:00") {}))
+        "timestamp-local ===")
+
+  (t/is (false? (et/project1 '(=== #xt/ldt "2020-01-01T00:00:00"
+                                   #xt/instant "2020-01-01T00:00:00Z") {}))
+        "timestamp-local !== timestamp-tz")
+
+  (t/is (true? (et/project1 '(=== #xt/date "2020-01-01" #xt/date "2020-01-01") {}))
+        "date ===")
+
+  (t/is (true? (et/project1 '(=== #xt/duration "PT1H" #xt/duration "PT1H") {}))
+        "duration ==="))

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -18,7 +18,7 @@
 ;; equality may well remain incorrect for now, it is not the goal
 (t/deftest clock-influences-equality-of-ambiguous-datetimes-test
   (t/are [expected a b zone-id]
-      (= expected (-> (tu/query-ra [:project [{'res '(= ?a ?b)}]
+      (= expected (-> (tu/query-ra [:project [{'res '(== ?a ?b)}]
                                     [:table [{}]]]
                                    {:args {:a a, :b b}
                                     :current-time Instant/EPOCH
@@ -911,7 +911,7 @@
                 now instant-gen]
     (= (= (->inst t1 now default-tz)
           (->inst t2 now default-tz))
-       (->> (tu/query-ra [:project [{'res '(= ?t1 ?t2)}]
+       (->> (tu/query-ra [:project [{'res '(== ?t1 ?t2)}]
                           [:table [{}]]]
                          {:args {:t1 t1, :t2 t2}
                           :current-time now
@@ -1112,13 +1112,13 @@
   (t/testing "comparing intervals with different types"
     (t/is (anomalous? [:incorrect nil
                        #"Cannot compare intervals with different units"]
-                      (et/project1 '(= (single-field-interval 1 "YEAR" 2 0) (single-field-interval 365 "DAY" 2 0)) {}))))
+                      (et/project1 '(== (single-field-interval 1 "YEAR" 2 0) (single-field-interval 365 "DAY" 2 0)) {}))))
 
   (t/testing "comparing year month intervals"
     (t/are [expected expr] (= expected (et/project1 expr {}))
       ;; = 
-      true '(= (single-field-interval 1 "YEAR" 2 0) (single-field-interval 12 "MONTH" 2 0))
-      false '(= (single-field-interval 1 "YEAR" 2 0) (single-field-interval 1 "MONTH" 2 0))
+      true '(== (single-field-interval 1 "YEAR" 2 0) (single-field-interval 12 "MONTH" 2 0))
+      false '(== (single-field-interval 1 "YEAR" 2 0) (single-field-interval 1 "MONTH" 2 0))
 
       ;; <
       true '(< (single-field-interval 1 "YEAR" 2 0) (single-field-interval 2 "YEAR" 2 0))
@@ -1145,13 +1145,13 @@
       (t/is (thrown-with-msg?
              RuntimeException
              #"Cannot compare month-day-micro/nano intervals when month component is non-zero."
-             (et/project1 '(= interval interval) test-doc)))))
+             (et/project1 '(== interval interval) test-doc)))))
 
   (t/testing "comparing month-day-nano intervals"
     (t/are [expected expr] (= expected (et/project1 expr {}))
       ;; =
-      true '(= (multi-field-interval "1 0" "DAY" 2 "HOUR" 2) (multi-field-interval "1 0" "DAY" 2 "HOUR" 2))
-      false '(= (multi-field-interval "1 0" "DAY" 2 "HOUR" 2) (multi-field-interval "1 2" "DAY" 2 "HOUR" 2))
+      true '(== (multi-field-interval "1 0" "DAY" 2 "HOUR" 2) (multi-field-interval "1 0" "DAY" 2 "HOUR" 2))
+      false '(== (multi-field-interval "1 0" "DAY" 2 "HOUR" 2) (multi-field-interval "1 2" "DAY" 2 "HOUR" 2))
 
       ;; <
       false '(< (multi-field-interval "1 0" "DAY" 2 "HOUR" 2) (multi-field-interval "1 0" "DAY" 2 "HOUR" 2))

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -60,7 +60,7 @@
             "mixing types")
 
       (t/is (= (repeat 1000 true)
-               (project '(= a d)))
+               (project '(== a d)))
             "predicate")
 
       (t/is (= (mapv #(Math/sin ^double %) (range 1000))
@@ -68,7 +68,7 @@
             "math")
 
       (t/is (= (interleave (map float (range)) (repeat 500 0))
-               (project '(if (= 0 (mod a 2)) (/ a 2) 0)))
+               (project '(if (== 0 (mod a 2)) (/ a 2) 0)))
             "if")
 
       (t/is (anomalous? [:incorrect nil] (project '(vec a)))
@@ -1678,17 +1678,17 @@
              (run-projection rel '(.. {:x {:y y}} x y))))))
 
 (t/deftest test-struct-equals
-  (t/is (= true (project1 '(= {} {}) {})))
-  (t/is (= false (project1 '(= {:a 1, :b 2} {:a 1, :b 2, :c 3}) {})))
-  (t/is (= false (project1 '(= {:a 1, :b 2, :c 3} {:a 1, :b 2} ) {})))
+  (t/is (= true (project1 '(== {} {}) {})))
+  (t/is (= false (project1 '(== {:a 1, :b 2} {:a 1, :b 2, :c 3}) {})))
+  (t/is (= false (project1 '(== {:a 1, :b 2, :c 3} {:a 1, :b 2} ) {})))
 
-  (t/is (= true (project1 '(= {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3}) {})))
-  (t/is (= false (project1 '(= {:a 1, :b 2, :c 4} {:a 1, :b 2, :c 3}) {})))
-  (t/is (= true (project1 '(= {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3.0}) {})))
-  (t/is (= false (project1 '(= {:a 1, :b 2, :c 2.5} {:a 1, :b 2, :c 3.0}) {})))
+  (t/is (= true (project1 '(== {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3}) {})))
+  (t/is (= false (project1 '(== {:a 1, :b 2, :c 4} {:a 1, :b 2, :c 3}) {})))
+  (t/is (= true (project1 '(== {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3.0}) {})))
+  (t/is (= false (project1 '(== {:a 1, :b 2, :c 2.5} {:a 1, :b 2, :c 3.0}) {})))
 
-  (t/is (= nil (project1 '(= {:a 1, :b 2, :c nil} {:a 1, :b 2, :c 3.0}) {})))
-  (t/is (= false (project1 '(= {:a 1, :b 3, :c nil} {:a 1, :b 2, :c 3.0}) {}))))
+  (t/is (= nil (project1 '(== {:a 1, :b 2, :c nil} {:a 1, :b 2, :c 3.0}) {})))
+  (t/is (= false (project1 '(== {:a 1, :b 3, :c nil} {:a 1, :b 2, :c 3.0}) {}))))
 
 
 (t/deftest test-struct-not-equals
@@ -1747,19 +1747,19 @@
     (t/is (= [42] (project1 '[(+ 1 a)] {:a 41})))))
 
 (t/deftest test-list-equal
-  (t/is (= true (project1 '(= [] []) {})))
-  (t/is (= false (project1 '(= [1 2] [1 2 3]) {})))
-  (t/is (= false (project1 '(= [1 2 3] [1 2]) {})))
+  (t/is (= true (project1 '(== [] []) {})))
+  (t/is (= false (project1 '(== [1 2] [1 2 3]) {})))
+  (t/is (= false (project1 '(== [1 2 3] [1 2]) {})))
 
-  (t/is (= true (project1 '(= [1 2 3] [1 2 3]) {})))
-  (t/is (= false (project1 '(= [1 2 4] [1 2 3]) {})))
-  (t/is (= true (project1 '(= [1 2 3] [1 2 3.0]) {})))
-  (t/is (= false (project1 '(= [1 2 2.5] [1 2 3.0]) {})))
+  (t/is (= true (project1 '(== [1 2 3] [1 2 3]) {})))
+  (t/is (= false (project1 '(== [1 2 4] [1 2 3]) {})))
+  (t/is (= true (project1 '(== [1 2 3] [1 2 3.0]) {})))
+  (t/is (= false (project1 '(== [1 2 2.5] [1 2 3.0]) {})))
 
-  (t/is (= nil (project1 '(= [1 2 nil] [1 2 3.0]) {})))
-  (t/is (= false (project1 '(= [1 3 nil] [1 2 3.0]) {})))
+  (t/is (= nil (project1 '(== [1 2 nil] [1 2 3.0]) {})))
+  (t/is (= false (project1 '(== [1 3 nil] [1 2 3.0]) {})))
 
-  (t/is (= true (project1 '(= [[1 2] [3 4]] [[1 2] [3 4]]) {}))))
+  (t/is (= true (project1 '(== [[1 2] [3 4]] [[1 2] [3 4]]) {}))))
 
 (t/deftest test-list-diff
   (t/is (= false (project1 '(<> [] []) {})))
@@ -1783,7 +1783,7 @@
 
   #_ ; TODO `=` on sets
   (t/is (= true
-           (project1 '(= #{1 2 3} a)
+           (project1 '(== #{1 2 3} a)
                      {:a #{1 2 3}})))
 
   (t/is (= {:roles #{:a :b :c}}
@@ -2064,7 +2064,7 @@
 
 (t/deftest test-uuids
   (t/is (= true
-           (project1 '(= #uuid "00000000-0000-0000-0000-000000000000" a)
+           (project1 '(== #uuid "00000000-0000-0000-0000-000000000000" a)
                      {:a #uuid "00000000-0000-0000-0000-000000000000"}))))
 
 (t/deftest test-cast-uuids
@@ -2130,7 +2130,7 @@
                      {:a1 3, :a2 "3"}]))))
 
 (t/deftest list-equality-batch-bindings-5047
-  (t/is (false? (->> (tu/query-ra '[:project [{ret (= [#xt/instant "1970-01-01T00:00:00Z"]
+  (t/is (false? (->> (tu/query-ra '[:project [{ret (== [#xt/instant "1970-01-01T00:00:00Z"]
                                                       [#xt/ldt "1970-01-01T00:00"])}]
                                     [:table [{}]]]
                                   {:default-tz #xt/zone "America/New_York"})

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -2135,3 +2135,13 @@
                                     [:table [{}]]]
                                   {:default-tz #xt/zone "America/New_York"})
                      first :ret))))
+
+(t/deftest test-type-strict-equality
+  (t/is (true? (project1 '(=== 3 3) {})) "int === int")
+  (t/is (true? (project1 '(=== 3.0 3.0) {})) "float === float")
+  (t/is (false? (project1 '(=== 3 3.0) {})) "int !== float")
+  (t/is (true? (project1 '(== 3 3.0) {})) "int == float (cross-type coercion)")
+  (t/is (true? (project1 '(=== "foo" "foo") {})))
+  (t/is (false? (project1 '(=== "foo" "bar") {})))
+  (t/is (true? (project1 '(=== a a) {:a nil})) "null === null")
+  (t/is (nil? (project1 '(== a a) {:a nil})) "null == null returns null"))

--- a/src/test/clojure/xtdb/logical_plan_test.clj
+++ b/src/test/clojure/xtdb/logical_plan_test.clj
@@ -87,7 +87,7 @@
        true
        (xt/template
         [:select
-         '(= ~(sql/->col-sym '_valid_time) 1)
+         '(== ~(sql/->col-sym '_valid_time) 1)
          [:project
           [{~(sql/->col-sym '_foo) 4}
            {~(sql/->col-sym '_valid_time)
@@ -102,7 +102,7 @@
        true
        (xt/template
         [:select
-         '(= ~(sql/->col-sym '_valid_time) ~(sql/->col-sym '_foo))
+         '(== ~(sql/->col-sym '_valid_time) ~(sql/->col-sym '_foo))
          [:project
           [{~(sql/->col-sym '_foo) 4}
            {~(sql/->col-sym '_valid_time)

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -42,22 +42,22 @@
 
   (t/is (= [{:num 1} {:num 1.0}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{num (= num 1)}]]
+                          [{num (== num 1)}]]
                         {:node tu/*node*})))
 
   (t/is (= [{:num 2.0}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{num (= num 2)}]]
+                          [{num (== num 2)}]]
                         {:node tu/*node*})))
 
   (t/is (= [{:num 4}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{num (= num ?x)}]]
+                          [{num (== num ?x)}]]
                         {:node tu/*node*, :args {:x (byte 4)}})))
 
   (t/is (= [{:num 3}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{num (= num ?x)}]]
+                          [{num (== num ?x)}]]
                         {:node tu/*node*, :args {:x (float 3)}}))))
 
 (deftest test-bloom-filter-for-datetime-types-2133
@@ -74,21 +74,21 @@
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{timestamp (= timestamp #xt/zoned-date-time "2010-01-01T00:00:00Z")}]]
+                          [{timestamp (== timestamp #xt/zoned-date-time "2010-01-01T00:00:00Z")}]]
                         {:node tu/*node*, :default-tz #xt/zone "Z"})))
 
   (t/is (= [{:timestamp #xt/date "2010-01-01"}
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{timestamp (= timestamp ?x)}]]
+                          [{timestamp (== timestamp ?x)}]]
                         {:node tu/*node*, :default-tz #xt/zone "Z", :args {:x #xt/date "2010-01-01"}})))
 
   (t/is (= [{:timestamp #xt/date "2010-01-01"}
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{timestamp (= timestamp #xt/date-time "2010-01-01T00:00:00")}]]
+                          [{timestamp (== timestamp #xt/date-time "2010-01-01T00:00:00")}]]
                         {:node tu/*node*, :default-tz #xt/zone "Z"}))))
 
 (deftest test-bloom-filter-for-time-types
@@ -101,7 +101,7 @@
 
   (t/is (= [{:time #xt/time "04:05:06"}]
            (tu/query-ra '[:scan {:table #xt/table xt_docs}
-                          [{time (= time #xt/time "04:05:06")}]]
+                          [{time (== time #xt/time "04:05:06")}]]
                         {:node tu/*node*, :default-tz #xt/zone "Z"}))))
 
 (deftest test-min-max-on-xt-id
@@ -166,7 +166,7 @@
   (tu/finish-block! tu/*node*)
 
   (let [metadata-mgr (.getMetadataManager (db/primary-db tu/*node*))
-        true-selector (expr.meta/->metadata-selector tu/*allocator* '(= boolean_or_int true) '{boolean_or_int #xt/field {"boolean_or_int" :bool}} vw/empty-args)]
+        true-selector (expr.meta/->metadata-selector tu/*allocator* '(== boolean_or_int true) '{boolean_or_int #xt/field {"boolean_or_int" :bool}} vw/empty-args)]
 
     (t/testing "L0"
       (let [meta-file-path (Trie/metaFilePath "public$xt_docs" ^String (trie/->l0-trie-key 0))]

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -536,11 +536,11 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
             {:depth "  ->", :op :rename
              :explain {:prefix "u.1"}}
             {:depth "    ->", :op :select
-             :explain {:predicate "(= (+ a b) 12)"}}
+             :explain {:predicate "(== (+ a b) 12)"}}
             {:depth "      ->", :op :scan
              :explain {:table "xtdb.public.users"
                        :columns ["foo" "a" "b" "_id"]
-                       :predicates ["(= b 1)"]}}]
+                       :predicates ["(== b 1)"]}}]
            (xt/q tu/*node*
                  "EXPLAIN SELECT u._id, u.foo FROM users u WHERE u.a + u.b = 12 AND u.b = 1"))))
 
@@ -794,7 +794,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
   (t/is (= [{:v 904292726}]
            (tu/query-ra
-            '[:select (= (cast "bar" :regclass) v)
+            '[:select (== (cast "bar" :regclass) v)
               [:table [{v 904292726} {v 111}]]]
             {:node tu/*node*}))
         "select")
@@ -802,7 +802,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (t/is (= [{:col 904292726}]
            (tu/query-ra
             '[:scan {:table #xt/table bar}
-              [{col (= col (cast "bar" :regclass))}]]
+              [{col (== col (cast "bar" :regclass))}]]
             {:node tu/*node*}))
         "scan pred"))
 
@@ -1082,7 +1082,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (t/is (= [{:xt/id :toto, :col 3}]
            (tu/query-ra
             '[:join [{col col}]
-              [:scan {:table #xt/table xt_docs} [_id {col (= col 3)}]]
+              [:scan {:table #xt/table xt_docs} [_id {col (== col 3)}]]
               [:scan {:table #xt/table xt_docs} [_id col]]]
             {:node tu/*node*}))))
 

--- a/src/test/clojure/xtdb/operator/apply_test.clj
+++ b/src/test/clojure/xtdb/operator/apply_test.clj
@@ -11,7 +11,7 @@
                            [[{:c_id "c1", :c_name "Alan"}
                              {:c_id "c2", :c_name "Bob"}
                              {:c_id "c3", :c_name "Charlie"}]]]
-                          [:select '(= o_customer_id ?c_id)
+                          [:select '(== o_customer_id ?c_id)
                            [::tu/pages
                             [[{:o_customer_id "c1", :o_value 12.34}
                               {:o_customer_id "c1", :o_value 14.80}]
@@ -43,7 +43,7 @@
                   {:c-id "c2", :c-name "Bob", :match true}
                   {:c-id "c3", :c-name "Charlie", :match false}]
             :types '{c_id #xt/type :utf8, c_name #xt/type :utf8, match #xt/type [:? :bool]}}
-           (-> (tu/query-ra [:apply '{:mark-join {match (= ?c_id o_customer_id)}} '{c_id ?c_id}
+           (-> (tu/query-ra [:apply '{:mark-join {match (== ?c_id o_customer_id)}} '{c_id ?c_id}
                              [::tu/pages
                               [[{:c_id "c1", :c_name "Alan"}
                                 {:c_id "c2", :c_name "Bob"}
@@ -57,14 +57,14 @@
 
   (t/is (= {:res [{:x 0}]
             :types '{x #xt/type :i64, match #xt/type [:? :bool]}}
-           (-> (tu/query-ra '[:apply {:mark-join {match (= 4 y)}} {}
+           (-> (tu/query-ra '[:apply {:mark-join {match (== 4 y)}} {}
                               [:table [{x 0}]]
                               [:table [{y nil}]]]
                             {:with-types? true})))
         "nil in RHS")
 
   (t/is (= [{:x 0, :match false} {:x 1, :match false}]
-           (tu/query-ra '[:apply {:mark-join {match (= nil z)}} {}
+           (tu/query-ra '[:apply {:mark-join {match (== nil z)}} {}
                           [:table [{:x 0}, {:x 1}]]
                           [:project [{z 1}]
                            [:select false
@@ -76,7 +76,7 @@
             {:y 1, :a 1, :b 2}]
            (tu/query-ra '[:apply :single-join {y ?y}
                           [:table [{:y 0} {:y 1}]]
-                          [:select (= ?y a)
+                          [:select (== ?y a)
                            [:table ?x]]]
                         {:args {:x [{:a 1, :b 2}]}})))
 
@@ -129,7 +129,7 @@
                [:table [{:z 0}, {:z 1}]]
                [:apply :single-join {}
                 [:table [{:x 0}, {:x 1}]]
-                [:select (= ?x2 y)
+                [:select (== ?x2 y)
                  [:table [{:y 0}, {:y 1}]]]]] {}))))
 
 (t/deftest test-shadowed-param
@@ -140,19 +140,19 @@
                [:table [{:z 0}, {:z 1}]]
                [:apply :single-join {x ?foo}
                 [:table [{:x 1}]]
-                [:select (= ?foo y)
+                [:select (== ?foo y)
                  [:table [{:y 0}]]]]] {}))))
 
 (t/deftest test-forwarding-nullable-type-information-494
   (t/is (= [{:x 0, :z 0, :y 0}]
            (tu/query-ra
-             '[:select (= z y)
+             '[:select (== z y)
                [:apply :single-join {x ?x1}
                 [:apply :single-join {x ?x2}
                  [:table [{:x 0}, {:x 1}]]
-                 [:select (= ?x2 z)
+                 [:select (== ?x2 z)
                   [:table [{:z 0}, {:z 2}]]]]
-                [:select (= ?x1 y)
+                [:select (== ?x1 y)
                  [:table [{:y 0}, {:y 2}]]]]] {}))))
 
 (deftest test-missing-column-in-independent-rel
@@ -162,7 +162,7 @@
          '[:apply :cross-join
            {foo ?bar}
            [:table [{:foo 1}]]
-           [:select (= baz ?bar)
+           [:select (== baz ?bar)
             [:table [{:baz 1}]]]] {}))
     "col with non null type")
 
@@ -184,6 +184,6 @@
         '[:apply :cross-join
           {not_foo ?bar}
           [:table [{:foo 1}]]
-          [:select (= baz ?bar)
+          [:select (== baz ?bar)
            [:table [{:baz 1}]]]] {})
       "not_foo missing")))

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -434,21 +434,21 @@
     (t/is (= [{{:a 12, :b 42} 1
                {:a 12, :b 44} 1
                {:a 10, :b 42} 2}]
-             (->> (tu/query-ra [:left-outer-join '[{a c} (> b d) (= c -1)] left right]
+             (->> (tu/query-ra [:left-outer-join '[{a c} (> b d) (== c -1)] left right]
                                {:preserve-pages? true})
                   (mapv frequencies))))
 
     (t/is (= [{{:a 12, :b 42} 1
                {:a 12, :b 44} 1
                {:a 10, :b 42} 2}]
-             (->> (tu/query-ra [:left-outer-join '[{a c} (and (= c -1) (> b d))] left right]
+             (->> (tu/query-ra [:left-outer-join '[{a c} (and (== c -1) (> b d))] left right]
                                {:preserve-pages? true})
                   (mapv frequencies))))
 
     (t/is (= [{{:a 12, :b 42} 1
                {:a 12, :b 44} 1
                {:a 10, :b 42} 2}]
-             (->> (tu/query-ra [:left-outer-join '[{a c} {b d} (= c -1)] left right]
+             (->> (tu/query-ra [:left-outer-join '[{a c} {b d} (== c -1)] left right]
                                {:preserve-pages? true})
                   (mapv frequencies))))))
 
@@ -571,7 +571,7 @@
               {:a 10, :b 42} 2
               {:c 11, :d 42} 1}
 
-             (->> (tu/query-ra [:full-outer-join '[{a c} (not (= b 44))] left right])
+             (->> (tu/query-ra [:full-outer-join '[{a c} (not (== b 44))] left right])
                   (frequencies))))
 
     (t/is (= {{:a 12, :b 42} 1
@@ -670,7 +670,7 @@
     (t/is (= {{:a 12, :b 44} 1
               {:a 10, :b 42} 2}
 
-             (->> (tu/query-ra [:anti-join '[{a c} (not (= b 44))] left right])
+             (->> (tu/query-ra [:anti-join '[{a c} (not (== b 44))] left right])
                   (frequencies))))
 
     (t/is (= {{:a 12, :b 42} 1
@@ -944,12 +944,12 @@
       ;;
       ;;Instead we produce unconnected subgraphs (in this case 3) and then add the
       ;;join conditions to the outermost join.
-      (t/is (= '[[0] [1] ([:pred-expr (= (+ name person) foo)]) [2]]
+      (t/is (= '[[0] [1] ([:pred-expr (== (+ name person) foo)]) [2]]
                (:join-order
                 (lp/emit-expr
                  (s/conform ::lp/logical-plan
                             '[:mega-join
-                              [(= (+ name person) foo)]
+                              [(== (+ name person) foo)]
                               [[:table [{:name 1}]]
                                [:table [{:person 1}]]
                                [:table [{:foo 2 :bar "woo"}
@@ -959,7 +959,7 @@
       (t/is (= [{:person 1, :bar "woo", :name 1, :foo 2}]
                (tu/query-ra
                 '[:mega-join
-                  [(= (+ name person) foo)]
+                  [(== (+ name person) foo)]
                   [[:table [{:name 1}]]
                    [:table [{:person 1}]]
                    [:table [{:foo 2 :bar "woo"}
@@ -970,7 +970,7 @@
    (= '[:equi-condition {t0_n t1_n}]
       (join/adjust-to-equi-condition
        '{:cols #{t1_n t0_n},
-         :condition [:pred-expr (= t1_n t0_n)],
+         :condition [:pred-expr (== t1_n t0_n)],
          :condition-id 0,
          :cols-from-current-rel #{t0_n},
          :other-cols #{t1_n},
@@ -1045,10 +1045,10 @@
 (t/deftest test-non-joining-join-conditions
   (t/testing "non joining join conditions are added at the earliest possible point"
     (let [plan '[:mega-join
-                 [(= a b) (= b 1)]
+                 [(== a b) (== b 1)]
                  [[:table [{:a 1}]]
                   [:table [{:b 1}]]]]]
-      (t/is (= '[[0 [[:equi-condition {a b}] [:pred-expr (= b 1)]] 1]]
+      (t/is (= '[[0 [[:equi-condition {a b}] [:pred-expr (== b 1)]] 1]]
                (:join-order (lp/emit-expr (s/conform ::lp/logical-plan plan) {}))))
       (t/is (= [{:a 1, :b 1}] (tu/query-ra plan))))))
 

--- a/src/test/clojure/xtdb/operator/select_test.clj
+++ b/src/test/clojure/xtdb/operator/select_test.clj
@@ -37,6 +37,6 @@
               [:table [{}]]])))
 
   (t/is (= [{} {} {}]
-           (tu/query-ra '[:select (= ?ap_n 2)
+           (tu/query-ra '[:select (== ?ap_n 2)
                           [:table [{} {} {}]]]
                         {:args {:ap-n 2}}))))

--- a/src/test/clojure/xtdb/operator/table_test.clj
+++ b/src/test/clojure/xtdb/operator/table_test.clj
@@ -91,7 +91,7 @@
                           [:union-all
                            [:project
                             [{x50 true}]
-                            [:select (= ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
+                            [:select (== ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
                            [:table [{x50 false}]]]]
                         {:args {:x53 "AIR"}})))
 
@@ -100,7 +100,7 @@
                           [:union-all
                            [:project
                             [{x50 true}]
-                            [:select (= ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
+                            [:select (== ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
                            [:table [{x50 false}]]]]
                         {:args {:x53 "AIR REG"}})))
 
@@ -109,7 +109,7 @@
                           [:union-all
                            [:project
                             [{x50 true}]
-                            [:select (= ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
+                            [:select (== ?x53 x48) [:table [{x48 "AIR"} {x48 "AIR REG"}]]]]
                            [:table [{x50 false}]]]]
                         {:args {:x53 "RAIL"}}))))
 

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -318,7 +318,7 @@
     "1 >= 2" '(>= 1 2)
     "1 < 2" '(< 1 2)
     "1 <= 2" '(<= 1 2)
-    "1 = 2" '(= 1 2)
+    "1 = 2" '(== 1 2)
     "1 != 2" '(<> 1 2)
     "1 <> 2" '(<> 1 2)
     "2 BETWEEN 1 AND 3" '(between 2 1 3)
@@ -1172,7 +1172,7 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     OVERLAPS PERIOD(TIMESTAMP '2002-01-01 00:00:00+00:00', TIMESTAMP '2003-01-01 00:00:00+00:00')"
 
     '(and
-      (=
+      (==
        (lower f/_system_time)
        (lower
         (period
@@ -1204,7 +1204,7 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
        xtdb/end-of-time))
     "foo._SYSTEM_TIME SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
-    '(=
+    '(==
       (coalesce (upper f/_valid_time) xtdb/end-of-time)
       (lower
        (period
@@ -1212,7 +1212,7 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
         #xt/zoned-date-time "2001-01-01T00:00Z")))
     "foo._VALID_TIME IMMEDIATELY PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
 
-    '(=
+    '(==
       (lower f/_valid_time)
       (coalesce
        (upper
@@ -1579,8 +1579,8 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     (t/is (= '(and) (plan-expr "WHERE")))
 
     (t/is (= '(and) (plan-expr "WHERE , ,")))
-    (t/is (= '(and (= f/a 1)) (plan-expr "WHERE , a = 1")))
-    (t/is (= '(and (= f/a 1) (= f/b 2)) (plan-expr "WHERE a = 1, , b = 2 ,")))))
+    (t/is (= '(and (== f/a 1)) (plan-expr "WHERE , a = 1")))
+    (t/is (= '(and (== f/a 1) (== f/b 2)) (plan-expr "WHERE a = 1, , b = 2 ,")))))
 
 (t/deftest select-snapshot-token
   (t/is (= [{:token (basis/->time-basis-str {"xtdb" [nil]})}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/any-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/any-in-where.edn
@@ -5,7 +5,7 @@
   [:semi-join
    [(> _needle z)]
    [:map
-    [{_needle (= x.1/z 1)}]
+    [{_needle (== x.1/z 1)}]
     [:rename x.1 [:scan {:table #xt/table x} [y z]]]]
    [:project
     [{z y.3/z}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
@@ -9,4 +9,4 @@
     ms.2
     [:scan
      {:table #xt/table movie_star}
-     [{birthdate (= birthdate 1960)} name]]]]]]
+     [{birthdate (== birthdate 1960)} name]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
@@ -3,5 +3,5 @@
  [:rename
   si.1
   [:select
-   (= name lastname)
+   (== name lastname)
    [:scan {:table #xt/table stars_in} [lastname name]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
@@ -4,5 +4,5 @@
   [[_ob2 {:direction :desc, :null-ordering :nulls-first}]
    [si.1/movie_title {:direction :asc, :null-ordering :nulls-last}]]
   [:project
-   [si.1/movie_title {_ob2 (= si.1/year "foo")}]
+   [si.1/movie_title {_ob2 (== si.1/year "foo")}]
    [:rename si.1 [:scan {:table stars_in} [year movie_title]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -3,5 +3,5 @@
  [:order-by
   [[_ob2 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
-   [{_column_1 (= si.1/year "foo")} {_ob2 (= si.1/year "foo")}]
+   [{_column_1 (== si.1/year "foo")} {_ob2 (== si.1/year "foo")}]
    [:rename si.1 [:scan {:table #xt/table stars_in} [year]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
@@ -9,4 +9,4 @@
     ms.2
     [:scan
      {:table #xt/table movie_star}
-     [{birthdate (< birthdate 1960)} {name (= name "Foo")}]]]]]]
+     [{birthdate (< birthdate 1960)} {name (== name "Foo")}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
@@ -13,4 +13,4 @@
       ms.2
       [:scan
        {:table #xt/table movie_star}
-       [{birthdate (= birthdate 1960)} name]]]]]]]]
+       [{birthdate (== birthdate 1960)} name]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
@@ -1,9 +1,9 @@
 [:project
- [{some_column (= 1 _sq_2)}]
+ [{some_column (== 1 _sq_2)}]
  [:apply
   :single-join
   {x.1/z ?_sq_z_3}
-  [:rename x.1 [:scan {:table #xt/table x} [{y (= y 1)} z]]]
+  [:rename x.1 [:scan {:table #xt/table x} [{y (== y 1)} z]]]
   [:project
-   [{_sq_2 (= foo.3/bar ?_sq_z_3)}]
+   [{_sq_2 (== foo.3/bar ?_sq_z_3)}]
    [:rename foo.3 [:scan {:table #xt/table foo} [bar]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
@@ -8,7 +8,7 @@
     customers.1
     [:scan
      {:table #xt/table customers}
-     [{country (= country "Mexico")} custno]]]
+     [{country (== country "Mexico")} custno]]]
    [:project
     [{custno orders.3/custno}]
     [:rename orders.3 [:scan {:table #xt/table orders} [custno]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
@@ -3,7 +3,7 @@
  [:map
   [{_sq_3 _min_out_6}]
   [:select
-   (= e.2/grade _min_out_6)
+   (== e.2/grade _min_out_6)
    [:group-by
     [s.1/name
      s.1/id

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
@@ -16,8 +16,8 @@
      {_avg_out_8 (avg e2.4/grade)}]
     [:left-outer-join
      [(or
-       (= s.1/id e2.4/sid)
-       (and (= e2.4/curriculum s.1/major) (> s.1/year e2.4/date)))]
+       (== s.1/id e2.4/sid)
+       (and (== e2.4/curriculum s.1/major) (> s.1/year e2.4/date)))]
      [:map
       [{_row_number_0 (row-number)}]
       [:mega-join
@@ -28,7 +28,7 @@
           {:table #xt/table students}
           [name
            year
-           {major (or (= major "CS") (= major "Games Eng"))}
+           {major (or (== major "CS") (== major "Games Eng"))}
            id]]]
         [:rename
          e.2

--- a/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -10,6 +10,6 @@
     [[:rename {a x1, b x2} [:scan {:table r} [a b]]]
      [:rename {c x4} [:scan {:table s} [c]]]]]
    [:semi-join
-    [(= x10 ?x14) {x7 x9}]
-    [:rename {a x6, b x7} [:scan {:table r} [{a (= a ?x13)} b]]]
+    [(== x10 ?x14) {x7 x9}]
+    [:rename {a x6, b x7} [:scan {:table r} [{a (== a ?x13)} b]]]
     [:rename {a x9, b x10} [:scan {:table r} [a b]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
@@ -21,4 +21,4 @@
    [:scan
     {:table #xt/table t1,
      :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}
-    [{col1 (= col1 30)} _valid_to _valid_from _iid]]]]]
+    [{col1 (== col1 30)} _valid_to _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
@@ -21,4 +21,4 @@
    [:scan
     {:table #xt/table t1,
      :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}
-    [{col1 (= col1 30)} _valid_to _valid_from _iid]]]]]
+    [{col1 (== col1 30)} _valid_to _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
@@ -2,7 +2,7 @@
  [{_column_1 _sq_2}]
  [:mark-join
   {_sq_2 [{x.1/y z}]}
-  [:rename x.1 [:scan {:table #xt/table x} [y {z (= z 10)}]]]
+  [:rename x.1 [:scan {:table #xt/table x} [y {z (== z 10)}]]]
   [:project
    [{z y.3/z}]
    [:rename y.3 [:scan {:table #xt/table y} [z]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/exists-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/exists-in-where.edn
@@ -4,7 +4,7 @@
   [{_sq_2 true}]
   [:semi-join
    [{x.1/y z}]
-   [:rename x.1 [:scan {:table #xt/table x} [y {z (= z 10.0)}]]]
+   [:rename x.1 [:scan {:table #xt/table x} [y {z (== z 10.0)}]]]
    [:project
     [{z y.3/z}]
     [:rename y.3 [:scan {:table #xt/table y} [z]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/from-where-param-order-bug-4305.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/from-where-param-order-bug-4305.edn
@@ -4,4 +4,4 @@
   foo.1
   [:scan
    {:table #xt/table foo, :for-valid-time [:at ?_0]}
-   [{_id (= _id ?_1)}]]]]
+   [{_id (== _id ?_1)}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-2.edn
@@ -4,4 +4,4 @@
   y.2
   [:project
    [{z z.1/z}]
-   [:rename z.1 [:scan {:table #xt/table z} [{z (= z 1)}]]]]]]
+   [:rename z.1 [:scan {:table #xt/table z} [{z (== z 1)}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
@@ -8,7 +8,7 @@
     [{f.1/b xt.values.5/_column_1}]
     [:semi-join
      [{f.1/a xt.values.3/_column_1}]
-     [:rename f.1 [:scan {:table #xt/table foo} [{a (= a 42)} b]]]
+     [:rename f.1 [:scan {:table #xt/table foo} [{a (== a 42)} b]]]
      [:rename
       xt.values.3
       [:table [_column_1] [{:_column_1 1} {:_column_1 2}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
@@ -22,8 +22,8 @@
        (<
         _valid_from
         (coalesce #xt/date "2004-01-01" xtdb/end-of-time))
-       (= _valid_from 4))}
-     {_system_from (= _system_from 20)}
+       (== _valid_from 4))}
+     {_system_from (== _system_from 20)}
      {_system_to (<= _system_to 23)}
      {_valid_to
       (and
@@ -34,7 +34,7 @@
        (<
         _valid_from
         (coalesce #xt/date "2004-01-01" xtdb/end-of-time))
-       (= _valid_from 4))}
+       (== _valid_from 4))}
      {_valid_to
       (and
        (> (coalesce _valid_to xtdb/end-of-time) #xt/date "2000-01-01")

--- a/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
@@ -1,7 +1,7 @@
 [:project
  [{a f.1/a}]
  [:select
-  (or _sq_2 (= f.1/b 42))
+  (or _sq_2 (== f.1/b 42))
   [:mark-join
    {_sq_2 [{f.1/a xt.values.3/_column_1}]}
    [:rename f.1 [:scan {:table #xt/table foo} [a b]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
@@ -1,7 +1,7 @@
 [:project
  [{a f.1/a}]
  [:select
-  (= true _sq_2)
+  (== true _sq_2)
   [:mark-join
    {_sq_2 [true]}
    [:rename f.1 [:scan {:table #xt/table foo} [a]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/not-exists-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/not-exists-in-where.edn
@@ -4,7 +4,7 @@
   [{_sq_2 true}]
   [:anti-join
    [{x.1/y z}]
-   [:rename x.1 [:scan {:table #xt/table x} [y {z (= z 10)}]]]
+   [:rename x.1 [:scan {:table #xt/table x} [y {z (== z 10)}]]]
    [:project
     [{z y.3/z}]
     [:rename y.3 [:scan {:table #xt/table y} [z]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
@@ -15,4 +15,4 @@
      z.4
      [:scan
       {:table #xt/table z}
-      [{baz (= baz ?_sq_biz_5)} {bar (= bar ?_sq_foo_4)}]]]]]]]
+      [{baz (== baz ?_sq_biz_5)} {bar (== bar ?_sq_foo_4)}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-1.edn
@@ -1,8 +1,8 @@
 [:project
- [{some_column (= 1 _sq_2)}]
+ [{some_column (== 1 _sq_2)}]
  [:single-join
   []
-  [:rename x.1 [:scan {:table #xt/table x} [{y (= y 1)}]]]
+  [:rename x.1 [:scan {:table #xt/table x} [{y (== y 1)}]]]
   [:project
    [{_sq_2 foo.3/bar}]
    [:rename foo.3 [:scan {:table #xt/table foo} [bar]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-2.edn
@@ -1,8 +1,8 @@
 [:project
- [{some_column (= 1 _sq_2)}]
+ [{some_column (== 1 _sq_2)}]
  [:single-join
   []
-  [:rename x.1 [:scan {:table #xt/table x} [{y (= y 1)}]]]
+  [:rename x.1 [:scan {:table #xt/table x} [{y (== y 1)}]]]
   [:project
    [{_sq_2 _max_out_4}]
    [:group-by

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-where.edn
@@ -1,7 +1,7 @@
 [:project
  [{some_column x.1/y}]
  [:select
-  (= x.1/y _sq_2)
+  (== x.1/y _sq_2)
   [:single-join
    []
    [:rename x.1 [:scan {:table #xt/table x} [y]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -4,7 +4,7 @@
   []
   [[:rename foo.1 [:scan {:table #xt/table foo} [a]]]
    [:select
-    (= bar.2/c _sq_3)
+    (== bar.2/c _sq_3)
     [:apply
      :single-join
      {bar.2/b ?_sq_b_4}
@@ -13,4 +13,4 @@
       [{_sq_3 foo.4/b}]
       [:rename
        foo.4
-       [:scan {:table #xt/table foo} [{a (= a ?_sq_b_4)} b]]]]]]]]]
+       [:scan {:table #xt/table foo} [{a (== a ?_sq_b_4)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -6,11 +6,11 @@
    [:select
     _sq_3
     [:apply
-     {:mark-join {_sq_3 (= ?_needle b)}}
+     {:mark-join {_sq_3 (== ?_needle b)}}
      {bar.2/b ?_sq_b_4, bar.2/c ?_needle}
      [:rename bar.2 [:scan {:table #xt/table bar} [c b]]]
      [:project
       [{b foo.4/b}]
       [:rename
        foo.4
-       [:scan {:table #xt/table foo} [{a (= a ?_sq_b_4)} b]]]]]]]]]
+       [:scan {:table #xt/table foo} [{a (== a ?_sq_b_4)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
@@ -4,7 +4,7 @@
   []
   [[:rename foo.1 [:scan {:table #xt/table foo} [a]]]
    [:select
-    (= bar.2/c _sq_3)
+    (== bar.2/c _sq_3)
     [:single-join
      []
      [:rename bar.2 [:scan {:table #xt/table bar} [c]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-date-date.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-date-date.edn
@@ -8,4 +8,4 @@
     [{_system_from (<= _system_from #xt/date "3000-01-01")}
      {system_time_end (> system_time_end #xt/date "2999-01-01")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-ts-ts.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-ts-ts.edn
@@ -12,4 +12,4 @@
      {system_time_end
       (> system_time_end #xt/zoned-date-time "2999-01-01T00:00Z")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-when-a-before-b.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-when-a-before-b.edn
@@ -4,4 +4,4 @@
   [x1]
   [:rename
    {bar x1, _table x2}
-   [:select false [:scan [bar {_table (= _table "foo")}]]]]]]
+   [:select false [:scan [bar {_table (== _table "foo")}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-when-a-equal-b.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-a-and-b-when-a-equal-b.edn
@@ -11,4 +11,4 @@
        #xt/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end (> system_time_end #xt/date "3000-01-01")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-date-date.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-date-date.edn
@@ -8,4 +8,4 @@
     [{_system_from (< _system_from #xt/date "3000-01-01")}
      {system_time_end (> system_time_end #xt/date "2999-01-01")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-date-ts.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-date-ts.edn
@@ -9,4 +9,4 @@
       (< _system_from #xt/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end (> system_time_end #xt/date "2999-01-01")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-ts-ts.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-ts-ts.edn
@@ -10,4 +10,4 @@
      {system_time_end
       (> system_time_end #xt/zoned-date-time "2999-01-01T00:00Z")}
      bar
-     {_table (= _table "foo")}]]]]]
+     {_table (== _table "foo")}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-when-a-before-b.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b-when-a-before-b.edn
@@ -4,4 +4,4 @@
   [x1]
   [:rename
    {bar x1, _table x2}
-   [:select false [:scan [bar {_table (= _table "foo")}]]]]]]
+   [:select false [:scan [bar {_table (== _table "foo")}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
@@ -2,9 +2,9 @@
  [{_column_1 _sq_2}]
  [:single-join
   []
-  [:rename a.1 [:scan {:table #xt/table a} [{a (= a 42)}]]]
+  [:rename a.1 [:scan {:table #xt/table a} [{a (== a 42)}]]]
   [:group-by
    [{_sq_2 (vec_agg b1)}]
    [:project
     [{b1 b.3/b1}]
-    [:rename b.3 [:scan {:table #xt/table b} [{b2 (= b2 42)} b1]]]]]]]
+    [:rename b.3 [:scan {:table #xt/table b} [{b2 (== b2 42)} b1]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -3,11 +3,11 @@
  [:apply
   :single-join
   {a.1/b ?_sq_b_3}
-  [:rename a.1 [:scan {:table #xt/table a} [{a (= a 42)} b]]]
+  [:rename a.1 [:scan {:table #xt/table a} [{a (== a 42)} b]]]
   [:group-by
    [{_sq_2 (vec_agg b1)}]
    [:project
     [{b1 b.3/b1}]
     [:rename
      b.3
-     [:scan {:table #xt/table b} [{b2 (= b2 ?_sq_b_3)} b1]]]]]]]
+     [:scan {:table #xt/table b} [{b2 (== b2 ?_sq_b_3)} b1]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
@@ -2,4 +2,4 @@
  [{a foo.1/a}]
  [:rename
   foo.1
-  [:scan {:table #xt/table foo} [a {c (= c ?_1)} {b (= b ?_0)}]]]]
+  [:scan {:table #xt/table foo} [a {c (== c ?_1)} {b (== b ?_0)}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -4,7 +4,7 @@
   []
   [[:rename
     foo.1
-    [:scan {:table #xt/table foo} [a {c (= c ?_2)} {b (= b ?_1)}]]]
+    [:scan {:table #xt/table foo} [a {c (== c ?_2)} {b (== b ?_1)}]]]
    [:rename
     bar.3
     [:rename
@@ -13,4 +13,4 @@
       [{bar.2/b bar.2/b}]
       [:rename
        bar.2
-       [:scan {:table #xt/table bar} [{c (= c ?_0)} b]]]]]]]]]
+       [:scan {:table #xt/table bar} [{c (== c ?_0)} b]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
@@ -5,4 +5,4 @@
   [:rename t1.1 [:scan {:table #xt/table t1} [col1]]]
   [:project
    [{_sq_2 ?_0}]
-   [:rename bar.3 [:scan {:table #xt/table bar} [{col1 (= col1 4)}]]]]]]
+   [:rename bar.3 [:scan {:table #xt/table bar} [{col1 (== col1 4)}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -24,4 +24,4 @@
    u.1
    [:scan
     {:table #xt/table users, :for-valid-time [:in ?_0 ?_1]}
-    [_valid_to {id (= id ?_3)} _valid_from _iid]]]]]
+    [_valid_to {id (== id ?_3)} _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
@@ -14,4 +14,4 @@
       o.3
       [:scan
        {:table #xt/table orders}
-       [{customer_id (= customer_id ?_sq__id_3)} _id value]]]]]]]]
+       [{customer_id (== customer_id ?_sq__id_3)} _id value]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
@@ -14,4 +14,4 @@
      c.3
      [:scan
       {:table #xt/table customers}
-      [{_id (= _id ?_sq_customer_id_3)} name]]]]]]]
+      [{_id (== _id ?_sq_customer_id_3)} name]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
@@ -26,4 +26,4 @@
        prop_owner.1
        [:scan
         {:table #xt/table prop_owner, :for-system-time :all-time}
-        [_system_from {id (= id 1)}]]]]]]]]]
+        [_system_from {id (== id 1)}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-scalar-extends.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-scalar-extends.edn
@@ -1,5 +1,5 @@
 [:project
  [{_foo 4} {_valid_time (period _valid_from _valid_to)}]
  [:select
-  '(= (period _valid_from _valid_to) 1)
+  '(== (period _valid_from _valid_to) 1)
   [:scan {:table public/docs} [_bar]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -16,4 +16,4 @@
    [:scan
     {:table #xt/table users,
      :for-valid-time [:in #xt/date "2020-05-01" nil]}
-    [_valid_to {id (= id ?_0)} _valid_from _iid]]]]]
+    [_valid_to {id (== id ?_0)} _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-erase-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-erase-plan.edn
@@ -7,4 +7,4 @@
     {:table #xt/table users,
      :for-system-time :all-time,
      :for-valid-time :all-time}
-    [{id (= id ?_0)} _iid]]]]]
+    [{id (== id ?_0)} _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -22,4 +22,4 @@
    [:scan
     {:table #xt/table users,
      :for-valid-time [:in #xt/date "2021-07-01" nil]}
-    [_valid_to last_name {id (= id ?_0)} _valid_from _iid]]]]]
+    [_valid_to last_name {id (== id ?_0)} _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -27,7 +27,7 @@
     [:map
      [{_sq_6 _min_out_12}]
      [:select
-      (= ps.3/ps_supplycost _min_out_12)
+      (== ps.3/ps_supplycost _min_out_12)
       [:group-by
        [p.1/_id
         p.1/p_size
@@ -63,7 +63,7 @@
             r.5
             [:scan
              {:table #xt/table region}
-             [_id {r_name (= r_name "EUROPE")}]]]
+             [_id {r_name (== r_name "EUROPE")}]]]
            [:rename
             n.4
             [:scan {:table #xt/table nation} [_id n_name n_regionkey]]]
@@ -77,7 +77,7 @@
             [:scan
              {:table #xt/table part}
              [_id
-              {p_size (= p_size 15)}
+              {p_size (== p_size 15)}
               p_mfgr
               {p_type (like p_type "%BRASS")}]]]
            [:rename
@@ -99,7 +99,7 @@
            r.10
            [:scan
             {:table #xt/table region}
-            [_id {r_name (= r_name "EUROPE")}]]]
+            [_id {r_name (== r_name "EUROPE")}]]]
           [:rename
            n.9
            [:scan {:table #xt/table nation} [_id n_regionkey]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
@@ -34,7 +34,7 @@
          c.1
          [:scan
           {:table #xt/table customer}
-          [_id {c_mktsegment (= c_mktsegment "BUILDING")}]]]
+          [_id {c_mktsegment (== c_mktsegment "BUILDING")}]]]
         [:rename
          o.2
          [:scan

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
@@ -19,7 +19,7 @@
         r.6
         [:scan
          {:table #xt/table region}
-         [_id {r_name (= r_name "ASIA")}]]]
+         [_id {r_name (== r_name "ASIA")}]]]
        [:rename
         n.5
         [:scan {:table #xt/table nation} [_id n_name n_regionkey]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
@@ -29,8 +29,8 @@
       [:mega-join
        [{c.4/c_nationkey n2.6/_id}
         (or
-         (and (= n1.5/n_name "FRANCE") (= n2.6/n_name "GERMANY"))
-         (and (= n1.5/n_name "GERMANY") (= n2.6/n_name "FRANCE")))
+         (and (== n1.5/n_name "FRANCE") (== n2.6/n_name "GERMANY"))
+         (and (== n1.5/n_name "GERMANY") (== n2.6/n_name "FRANCE")))
         {s.1/s_nationkey n1.5/_id}
         {o.3/o_custkey c.4/_id}
         {l.2/l_orderkey o.3/_id}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
@@ -12,7 +12,7 @@
     [:map
      [{_sum_in_11
        (cond
-        (= all_nations.9/nation "BRAZIL")
+        (== all_nations.9/nation "BRAZIL")
         all_nations.9/volume
         0)}]
      [:rename
@@ -33,7 +33,7 @@
           r.8
           [:scan
            {:table #xt/table region}
-           [_id {r_name (= r_name "AMERICA")}]]]
+           [_id {r_name (== r_name "AMERICA")}]]]
          [:rename n2.7 [:scan {:table #xt/table nation} [_id n_name]]]
          [:rename
           n1.6
@@ -65,7 +65,7 @@
           p.1
           [:scan
            {:table #xt/table part}
-           [_id {p_type (= p_type "ECONOMY ANODIZED STEEL")}]]]
+           [_id {p_type (== p_type "ECONOMY ANODIZED STEEL")}]]]
          [:rename
           s.2
           [:scan

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
@@ -41,7 +41,7 @@
          [:scan
           {:table #xt/table lineitem}
           [l_orderkey
-           {l_returnflag (= l_returnflag "R")}
+           {l_returnflag (== l_returnflag "R")}
            l_extendedprice
            l_discount]]]
         [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
@@ -21,7 +21,7 @@
           n.3
           [:scan
            {:table #xt/table nation}
-           [_id {n_name (= n_name "GERMANY")}]]]
+           [_id {n_name (== n_name "GERMANY")}]]]
          [:rename
           ps.1
           [:scan
@@ -42,7 +42,7 @@
            n.9
            [:scan
             {:table #xt/table nation}
-            [_id {n_name (= n_name "GERMANY")}]]]
+            [_id {n_name (== n_name "GERMANY")}]]]
           [:rename
            ps.7
            [:scan

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
@@ -21,8 +21,8 @@
       {_sum_in_6
        (cond
         (or
-         (= o.1/o_orderpriority "1-URGENT")
-         (= o.1/o_orderpriority "2-HIGH"))
+         (== o.1/o_orderpriority "1-URGENT")
+         (== o.1/o_orderpriority "2-HIGH"))
         1
         0)}]
      [:map

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
@@ -37,7 +37,7 @@
      revenue.6/total_revenue
      {_ob10 s.5/_id}]
     [:select
-     (= revenue.6/total_revenue _sq_7)
+     (== revenue.6/total_revenue _sq_7)
      [:single-join
       []
       [:mega-join

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -31,8 +31,8 @@
           [:scan
            {:table #xt/table part}
            [_id
-            {p_brand (= p_brand "Brand#23")}
-            {p_container (= p_container "MED BOX")}]]]]]]
+            {p_brand (== p_brand "Brand#23")}
+            {p_container (== p_container "MED BOX")}]]]]]]
       [:rename
        l.4
        [:scan {:table #xt/table lineitem} [l_quantity l_partkey]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
@@ -12,34 +12,34 @@
         (and
          (and
           (and
-           (and (= p.2/p_brand "Brand#12") _sq_3)
+           (and (== p.2/p_brand "Brand#12") _sq_3)
            (>= l.1/l_quantity 1))
           (<= l.1/l_quantity (+ 1 10)))
          (between p.2/p_size 1 5))
         _sq_5)
-       (= l.1/l_shipinstruct "DELIVER IN PERSON"))
+       (== l.1/l_shipinstruct "DELIVER IN PERSON"))
       (and
        (and
         (and
          (and
           (and
-           (and (= p.2/p_brand "Brand#23") _sq_7)
+           (and (== p.2/p_brand "Brand#23") _sq_7)
            (>= l.1/l_quantity 10))
           (<= l.1/l_quantity (+ 10 10)))
          (between p.2/p_size 1 10))
         _sq_9)
-       (= l.1/l_shipinstruct "DELIVER IN PERSON")))
+       (== l.1/l_shipinstruct "DELIVER IN PERSON")))
      (and
       (and
        (and
         (and
          (and
-          (and (= p.2/p_brand "Brand#34") _sq_11)
+          (and (== p.2/p_brand "Brand#34") _sq_11)
           (>= l.1/l_quantity 20))
          (<= l.1/l_quantity (+ 20 10)))
         (between p.2/p_size 1 15))
        _sq_13)
-      (= l.1/l_shipinstruct "DELIVER IN PERSON")))
+      (== l.1/l_shipinstruct "DELIVER IN PERSON")))
     [:mark-join
      {_sq_13 [{l.1/l_shipmode xt.values.14/_column_1}]}
      [:mark-join

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -67,4 +67,4 @@
        n.2
        [:scan
         {:table #xt/table nation}
-        [_id {n_name (= n_name "CANADA")}]]]]]]]]]
+        [_id {n_name (== n_name "CANADA")}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
@@ -21,12 +21,12 @@
           n.4
           [:scan
            {:table #xt/table nation}
-           [_id {n_name (= n_name "SAUDI ARABIA")}]]]
+           [_id {n_name (== n_name "SAUDI ARABIA")}]]]
          [:rename
           o.3
           [:scan
            {:table #xt/table orders}
-           [{o_orderstatus (= o_orderstatus "F")} _id]]]
+           [{o_orderstatus (== o_orderstatus "F")} _id]]]
          [:rename
           s.1
           [:scan {:table #xt/table supplier} [s_name _id s_nationkey]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
@@ -6,11 +6,11 @@
     foo.3
     [:project
      [{_id bar.1/_id}]
-     [:rename bar.1 [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]
+     [:rename bar.1 [:scan {:table #xt/table bar} [{_id (== _id 5)}]]]]]
    [:rename
     baz.4
     [:project
      [{_id bar.1/_id}]
      [:rename
       bar.1
-      [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]]]]
+      [:scan {:table #xt/table bar} [{_id (== _id 5)}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-mat-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-mat-clause.edn
@@ -2,7 +2,7 @@
  [foo.2
   [:project
    [{_id bar.1/_id}]
-   [:rename bar.1 [:scan {:table #xt/table bar} [{_id (= _id 5)}]]]]]
+   [:rename bar.1 [:scan {:table #xt/table bar} [{_id (== _id 5)}]]]]]
  [:project
   [{foo_id foo.3/_id} {baz_id baz.4/_id}]
   [:mega-join


### PR DESCRIPTION
(pre-req for #5030)

This PR adds a type-strict equality operator (`===`) to the expression engine, renaming the existing `=` to `==`. 

(NB no change to SQL - just that SQL `=` compiles to EE `==`)

`=` was potentially ambiguous (Clojure semantics? SQL semantics?), so I've gone with the prior art of `==` vs `===` (removing `=` entirely).

Semantics:
- `==` performs value-based (type coercing) 3VL equality
- `===` is type-strict - cross-type comparisons return `false`
- `(=== nil nil)` returns `true`, while `(== nil nil)` returns `null` (SQL semantics)

Examples:
- `(== 3 3.0)` → `true` (numeric coercion)
- `(=== 3 3.0)` → `false` (different types)
- `(== #xt/zdt "2020-01-01T00:00:00Z" #xt/zdt "2020-01-01T01:00:00+01:00")` → `true` (same instant)
- `(=== #xt/zdt "2020-01-01T00:00:00Z" #xt/zdt "2020-01-01T01:00:00+01:00")` → `false` (different TZ strings)
- `(== nil nil)` → `null`
- `(=== nil nil)` → `true`