### PR TITLE
Read only secondaries, #4643

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -224,7 +224,7 @@
          (into {} (map (fn [db-name]
                          ;; TODO multi-part
                          [db-name [(-> (.databaseOrNull db-cat db-name)
-                                       (.getLogProcessor)
+                                       (.getLog)
                                        (.getLatestSubmittedMsgId))]])))))
 
   (latest-processed-msg-ids [_]

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -38,7 +38,11 @@ class InMemoryLog(
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openLog(clusters: Map<LogClusterAlias, Cluster>) = InMemoryLog(instantSource, epoch, coroutineContext)
+        override fun openLog(clusters: Map<LogClusterAlias, Cluster>) =
+            InMemoryLog(instantSource, epoch, coroutineContext)
+
+        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
+            ReadOnlyLog(openLog(clusters))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.inMemoryLog = inMemoryLog {  }

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -312,6 +312,9 @@ class LocalLog(
         override fun openLog(clusters: Map<LogClusterAlias, Cluster>) =
             LocalLog(path, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
 
+        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
+            ReadOnlyLocalLog(path, epoch, coroutineContext)
+
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {
                 this.path = this@Factory.path.toString()

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -17,6 +17,7 @@ import xtdb.log.proto.*
 import xtdb.log.proto.LogMessage.MessageCase
 import xtdb.storage.StorageEpoch
 import xtdb.trie.BlockIndex
+import xtdb.util.MsgIdUtil
 import xtdb.util.asPath
 import java.nio.ByteBuffer
 import java.nio.file.Path
@@ -149,6 +150,7 @@ interface Log : AutoCloseable {
 
     interface Factory {
         fun openLog(clusters: Map<LogClusterAlias, Cluster>): Log
+        fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>): Log
 
         fun writeTo(dbConfig: DatabaseConfig.Builder)
 
@@ -204,6 +206,9 @@ interface Log : AutoCloseable {
     val latestSubmittedOffset: LogOffset
 
     val epoch: Int
+
+    val latestSubmittedMsgId: MessageId
+        get() = MsgIdUtil.offsetToMsgId(epoch, latestSubmittedOffset)
 
     class MessageMetadata(
         val logOffset: LogOffset,

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -1,0 +1,180 @@
+package xtdb.api.log
+
+import kotlinx.coroutines.*
+import xtdb.api.log.Log.*
+import xtdb.error.Incorrect
+import xtdb.time.InstantUtil.fromMicros
+import java.io.DataInputStream
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.ClosedByInterruptException
+import java.nio.channels.FileChannel
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.READ
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.WatchKey
+import kotlin.coroutines.CoroutineContext
+import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.time.Duration.Companion.seconds
+import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
+import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
+
+/**
+ * A read-only version of LocalLog that watches the log file for new messages
+ * written by another process (the primary cluster).
+ */
+class ReadOnlyLocalLog(
+    rootPath: Path,
+    override val epoch: Int,
+    coroutineContext: CoroutineContext = Dispatchers.Default
+) : Log {
+
+    private val scope = CoroutineScope(coroutineContext)
+    private val logFilePath = rootPath.resolve("LOG")
+    private val watchService = FileSystems.getDefault().newWatchService()
+
+    init {
+        // Watch the parent directory for modifications to the LOG file
+        rootPath.register(watchService, ENTRY_MODIFY)
+    }
+
+    companion object {
+        private fun messageSizeBytes(size: Int) = 1 + INT_BYTES + LONG_BYTES + size + LONG_BYTES
+        private const val RECORD_SEPARATOR = 0x1E.toByte()
+
+        private fun readLatestSubmittedOffset(logFilePath: Path): LogOffset {
+            if (!logFilePath.exists()) return -1
+
+            return FileChannel.open(logFilePath, READ).use { ch ->
+                val chSize = ch.size()
+                if (chSize == 0L) return -1
+
+                val buf = ByteBuffer.allocateDirect(LONG_BYTES)
+                check(ch.read(buf, chSize - LONG_BYTES) == LONG_BYTES) {
+                    "Failed to read last offset in log file"
+                }
+
+                buf.flip().getLong()
+                    .also { offset ->
+                        check(offset in 0..<chSize) { "Invalid offset in log file: $offset" }
+                        ch.position(offset)
+                        DataInputStream(Channels.newInputStream(ch)).use { dataStream ->
+                            check(dataStream.readByte() == RECORD_SEPARATOR) {
+                                "log file corrupted - expected record separator at $offset"
+                            }
+
+                            val size = dataStream.readInt()
+                            check(chSize == offset + messageSizeBytes(size)) {
+                                "log file corrupted - record at $offset specifies size $size, but file size is $chSize"
+                            }
+                        }
+                    }
+            }
+        }
+
+        private fun FileChannel.readMessage(): Record? {
+            val pos = position()
+            val headerBuf = ByteBuffer.allocateDirect(1 + INT_BYTES + LONG_BYTES)
+                .also { read(it); it.flip() }
+
+            check(headerBuf.get() == RECORD_SEPARATOR) { "log file corrupted at $pos - expected record separator" }
+            val size = headerBuf.getInt()
+
+            val message =
+                Message.parse(ByteBuffer.allocate(size).also { read(it); it.flip() }.array())
+                    ?: return null
+
+            return Record(pos, fromMicros(headerBuf.getLong()), message)
+                .also { position(pos + messageSizeBytes(size)) }
+        }
+    }
+
+    @Volatile
+    override var latestSubmittedOffset: LogOffset = readLatestSubmittedOffset(logFilePath)
+        private set
+
+    override fun appendMessage(message: Message) =
+        throw Incorrect("Cannot append to read-only database log")
+
+    override fun readLastMessage(): Message? {
+        if (latestSubmittedOffset < 0) return null
+
+        return FileChannel.open(logFilePath, READ).use { ch ->
+            ch.position(latestSubmittedOffset)
+            ch.readMessage()?.message
+        }
+    }
+
+    override fun subscribe(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
+        var currentOffset = latestProcessedOffset
+
+        val subscription = scope.launch(SupervisorJob()) {
+            try {
+                // First, catch up on any existing messages
+                readNewMessages(currentOffset, subscriber)?.let { currentOffset = it }
+
+                // Then watch for new changes
+                while (true) {
+                    val key: WatchKey = runInterruptible(Dispatchers.IO) { watchService.take() }
+
+                    var logModified = false
+                    for (event in key.pollEvents()) {
+                        val changedPath = event.context() as? Path
+                        if (changedPath?.name == "LOG") {
+                            logModified = true
+                        }
+                    }
+
+                    if (logModified) {
+                        readNewMessages(currentOffset, subscriber)?.let { currentOffset = it }
+                    }
+
+                    if (!key.reset()) {
+                        break // Directory no longer accessible
+                    }
+                }
+            } catch (_: ClosedByInterruptException) {
+                cancel()
+            } catch (_: InterruptedException) {
+                cancel()
+            }
+        }
+
+        return Subscription { runBlocking { withTimeout(5.seconds) { subscription.cancelAndJoin() } } }
+    }
+
+    private fun readNewMessages(currentOffset: LogOffset, subscriber: Subscriber): LogOffset? {
+        val newLatestOffset = readLatestSubmittedOffset(logFilePath)
+
+        if (newLatestOffset <= currentOffset) return null
+
+        latestSubmittedOffset = newLatestOffset
+
+        var lastOffset = currentOffset
+        FileChannel.open(logFilePath, READ).use { ch ->
+            // Position after the current offset
+            if (currentOffset >= 0) {
+                ch.position(currentOffset)
+                ch.readMessage() // skip past current
+            }
+
+            // Read all new messages
+            while (ch.position() <= newLatestOffset) {
+                val record = ch.readMessage()
+                if (record != null) {
+                    subscriber.processRecords(listOf(record))
+                    lastOffset = record.logOffset
+                }
+            }
+        }
+
+        return lastOffset
+    }
+
+    override fun close() {
+        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
+        watchService.close()
+    }
+}

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
@@ -1,0 +1,12 @@
+package xtdb.api.log
+
+import xtdb.error.Incorrect
+
+/**
+ * A wrapper around a Log that prevents write operations.
+ * Used for read-only database attachments.
+ */
+class ReadOnlyLog(private val delegate: Log) : Log by delegate {
+    override fun appendMessage(message: Log.Message) =
+        throw Incorrect("Cannot append to read-only database log")
+}

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -9,4 +9,6 @@ interface TableCatalog {
     fun getField(table: TableRef, columnName: ColumnName): Field?
     fun getFields(table: TableRef): Map<ColumnName, Field>?
     val fields: Map<TableRef, Map<ColumnName, Field>>
+
+    fun refresh()
 }

--- a/core/src/main/kotlin/xtdb/storage/BufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/BufferPool.kt
@@ -8,6 +8,7 @@ import xtdb.ArrowWriter
 import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.arrow.Relation
 import xtdb.arrow.unsupported
+import xtdb.error.Fault
 import xtdb.util.StringUtil.fromLexHex
 import xtdb.util.asPath
 import java.nio.ByteBuffer
@@ -105,3 +106,41 @@ val BufferPool.latestAvailableBlockIndex0: Long
 
 val BufferPool.latestAvailableBlockIndex: Long
     get() = latestAvailableBlockCache.get(this) { it.latestAvailableBlockIndex0 }
+
+/**
+ * A wrapper around a BufferPool that prevents write operations.
+ * Used for read-only database attachments.
+ */
+class ReadOnlyBufferPool(private val delegate: BufferPool) : BufferPool {
+    override val epoch: StorageEpoch get() = delegate.epoch
+
+    override fun getByteArray(key: Path): ByteArray = delegate.getByteArray(key)
+
+    override fun getFooter(key: Path): ArrowFooter = delegate.getFooter(key)
+
+    override suspend fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch = delegate.getRecordBatch(key, idx)
+
+    override fun putObject(key: Path, buffer: ByteBuffer) {
+        throw Fault("Attempted write to read-only storage: $key")
+    }
+
+    override fun listAllObjects(): Iterable<StoredObject> = delegate.listAllObjects()
+
+    override fun listAllObjects(dir: Path): Iterable<StoredObject> = delegate.listAllObjects(dir)
+
+    override fun copyObject(src: Path, dest: Path) {
+        throw Fault("Attempted copy in read-only storage: $src -> $dest")
+    }
+
+    override fun deleteIfExists(key: Path) {
+        throw Fault("Attempted delete from read-only storage: $key")
+    }
+
+    override fun openArrowWriter(key: Path, rel: Relation): ArrowWriter {
+        throw Fault("Attempted write to read-only storage: $key")
+    }
+
+    override fun close() {
+        delegate.close()
+    }
+}

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Transient
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
 import xtdb.api.log.LogOffset
+import xtdb.api.log.ReadOnlyLog
 import xtdb.database.proto.DatabaseConfig
 import java.time.Instant
 import java.time.InstantSource
@@ -26,6 +27,9 @@ class RecordingLog(private val instantSource: InstantSource, messages: List<Log.
         fun messages(messages: List<Log.Message>) = apply { this.messages = messages }
 
         override fun openLog(clusters: Map<LogClusterAlias, Log.Cluster>) = RecordingLog(instantSource, messages)
+
+        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
+            ReadOnlyLog(openLog(clusters))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) = Unit
     }

--- a/core/src/main/kotlin/xtdb/trie/TrieCatalog.kt
+++ b/core/src/main/kotlin/xtdb/trie/TrieCatalog.kt
@@ -12,4 +12,6 @@ interface TrieCatalog {
     fun garbageTries(table: TableRef, asOf: Instant) : Set<TrieKey>
     fun deleteTries(table: TableRef, garbageTrieKeys: Set<TrieKey>)
     fun listAllTrieKeys(table: TableRef) : List<TrieKey>
+
+    fun refresh()
 }

--- a/core/src/main/proto/xtdb/database/proto/db.proto
+++ b/core/src/main/proto/xtdb/database/proto/db.proto
@@ -6,6 +6,11 @@ option java_multiple_files = true;
 
 import "google/protobuf/any.proto";
 
+enum DatabaseMode {
+    READ_WRITE = 0;
+    READ_ONLY = 1;
+}
+
 message InMemoryLog {
 }
 
@@ -39,5 +44,7 @@ message DatabaseConfig {
         LocalStorage local_storage = 5;
         RemoteStorage remote_storage = 6;
     }
+
+    DatabaseMode mode = 7;
 }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -121,7 +121,7 @@ class NodeSimulationTest : SimulationTestBase() {
             Compactor.Impl(compactorDriver, null, jobCalculator, false, 2, dispatcher)
         }
         trieCatalogs = List(numberOfSystems) {
-            createTrieCatalog.invoke(mutableMapOf<Any, Any>(), 100 * 1024 * 1024) as TrieCatalog
+            createTrieCatalog.invoke(null, null, mutableMapOf<Any, Any>(), 100 * 1024 * 1024) as TrieCatalog
         }
         blockCatalogs = List(numberOfSystems) { i ->
             BlockCatalog("xtdb", sharedBufferPool)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -305,7 +305,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         }
 
         trieCatalogs = List(numberOfSystems) {
-            createTrieCatalog.invoke(mutableMapOf<Any, Any>(), 100 * 1024 * 1024) as TrieCatalog
+            createTrieCatalog.invoke(null, null, mutableMapOf<Any, Any>(), 100 * 1024 * 1024) as TrieCatalog
         }
 
         // All databases share the same buffer pool

--- a/docs/src/content/docs/about/dbs-in-xtdb.md
+++ b/docs/src/content/docs/about/dbs-in-xtdb.md
@@ -3,32 +3,37 @@ title: Databases in XTDB
 ---
 
 <details>
-  <summary>Changelog (last updated v2.1)</summary>
-  
+  <summary>Changelog (last updated v2.1.1)</summary>
+
+v2.1.1 (unreleased): read-only secondary databases
+
+: XTDB now supports read-only secondary databases.
+
+  When attaching a database, you may specify `mode: read-only` in its configuration.
+
 v2.1: multi-database support
 
 : XTDB now supports multiple databases within a single XTDB cluster.
-  
+
   Previously, an XTDB cluster only had a single database; XTDB clusters were entirely isolated from each other.
-  
+
   v2.1 added `ATTACH DATABASE` and `DETACH DATABASE` statements.
 
-  
 </details>
 
 The term 'database' is very much overloaded in the database world.
 
-In PostgreSQL, a database is a collection of schemas, which are collections of tables. 
-In MySQL, a database is synonymous with a schema. 
+In PostgreSQL, a database is a collection of schemas, which are collections of tables.
+In MySQL, a database is synonymous with a schema.
 In SQLite, a database is a single file containing multiple tables.
 In MongoDB, a database is a collection of collections.
 The SQL specification calls these a 'catalog'.
 
 Given this variance, let's define what this means in XTDB:
 
-- An XTDB database is a collection of tables. 
+- An XTDB database is a collection of tables.
   Tables may be grouped into 'schemas' - XT has relatively little knowledge of schemas beyond tables optionally having two-part names (`schema.table`).
-  
+
   If the schema is not specified, the default schema is named `public`.
 - A single database in XTDB shares a [transaction log](/ops/config/log) and [object storage](/ops/config/storage) with other consumers of that database.
 - Multiple XTDB nodes that share a 'primary' database (named `xtdb`) are considered an XTDB 'cluster' - they share a transaction log and object storage for that database.
@@ -40,7 +45,7 @@ Given this variance, let's define what this means in XTDB:
 - When you connect to an XTDB node, as part of the connection string, you will specify a database.
   (e.g. in JDBC: `jdbc:xtdb://localhost:5432/my-db`).
 
-  XTDB supports cross-database queries - queries may refer to tables in other databases by using fully-qualified names (e.g. `FROM database.schema.table`). 
+  XTDB supports cross-database queries - queries may refer to tables in other databases by using fully-qualified names (e.g. `FROM database.schema.table`).
   Unqualified tables are assumed to be from the database you connected to.
 - Transactions are submitted to one database and may only refer to tables within that database.
 
@@ -48,7 +53,7 @@ Given this variance, let's define what this means in XTDB:
   
 ## What does this mean for me?
 
-This decoupling of databases (storage) and clusters (compute) enables a **data mesh architecture** - organize your databases around business domains (orders, customers, products), while each application team runs their own compute cluster. 
+This decoupling of databases (storage) and clusters (compute) enables a **data mesh architecture** - organize your databases around business domains (orders, customers, products), while each application team runs their own compute cluster.
 Teams can attach secondary databases to access shared domain data, aligning your data model with your organization's structure while keeping compute independent.
 
 ```d2
@@ -115,25 +120,25 @@ Compute.Cluster2 -> Storage.ordersDb: secondary {
 ```
 
 ## Database architecture
-  
+
 A single database in XTDB consists of the following components:
-  
+
 ![XTDB node architecture](/images/docs/xtdb-node-1.svg)
 
 Write-ahead log (WAL)
 
-: shared component responsible for ensuring all the nodes in the cluster agree on a total ordering of transactions within the database. 
+: shared component responsible for ensuring all the nodes in the cluster agree on a total ordering of transactions within the database.
 
   e.g. Kafka
 
 Indexer
 
 : consumes transactions from the log, makes the results available to the query engine.
-  
+
   - at the end of a block (~100k rows/4 hours), the indexer writes the block to the object store.
   - nodes compete to write blocks - although blocks are deterministic, so it doesn't matter who wins.
   - new/restarting nodes start consuming from the most recent block in the object store.
-  
+
 Object store
 
 : shared storage for block files.
@@ -145,7 +150,7 @@ Compactor
 
 Query engine
 : serves queries, reading the object store (via local caches) and recently indexed transactions.
-  
+
 For more details on XTDB's storage and its optimisations, check out the ['Building a Bitemporal Index'](https://xtdb.com/blog/building-a-bitemp-index-3-storage) series.
 
 ## Attaching/Detaching secondary databases (v2.1+)
@@ -165,6 +170,8 @@ ATTACH DATABASE my_secondary WITH $$
     path: 'my-secondary-db/log'
   storage: !Local
     path: 'my-secondary-db/storage'
+
+  mode: 'read-write' -- or 'read-only', v2.1.1+
 $$
 ```
 
@@ -184,9 +191,17 @@ ATTACH DATABASE my_secondary WITH $$
 $$
 ```
 
-To detach a database, send `DETACH DATABASE my_secondary`.
+- To detach a database, send `DETACH DATABASE my_secondary`.
 
-<!-- See also: [secondary databases reference](/ops/config/dbs) -->
+### Read-only secondary databases (v2.1.1+)
+
+Secondary databases may be attached as read-only by specifying `mode: read-only` in the configuration.
+This will prevent transactions from being submitted to that database through read-only nodes, and will ensure that the nodes in this cluster do not attempt to write blocks to its object-store.
+
+In this mode, the secondary cluster will continue to index transactions locally, but will pause at block boundaries to await a node in a read-write cluster writing the block to the object-store.
+Once a read-write cluster node has written the block, the read-only cluster will download it and continue indexing.
+
+Clusters do not perform compaction on read-only secondary databases.
 
 ## Querying multiple databases
 

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -261,6 +261,9 @@ class KafkaCluster(
             return cluster.KafkaLog(clusterAlias, topic, epoch)
         }
 
+        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
+            ReadOnlyLog(openLog(clusters))
+
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.setOtherLog(ProtoAny.pack(kafkaLogConfig {
                 this.topic = this@LogFactory.topic

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -37,7 +37,7 @@
         (->> (transduce (map (fn [[trie-key size]]
                                (-> (trie/parse-trie-key trie-key)
                                    (assoc :data-file-size (or size -1)))))
-                        (completing (partial cat/apply-trie-notification opts))
+                        (completing #(cat/apply-trie-notification %1 %2 opts))
                         {}))
         (as-> table-cat (c/compaction-jobs #xt/table foo, table-cat opts))
         (->> (into #{} (map (fn [job]

--- a/src/test/clojure/xtdb/read_only_secondary_test.clj
+++ b/src/test/clojure/xtdb/read_only_secondary_test.clj
@@ -1,0 +1,173 @@
+(ns xtdb.read-only-secondary-test
+  (:require [clojure.test :as t]
+            [next.jdbc :as jdbc]
+            [xtdb.api :as xt]
+            [xtdb.log :as xt-log]
+            [xtdb.node :as xtn]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import [xtdb.database Database]))
+
+(t/deftest attach-read-write-database-explicit
+  (with-open [node (xtn/start-node)]
+    (jdbc/execute! node ["ATTACH DATABASE rw_db WITH $$ mode: read-write $$"])
+
+    (xt/submit-tx node [[:put-docs :foo {:xt/id "test"}]]
+                  {:database :rw_db})
+
+    (t/is (= [{:xt/id "test"}]
+             (xt/q node "SELECT * FROM rw_db.foo"))
+          "read-write database allows writes")))
+
+(t/deftest attach-read-only-database
+  (with-open [node (xtn/start-node)]
+    (jdbc/execute! node ["ATTACH DATABASE ro_db WITH $$ mode: read-only $$"])
+
+    (t/is (= [{:xt/id 0, :committed true}]
+             (xt/q node "SELECT _id, committed FROM xt.txs"))
+          "attach-db transaction committed")
+
+    (t/is (thrown-with-msg? Exception #"read-only database log"
+                            (xt/submit-tx node [[:put-docs :foo {:xt/id "test"}]]
+                                          {:database :ro_db}))
+          "read-only database rejects writes via log")
+
+    (t/is (= [] (xt/q node "SELECT * FROM ro_db.foo"))
+          "read-only database allows reads")))
+
+(t/deftest read-only-secondary-follows-primary
+  (let [node-dir (util/->path "target/read-only-secondary/follows-primary")]
+    (util/delete-dir node-dir)
+
+    (with-open [primary-node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                              :storage [:local {:path (.resolve node-dir "objects")}]})]
+
+      (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "from-primary"}]])
+
+      (with-open [secondary-node (xtn/start-node)]
+
+        (jdbc/execute! secondary-node ["
+ATTACH DATABASE shared_db WITH $$
+  log: !Local
+    path: 'target/read-only-secondary/follows-primary/log'
+  storage: !Local
+    path: 'target/read-only-secondary/follows-primary/objects'
+  mode: read-only
+$$"])
+
+        (t/is (= [{:xt/id "from-primary"}]
+                 (xt/q secondary-node "SELECT * FROM shared_db.foo"))
+              "read-only secondary can read data written by primary")
+
+        (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "from-primary", :v 2}]])
+
+        (xt-log/sync-node secondary-node)
+
+        (t/is (= [{:xt/id "from-primary", :v 2}]
+                 (xt/q secondary-node "SELECT * FROM shared_db.foo"))
+              "read-only secondary can read updated data")
+
+        (t/is (thrown-with-msg? Exception #"read-only"
+                                (xt/submit-tx secondary-node [[:put-docs :foo {:xt/id "from-secondary"}]]
+                                              {:database :shared_db}))
+              "read-only secondary rejects writes")))))
+
+(t/deftest read-only-secondary-detects-external-log-writes
+  (let [node-dir (util/->path "target/read-only-secondary/external-writes")]
+    (util/delete-dir node-dir)
+
+    ;; Phase 1: Start a "submit-only" node
+    (with-open [submit-node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                             :storage [:local {:path (.resolve node-dir "objects")}]
+                                             :indexer {:enabled? false}
+                                             :compactor {:threads 0}})]
+
+      (xt/submit-tx submit-node [[:put-docs :foo {:xt/id "tx1"}]])
+      (xt/submit-tx submit-node [[:put-docs :foo {:xt/id "tx2"}]])
+
+      ;; Phase 2: Start a read-only secondary that should detect log changes via file watcher
+      (with-open [secondary-node (xtn/start-node)]
+
+        (jdbc/execute! secondary-node ["
+ATTACH DATABASE shared_db WITH $$
+  log: !Local
+    path: 'target/read-only-secondary/external-writes/log'
+  storage: !Local
+    path: 'target/read-only-secondary/external-writes/objects'
+  mode: read-only
+$$"])
+
+        (t/is (= #{{:xt/id "tx1"} {:xt/id "tx2"}}
+                 (set (xt/q secondary-node "SELECT * FROM shared_db.foo")))
+              "read-only secondary indexes transactions from log")
+
+        ;; Phase 3: Submit more transactions from the submit-only node
+        (xt/submit-tx submit-node [[:put-docs :foo {:xt/id "tx3"}]])
+
+        ;; Give the file watcher time to detect the change
+        (Thread/sleep 100)
+        (xt-log/sync-node secondary-node)
+
+        (t/is (= #{{:xt/id "tx1"} {:xt/id "tx2"} {:xt/id "tx3"}}
+                 (set (xt/q secondary-node "SELECT * FROM shared_db.foo")))
+              "read-only secondary detects new transactions written by external process")
+
+        (tu/flush-block! submit-node)
+        (xt/submit-tx submit-node [[:put-docs :foo {:xt/id "tx4"}]])
+
+        (let [!fut (future
+                     (Thread/sleep 100)
+                     (xt-log/sync-node secondary-node))]
+          (Thread/sleep 200)
+          (t/is (not (realized? !fut))
+                "blocks til the primary writes the block")
+
+          ;; Phase 4: Start a full primary node
+          (with-open [primary-node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                                    :storage [:local {:path (.resolve node-dir "objects")}]})]
+
+            (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "tx5"}]])
+
+            (Thread/sleep 100)
+            @!fut
+
+            (t/is (= #{{:xt/id "tx1"} {:xt/id "tx2"} {:xt/id "tx3"} {:xt/id "tx4"} {:xt/id "tx5"}}
+                     (set (xt/q secondary-node "SELECT * FROM shared_db.foo")))
+                  "read-only secondary sees tx written by full primary node")))))))
+
+(t/deftest read-only-secondary-survives-block-flush
+  (let [node-dir (util/->path "target/read-only-secondary/block-flush")]
+    (util/delete-dir node-dir)
+
+    (with-open [primary-node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                              :storage [:local {:path (.resolve node-dir "objects")}]})]
+
+      ;; Write some data to primary before block flush
+      (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "before-block-1"}]])
+      (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "before-block-2"}]])
+
+      (with-open [secondary-node (xtn/start-node)]
+
+        (jdbc/execute! secondary-node ["
+ATTACH DATABASE shared_db WITH $$
+  log: !Local
+    path: 'target/read-only-secondary/block-flush/log'
+  storage: !Local
+    path: 'target/read-only-secondary/block-flush/objects'
+  mode: read-only
+$$"])
+
+        (t/is (= #{{:xt/id "before-block-1"} {:xt/id "before-block-2"}}
+                 (set (xt/q secondary-node "SELECT * FROM shared_db.foo")))
+              "read-only secondary sees data before block flush")
+
+        (tu/flush-block! primary-node)
+        (xt-log/sync-node primary-node)
+        (xt/submit-tx primary-node [[:put-docs :foo {:xt/id "after-block-1"}]])
+
+        (Thread/sleep 100)
+        (xt-log/sync-node secondary-node)
+
+        (t/is (= #{{:xt/id "before-block-1"} {:xt/id "before-block-2"} {:xt/id "after-block-1"}}
+                 (set (xt/q secondary-node "SELECT * FROM shared_db.foo")))
+              "read-only secondary sees data after block flush (including block data)")))))

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,7 +1,8 @@
 {:block-idx 0,
- :latest-processed-msg-id 114,
+ :latest-processed-msg-id 116,
  :table-names #{"xt/txs"},
  :secondary-dbs
  {"new_db"
   {:log [:local {:path true}],
-   :storage [:local {:path true, :epoch 0}]}}}
+   :storage [:local {:path true, :epoch 0}],
+   :mode :read-write}}}


### PR DESCRIPTION
This PR adds read-only secondaries to XT, resolves #4643 

config:

```sql
ATTACH DATABASE my_secondary WITH $$
  log: !Local
    path: 'my-secondary-db/log'
  storage: !Local
    path: 'my-secondary-db/storage'

  mode: 'read-only' -- 'read-write' is default
$$
```

- This will prevent transactions from being submitted to that database through read-only nodes, and will ensure that the nodes in this cluster do not attempt to write blocks to its object-store.
- Secondary clusters will continue to index transactions locally, but will pause at block boundaries to await a node in a read-write cluster writing the block to the object-store.
Once a read-write cluster node has written the block, the read-only cluster will download it and continue indexing.
- Clusters do not perform compaction on read-only secondary databases.

