### PR TITLE
Disable binary format for timestamptz in xtdb jdbc driver

### DIFF
--- a/src/test/clojure/xtdb/sql/logic_test/runner.clj
+++ b/src/test/clojure/xtdb/sql/logic_test/runner.clj
@@ -321,8 +321,10 @@
 
 (defn with-xtdb [f]
   (require 'xtdb.sql.logic-test.xtdb-engine)
-  (binding [*db-engine* tu/*node*]
-    (f)))
+  (let [node tu/*node*]
+    (with-open [conn (.getConnection node)]
+      (binding [*db-engine* (assoc node :conn conn)]
+        (f)))))
 
 (defn with-jdbc [url f]
   (with-open [c (DriverManager/getConnection url)]

--- a/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
+++ b/src/test/kotlin/xtdb/jdbc/XtConnectionTest.kt
@@ -85,4 +85,24 @@ class XtConnectionTest {
             }
         }
     }
+
+    @Test
+    fun `test timestamptz via xtdb jdbc driver is always text format, so that ZoneId is preserved`(node: Xtdb) {
+
+        node.createConnectionBuilder()
+            .option("prepareThreshold", "-1")
+            .option("binaryTransfer", "true")
+            .build().use { conn ->
+            conn.prepareStatement("SELECT TIMESTAMP '2020-05-01+01:00[Europe/London]' ts").use { stmt ->
+                stmt.executeQuery().use { res ->
+                    res.next()
+                    assertEquals(
+                        "2020-05-01+01:00[Europe/London]".asZonedDateTime(),
+                        res.getObject(1)
+                    )
+                }
+            }
+
+        }
+    }
 }


### PR DESCRIPTION
This is because we rely on the text formatter and iso8601 datestyle to roundtrip ZDTs. The binary format does not allow for this, meaning the ZoneID is lost.

As of https://github.com/xtdb/xtdb/pull/3885 pgwire_test has been using the xtdb driver as that is whats loaded first by the driver manager. This means its properties and behaviour are such as https://github.com/xtdb/xtdb/pull/4433 are implicitly being tested. 

I think ideally we want to split this namespace into tests which intentionally cover xtdb jdbc driver behaviour, and those attempting to test pgwire server/implementation via pgjdbc. As a step towards that I've added an explicit pgjdbc-conn helper which tests can instead use.  

PR also changes SLT to use a single conn per SLT file, rather than creating a new one for every statement. ~40% speed up in SLT across the board. Likely through a combination of reusing prepared statements and avoiding recreating the conn every time. 