### PR TITLE
Split out impl and driver on garbage collector.

### DIFF
--- a/core/src/main/clojure/xtdb/garbage_collector.clj
+++ b/core/src/main/clojure/xtdb/garbage_collector.clj
@@ -4,7 +4,7 @@
             [xtdb.util :as util])
   (:import [xtdb.api Xtdb$Config GarbageCollectorConfig]
            xtdb.database.Database$Catalog
-           [xtdb.garbage_collector GarbageCollector]))
+           [xtdb.garbage_collector GarbageCollector$Impl GarbageCollector$Driver]))
 
 (defmethod xtn/apply-config! :xtdb/garbage-collector [^Xtdb$Config config _
                                                       {:keys [enabled? blocks-to-keep garbage-lifetime approx-run-interval]}]
@@ -24,13 +24,13 @@
 
 (defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [^Database$Catalog db-cat, enabled? blocks-to-keep garbage-lifetime approx-run-interval]}]
   ;; TODO multi-db
-  (let [gc (GarbageCollector. (.getPrimary db-cat) blocks-to-keep garbage-lifetime approx-run-interval)]
+  (let [gc (GarbageCollector$Impl. (.getPrimary db-cat) (GarbageCollector$Driver/real) blocks-to-keep garbage-lifetime approx-run-interval)]
     (when enabled? (.start gc))
     gc))
 
-(defmethod ig/halt-key! :xtdb/garbage-collector [_ ^GarbageCollector gc]
+(defmethod ig/halt-key! :xtdb/garbage-collector [_ ^GarbageCollector$Impl gc]
   (when gc
     (.close gc)))
 
-(defn garbage-collector ^xtdb.garbage_collector.GarbageCollector [node]
+(defn garbage-collector ^xtdb.garbage_collector.GarbageCollector$Impl [node]
   (util/component node :xtdb/garbage-collector))

--- a/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
@@ -2,11 +2,14 @@ package xtdb.garbage_collector
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.plus
 import org.slf4j.LoggerFactory
 import xtdb.database.IDatabase
+import xtdb.table.TableRef
 import xtdb.time.microsAsInstant
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
+import xtdb.trie.TrieKey
 import java.io.Closeable
 import java.time.Duration
 import java.time.Instant
@@ -16,77 +19,108 @@ import kotlin.time.Duration.Companion.seconds
 
 private val LOGGER = LoggerFactory.getLogger(GarbageCollector::class.java)
 
-class GarbageCollector @JvmOverloads constructor(
-    db: IDatabase,
-    private val blocksToKeep: Int,
-    private val garbageLifetime: Duration,
-    private val approxRunInterval: Duration,
-    private val coroutineCtx: CoroutineContext = Dispatchers.IO
-) : Closeable {
-    private val parentJob = Job()
-    private val blockCatalog = db.blockCatalog
-    private val trieCatalog = db.trieCatalog
-    private val bufferPool = db.bufferPool
 
-    private val blockGc = BlockGarbageCollector(blockCatalog, bufferPool, blocksToKeep)
+interface GarbageCollector : Closeable {
+    fun garbageCollectTries(garbageAsOf: Instant? = null)
+    fun collectGarbage()
+    fun start()
 
-    private fun defaultGarbageAsOf(): Instant? =
-        blockCatalog.blockFromLatest(blocksToKeep)
-            ?.let { it.latestCompletedTx.systemTime.microsAsInstant - garbageLifetime }
+    interface Driver : AutoCloseable {
+        suspend fun deleteGarbageTries(tableName: TableRef, garbageTries: Set<TrieKey>)
 
-    @JvmOverloads
-    fun garbageCollectTries(garbageAsOf: Instant? = defaultGarbageAsOf()) {
-        if (garbageAsOf == null) return
+        interface Factory {
+            fun create(db: IDatabase): Driver
+        }
 
-        LOGGER.debug("Garbage collecting data older than {}", garbageAsOf)
+        companion object {
+            @JvmStatic
+            fun real() = object : Factory {
+                override fun create(db: IDatabase) = object : Driver {
+                    private val trieCatalog = db.trieCatalog
+                    private val bufferPool = db.bufferPool
 
-        try {
-            LOGGER.debug("Starting trie garbage collection")
-            val tableNames = blockCatalog.allTables.shuffled().take(100)
+                    override suspend fun deleteGarbageTries(tableName: TableRef, garbageTries: Set<TrieKey>) {
+                        for (garbageTrie in garbageTries) {
+                            bufferPool.deleteIfExists(tableName.metaFilePath(garbageTrie))
+                            bufferPool.deleteIfExists(tableName.dataFilePath(garbageTrie))
+                        }
+                        trieCatalog.deleteTries(tableName, garbageTries)
+                    }
 
-            for (tableName in tableNames) {
-                val garbageTries = trieCatalog.garbageTries(tableName, garbageAsOf)
-                for (garbageTrie in garbageTries) {
-                    bufferPool.deleteIfExists(tableName.metaFilePath(garbageTrie))
-                    bufferPool.deleteIfExists(tableName.dataFilePath(garbageTrie))
+                    override fun close() {}
                 }
-                trieCatalog.deleteTries(tableName, garbageTries)
-            }
-            LOGGER.debug("Trie garbage collection completed")
-
-        } catch (e: Exception) {
-            LOGGER.warn("Block garbage collection failed", e)
-        } catch (e: Throwable) {
-            throw RuntimeException("Error encountered during Block garbage collection: ", e)
-        }
-    }
-
-    fun collectGarbage() {
-        LOGGER.debug("Starting block garbage collection")
-        blockGc.garbageCollectBlocks()
-        LOGGER.debug("Block garbage collection completed")
-
-        garbageCollectTries()
-        LOGGER.debug("Next GC run scheduled in ${approxRunInterval.toMillis()}ms")
-    }
-
-    fun start() {
-        LOGGER.debug(
-            "Starting GarbageCollector with approxRunInterval: {}, blocksToKeep: {}",
-            approxRunInterval, blocksToKeep
-        )
-
-        CoroutineScope(coroutineCtx + parentJob).launch {
-            delay(Random.nextLong(approxRunInterval.toMillis()))
-            while (isActive) {
-                collectGarbage()
-                delay(approxRunInterval.toMillis())
             }
         }
     }
 
-    override fun close() {
-        runBlocking { withTimeout(5.seconds) { parentJob.cancelAndJoin() } }
-        LOGGER.debug("GarbageCollector shut down")
+    class Impl @JvmOverloads constructor(
+        db: IDatabase,
+        driverFactory: Driver.Factory,
+        private val blocksToKeep: Int,
+        private val garbageLifetime: Duration,
+        private val approxRunInterval: Duration,
+        private val coroutineCtx: CoroutineContext = Dispatchers.IO
+    ) : GarbageCollector {
+        private val parentJob = Job()
+        private val driver = driverFactory.create(db)
+        private val blockCatalog = db.blockCatalog
+        private val trieCatalog = db.trieCatalog
+        private val bufferPool = db.bufferPool
+        private val blockGc = BlockGarbageCollector(blockCatalog, bufferPool, blocksToKeep)
+
+        private fun defaultGarbageAsOf(): Instant? =
+            blockCatalog.blockFromLatest(blocksToKeep)
+                ?.let { it.latestCompletedTx.systemTime.microsAsInstant - garbageLifetime }
+
+        override fun garbageCollectTries(garbageAsOf: Instant?) {
+            val asOf = garbageAsOf ?: defaultGarbageAsOf() ?: return
+
+            LOGGER.debug("Garbage collecting data older than {}", asOf)
+
+            try {
+                LOGGER.debug("Starting trie garbage collection")
+                val tableNames = blockCatalog.allTables.shuffled().take(100)
+                for (tableName in tableNames) {
+                    val garbageTries = trieCatalog.garbageTries(tableName, asOf)
+                    runBlocking { driver.deleteGarbageTries(tableName, garbageTries) }
+                }
+                LOGGER.debug("Trie garbage collection completed")
+
+            } catch (e: Exception) {
+                LOGGER.warn("Trie garbage collection failed", e)
+            } catch (e: Throwable) {
+                throw RuntimeException("Error encountered during Trie garbage collection: ", e)
+            }
+        }
+
+        override fun collectGarbage() {
+            LOGGER.debug("Starting block garbage collection")
+            blockGc.garbageCollectBlocks()
+            LOGGER.debug("Block garbage collection completed")
+
+            garbageCollectTries()
+            LOGGER.debug("Next GC run scheduled in ${approxRunInterval.toMillis()}ms")
+        }
+
+        override fun start() {
+            LOGGER.debug(
+                "Starting GarbageCollector with approxRunInterval: {}, blocksToKeep: {}",
+                approxRunInterval, blocksToKeep
+            )
+
+            CoroutineScope(coroutineCtx + parentJob).launch {
+                delay(Random.nextLong(approxRunInterval.toMillis()))
+                while (isActive) {
+                    collectGarbage()
+                    delay(approxRunInterval.toMillis())
+                }
+            }
+        }
+
+        override fun close() {
+            runBlocking { withTimeout(5.seconds) { parentJob.cancelAndJoin() } }
+            LOGGER.debug("GarbageCollector shut down")
+        }
     }
 }
+

--- a/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
+++ b/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
@@ -8,6 +8,7 @@ import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.TrieKey
 import xtdb.util.debug
 import xtdb.util.logger
+import java.nio.file.Path
 
 private val LOGGER = GarbageCollectorMockDriver::class.logger
 
@@ -18,17 +19,16 @@ class GarbageCollectorMockDriver() : GarbageCollector.Driver.Factory {
         private val bufferPool = db.bufferPool
         private val trieCatalog = db.trieCatalog
 
-        override suspend fun deleteGarbageTries(tableName: TableRef, garbageTries: Set<TrieKey>) {
-            for (garbageTrie in garbageTries) {
-                LOGGER.debug("Deleting data file for garbage trie $garbageTrie")
-                bufferPool.deleteIfExists(tableName.metaFilePath(garbageTrie))
-                yield()
-                LOGGER.debug("Deleting meta file for garbage trie $garbageTrie")
-                bufferPool.deleteIfExists(tableName.dataFilePath(garbageTrie))
-                yield()
-            }
-            LOGGER.debug("Removing ${garbageTries.size} garbage tries from catalog for table $tableName")
-            trieCatalog.deleteTries(tableName, garbageTries)
+        override suspend fun deletePath(path: Path) {
+            yield()
+            LOGGER.debug("Deleting path $path")
+            bufferPool.deleteIfExists(path)
+        }
+
+        override suspend fun deleteTries(tableName: TableRef, trieKeys: Set<TrieKey>) {
+            yield()
+            LOGGER.debug("Removing ${trieKeys.size} tries from catalog for table $tableName")
+            trieCatalog.deleteTries(tableName, trieKeys)
         }
 
         override fun close() {}

--- a/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
+++ b/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
@@ -1,0 +1,37 @@
+package xtdb.garbage_collector
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.yield
+import org.slf4j.LoggerFactory
+import xtdb.database.IDatabase
+import xtdb.table.TableRef
+import xtdb.trie.Trie.dataFilePath
+import xtdb.trie.Trie.metaFilePath
+import xtdb.trie.TrieKey
+import java.time.Instant
+
+private val LOGGER = LoggerFactory.getLogger(GarbageCollectorMockDriver::class.java)
+
+class GarbageCollectorMockDriver() : GarbageCollector.Driver.Factory {
+    override fun create(db: IDatabase) = ForDatabase(db)
+
+    class ForDatabase(val db: IDatabase) : GarbageCollector.Driver {
+        private val bufferPool = db.bufferPool
+        private val trieCatalog = db.trieCatalog
+
+        override suspend fun deleteGarbageTries(tableName: TableRef, garbageTries: Set<TrieKey>) {
+            for (garbageTrie in garbageTries) {
+                LOGGER.debug("Deleting data file for garbage trie {}", garbageTrie)
+                bufferPool.deleteIfExists(tableName.metaFilePath(garbageTrie))
+                yield()
+                LOGGER.debug("Deleting meta file for garbage trie {}", garbageTrie)
+                bufferPool.deleteIfExists(tableName.dataFilePath(garbageTrie))
+                yield()
+            }
+            LOGGER.debug("Removing {} garbage tries from catalog for table {}", garbageTries.size, tableName)
+            trieCatalog.deleteTries(tableName, garbageTries)
+        }
+
+        override fun close() {}
+    }
+}

--- a/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
+++ b/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
@@ -1,16 +1,15 @@
 package xtdb.garbage_collector
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.yield
-import org.slf4j.LoggerFactory
 import xtdb.database.IDatabase
 import xtdb.table.TableRef
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.TrieKey
-import java.time.Instant
+import xtdb.util.debug
+import xtdb.util.logger
 
-private val LOGGER = LoggerFactory.getLogger(GarbageCollectorMockDriver::class.java)
+private val LOGGER = GarbageCollectorMockDriver::class.logger
 
 class GarbageCollectorMockDriver() : GarbageCollector.Driver.Factory {
     override fun create(db: IDatabase) = ForDatabase(db)
@@ -21,14 +20,14 @@ class GarbageCollectorMockDriver() : GarbageCollector.Driver.Factory {
 
         override suspend fun deleteGarbageTries(tableName: TableRef, garbageTries: Set<TrieKey>) {
             for (garbageTrie in garbageTries) {
-                LOGGER.debug("Deleting data file for garbage trie {}", garbageTrie)
+                LOGGER.debug("Deleting data file for garbage trie $garbageTrie")
                 bufferPool.deleteIfExists(tableName.metaFilePath(garbageTrie))
                 yield()
-                LOGGER.debug("Deleting meta file for garbage trie {}", garbageTrie)
+                LOGGER.debug("Deleting meta file for garbage trie $garbageTrie")
                 bufferPool.deleteIfExists(tableName.dataFilePath(garbageTrie))
                 yield()
             }
-            LOGGER.debug("Removing {} garbage tries from catalog for table {}", garbageTries.size, tableName)
+            LOGGER.debug("Removing ${garbageTries.size} garbage tries from catalog for table $tableName")
             trieCatalog.deleteTries(tableName, garbageTries)
         }
 


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3Arework-gc

- Reworks garbage collector to act a bit more like the compactor, with deletion of tries as a suspending function within the driver.
  - Switching this to an interface/Impl will ALSO help us with #5060  
- Also adds a MockDriver implementation.