### PR TITLE
Refactor :apply lp operator to take opts

### DIFF
--- a/core/src/main/clojure/xtdb/xtql/plan.clj
+++ b/core/src/main/clojure/xtdb/xtql/plan.clj
@@ -484,7 +484,7 @@
   (case type
     :scalar
     (if (seq tmp-expr-sym->expr-vec)
-      [:apply :single-join tmp-expr-sym->apply-param-sym
+      [:apply {:mode :single-join, :columns tmp-expr-sym->apply-param-sym}
        [:map tmp-expr-sym->expr-vec
         (wrap-expr-subqueries* plan arg-subqueries)]
        subquery]
@@ -493,8 +493,7 @@
        subquery])
     :exists
     (if (seq tmp-expr-sym->expr-vec)
-      [:apply {:mark-join {placeholder true}}
-       tmp-expr-sym->apply-param-sym
+      [:apply {:mode :mark-join, :columns tmp-expr-sym->apply-param-sym, :mark-join-projection {placeholder true}}
        [:map tmp-expr-sym->expr-vec
         (wrap-expr-subqueries* plan arg-subqueries)]
        subquery]
@@ -702,7 +701,7 @@
           [{acc-plan-with-unique-cols :ra-plan}
            {join-subquery-plan-with-unique-cols :ra-plan}] rels]
       (wrap-unify
-       {:ra-plan [:apply :cross-join tmp-expr-sym->apply-param-sym
+       {:ra-plan [:apply {:mode :cross-join, :columns tmp-expr-sym->apply-param-sym}
                   [:map tmp-expr-sym->expr-vec
                    (wrap-expr-subqueries acc-plan-with-unique-cols acc-provided-vars arg-subqueries)]
                   join-subquery-plan-with-unique-cols]}
@@ -719,9 +718,10 @@
      (if (seq tmp-expr-sym->expr-vec)
        (let [unifying-vars-apply-param-mapping (unifying-vars->apply-param-mapping unifying-vars)]
          (->
-          [:apply :left-outer-join (merge
-                                    tmp-expr-sym->apply-param-sym
-                                    unifying-vars-apply-param-mapping)
+          [:apply {:mode :left-outer-join
+                   :columns (merge
+                             tmp-expr-sym->apply-param-sym
+                             unifying-vars-apply-param-mapping)}
            [:map tmp-expr-sym->expr-vec
             (wrap-expr-subqueries (:ra-plan acc-plan) acc-provided-vars arg-subqueries)]
            (->> unifying-vars-apply-param-mapping

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -896,7 +896,7 @@
   (t/testing "params"
     (t/is (= [{:x1 1, :x2 1, :x4 3, :x3 1, :x5 2}]
              (tu/query-ra
-              '[:apply :cross-join {x5 ?x2}
+              '[:apply {:mode :cross-join, :columns {x5 ?x2}}
                 [::tu/pages [[{:x5 2}]]]
                 [:mega-join
                  [{x1 (- ?x2 1)}

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -93,7 +93,7 @@
     (t/is (= #{{:foo {:bar 42}} {:foo {:bar "forty-two"}}}
              (set (util/->clj (tu/query-ra
                                ;; the cross-join copies data from the underlying MultiVectorReader
-                               '[:apply :cross-join {}
+                               '[:apply {:mode :cross-join, :columns {}}
                                  [:table [{}]]
                                  [:scan {:table #xt/table xt_docs} [foo]]]
                                {:node node})))))))

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
@@ -5,8 +5,7 @@
   [:group-by
    [tab0.1/z _row_number_0 {_sum_out_6 (sum x.5/y)}]
    [:apply
-    :left-outer-join
-    {tab0.1/z ?_sq_z_3}
+    {:mode :left-outer-join, :columns {tab0.1/z ?_sq_z_3}}
     [:map
      [{_row_number_0 (row-number)}]
      [:rename tab0.1 [:scan {:table #xt/table tab0} [z]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
@@ -1,8 +1,7 @@
 [:project
  [{_column_1 _sq_2}]
  [:apply
-  :single-join
-  {tab0.1/z ?_sq_z_3}
+  {:mode :single-join, :columns {tab0.1/z ?_sq_z_3}}
   [:rename tab0.1 [:scan {:table #xt/table tab0} [z]]]
   [:project
    [{_sq_2 _array_agg_out6}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
@@ -1,8 +1,7 @@
 [:project
  [{some_column (== 1 _sq_2)}]
  [:apply
-  :single-join
-  {x.1/z ?_sq_z_3}
+  {:mode :single-join, :columns {x.1/z ?_sq_z_3}}
   [:rename x.1 [:scan {:table #xt/table x} [{y (== y 1)} z]]]
   [:project
    [{_sq_2 (== foo.3/bar ?_sq_z_3)}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -3,8 +3,7 @@
  [:project
   [x1 x2]
   [:apply
-   :semi-join
-   {x2 ?x13, x4 ?x14}
+   {:mode :semi-join, :columns {x2 ?x13, x4 ?x14}}
    [:mega-join
     []
     [[:rename {a x1, b x2} [:scan {:table r} [a b]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
@@ -3,8 +3,7 @@
  [:select
   {:predicate _sq_3}
   [:apply
-   {:mark-join {_sq_3 true}}
-   {y.2/biz ?_sq_biz_5, x.1/foo ?_sq_foo_4}
+   {:mode :mark-join, :columns {y.2/biz ?_sq_biz_5, x.1/foo ?_sq_foo_4}, :mark-join-projection {_sq_3 true}}
    [:mega-join
     []
     [[:rename x.1 [:scan {:table #xt/table x} [foo]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -6,8 +6,7 @@
    [:select
     {:predicate (== bar.2/c _sq_3)}
     [:apply
-     :single-join
-     {bar.2/b ?_sq_b_4}
+     {:mode :single-join, :columns {bar.2/b ?_sq_b_4}}
      [:rename bar.2 [:scan {:table #xt/table bar} [c b]]]
      [:project
       [{_sq_3 foo.4/b}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -6,8 +6,7 @@
    [:select
     {:predicate _sq_3}
     [:apply
-     {:mark-join {_sq_3 (== ?_needle b)}}
-     {bar.2/b ?_sq_b_4, bar.2/c ?_needle}
+     {:mode :mark-join, :columns {bar.2/b ?_sq_b_4, bar.2/c ?_needle}, :mark-join-projection {_sq_3 (== ?_needle b)}}
      [:rename bar.2 [:scan {:table #xt/table bar} [c b]]]
      [:project
       [{b foo.4/b}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
@@ -3,8 +3,7 @@
  [:project
   [x7]
   [:apply
-   :single-join
-   {x1 ?x8, x2 ?x9}
+   {:mode :single-join, :columns {x1 ?x8, x2 ?x9}}
    [:rename
     {_valid_from x1, _valid_to x2}
     [:scan {:table bar} [_valid_from _valid_to]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
@@ -3,8 +3,7 @@
  [:project
   [x4]
   [:apply
-   :single-join
-   {x1 ?x8, x2 ?x9}
+   {:mode :single-join, :columns {x1 ?x8, x2 ?x9}}
    [:rename
     {_valid_from x1, _valid_to x2}
     [:scan {:table bar} [_valid_from _valid_to]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -1,8 +1,7 @@
 [:project
  [{_column_1 _sq_2}]
  [:apply
-  :single-join
-  {a.1/b ?_sq_b_3}
+  {:mode :single-join, :columns {a.1/b ?_sq_b_3}}
   [:rename a.1 [:scan {:table #xt/table a} [{a (== a 42)} b]]]
   [:group-by
    [{_sq_2 (vec_agg b1)}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
@@ -1,8 +1,7 @@
 [:project
  [{customer_id c.1/_id} {name c.1/name} {orders _sq_2}]
  [:apply
-  :single-join
-  {c.1/_id ?_sq__id_3}
+  {:mode :single-join, :columns {c.1/_id ?_sq__id_3}}
   [:rename c.1 [:scan {:table #xt/table customers} [_id name]]]
   [:group-by
    [{_sq_2 (array_agg _sq_2)}]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
@@ -1,8 +1,7 @@
 [:project
  [{order_id o.1/_id} {value o.1/value} {customer _sq_2}]
  [:apply
-  :single-join
-  {o.1/customer_id ?_sq_customer_id_3}
+  {:mode :single-join, :columns {o.1/customer_id ?_sq_customer_id_3}}
   [:rename
    o.1
    [:scan {:table #xt/table orders} [customer_id _id value]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
@@ -1,8 +1,7 @@
 [:project
  [{_column_1 _sq_2}]
  [:apply
-  :single-join
-  {bar.1/_valid_time ?_sq__valid_time_3}
+  {:mode :single-join, :columns {bar.1/_valid_time ?_sq__valid_time_3}}
   [:rename
    bar.1
    [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
@@ -1,8 +1,7 @@
 [:project
  [{_column_1 _sq_2}]
  [:apply
-  :single-join
-  {bar.1/_valid_time ?_sq__valid_time_3}
+  {:mode :single-join, :columns {bar.1/_valid_time ?_sq__valid_time_3}}
   [:rename
    bar.1
    [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/use-parent-left-scope-in-nested-join-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/use-parent-left-scope-in-nested-join-table.edn
@@ -1,8 +1,7 @@
 [:project
  [{i1 u1.4/i1} {i2 u2.6/i2} {x1 u1.4/x1} {x2 u2.6/x2}]
  [:apply
-  :cross-join
-  {r1.1/xs ?_sq_xs_2, r2.2/xs ?_sq_xs_4}
+  {:mode :cross-join, :columns {r1.1/xs ?_sq_xs_2, r2.2/xs ?_sq_xs_4}}
   [:mega-join
    []
    [[:rename r1.1 [:scan {:table #xt/table r1} [xs]]]


### PR DESCRIPTION
Removes structural differences between mark and other modes.

Also fixes bug in push-selection-down-past-apply rule which was incorrectly matching on :join, which isn't an apply mode.