### PR TITLE
add OID cast

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -145,7 +145,7 @@ identifier
         | 'ROLE'
         | 'USER' | 'PASSWORD'
         | 'VARBINARY' | 'BYTEA'
-        | 'URI'
+        | 'URI' | 'OID'
         | 'COPY' | 'FORMAT'
         | 'ATTACH' | 'DETACH' | 'DATABASE'
         | METADATA
@@ -177,6 +177,7 @@ dataType
     | 'ROW' '(' fieldDefinition (',' fieldDefinition)* ')' # RowType
     | 'REGCLASS' #RegClassType
     | 'REGPROC' #RegProcType
+    | 'OID' #OidType
     | 'KEYWORD' #KeywordType
     | 'UUID' #UuidType
     | 'VARBINARY' #VarbinaryType

--- a/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
+++ b/core/src/main/antlr/xtdb/antlr/SqlLexer.g4
@@ -244,6 +244,7 @@ OF : 'OF' ;
 OFF : 'OFF' ;
 OFFSET : 'OFFSET' ;
 ON : 'ON' ;
+OID : 'OID' ;
 ONLY : 'ONLY' ;
 OR : 'OR' ;
 ORDER : 'ORDER' ;

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1041,6 +1041,7 @@
 
   (visitRegClassType [_ _] {:cast-type :regclass, :cast-opts {}})
   (visitRegProcType [_ _] {:cast-type :regproc, :cast-opts {}})
+  (visitOidType [_ _] {:cast-type :i32})
 
   (visitCharacterStringType [_ _] {:cast-type :utf8})
 


### PR DESCRIPTION
This `CAST AS OID` implementation is a simplified compatibility shim that treats OID as an alias for i32.