### PR TITLE
[bench] Disable Job retries (backoffLimit: 0)

### DIFF
--- a/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-auctionmark.yaml
@@ -22,7 +22,7 @@ spec:
   parallelism: 1
   completions: 1
   {{- end }}
-  backoffLimit: 1
+  backoffLimit: 0
   ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 0 }}
   template:
     metadata:

--- a/modules/bench/cloud/helm/templates/benchmark-readings.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-readings.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  backoffLimit: 1
+  backoffLimit: 0
   ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 0 }}
   template:
     metadata:

--- a/modules/bench/cloud/helm/templates/benchmark-tpch.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-tpch.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  backoffLimit: 1
+  backoffLimit: 0
   ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 0 }}
   template:
     metadata:

--- a/modules/bench/cloud/helm/templates/benchmark-yakbench.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-yakbench.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  backoffLimit: 1
+  backoffLimit: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Benchmarks shouldn't retry on failure - if something goes wrong we want to know immediately, not have a second run pollute the data with stale state from the failed run.