### PR TITLE
UPDATE filters duplicate updates, #5030

### DIFF
--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -427,9 +427,6 @@
                      (and
                       (t/testing "three transactions recorded"
                         (= 3 (count (xt/q node "FROM xt.txs"))))
-                      (t/testing "document should have 3 versions in history"
-                        (let [res (xt/q node "SELECT *, _valid_from FROM docs FOR VALID_TIME ALL WHERE _id = 1")]
-                          (= 3 (count res))))
                       (t/testing "document has value equal to all of the updates merged"
                         (let [res (first (xt/q node "SELECT * FROM docs WHERE _id = 1")) 
                               record-fields [record (:fields update-statement-1) (:fields update-statement-2)]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1341,7 +1341,7 @@
   (t/is (=plan-file
          "test-for-all-valid-time-387-update"
          (sql/plan "UPDATE users FOR ALL VALID_TIME SET first_name = 'Sue'"
-                   {:table-info {#xt/table users #{}}})))
+                   {:table-info {#xt/table users #{"first_name"}}})))
 
   (t/is (=plan-file
          "test-for-all-valid-time-387-delete"

--- a/src/test/clojure/xtdb/update_test.clj
+++ b/src/test/clojure/xtdb/update_test.clj
@@ -1,0 +1,193 @@
+(ns xtdb.update-test
+  (:require [clojure.string :as str]
+            [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.compactor :as c]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-allocator tu/with-mock-clock tu/with-node)
+
+(t/deftest update-doesnt-put-unchanged-versions-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs
+                             {:xt/id 1, :a 1}
+                             {:xt/id 2, :a 2}
+                             {:xt/id 3, :a 3, :b 3}
+                             {:xt/id 4, :a 4, :b 4}
+                             {:xt/id 5, :a 5, :b nil}
+                             {:xt/id 6, :a nil}
+                             {:xt/id 7, :a 7}]])
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 1 WHERE _id = 1"])
+  (t/is (= [{:xt/id 1, :a 1, :xt/valid-from #xt/zdt "2020-01-01[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 1"))
+        "update all cols, but unchanged")
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 2, b = 2 WHERE _id = 2"])
+  (t/is (= [{:xt/id 2, :a 2, :xt/valid-from #xt/zdt "2020-01-01[UTC]", :xt/valid-to #xt/zdt "2020-01-03[UTC]"}
+            {:xt/id 2, :a 2, :b 2, :xt/valid-from #xt/zdt "2020-01-03[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 2 ORDER BY _valid_from"))
+        "existing cols unchanged, add non-existing cols")
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET b = 3 WHERE _id = 3"])
+  (t/is (= [{:xt/id 3, :a 3, :b 3, :xt/valid-from #xt/zdt "2020-01-01[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 3"))
+        "col unchanged, other existing cols")
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 4, b = 5 WHERE _id = 4"])
+  (t/is (= [{:xt/id 4, :a 4, :b 4, :xt/valid-from #xt/zdt "2020-01-01[UTC]", :xt/valid-to #xt/zdt "2020-01-05[UTC]"}
+            {:xt/id 4, :a 4, :b 5, :xt/valid-from #xt/zdt "2020-01-05[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 4 ORDER BY _valid_from"))
+        "one col unchanged, one col changed")
+
+  (t/testing "null handling"
+    (xt/execute-tx tu/*node* ["UPDATE docs SET b = NULL WHERE _id = 5"])
+    (t/is (= [{:xt/id 5, :a 5, :xt/valid-from #xt/zdt "2020-01-01[UTC]"}]
+             (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 5"))
+          "update b from NULL to NULL - should not create new version")
+
+    (xt/execute-tx tu/*node* ["UPDATE docs SET a = NULL WHERE _id = 6"])
+    (t/is (= [{:xt/id 6, :xt/valid-from #xt/zdt "2020-01-01[UTC]"}]
+             (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 6"))
+          "update a from NULL to NULL - should not create new version")
+
+    (xt/execute-tx tu/*node* ["UPDATE docs SET a = NULL WHERE _id = 7"])
+    (t/is (= [{:xt/id 7, :a 7, :xt/valid-from #xt/zdt "2020-01-01[UTC]", :xt/valid-to #xt/zdt "2020-01-08[UTC]"}
+              {:xt/id 7, :xt/valid-from #xt/zdt "2020-01-08[UTC]"}]
+             (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME WHERE _id = 7 ORDER BY _valid_from"))
+          "update a from value to NULL - should create new version")))
+
+(t/deftest update-changes-types-if-requested-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :a 1} {:xt/id 2, :a 2}]])
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 1.0 WHERE _id = 1"
+                            "UPDATE docs SET a = 2 WHERE _id = 2"])
+
+  (t/is (= [{:xt/id 1, :a 1,          
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 1, :a 1.0, :xt/valid-from #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 2, :a 2, :xt/valid-from #xt/zdt "2020-01-01Z[UTC]"}]
+           (xt/q tu/*node* "SELECT _id, a, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _id, _valid_from"))))
+
+(t/deftest update-null-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :a 1}]])
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = NULL WHERE _id = 1"])
+  (tu/flush-block! tu/*node*)
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = NULL WHERE _id = 1"])
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 2 WHERE _id = 1"])
+
+  (t/is (= [{:xt/id 1, :a 1,          
+             :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]"}
+            {:xt/id 1,
+             :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]"}
+            {:xt/id 1, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _valid_from"))))
+
+(t/deftest update-for-portion-of-idempotency-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs
+                             {:xt/id 1, :xt/valid-from #xt/instant "2020-01-01Z", :a 1}
+                             {:xt/id 1, :xt/valid-from #xt/instant "2020-01-03Z", :a 1.0}]])
+
+  (xt/execute-tx tu/*node* ["UPDATE docs FOR VALID_TIME FROM TIMESTAMP '2020-01-02Z' TO TIMESTAMP '2020-01-04Z' SET a = 1 WHERE _id = 1"])
+
+  (t/is (= [{:xt/id 1, :a 1,
+             :xt/system-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-03Z[UTC]"}
+            {:xt/id 1, :a 1.0,
+             :xt/system-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/system-to #xt/zdt "2020-01-02Z[UTC]",
+             :xt/valid-from #xt/zdt "2020-01-03Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-04Z[UTC]"}
+            {:xt/id 1, :a 1.0,
+             :xt/system-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-from #xt/zdt "2020-01-04Z[UTC]"}
+            {:xt/id 1, :a 1,          
+             :xt/system-from #xt/zdt "2020-01-02Z[UTC]",
+             :xt/valid-from #xt/zdt "2020-01-03Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-04Z[UTC]"}]
+           (xt/q tu/*node* (->> ["SELECT *, _system_from, _system_to, _valid_from, _valid_to"
+                                 "FROM docs FOR ALL VALID_TIME FOR ALL SYSTEM_TIME"
+                                 "ORDER BY _system_from, _valid_from"]
+                                (str/join "\n"))))))
+
+(t/deftest update-bulk-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs
+                             {:xt/id 1, :a 1}
+                             {:xt/id 2, :a 2}
+                             {:xt/id 3, :a 3}]])
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = 1"])
+
+  (t/is (= [{:xt/id 1, :a 1 
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]"}          
+            {:xt/id 2, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 2, :a 1,
+             :xt/valid-from #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 3, :a 3,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 3, :a 1,
+             :xt/valid-from #xt/zdt "2020-01-02Z[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _id, _valid_from"))))
+
+(t/deftest update-bulk-5030
+  (xt/execute-tx tu/*node* [[:put-docs :docs
+                             {:xt/id 1, :a 1}
+                             {:xt/id 2, :a 2}
+                             {:xt/id 3, :a 3}]])
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = a + 0"])
+  (xt/execute-tx tu/*node* ["UPDATE docs SET a = a + 1 WHERE _id = 3"])
+
+  (t/is (= [{:xt/id 1, :a 1 
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]"}          
+            {:xt/id 2, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]"}
+            {:xt/id 3, :a 3,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-03Z[UTC]"}
+            {:xt/id 3, :a 4,
+             :xt/valid-from #xt/zdt "2020-01-03Z[UTC]"}]
+           (xt/q tu/*node* "SELECT *, _valid_from, _valid_to FROM docs FOR ALL VALID_TIME ORDER BY _id, _valid_from"))))
+
+(t/deftest test-after-compaction
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :a 1}]])
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :a 2}]])
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 2, :a 3}]])
+
+  (tu/flush-block! tu/*node*)
+  (c/compact-all! tu/*node* #xt/duration "PT1S")
+
+  (xt/execute-tx tu/*node* ["UPDATE docs FOR ALL VALID_TIME SET a = 2"])
+  (t/is (= [{:xt/id 1, :a 1,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/system-to #xt/zdt "2020-01-04Z[UTC]"}
+            {:xt/id 1, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/valid-to #xt/zdt "2020-01-02Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-04Z[UTC]"}
+            {:xt/id 1, :a 1,
+             :xt/valid-from #xt/zdt "2020-01-02Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-01Z[UTC]",
+             :xt/system-to #xt/zdt "2020-01-02Z[UTC]"}
+            {:xt/id 1, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-02Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-02Z[UTC]"}
+
+            {:xt/id 2, :a 3,
+             :xt/valid-from #xt/zdt "2020-01-03Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-03Z[UTC]",
+             :xt/system-to #xt/zdt "2020-01-04Z[UTC]"}
+            {:xt/id 2, :a 2,
+             :xt/valid-from #xt/zdt "2020-01-03Z[UTC]",
+             :xt/system-from #xt/zdt "2020-01-04Z[UTC]"}]
+           (xt/q tu/*node* (->> ["SELECT *, _valid_from, _valid_to, _system_from, _system_to"
+                                 "FROM docs FOR ALL VALID_TIME FOR ALL SYSTEM_TIME"
+                                 "ORDER BY _id, _valid_from"]
+                                (str/join "\n"))))))

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
@@ -5,4 +5,6 @@
   [:rename t1.1 [:scan {:table #xt/table t1} [col1]]]
   [:project
    [{_sq_2 ?_0}]
-   [:rename bar.3 [:scan {:table #xt/table bar} [{col1 (== col1 4)}]]]]]]
+   [:rename
+    bar.3
+    [:scan {:table #xt/table bar} [{col1 (== col1 4)}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -15,13 +15,17 @@
   first_name
   id]
  [:project
-  ({_iid u.1/_iid}
+  [{_iid u.1/_iid}
    {_valid_from u.1/_valid_from}
    {_valid_to u.1/_valid_to}
    {first_name ?_2}
-   {id u.1/id})
+   {id u.1/id}]
   [:rename
    u.1
    [:scan
     {:table #xt/table users, :for-valid-time [:in ?_0 ?_1]}
-    [_valid_to {id (== id ?_3)} _valid_from _iid]]]]]
+    [_valid_to
+     {id (== id ?_3)}
+     _valid_from
+     {first_name (or (not (boolean (=== ?_2 first_name))))}
+     _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -14,13 +14,16 @@
      xtdb/end-of-time))}
   col1]
  [:project
-  ({_iid t1.1/_iid}
+  [{_iid t1.1/_iid}
    {_valid_from t1.1/_valid_from}
    {_valid_to t1.1/_valid_to}
-   {col1 ?_0})
+   {col1 ?_0}]
   [:rename
    t1.1
    [:scan
     {:table #xt/table t1,
      :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}
-    [_valid_to _valid_from _iid]]]]]
+    [{col1 (or (not (boolean (=== ?_0 col1))))}
+     _valid_to
+     _valid_from
+     _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
@@ -1,10 +1,13 @@
 [:project
- ({_iid users.1/_iid}
+ [{_iid users.1/_iid}
   {_valid_from users.1/_valid_from}
   {_valid_to users.1/_valid_to}
-  {first_name "Sue"})
+  {first_name "Sue"}]
  [:rename
   users.1
   [:scan
    {:table #xt/table users, :for-valid-time :all-time}
-   [_valid_to _valid_from _iid]]]]
+   [_valid_to
+    _valid_from
+    {first_name (or (not (boolean (=== "Sue" first_name))))}
+    _iid]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -1,12 +1,14 @@
 [:project
- ({_iid foo.1/_iid}
+ [{_iid foo.1/_iid}
   {_valid_from foo.1/_valid_from}
   {_valid_to foo.1/_valid_to}
   {bar foo.1/baz}
   {baz foo.1/baz}
-  {quux foo.1/quux})
+  {quux foo.1/quux}]
  [:rename
   foo.1
-  [:scan
-   {:table #xt/table foo, :for-valid-time :all-time}
-   [_valid_to baz quux _valid_from _iid]]]]
+  [:select
+   (or (not (boolean (=== baz bar))))
+   [:scan
+    {:table #xt/table foo, :for-valid-time :all-time}
+    [_valid_to bar baz quux _valid_from _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -1,5 +1,5 @@
 [:project
- ({_iid foo.1/_iid}
+ [{_iid foo.1/_iid}
   {_valid_from foo.1/_valid_from}
   {_valid_to foo.1/_valid_to}
   {bar
@@ -10,9 +10,22 @@
     (>
      (coalesce (upper foo.1/_system_time) xtdb/end-of-time)
      (lower foo.1/_valid_time)))}
-  {baz foo.1/baz})
+  {baz foo.1/baz}]
  [:rename
   foo.1
-  [:scan
-   {:table #xt/table foo, :for-valid-time :all-time}
-   [_valid_to baz _system_time _valid_from _valid_time _iid]]]]
+  [:select
+   (or
+    (not
+     (boolean
+      (===
+       (and
+        (<
+         (lower _system_time)
+         (coalesce (upper _valid_time) xtdb/end-of-time))
+        (>
+         (coalesce (upper _system_time) xtdb/end-of-time)
+         (lower _valid_time)))
+       bar))))
+   [:scan
+    {:table #xt/table foo, :for-valid-time :all-time}
+    [_valid_to bar baz _system_time _valid_from _valid_time _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -11,15 +11,20 @@
   id
   last_name]
  [:project
-  ({_iid u.1/_iid}
+  [{_iid u.1/_iid}
    {_valid_from u.1/_valid_from}
    {_valid_to u.1/_valid_to}
    {first_name "Sue"}
    {id u.1/id}
-   {last_name u.1/last_name})
+   {last_name u.1/last_name}]
   [:rename
    u.1
    [:scan
     {:table #xt/table users,
      :for-valid-time [:in #xt/date "2021-07-01" nil]}
-    [_valid_to last_name {id (== id ?_0)} _valid_from _iid]]]]]
+    [_valid_to
+     last_name
+     {id (== id ?_0)}
+     _valid_from
+     {first_name (or (not (boolean (=== "Sue" first_name))))}
+     _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
@@ -14,13 +14,16 @@
      xtdb/end-of-time))}
   col1]
  [:project
-  ({_iid u.1/_iid}
+  [{_iid u.1/_iid}
    {_valid_from u.1/_valid_from}
    {_valid_to u.1/_valid_to}
-   {col1 30})
+   {col1 30}]
   [:rename
    u.1
    [:scan
     {:table #xt/table t1,
      :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}
-    [_valid_to _valid_from _iid]]]]]
+    [{col1 (or (not (boolean (=== 30 col1))))}
+     _valid_to
+     _valid_from
+     _iid]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
@@ -14,13 +14,16 @@
      xtdb/end-of-time))}
   col1]
  [:project
-  ({_iid t1.1/_iid}
+  [{_iid t1.1/_iid}
    {_valid_from t1.1/_valid_from}
    {_valid_to t1.1/_valid_to}
-   {col1 30})
+   {col1 30}]
   [:rename
    t1.1
    [:scan
     {:table #xt/table t1,
      :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}
-    [_valid_to _valid_from _iid]]]]]
+    [{col1 (or (not (boolean (=== 30 col1))))}
+     _valid_to
+     _valid_from
+     _iid]]]]]


### PR DESCRIPTION
first part of #5030 (PATCH out of scope of this PR)

This PR changes `UPDATE` to not create new rows iff all of the values remain the same. 

This uses type-strict equality (see #5062) so that if you have a doc `{:xt/id 1, :a 1}` and you `UPDATE docs SET a = 1.0 WHERE _id = 1`, a new record will be created.

Will spend some time expanding the property test suite, but wanted to get a first pass available quickly.