### PR TITLE
Ensured that `xt.version()` uniquely identifies an XTDB version

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1,6 +1,5 @@
 (ns xtdb.expression
-  (:require [clojure.java.shell :as sh]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [xtdb.error :as err]
             [xtdb.expression.macro :as macro]
             [xtdb.rewrite :refer [zmatch]]
@@ -43,19 +42,7 @@
 (def postgres-server-version "16")
 
 (defn xtdb-server-version []
-  ;; TODO this won't work if the user has XT in-process in their own git repo.
-  (or (System/getenv "XTDB_VERSION")
-
-      (util/implementation-version)
-
-      (when-let [git-sha (System/getenv "GIT_SHA")]
-        (subs git-sha 0 7))
-
-      (let [{:keys [out ^long exit]} (sh/sh "git" "rev-parse" "--short" "HEAD")]
-        (when (zero? exit)
-          (str/trim out)))
-
-      "unknown"))
+  (util/xtdb-version-string))
 
 (defn form->expr [form {:keys [vec-fields param-fields locals] :as env}]
   (cond

--- a/main/src/main/clojure/xtdb/main.clj
+++ b/main/src/main/clojure/xtdb/main.clj
@@ -12,20 +12,8 @@
             [xtdb.util :as util])
   (:import java.io.File))
 
-(defn version-string []
-  (let [version (some-> (System/getenv "XTDB_VERSION")
-                        str/trim
-                        not-empty)
-        git-sha (some-> (System/getenv "GIT_SHA")
-                        str/trim
-                        not-empty
-                        (subs 0 7))]
-    (str "XTDB"
-         (if version (str " " version) " 2.x")
-         (when git-sha (str " [" git-sha "]")))))
-
 (defn print-help []
-  (println (str "--- " (version-string) " ---"))
+  (println (str "--- " (util/xtdb-version-string) " ---"))
   (newline)
   (println "XTDB has several top-level commands to choose from:")
   (println " * `node` (default, can be omitted): starts an XT node")
@@ -274,7 +262,7 @@
 
 (defn -main [& args]
   (binding [*out* *err*]
-    (println (str "Starting " (version-string) " ...")))
+    (println (str "Starting " (util/xtdb-version-string) " ...")))
 
   (util/install-uncaught-exception-handler!)
 


### PR DESCRIPTION
...by always including the git sha.

Made single XTDB version string for all uses.