### PR TITLE
Add tracing on transactions

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -23,6 +23,7 @@
             [xtdb.vector.reader :as vr])
   (:import (clojure.lang MapEntry)
            (io.micrometer.core.instrument Counter Timer)
+           (io.micrometer.tracing Tracer)
            (java.nio ByteBuffer)
            (java.time Instant InstantSource)
            (java.time.temporal ChronoUnit)
@@ -34,6 +35,7 @@
            (xtdb.database Database Database$Catalog)
            (xtdb.error Anomaly$Caller Interrupted)
            (xtdb.indexer Indexer Indexer$ForDatabase Indexer$TxSink LiveIndex LiveIndex$Tx LiveTable$Tx OpIndexer RelationIndexer Snapshot Snapshot$Source)
+           (xtdb.table TableRef)
            (xtdb.query IQuerySource PreparedQuery)))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -85,7 +87,7 @@
   `(let [data# ~data]
      (try
        (err/wrap-anomaly data#
-         ~@body)
+                         ~@body)
        (catch Interrupted e# (throw e#))
        (catch Anomaly$Caller e# (throw e#))
        (catch Throwable e#
@@ -109,7 +111,7 @@
 
 (defn- ->put-docs-indexer ^xtdb.indexer.OpIndexer [^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx, ^VectorReader tx-ops-rdr,
                                                    ^Database db, ^Instant system-time
-                                                   {:keys [indexer tx-key]}]
+                                                   {:keys [indexer tx-key ^Tracer tracer]}]
   (let [db-name (.getName db)
         put-leg (.vectorFor tx-ops-rdr "put-docs")
         iids-rdr (.vectorFor put-leg "iids")
@@ -158,7 +160,7 @@
 
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
-        (let [table (table/->ref db-name (.getLeg docs-rdr tx-op-idx))
+        (let [^TableRef table (table/->ref db-name (.getLeg docs-rdr tx-op-idx))
 
               {:keys [^VectorReader docs-rdr, ^VectorReader id-rdr, ^LiveTable$Tx live-table-tx, ^RowCopier doc-copier
                       ^VectorReader row-valid-from-rdr, ^VectorReader row-valid-to-rdr]}
@@ -174,37 +176,40 @@
               doc-start-idx (.getListStartIndex docs-rdr tx-op-idx)
               ^long iid-start-idx (or (some-> iids-rdr (.getListStartIndex tx-op-idx))
                                       Long/MIN_VALUE)]
-          (dotimes [row-idx (.getListCount docs-rdr tx-op-idx)]
-            (let [doc-idx (+ doc-start-idx row-idx)
-                  valid-from (if (and row-valid-from-rdr (not (.isNull row-valid-from-rdr doc-idx)))
-                               (.getLong row-valid-from-rdr doc-idx)
-                               valid-from)
-                  valid-to (if (and row-valid-to-rdr (not (.isNull row-valid-to-rdr doc-idx)))
-                             (.getLong row-valid-to-rdr doc-idx)
-                             valid-to)]
+          (metrics/with-span tracer "xtdb.transaction.put-docs" {:attributes {:db (.getDbName table)
+                                                                              :schema (.getSchemaName table)
+                                                                              :table (.getTableName table)}}
+            (dotimes [row-idx (.getListCount docs-rdr tx-op-idx)]
+              (let [doc-idx (+ doc-start-idx row-idx)
+                    valid-from (if (and row-valid-from-rdr (not (.isNull row-valid-from-rdr doc-idx)))
+                                 (.getLong row-valid-from-rdr doc-idx)
+                                 valid-from)
+                    valid-to (if (and row-valid-to-rdr (not (.isNull row-valid-to-rdr doc-idx)))
+                               (.getLong row-valid-to-rdr doc-idx)
+                               valid-to)]
 
-              (when-not (> valid-to valid-from)
-                (throw (err/incorrect :xtdb.indexer/invalid-valid-times
-                                      "Invalid valid times"
-                                      {:valid-from (time/micros->instant valid-from)
-                                       :valid-to (time/micros->instant valid-to)})))
+                (when-not (> valid-to valid-from)
+                  (throw (err/incorrect :xtdb.indexer/invalid-valid-times
+                                        "Invalid valid times"
+                                        {:valid-from (time/micros->instant valid-from)
+                                         :valid-to (time/micros->instant valid-to)})))
 
-              (with-crash-log indexer "error putting document"
+                (with-crash-log indexer "error putting document"
                   {:table table, :tx-key tx-key, :tx-op-idx tx-op-idx, :doc-idx doc-idx}
                   {:live-idx live-idx, :live-table-tx live-table-tx, :tx-ops-rdr tx-ops-rdr}
 
-                (.logPut live-table-tx
-                         (if iid-rdr
-                           (.getBytes iid-rdr (+ iid-start-idx row-idx))
-                           (ByteBuffer/wrap (util/->iid (.getObject id-rdr doc-idx))))
-                         valid-from valid-to
-                         #(.copyRow doc-copier doc-idx))))))
+                  (.logPut live-table-tx
+                           (if iid-rdr
+                             (.getBytes iid-rdr (+ iid-start-idx row-idx))
+                             (ByteBuffer/wrap (util/->iid (.getObject id-rdr doc-idx))))
+                           valid-from valid-to
+                           #(.copyRow doc-copier doc-idx)))))))
 
         nil))))
 
 (defn- ->delete-docs-indexer ^xtdb.indexer.OpIndexer [^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx, ^VectorReader tx-ops-rdr,
                                                       ^Database db, ^Instant current-time
-                                                      {:keys [indexer tx-key]}]
+                                                      {:keys [indexer tx-key ^Tracer tracer]}]
   (let [db-name (.getName db)
         delete-leg (.vectorFor tx-ops-rdr "delete-docs")
         table-rdr (.vectorFor delete-leg "table")
@@ -215,7 +220,7 @@
         current-time-µs (time/instant->micros current-time)]
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
-        (let [table (table/->ref db-name (.getObject table-rdr tx-op-idx))
+        (let [^TableRef table (table/->ref db-name (.getObject table-rdr tx-op-idx))
               live-table-tx (.liveTable live-idx-tx table)
               valid-from (if (.isNull valid-from-rdr tx-op-idx)
                            current-time-µs
@@ -231,19 +236,22 @@
                                   {:valid-from (time/micros->instant valid-from)
                                    :valid-to (time/micros->instant valid-to)})))
 
-          (let [iids-start-idx (.getListStartIndex iids-rdr tx-op-idx)]
-            (dotimes [iid-idx (.getListCount iids-rdr tx-op-idx)]
-              (with-crash-log indexer "error deleting documents"
+          (metrics/with-span tracer "xtdb.transaction.delete-docs" {:attributes {:db (.getDbName table)
+                                                                                 :schema (.getSchemaName table)
+                                                                                 :table (.getTableName table)}}
+            (let [iids-start-idx (.getListStartIndex iids-rdr tx-op-idx)]
+              (dotimes [iid-idx (.getListCount iids-rdr tx-op-idx)]
+                (with-crash-log indexer "error deleting documents"
                   {:table table, :tx-key tx-key, :tx-op-idx tx-op-idx, :iid-idx iid-idx}
                   {:live-idx live-idx, :live-table-tx live-table-tx, :tx-ops-rdr tx-ops-rdr}
 
-                (.logDelete live-table-tx (.getBytes iid-rdr (+ iids-start-idx iid-idx))
-                            valid-from valid-to)))))
+                  (.logDelete live-table-tx (.getBytes iid-rdr (+ iids-start-idx iid-idx))
+                              valid-from valid-to))))))
 
         nil))))
 
 (defn- ->erase-docs-indexer ^xtdb.indexer.OpIndexer [^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx, ^VectorReader tx-ops-rdr
-                                                     ^Database db, {:keys [indexer tx-key]}]
+                                                     ^Database db, {:keys [indexer tx-key ^Tracer tracer]}]
   (let [db-name (.getName db)
         erase-leg (.vectorFor tx-ops-rdr "erase-docs")
         table-rdr (.vectorFor erase-leg "table")
@@ -251,18 +259,21 @@
         iid-rdr (.getListElements iids-rdr)]
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
-        (let [table (table/->ref db-name (.getObject table-rdr tx-op-idx))
+        (let [^TableRef table (table/->ref db-name (.getObject table-rdr tx-op-idx))
               live-table (.liveTable live-idx-tx table)
               iids-start-idx (.getListStartIndex iids-rdr tx-op-idx)]
 
           (when (xt-log/forbidden-table? table) (throw (xt-log/forbidden-table-ex table)))
 
-          (dotimes [iid-idx (.getListCount iids-rdr tx-op-idx)]
-            (with-crash-log indexer "error erasing documents"
+          (metrics/with-span tracer "xtdb.transaction.erase-docs" {:attributes {:db (.getDbName table)
+                                                                                :schema (.getSchemaName table)
+                                                                                :table (.getTableName table)}}
+            (dotimes [iid-idx (.getListCount iids-rdr tx-op-idx)]
+              (with-crash-log indexer "error erasing documents"
                 {:table table, :tx-key tx-key, :tx-op-idx tx-op-idx, :iid-idx iid-idx}
                 {:live-idx live-idx, :live-table live-table, :tx-ops-rdr tx-ops-rdr}
 
-              (.logErase live-table (.getBytes iid-rdr (+ iids-start-idx iid-idx))))))
+                (.logErase live-table (.getBytes iid-rdr (+ iids-start-idx iid-idx)))))))
 
         nil))))
 
@@ -286,8 +297,8 @@
                   live-table-tx (.liveTable live-idx-tx table)]
 
               (with-crash-log indexer "error upserting rows"
-                  {:table table, :tx-key tx-key}
-                  {:live-idx live-idx, :live-table-tx live-table-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
+                {:table table, :tx-key tx-key}
+                {:live-idx live-idx, :live-table-tx live-table-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
                 (let [live-idx-table-copier (.rowCopier (RelationAsStructReader. "content" content-rel)
                                                         (.getDocWriter live-table-tx))]
                   (when-not id-col
@@ -297,22 +308,22 @@
 
                   (dotimes [idx row-count]
                     (err/wrap-anomaly {:table table, :tx-key tx-key, :row-idx idx}
-                      (let [eid (.getObject id-col idx)
-                            valid-from (if (and valid-from-rdr (not (.isNull valid-from-rdr idx)))
-                                         (.getLong valid-from-rdr idx)
-                                         current-time-µs)
-                            valid-to (if (and valid-to-rdr (not (.isNull valid-to-rdr idx)))
-                                       (.getLong valid-to-rdr idx)
-                                       Long/MAX_VALUE)]
-                        (when (> valid-from valid-to)
-                          (throw (err/incorrect :xtdb.indexer/invalid-valid-times
-                                                "Invalid valid times"
-                                                {:valid-from (time/micros->instant valid-from)
-                                                 :valid-to (time/micros->instant valid-to)})))
+                                      (let [eid (.getObject id-col idx)
+                                            valid-from (if (and valid-from-rdr (not (.isNull valid-from-rdr idx)))
+                                                         (.getLong valid-from-rdr idx)
+                                                         current-time-µs)
+                                            valid-to (if (and valid-to-rdr (not (.isNull valid-to-rdr idx)))
+                                                       (.getLong valid-to-rdr idx)
+                                                       Long/MAX_VALUE)]
+                                        (when (> valid-from valid-to)
+                                          (throw (err/incorrect :xtdb.indexer/invalid-valid-times
+                                                                "Invalid valid times"
+                                                                {:valid-from (time/micros->instant valid-from)
+                                                                 :valid-to (time/micros->instant valid-to)})))
 
-                        ;; FIXME something in the generated SQL generates rows with `(= vf vt)`, which is also unacceptable
-                        (when (< valid-from valid-to)
-                          (.logPut live-table-tx (ByteBuffer/wrap (util/->iid eid)) valid-from valid-to #(.copyRow live-idx-table-copier idx)))))))))))))))
+                                        ;; FIXME something in the generated SQL generates rows with `(= vf vt)`, which is also unacceptable
+                                        (when (< valid-from valid-to)
+                                          (.logPut live-table-tx (ByteBuffer/wrap (util/->iid eid)) valid-from valid-to #(.copyRow live-idx-table-copier idx)))))))))))))))
 
 (defn- ->delete-rel-indexer ^xtdb.indexer.RelationIndexer [^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx, ^VectorReader tx-ops-rdr, {:keys [indexer tx-key]}]
   (reify RelationIndexer
@@ -327,8 +338,8 @@
 
         (dotimes [idx row-count]
           (with-crash-log indexer "error deleting rows"
-              {:table table, :tx-key tx-key, :row-idx idx}
-              {:live-idx live-idx, :live-table-tx live-idx-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
+            {:table table, :tx-key tx-key, :row-idx idx}
+            {:live-idx live-idx, :live-table-tx live-idx-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
 
             (let [iid (.getBytes iid-rdr idx)
                   valid-from (.getLong valid-from-rdr idx)
@@ -354,8 +365,8 @@
 
         (dotimes [idx row-count]
           (with-crash-log indexer "error erasing rows"
-              {:table table, :tx-key tx-key, :row-idx idx}
-              {:live-idx live-idx, :live-table-tx live-idx-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
+            {:table table, :tx-key tx-key, :row-idx idx}
+            {:live-idx live-idx, :live-table-tx live-idx-tx, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
 
             (let [iid (.getBytes iid-rdr idx)]
               (-> (.liveTable live-idx-tx table)
@@ -397,7 +408,7 @@
 
 (defn- query-indexer [allocator, ^IQuerySource q-src, db-cat, ^RelationIndexer rel-idxer, tx-opts, {:keys [stmt] :as query-opts}]
   (let [^PreparedQuery pq (.prepareQuery q-src stmt db-cat tx-opts)]
-    (-> (fn eval-query [^RelationReader args] 
+    (-> (fn eval-query [^RelationReader args]
           (with-open [res (-> (.openQuery pq (-> (select-keys tx-opts [:snapshot-token :current-time :default-tz :tracer :query-text])
                                                  (assoc :args args, :close-args? false))))]
             (.forEachRemaining res
@@ -419,8 +430,8 @@
         (let [selection (int-array 1)]
           (dotimes [idx (.getRowCount param-rel)]
             (err/wrap-anomaly {:arg-idx idx}
-              (aset selection 0 idx)
-              (eval-query (-> param-rel (.select selection))))))))))
+                              (aset selection 0 idx)
+                              (eval-query (-> param-rel (.select selection))))))))))
 
 (defn- patch-rel! [table, ^LiveIndex live-idx, ^LiveTable$Tx live-table, ^RelationReader rel {:keys [indexer tx-key]}]
   (let [row-count (.getRowCount rel)]
@@ -431,8 +442,8 @@
             to-rdr (.vectorForOrNull rel "_valid_to")]
         (dotimes [idx row-count]
           (with-crash-log indexer "error patching rows"
-              {:table table, :tx-key tx-key, :row-idx idx}
-              {:live-idx live-idx, :live-table live-table, :query-rel rel}
+            {:table table, :tx-key tx-key, :row-idx idx}
+            {:live-idx live-idx, :live-table live-table, :query-rel rel}
 
             (.logPut live-table
                      (.getBytes iid-rdr idx)
@@ -442,7 +453,7 @@
 
 (defn- ->patch-docs-indexer [^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx, ^VectorReader tx-ops-rdr,
                              ^IQuerySource q-src, ^Database$Catalog db-cat, ^Instant system-time
-                             {:keys [default-db] :as tx-opts}]
+                             {:keys [default-db ^Tracer tracer] :as tx-opts}]
   (let [patch-leg (.vectorFor tx-ops-rdr "patch-docs")
         iids-rdr (.vectorFor patch-leg "iids")
         iid-rdr (.getListElements iids-rdr)
@@ -453,7 +464,7 @@
 
         system-time-µs (time/instant->micros system-time)]
     (letfn [(->table-idxer [^String table-name]
-              (let [table (table/->ref default-db table-name)]
+              (let [^TableRef table (table/->ref default-db table-name)]
                 (when (xt-log/forbidden-table? table)
                   (throw (xt-log/forbidden-table-ex table)))
 
@@ -479,33 +490,35 @@
                             (throw (err/incorrect :xtdb.indexer/invalid-valid-times
                                                   "Invalid valid times"
                                                   {:valid-from valid-from, :valid-to valid-to})))
+                          (metrics/with-span tracer "xtdb.transaction.patch-docs" {:attributes {:db (.getDbName table)
+                                                                                                :schema (.getSchemaName table)
+                                                                                                :table (.getTableName table)}}
+                            (let [table-info (-> (with-open [snap (.openSnapshot (.getSnapSource (.databaseOrNull db-cat default-db)))]
+                                                   (.getSchema snap))
+                                                 (sql/xform-table-info default-db))
+                                  pq (.prepareQuery q-src (-> (sql/plan-patch {:table-info table-info}
+                                                                              {:table table
+                                                                               :valid-from valid-from
+                                                                               :valid-to valid-to
+                                                                               :patch-rel (sql/->QueryExpr '[:table [_iid doc]
+                                                                                                             ?patch_docs]
+                                                                                                           '[_iid doc])})
+                                                              (lp/rewrite-plan))
+                                                    db-cat tx-opts)
+                                  args (vr/rel-reader [(SingletonListReader.
+                                                        "?patch_docs"
+                                                        (RelationAsStructReader.
+                                                         "patch_doc"
+                                                         (vr/rel-reader [(-> (.select iid-rdr (.getListStartIndex iids-rdr tx-op-idx) (.getListCount iids-rdr tx-op-idx))
+                                                                             (.withName "_iid"))
+                                                                         (-> (.select doc-rdr (.getListStartIndex table-docs-rdr tx-op-idx) (.getListCount table-docs-rdr tx-op-idx))
+                                                                             (.withName "doc"))])))])]
 
-                          (let [table-info (-> (with-open [snap (.openSnapshot (.getSnapSource (.databaseOrNull db-cat default-db)))]
-                                                 (.getSchema snap))
-                                               (sql/xform-table-info default-db))
-                                pq (.prepareQuery q-src (-> (sql/plan-patch {:table-info table-info}
-                                                                            {:table table
-                                                                             :valid-from valid-from
-                                                                             :valid-to valid-to
-                                                                             :patch-rel (sql/->QueryExpr '[:table [_iid doc]
-                                                                                                           ?patch_docs]
-                                                                                                         '[_iid doc])})
-                                                            (lp/rewrite-plan))
-                                                  db-cat tx-opts)
-                                args (vr/rel-reader [(SingletonListReader.
-                                                      "?patch_docs"
-                                                      (RelationAsStructReader.
-                                                       "patch_doc"
-                                                       (vr/rel-reader [(-> (.select iid-rdr (.getListStartIndex iids-rdr tx-op-idx) (.getListCount iids-rdr tx-op-idx))
-                                                                           (.withName "_iid"))
-                                                                       (-> (.select doc-rdr (.getListStartIndex table-docs-rdr tx-op-idx) (.getListCount table-docs-rdr tx-op-idx))
-                                                                           (.withName "doc"))])))])]
-
-                            (with-open [res (.openQuery pq (-> (select-keys tx-opts [:snapshot-token :current-time :default-tz])
-                                                               (assoc :args args, :close-args? false)))]
-                              (.forEachRemaining res
-                                                 (fn [^RelationReader rel]
-                                                   (patch-rel! table live-idx live-table rel tx-opts))))))))))))]
+                              (with-open [res (.openQuery pq (-> (select-keys tx-opts [:snapshot-token :current-time :default-tz])
+                                                                 (assoc :args args, :close-args? false)))]
+                                (.forEachRemaining res
+                                                   (fn [^RelationReader rel]
+                                                     (patch-rel! table live-idx live-table rel tx-opts)))))))))))))]
 
       (let [tables (->> (.getLegNames docs-rdr)
                         (into {} (keep (fn [table-name]
@@ -542,7 +555,7 @@
 
 (defn- ->sql-indexer ^xtdb.indexer.OpIndexer [^BufferAllocator allocator, ^LiveIndex live-idx, ^LiveIndex$Tx live-idx-tx
                                               ^VectorReader tx-ops-rdr, ^IQuerySource q-src, db-cat,
-                                              {:keys [default-db tx-key tracer] :as tx-opts}]
+                                              {:keys [default-db tx-key ^Tracer tracer] :as tx-opts}]
   (let [sql-leg (.vectorFor tx-ops-rdr "sql")
         query-rdr (.vectorFor sql-leg "query")
         args-rdr (.vectorFor sql-leg "args")
@@ -556,34 +569,34 @@
       (indexOp [_ tx-op-idx]
         (let [query-str (.getObject query-rdr tx-op-idx)]
           (err/wrap-anomaly {:sql query-str, :tx-op-idx tx-op-idx, :tx-key tx-key}
-            (util/with-open [^Relation$ILoader args-loader (open-args-rdr allocator args-rdr tx-op-idx)]
-              (metrics/with-span tracer "xtdb.transaction.sql" {:attributes {:query.text query-str}} 
-                (let [[q-tag q-args] (parse-sql/parse-statement query-str {:default-db default-db})
-                      tx-opts (assoc tx-opts 
-                                     :arg-fields (some-> args-loader (.getSchema) (.getFields))
-                                     :query-text query-str)]
-                  (case q-tag
-                    :insert (foreach-arg-row allocator args-loader
-                                             (query-indexer allocator q-src db-cat upsert-idxer tx-opts q-args))
-                    :patch (foreach-arg-row allocator args-loader
-                                            (query-indexer allocator q-src db-cat patch-idxer tx-opts q-args))
-                    :update (foreach-arg-row allocator args-loader
-                                             (query-indexer allocator q-src db-cat upsert-idxer tx-opts q-args))
-                    :delete (foreach-arg-row allocator args-loader
-                                             (query-indexer allocator q-src db-cat delete-idxer tx-opts q-args))
-                    :erase (foreach-arg-row allocator args-loader
-                                            (query-indexer allocator q-src db-cat erase-idxer tx-opts q-args))
-                    :assert (foreach-arg-row allocator args-loader
-                                             (->assert-idxer q-src db-cat tx-opts q-args))
+                            (util/with-open [^Relation$ILoader args-loader (open-args-rdr allocator args-rdr tx-op-idx)]
+                              (metrics/with-span tracer "xtdb.transaction.sql" {:attributes {:query.text query-str}}
+                                (let [[q-tag q-args] (parse-sql/parse-statement query-str {:default-db default-db})
+                                      tx-opts (assoc tx-opts
+                                                     :arg-fields (some-> args-loader (.getSchema) (.getFields))
+                                                     :query-text query-str)]
+                                  (case q-tag
+                                    :insert (foreach-arg-row allocator args-loader
+                                                             (query-indexer allocator q-src db-cat upsert-idxer tx-opts q-args))
+                                    :patch (foreach-arg-row allocator args-loader
+                                                            (query-indexer allocator q-src db-cat patch-idxer tx-opts q-args))
+                                    :update (foreach-arg-row allocator args-loader
+                                                             (query-indexer allocator q-src db-cat upsert-idxer tx-opts q-args))
+                                    :delete (foreach-arg-row allocator args-loader
+                                                             (query-indexer allocator q-src db-cat delete-idxer tx-opts q-args))
+                                    :erase (foreach-arg-row allocator args-loader
+                                                            (query-indexer allocator q-src db-cat erase-idxer tx-opts q-args))
+                                    :assert (foreach-arg-row allocator args-loader
+                                                             (->assert-idxer q-src db-cat tx-opts q-args))
 
-                    :create-user (let [{:keys [username password]} q-args]
-                                   (update-pg-user! live-idx-tx tx-key username password))
+                                    :create-user (let [{:keys [username password]} q-args]
+                                                   (update-pg-user! live-idx-tx tx-key username password))
 
-                    :alter-user (let [{:keys [username password]} q-args]
-                                  (update-pg-user! live-idx-tx tx-key username password))
+                                    :alter-user (let [{:keys [username password]} q-args]
+                                                  (update-pg-user! live-idx-tx tx-key username password))
 
-                    (throw (err/incorrect ::invalid-sql-tx-op "Invalid SQL query sent as transaction operation"
-                                          {:query query-str}))))))))
+                                    (throw (err/incorrect ::invalid-sql-tx-op "Invalid SQL query sent as transaction operation"
+                                                          {:query query-str}))))))))
 
         nil))))
 
@@ -634,7 +647,7 @@
                                ^Database db, ^LiveIndex live-index, table-catalog
                                ^Timer tx-timer
                                ^Counter tx-error-counter
-                               tracer]
+                               ^Tracer tracer]
   Indexer$ForDatabase
   (close [_]
     (util/close allocator))
@@ -706,23 +719,23 @@
 
                 (if-let [e (try
                              (err/wrap-anomaly {}
-                               (dotimes [tx-op-idx (.getValueCount tx-ops-rdr)]
-                                 (.recordCallable tx-timer
-                                                  #(case (.getLeg tx-ops-rdr tx-op-idx)
-                                                     "xtql" (throw (err/unsupported :xtdb/xtql-dml-removed
-                                                                                    (str/join ["XTQL DML is no longer supported, as of 2.0.0-beta7. "
-                                                                                               "Please use SQL DML statements instead - "
-                                                                                               "see the release notes for more information."])))
-                                                     "sql" (.indexOp ^OpIndexer @!sql-idxer tx-op-idx)
-                                                     "put-docs" (.indexOp ^OpIndexer @!put-docs-idxer tx-op-idx)
-                                                     "patch-docs" (.indexOp ^OpIndexer @!patch-docs-idxer tx-op-idx)
-                                                     "delete-docs" (.indexOp ^OpIndexer @!delete-docs-idxer tx-op-idx)
-                                                     "erase-docs" (.indexOp ^OpIndexer @!erase-docs-idxer tx-op-idx)
-                                                     "call" (throw (err/unsupported :xtdb/tx-fns-removed
-                                                                                    (str/join ["tx-fns are no longer supported, as of 2.0.0-beta7. "
-                                                                                               "Please use ASSERTs and SQL DML statements instead - "
-                                                                                               "see the release notes for more information."]))))))
-                               nil)
+                                               (dotimes [tx-op-idx (.getValueCount tx-ops-rdr)]
+                                                 (.recordCallable tx-timer
+                                                                  #(case (.getLeg tx-ops-rdr tx-op-idx)
+                                                                     "xtql" (throw (err/unsupported :xtdb/xtql-dml-removed
+                                                                                                    (str/join ["XTQL DML is no longer supported, as of 2.0.0-beta7. "
+                                                                                                               "Please use SQL DML statements instead - "
+                                                                                                               "see the release notes for more information."])))
+                                                                     "sql" (.indexOp ^OpIndexer @!sql-idxer tx-op-idx)
+                                                                     "put-docs" (.indexOp ^OpIndexer @!put-docs-idxer tx-op-idx)
+                                                                     "patch-docs" (.indexOp ^OpIndexer @!patch-docs-idxer tx-op-idx)
+                                                                     "delete-docs" (.indexOp ^OpIndexer @!delete-docs-idxer tx-op-idx)
+                                                                     "erase-docs" (.indexOp ^OpIndexer @!erase-docs-idxer tx-op-idx)
+                                                                     "call" (throw (err/unsupported :xtdb/tx-fns-removed
+                                                                                                    (str/join ["tx-fns are no longer supported, as of 2.0.0-beta7. "
+                                                                                                               "Please use ASSERTs and SQL DML statements instead - "
+                                                                                                               "see the release notes for more information."]))))))
+                                               nil)
 
                              (catch Anomaly$Caller e e))]
 
@@ -748,7 +761,7 @@
       (add-tx-row! (.getName db) live-idx-tx tx-key e {})
       (commit tx-key live-idx-tx (.getTxSink db)))))
 
-(defmethod ig/init-key :xtdb/indexer [_ {:keys [config, q-src, metrics-registry, tracer]}]
+(defmethod ig/init-key :xtdb/indexer [_ {:keys [config, q-src, metrics-registry, ^Tracer tracer]}]
   (let [tx-timer (metrics/add-timer metrics-registry "tx.op.timer"
                                     {:description "indicates the timing and number of transactions"})
         tx-error-counter (metrics/add-counter metrics-registry "tx.error")]

--- a/src/test/clojure/xtdb/tracer_test.clj
+++ b/src/test/clojure/xtdb/tracer_test.clj
@@ -143,56 +143,102 @@
                                   :span-processor span-processor}})]
 
         (xt/submit-tx node [[:sql "INSERT INTO users (_id, name) VALUES (1, 'Alice')"]])
-        (xt/submit-tx node [[:sql "UPDATE users SET foo='bar' WHERE name='alice'"]]) 
+        (xt/submit-tx node [[:sql "UPDATE users SET foo='bar' WHERE name='alice'"]])
         (xt/submit-tx node [[:patch-docs :users {:xt/id "alice" :foo "baz"}]])
         (xt/submit-tx node [[:delete-docs :users 1]])
         (xt/submit-tx node [[:erase-docs :users 1]])
-        
+
         ;; Give spans a moment to be exported
-        (Thread/sleep 100) 
-        
+        (Thread/sleep 100)
+
         (let [span-tree (build-span-tree @!spans)
-              tx-spans (filter #(string/includes? (:name %) "xtdb.transaction") span-tree)
-              tx-span-names (mapv :name tx-spans)]
+              tx-spans (filter #(= (:name %) "xtdb.transaction") span-tree)
+              tx-child-spans (mapv #(first (:children %)) tx-spans)]
+          (t/is (= 5 (count tx-spans)))
           ;; we may expect the patch/delete/erase to differ here if they go through delete-docs/erase-docs indexer
           (t/is (= ["xtdb.transaction.put-docs"
                     "xtdb.transaction.sql"
                     "xtdb.transaction.sql"
                     "xtdb.transaction.sql"
                     "xtdb.transaction.sql"]
-                   tx-span-names))
+                   (mapv :name tx-child-spans)))
           (let [[put-tx update-tx _patch-tx _delete-tx _erase-tx] tx-spans]
-            (t/is (= {:name "xtdb.transaction.put-docs"
-                      :attributes {"db" "xtdb"
-                                   "schema" "public" 
-                                   "table" "users"},
-                      :children []} 
-                     put-tx))
-            (t/is (= {:name "xtdb.transaction.sql"
-                      :attributes {"query.text" "UPDATE users SET foo='bar' WHERE name='alice'"},
+            (t/is (= {:name "xtdb.transaction"
+                      :attributes {"operations.count" "1"}
                       :children
-                      [{:name "xtdb.query"
+                      [{:name "xtdb.transaction.put-docs"
+                        :attributes {"db" "xtdb"
+                                     "schema" "public"
+                                     "table" "users"},
+                        :children []}]}
+                     put-tx))
+            (t/is (= {:name "xtdb.transaction"
+                      :attributes {"operations.count" "1"}
+                      :children
+                      [{:name "xtdb.transaction.sql"
                         :attributes {"query.text" "UPDATE users SET foo='bar' WHERE name='alice'"},
                         :children
-                        [{:name "query.cursor.project"
-                          :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
-                          :children []}
-                         {:name "query.cursor.project"
-                          :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
-                          :children []}
-                         {:name "query.cursor.rename"
-                          :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "rename"},
-                          :children []}
-                         {:name "query.cursor.select"
-                          :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "select"},
-                          :children []}
-                         {:name "query.cursor.scan.users"
-                          :attributes
-                          {"cursor.page_count" "0",
-                           "cursor.row_count" "0",
-                           "cursor.type" "scan",
-                           "db.name" "xtdb",
-                           "schema.name" "public",
-                           "table.name" "users"},
-                          :children []}]}]}
+                        [{:name "xtdb.query"
+                          :attributes {"query.text" "UPDATE users SET foo='bar' WHERE name='alice'"},
+                          :children
+                          [{:name "query.cursor.project"
+                            :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
+                            :children []}
+                           {:name "query.cursor.project"
+                            :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
+                            :children []}
+                           {:name "query.cursor.rename"
+                            :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "rename"},
+                            :children []}
+                           {:name "query.cursor.select"
+                            :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "select"},
+                            :children []}
+                           {:name "query.cursor.scan.users"
+                            :attributes
+                            {"cursor.page_count" "0",
+                             "cursor.row_count" "0",
+                             "cursor.type" "scan",
+                             "db.name" "xtdb",
+                             "schema.name" "public",
+                             "table.name" "users"},
+                            :children []}]}]}]}
                      update-tx))))))))
+
+(t/deftest test-transaction-multiple-ops-tracing
+  (t/testing "multiple SQL operations in one transaction create separate spans"
+    (let [!spans (atom [])
+          exporter (test-span-exporter !spans)
+          span-processor (SimpleSpanProcessor/create exporter)]
+      (with-open [node (xtn/start-node
+                        {:tracer {:enabled? true
+                                  :service-name "xtdb-test"
+                                  :span-processor span-processor}})]
+
+        (xt/submit-tx node [[:sql "INSERT INTO users (_id, name) VALUES (1, 'Alice')"]
+                            [:sql "INSERT INTO users2 (_id, name) VALUES (2, 'Bob')"]
+                            [:sql "INSERT INTO users3 (_id, name) VALUES (3, 'Charlie')"]])
+
+        ;; Give spans a moment to be exported
+        (Thread/sleep 100)
+
+        (let [span-tree (build-span-tree @!spans)
+              tx-span (first (filter #(= (:name %) "xtdb.transaction") span-tree))]
+          (t/is (= {:name "xtdb.transaction"
+                    :attributes {"operations.count" "3"}
+                    :children
+                    [{:name "xtdb.transaction.put-docs"
+                      :attributes {"db" "xtdb"
+                                   "schema" "public"
+                                   "table" "users"},
+                      :children []}
+                     {:name "xtdb.transaction.put-docs"
+                      :attributes {"db" "xtdb"
+                                   "schema" "public"
+                                   "table" "users2"},
+                      :children []}
+                     {:name "xtdb.transaction.put-docs"
+                      :attributes {"db" "xtdb"
+                                   "schema" "public"
+                                   "table" "users3"},
+                      :children []}]}
+                   tx-span)))))))


### PR DESCRIPTION
GH actions: https://github.com/danmason/xtdb/actions?query=branch%3Atrace-transactions++

Passes a tracer through the indexer and uses it to gather timings/info about individual transactions.

Adds top level transaction batch tracing which wraps all operations in the batch.
<img width="1862" height="1352" alt="image" src="https://github.com/user-attachments/assets/4caea1e3-ac46-49af-bfef-0018ab92817b" />


Adds tracing to SQL indexer and ensures any queries ran by the SQL indexer get captured and traced as a child span. 
- We pass the tracer + query text down within the openQuery calls made within the indexer, and these all get captured accordingly.

<img width="1740" height="594" alt="image" src="https://github.com/user-attachments/assets/f954dfbb-f6d6-436c-9a35-e6f94c6e82f1" />


Also adds slightly less detailed tracing to put-docs, delete-docs, erase-docs and patch-docs indexers - these aren't really getting used at the moment (aside from put-docs) and the level of detail is much less, so arguable if it's worth keeping them - I have separated these to a separate commit.
- We're only capturing what table they are being applied to, rather than the underlying operation itself. 

<img width="1760" height="338" alt="image" src="https://github.com/user-attachments/assets/9fc7d6af-c3b4-498f-a351-62b7f1f58b95" />
