### PR TITLE
perf: filter-pages uses recency to filter out whole pages

### DIFF
--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -125,11 +125,14 @@
            (let [valid-time (TemporalDimension. smallest-valid-from largest-valid-to)]
              (doseq [^Segment$PageMeta page non-taken-pages]
                (let [temporal-metadata (.getTemporalMetadata page)
-                     obj-largest-system-from (.getMaxSystemFrom temporal-metadata)]
+                     obj-largest-system-from (.getMaxSystemFrom temporal-metadata)
+                     page-recency (.getRecency page)]
                  (when (and (<= smallest-system-from obj-largest-system-from)
                             (.intersects (TemporalDimension. (.getMinValidFrom temporal-metadata)
                                                              (.getMaxValidTo temporal-metadata))
-                                         valid-time))
+                                         valid-time)
+                            (or (>= page-recency smallest-valid-from)
+                                (>= page-recency smallest-system-from)))
                    (.add leaves page)))))
            (vec leaves)))))))
 

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -277,6 +277,11 @@
         (< min-query-recency recency)
         true)))
 
+  (getRecency [_]
+    (if recency
+      (time/instant->micros (time/->instant recency {:default-tz ZoneOffset/UTC}))
+      Long/MAX_VALUE))
+
   (getTemporalMetadata [_]
     ;; if we reset compaction, we may not have temporal metadata until the next compaction
     ;; so we need to treat the file as if it contains _anything_

--- a/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
+++ b/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
@@ -25,10 +25,12 @@ import xtdb.trie.Trie
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.dataRelSchema
 import xtdb.trie.Trie.metaFilePath
+import xtdb.trie.RecencyMicros
 import xtdb.trie.TrieKey
 import xtdb.arrow.MergeTypes.Companion.mergeFields
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.util.*
+import xtdb.time.LocalDateTimeUtil.asMicros
 import java.nio.file.Path
 import java.time.LocalDate
 import java.util.*
@@ -241,6 +243,8 @@ private class LocalSegment(
 
     private val dataFile = dir.resolve(table.dataFilePath(trieKey))
     private val metaFile = dir.resolve(table.metaFilePath(trieKey))
+    private val parsedTrieKey = Trie.parseKey(trieKey)
+    private val recency: RecencyMicros = parsedTrieKey.recency?.atStartOfDay()?.asMicros ?: Long.MAX_VALUE
 
     inner class Metadata : Segment.Metadata<ArrowHashTrie.Leaf> {
         private val pageMetadata = PageMetadata.open(al, metaFile)
@@ -249,14 +253,14 @@ private class LocalSegment(
         // in the utility, we keep the Segments open throughout,
         // so can be excused for the dataLoader being used 'outside its lifetime'
         override fun page(leaf: ArrowHashTrie.Leaf) =
-            pageMeta(this@LocalSegment, this, leaf, UNBOUND_TEMPORAL_METADATA)
+            pageMeta(this@LocalSegment, this, leaf, UNBOUND_TEMPORAL_METADATA, recency)
 
         override fun testPage(leaf: ArrowHashTrie.Leaf) = true
 
         override fun close() = pageMetadata.close()
     }
 
-    override val part = Trie.parseKey(trieKey).part?.toArray()
+    override val part = parsedTrieKey.part?.toArray()
 
     override suspend fun openMetadata(): Metadata = Metadata()
 

--- a/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/MemorySegment.kt
@@ -20,7 +20,7 @@ class MemorySegment(val trie: MemoryHashTrie, val rel: RelationReader) : Segment
         override val trie: HashTrie<MemoryHashTrie.Leaf> get() = this@MemorySegment.trie
 
         override fun page(leaf: MemoryHashTrie.Leaf) =
-            pageMeta(this@MemorySegment, this, leaf, UNBOUND_TEMPORAL_METADATA)
+            pageMeta(this@MemorySegment, this, leaf, UNBOUND_TEMPORAL_METADATA, recency = Long.MAX_VALUE)
 
         override fun testPage(leaf: MemoryHashTrie.Leaf) = true
 

--- a/core/src/main/kotlin/xtdb/segment/Segment.kt
+++ b/core/src/main/kotlin/xtdb/segment/Segment.kt
@@ -7,6 +7,7 @@ import xtdb.arrow.RelationReader
 import xtdb.log.proto.TemporalMetadata
 import xtdb.segment.Segment.Page.Companion.page
 import xtdb.trie.HashTrie
+import xtdb.trie.RecencyMicros
 
 interface Segment<L> : AutoCloseable {
     val part: ByteArray?
@@ -37,14 +38,16 @@ interface Segment<L> : AutoCloseable {
     interface PageMeta<L> {
         val page: Page<L>
         val temporalMetadata: TemporalMetadata
+        val recency: RecencyMicros
 
         fun testMetadata(): Boolean
 
         companion object {
-            fun <L> pageMeta(seg: Segment<L>, meta: Metadata<L>, leaf: L, temporalMetadata: TemporalMetadata) =
+            fun <L> pageMeta(seg: Segment<L>, meta: Metadata<L>, leaf: L, temporalMetadata: TemporalMetadata, recency: RecencyMicros) =
                 object : PageMeta<L> {
                     override val page get() = page(seg, leaf)
                     override val temporalMetadata get() = temporalMetadata
+                    override val recency get() = recency
 
                     private var testMetadata: Boolean? = null
 

--- a/core/src/main/kotlin/xtdb/trie/Trie.kt
+++ b/core/src/main/kotlin/xtdb/trie/Trie.kt
@@ -24,6 +24,7 @@ import java.time.temporal.ChronoField
 
 typealias Level = Long
 typealias InstantMicros = Long
+typealias RecencyMicros = Long
 typealias RowIndex = Int
 typealias BlockIndex = Long
 typealias TableName = String

--- a/src/test/clojure/xtdb/segment/merge_plan_test.clj
+++ b/src/test/clojure/xtdb/segment/merge_plan_test.clj
@@ -12,6 +12,7 @@
 (defrecord MockPage [page metadata-matches? temporal-metadata]
   Segment$PageMeta
   (testMetadata [_] metadata-matches?)
+  (getRecency [_] Long/MAX_VALUE)
   (getTemporalMetadata [_] temporal-metadata))
 
 (defn ->mock-page

--- a/src/test/clojure/xtdb/segment/merge_plan_test.clj
+++ b/src/test/clojure/xtdb/segment/merge_plan_test.clj
@@ -9,24 +9,24 @@
 
 (t/use-fixtures :each tu/with-allocator)
 
-(defrecord MockPage [page metadata-matches? temporal-metadata]
+(defrecord MockPage [page metadata-matches? temporal-metadata recency]
   Segment$PageMeta
   (testMetadata [_] metadata-matches?)
-  (getRecency [_] Long/MAX_VALUE)
+  (getRecency [_] recency)
   (getTemporalMetadata [_] temporal-metadata))
 
 (defn ->mock-page
   ([page] (->mock-page page true))
-  ([page metadata-matches?] (->MockPage page metadata-matches? util/unconstraint-temporal-metadata))
+  ([page metadata-matches?] (->MockPage page metadata-matches? util/unconstraint-temporal-metadata Long/MAX_VALUE))
 
   ([page min-valid-from max-valid-to] (->mock-page page true min-valid-from max-valid-to))
   ([page metadata-matches? min-valid-from max-valid-to]
-   (->MockPage page metadata-matches? (tu/->temporal-metadata min-valid-from max-valid-to)))
+   (->MockPage page metadata-matches? (tu/->temporal-metadata min-valid-from max-valid-to) Long/MAX_VALUE))
 
   ([page metadata-matches? min-vf max-vt min-sf]
    (->mock-page page metadata-matches? min-vf max-vt min-sf Long/MAX_VALUE))
   ([page metadata-matches? min-vf max-vt min-sf max-sf]
-   (->MockPage page metadata-matches? (tu/->temporal-metadata min-vf max-vt min-sf max-sf))))
+   (->MockPage page metadata-matches? (tu/->temporal-metadata min-vf max-vt min-sf max-sf) Long/MAX_VALUE)))
 
 (def ^:private inst->micros (comp time/instant->micros time/->instant))
 
@@ -72,7 +72,6 @@
                              ->pages))
               "Take page 1. Page 0 valid-time overlpas."))
 
-
       (t/testing "Tighter constraints on query bounds"
         ;; TODO could we filter page 0 in the two assertions below?
         (t/is (= #{0 1} (->> (trie/filter-pages [(->mock-page 0 false vt0 vt2 sf1 sf2)
@@ -109,7 +108,6 @@
                              ->pages))
               "Take page 1. Page 2 can bound page 1 and we can't filter newer pages (no constraints on query system-time)."))
 
-
       (t/testing "Constraints on query bounds"
         ;; TODO can 2 be filtered here?
         (t/is (= #{1 2} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf2)
@@ -118,13 +116,11 @@
                              ->pages))
               "Take page 1. Page 2 overlaps in valid-time")
 
-
         (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf3)
                                                (->mock-page 2 false vt2 (inc vt3) sf3 sf3)]
                                               {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 sf3)})
                            ->pages))
               "Take page 1. Page 2 can bound page 1 and we can filter newer pages because of query system-time constraints.")))
-
 
     (t/is (= #{0 1 2} (->> (trie/filter-pages [(->mock-page 0 true vt0 Long/MAX_VALUE sf1 sf1)
                                                (->mock-page 1 false vt1 vt2 sf2 sf2)
@@ -211,3 +207,11 @@
 
           (t/is (= [2 3] (query-bounds->pages (tu/->temporal-bounds micros-2020 micros-2021 micros-2023 (inc micros-2023))))
                 "2020, but only 3 can bound page 2 in 2020"))))))
+
+(t/deftest test-filters-by-recency
+  (t/is (= [1]
+           (->> (trie/filter-pages [(->MockPage 1 true (tu/->temporal-metadata 20251205 Long/MAX_VALUE) Long/MAX_VALUE)
+                                    (->MockPage 2 false (tu/->temporal-metadata 20250706 Long/MAX_VALUE 20250707 20251208) 20250707)]
+                                   (tu/->temporal-bounds 20251212 Long/MAX_VALUE))
+
+                (mapv :page)))))

--- a/src/test/kotlin/xtdb/segment/TestSegment.kt
+++ b/src/test/kotlin/xtdb/segment/TestSegment.kt
@@ -2,6 +2,7 @@ package xtdb.segment
 
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
+import xtdb.trie.RecencyMicros
 
 class TestSegment(val name: String, val trie: TestTrie) : Segment<TestTrie.Leaf> {
     override val part = null
@@ -11,6 +12,7 @@ class TestSegment(val name: String, val trie: TestTrie) : Segment<TestTrie.Leaf>
         override suspend fun loadDataPage(al: BufferAllocator) = error("loadDataPage")
         override val page: Segment.Page<TestTrie.Leaf> get() = this
         override val temporalMetadata get() = error("temporalMetadata")
+        override val recency: RecencyMicros get() = Long.MAX_VALUE
         override fun testMetadata() = error("testMetadata")
     }
 


### PR DESCRIPTION
`filter-pages` now additionally uses recency to filter out segments.

We had a case where:
- because of some updates that had taken place last week where valid-to was explicitly set, the most recent historical partition (2025-12-15) had a relatively wide valid-time range (2w).
- some other updates had taken place last week for all valid-time - this meant that the max-system-from of old files (e.g. 2025-07-07) was relatively recent.
- the max-system-from of the older file was higher than the min-system-from of the newer file, meaning that we needed to read it - there _could_ have been some entries in the old file with a newer system-from that would have superseded the events in the newer file.

We did try eliding the old file if the query wasn't projecting any of the temporal columns - this wasn't a valid optimisation because the historical event can still split the current event. e.g.:
- Tx1: put T1→∞; Tx2: put (or delete) T2→T4
- Tx1 goes into current; Tx2 goes into historical
- Tx2 splits the Tx1 polygon into a 'U' shape - T1→T2 and T4→∞, with T1→∞ for ST<Tx2.

In the segment selection, we have two phases:

1. We select any files that directly match the query: set S1.
2. We select any files that may affect events in S1.

See #4111.

We then recognised that the recency of the older file actually guaranteed that none of the events in the old file could affect any of the events in the newer file, because if they did, the recency of the older file would be higher. 

<img width="1233" height="834" alt="image" src="https://github.com/user-attachments/assets/920a1ee0-127d-42ab-8f27-44b16bab1cb6" />

In this case, we know that none of the events in the 07-07 file can affect any event with both valid-from and system-from greater than 07-07 - the 12-05 file had a min VF and min SF of 12-05. Under the previous logic, the 07-07 would have been included because it had a max SF of 12-08, but with this change, it (and its cohort) are correctly elided.

Simple change in the end: only include the older file in phase 2 if the recency of the older file is greater than either the min VF or min SF - if it's less than _both_, it can be elided.