### PR TITLE
TxSink - Add initialScan

### DIFF
--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -229,6 +229,25 @@
        ;; the sort is needed as the table blocks need the current tries to be in the total order for restart
        (sort-by (juxt :level :block-idx #(or (:recency %) LocalDate/MAX)))))
 
+(defn l0-tries
+  [{:keys [tries]}]
+  (let [{:keys [live garbage]} (get tries [0 nil []])]
+    (concat live garbage)))
+
+(defn l0-blocks
+  "Returns a sorted seq of L0 blocks: [{:block-idx N, :tables [{:table TableRef, :trie-key String}]}]"
+  [^xtdb.trie.TrieCatalog trie-cat]
+  (->> (.getTables trie-cat)
+       (mapcat (fn [table]
+                 (map (fn [{:keys [block-idx trie-key]}]
+                        [block-idx {:table table :trie-key trie-key}])
+                      (l0-tries (trie-state trie-cat table)))))
+       (group-by first)
+       (map (fn [[block-idx pairs]]
+              {:block-idx block-idx
+               :tables (mapv second pairs)}))
+       (sort-by :block-idx)))
+
 (defn partitions [{:keys [tries]}]
   (map (fn [[[level recency part] {:keys [max-block-idx live nascent garbage]}]]
          {:level level

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -229,5 +229,6 @@
                  (-> (.getCompactor) (.threads 0))
                  (.setServer nil)
                  (.setFlightSql nil)
-                 (some-> (.getTxSink) (.enable true)))]
+                 (some-> (.getTxSink) (.enable true))
+                 (.readOnlyDatabases true))]
     (.open config)))

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -18,6 +18,7 @@
   ([^RelationReader rel start]
    (let [row-count (.getRowCount rel)
          iid-vec (.vectorFor rel "_iid")
+         system-from-vec (.vectorFor rel "_system_from")
          valid-from-vec (.vectorFor rel "_valid_from")
          valid-to-vec (.vectorFor rel "_valid_to")
          op-vec (.vectorFor rel "op")
@@ -27,6 +28,7 @@
              (let [leg (.getLeg op-vec i)]
                (cond-> {:iid (.getObject iid-vec i)
                         :valid-from (time/->instant (.getObject valid-from-vec i))
+                        :system-from (time/->instant (.getObject system-from-vec i))
                         :valid-to (let [vt (.getLong valid-to-vec i)]
                                     (when-not (= Long/MAX_VALUE vt)
                                       (time/->instant (.getObject valid-to-vec i))))}

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -117,13 +117,12 @@
 
 (defn- output-block-txs!
   [^Log output-log grouped-txs db-name block-idx encode-fn]
-  (loop [remaining-txs grouped-txs
-         tx-key nil]
-    (if-let [[system-time events] (first remaining-txs)]
-      (let [{:keys [tx-key message]} (events->tx-output system-time events db-name block-idx encode-fn)]
-        @(.appendMessage output-log message)
-        (recur (rest remaining-txs) tx-key))
-      tx-key)))
+  (reduce (fn [_ [system-time events]]
+            (let [{:keys [tx-key message]} (events->tx-output system-time events db-name block-idx encode-fn)]
+              @(.appendMessage output-log message)
+              tx-key))
+          nil
+          grouped-txs))
 
 (defn backfill-from-l0!
   [^BufferAllocator al ^BufferPool bp ^Log output-log db-name encode-fn ^TrieCatalog trie-cat last-message refresh!]

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -44,7 +44,7 @@
     {:db (.getDbName table)
      :schema (.getSchemaName table)
      :table (.getTableName table)
-     :ops (read-relation-rows live-relation start-pos)}))
+     :ops (map #(dissoc % :system-from) (read-relation-rows live-relation start-pos))}))
 
 (defn ->encode-fn [fmt]
   (case fmt
@@ -108,7 +108,7 @@
                                        {:db (.getDbName table)
                                         :schema (.getSchemaName table)
                                         :table (.getTableName table)
-                                        :ops events}))
+                                        :ops (map #(dissoc % :system-from) events)}))
                                 (into []))}
                   encode-fn
                   Log$Message$Tx.)}))

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -81,10 +81,11 @@
                      (update-vals #(mapv :event %)))]))
        (sort-by first)))
 
-(defmethod xtn/apply-config! :xtdb/tx-sink [^Xtdb$Config config _ {:keys [output-log format enable db-name]}]
+(defmethod xtn/apply-config! :xtdb/tx-sink [^Xtdb$Config config _ {:keys [output-log format enable db-name initial-scan]}]
   (.txSink config
            (cond-> (TxSinkConfig.)
              (some? enable) (.enable enable)
+             (some? initial-scan) (.initialScan initial-scan)
              (some? output-log) (.outputLog (log/->log-factory (first output-log) (second output-log)))
              (some? db-name) (.dbName db-name)
              (some? format) (.format (str (symbol format))))))

--- a/core/src/main/clojure/xtdb/tx_sink.clj
+++ b/core/src/main/clojure/xtdb/tx_sink.clj
@@ -76,6 +76,14 @@
         event (read-l0-data-file allocator buffer-pool (Trie/dataFilePath table trie-key))]
     {:table table :event event}))
 
+(defn group-events-by-system-time
+  [events]
+  (->> (group-by #(get-in % [:event :system-from]) events)
+       (map (fn [[k entries]]
+              [k (-> (group-by :table entries)
+                     (update-vals #(mapv :event %)))]))
+       (sort-by first)))
+
 (defmethod xtn/apply-config! :xtdb/tx-sink [^Xtdb$Config config _ {:keys [output-log format enable db-name]}]
   (.txSink config
            (cond-> (TxSinkConfig.)

--- a/core/src/main/kotlin/xtdb/api/TxSinkConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/TxSinkConfig.kt
@@ -8,11 +8,13 @@ data class TxSinkConfig(
     var dbName: String = "xtdb",
     var format: String = "transit+json",
     var outputLog: Log.Factory = Log.inMemoryLog,
+    var initialScan: Boolean = false,
 ) {
     // NOTE: Intentionally not serialized to prevent accidental enabling in cluster config
     var enable: Boolean = false
 
     fun enable(enable: Boolean = true) = apply { this.enable = enable }
+    fun initialScan(initialScan: Boolean) = apply { this.initialScan = initialScan }
     fun dbName(dbName: String) = apply { this.dbName = dbName }
     fun format(format: String) = apply { this.format = format }
     fun outputLog(log: Log.Factory) = apply { this.outputLog = log }

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -16,7 +16,8 @@
            (java.util.concurrent ConcurrentHashMap)
            (xtdb.api.storage ObjectStore$StoredObject)
            (xtdb.log.proto TemporalMetadata TrieMetadata)
-           (xtdb.trie_catalog TrieCatalog)))
+           (xtdb.trie_catalog TrieCatalog)
+           (xtdb.table TableRef)))
 
 (t/use-fixtures :once tu/with-allocator)
 
@@ -752,3 +753,44 @@
                  "l03-rc-p00-b01" "l03-rc-p01-b01" "l03-rc-p02-b01" "l03-rc-p03-b01"}
                (trie-keys (cat/all-tries (cat/trie-state cat table))))
             "garbage tries are removed"))))
+
+(t/deftest test-l0-blocks
+  (tu/with-tmp-dirs #{node-dir}
+    (with-open [node (tu/->local-node {:node-dir node-dir :compactor-threads 0})]
+      (let [trie-cat (.getTrieCatalog (db/primary-db node))]
+        (t/is (empty? (cat/l0-blocks trie-cat))
+              "Empty node should have no L0 blocks")
+
+        (xt/execute-tx node [[:put-docs :table_a {:xt/id 1}]
+                             [:put-docs :table_b {:xt/id 2}]])
+        (t/is (empty? (cat/l0-blocks trie-cat))
+              "Before finish-block, should still have no L0 blocks")
+
+        (tu/finish-block! node)
+        (t/is (= [0] (map :block-idx (cat/l0-blocks trie-cat)))
+              "Should have 1 block after first finish-block")
+
+        (xt/execute-tx node [[:put-docs :table_c {:xt/id 3}]])
+        (tu/finish-block! node)
+        (let [blocks (cat/l0-blocks trie-cat)
+              tables (for [block blocks]
+                       (for [t (:tables block)]
+                         (-> t :table TableRef/.getTableName keyword)))]
+          (t/is (= 2 (count blocks)) "Should have 2 blocks after second finish-block")
+          (t/is (= [0 1] (map :block-idx blocks)))
+          (t/is (= [[:table_a :table_b :txs] [:table_c :txs]] tables)))))))
+
+(t/deftest test-l0-blocks-includes-garbage
+  (tu/with-tmp-dirs #{node-dir}
+    (with-open [node (tu/->local-node {:node-dir node-dir :compactor-threads 1})]
+      (doseq [i (range 4)]
+        (xt/execute-tx node [[:put-docs :foo {:xt/id i}]])
+        (tu/finish-block! node))
+      (c/compact-all! node #xt/duration "PT1S")
+
+      (let [trie-cat (.getTrieCatalog (db/primary-db node))
+            blocks (cat/l0-blocks trie-cat)]
+        (t/is (seq (cat/compacted-trie-keys (cat/trie-state trie-cat #xt/table foo)))
+              "Compaction should have created non-L0 files")
+        (t/is (= 4 (count blocks))
+              "All L0 blocks should be visible even after compaction")))))

--- a/src/test/clojure/xtdb/tx_sink_kafka_test.clj
+++ b/src/test/clojure/xtdb/tx_sink_kafka_test.clj
@@ -10,12 +10,21 @@
             [xtdb.util :as util]
             [xtdb.api :as xt])
   (:import [org.apache.kafka.clients.consumer ConsumerRecord KafkaConsumer]
+           [org.apache.kafka.clients.admin AdminClient RecordsToDelete OffsetSpec ListOffsetsResult$ListOffsetsResultInfo]
+           [org.apache.kafka.common TopicPartition]
            org.testcontainers.kafka.ConfluentKafkaContainer
            org.testcontainers.utility.DockerImageName
            [xtdb.test.log RecordingLog]
            [xtdb.api.storage ObjectStore$StoredObject]))
 
 (def ^:private ^:dynamic *bootstrap-servers* nil)
+
+(defn truncate-topic [log-topic]
+  (with-open [^AdminClient admin (AdminClient/create (java.util.Map/of "bootstrap.servers" *bootstrap-servers*))]
+    (let [tp (TopicPartition. log-topic 0)
+          end-offsets @(.all (.listOffsets admin {tp (OffsetSpec/latest)}))
+          end-offset (.offset ^ListOffsetsResult$ListOffsetsResultInfo (get end-offsets tp))]
+      @(.all (.deleteRecords admin {tp (RecordsToDelete/beforeOffset end-offset)})))))
 
 (defonce ^ConfluentKafkaContainer kafka-container
   (ConfluentKafkaContainer. (DockerImageName/parse "confluentinc/cp-kafka:7.8.0")))
@@ -82,9 +91,9 @@
       (with-open [node (xtn/start-node node-opts)]
         (jdbc/execute! node ["INSERT INTO docs RECORDS {_id: 1}"])
         (let [msgs (consume-messages *bootstrap-servers* output-topic)]
-          (t/is (= 1 (count msgs)))
+          (t/is (= 1 (count msgs)))))
           ;; NOTE: No flush here, so offset isn't be committed yet
-          ,))
+
       ;; Restart node
       (with-open [node (xtn/start-node node-opts)]
         ;; Flush block to ensure node has processed all messages
@@ -184,6 +193,65 @@
 
             (t/is (= 1 (count (get-blocks)))
                   "After GC, only block 1 should exist")))
+
+        (deliver resume-backfill true)
+        ; TxSink will now resume and move onto indexing
+
+        (t/is (= (deref result 5000 :timeout) 3))
+        (t/is (not= (deref done 5000 :timeout) :timeout))))))
+
+(t/deftest ^:integration test-log-truncated-during-backfill
+  (util/with-tmp-dirs #{node-dir}
+    (let [log-topic (str "xtdb.kafka-test." (random-uuid))]
+      ;; Create block 0
+      (with-open [node (xtn/start-node {:storage [:local {:path (.resolve node-dir "storage")}]
+                                        :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                                        :log [:kafka {:cluster :my-kafka :topic log-topic}]
+                                        :compactor {:threads 0}})]
+        (xt/submit-tx node [[:put-docs :docs {:xt/id 0}]])
+        (tu/flush-block! node))
+
+      (let [first-block-done (promise)
+            resume-backfill (promise)
+            result (promise)
+            done (promise)]
+        ;; Start backfill in background thread then block
+        ;; This is to simulate the tx-sink taking so long that other nodes have moved on
+        (future
+          (try
+            (binding [tx-sink/*after-block-hook*
+                      (fn [block-idx]
+                        (when (= block-idx 0)
+                          (deliver first-block-done true)
+                          @resume-backfill))]
+              (with-open [node (xtn/start-node {:storage [:local {:path (.resolve node-dir "storage")}]
+                                                :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                                                :log [:kafka {:cluster :my-kafka :topic log-topic}]
+                                                :compactor {:threads 0}
+                                                :tx-sink {:enable true
+                                                          :initial-scan true
+                                                          :output-log [::tu/recording {}]
+                                                          :format :transit+json}})]
+                ; Works where sync & await-node don't for some reason
+                (xt/submit-tx node [[:put-docs :docs {:xt/id 2}]])
+                (deliver result (count (.getMessages ^RecordingLog (tu/get-output-log node))))))
+            (catch Exception e
+              (deliver result e)))
+          (deliver done true))
+
+        (deref first-block-done 5000 :timeout)
+
+        (with-open [node (xtn/start-node {:storage [:local {:path (.resolve node-dir "storage")}]
+                                          :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                                          :log [:kafka {:cluster :my-kafka :topic log-topic}]
+                                          :compactor {:threads 0}
+                                          :garbage-collector {:enabled true
+                                                              :blocks-to-keep 1
+                                                              :garbage-lifetime #xt/duration "PT1S"}})]
+          (xt/submit-tx node [[:put-docs :docs {:xt/id 1}]])
+          (tu/flush-block! node))
+
+        (truncate-topic log-topic)
 
         (deliver resume-backfill true)
         ; TxSink will now resume and move onto indexing

--- a/src/test/clojure/xtdb/tx_sink_test.clj
+++ b/src/test/clojure/xtdb/tx_sink_test.clj
@@ -53,7 +53,7 @@
                                     :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
-                                    :doc {"_id" :doc1, "value" "test"}}]}
+                                    :doc {:xt/id :doc1, :value "test"}}]}
                             {:db "xtdb"
                              :schema "xt"
                              :table "txs"
@@ -62,9 +62,9 @@
                                     :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
-                                    :doc {"_id" 0
-                                          "system_time" #xt/zdt "2020-01-01T00:00[UTC]"
-                                          "committed" true}}]}]})
+                                    :doc {:xt/id 0
+                                          :system-time #xt/zdt "2020-01-01T00:00[UTC]"
+                                          :committed true}}]}]})
                  (util/->clj msg))))
 
       (jdbc/execute! node ["INSERT INTO docs RECORDS {_id: 1, a: 1, b: {c: [1, 2, 3], d: 'test'}}, {_id: 2, a: 2}, {_id: 3, a: 3}"])
@@ -207,7 +207,7 @@
           (let [puts (filter #(= :put (:op %)) rows)]
             (t/is (= 2 (count puts)))
             (t/is (every? :doc puts))
-            (t/is (= #{"first" "second"} (->> puts (map #(get-in % [:doc "value"])) set)))))
+            (t/is (= #{"first" "second"} (->> puts (map #(get-in % [:doc :value])) set)))))
 
         (t/testing "delete operations"
           (let [deletes (filter #(= :delete (:op %)) rows)]
@@ -239,7 +239,7 @@
                                 (filter (fn [{:keys [^TableRef table]}]
                                           (= table-filter (.getTableName table))))
                                 (map :event)))
-            event-values #(get-in % [:doc "value"])]
+            event-values #(get-in % [:doc :value])]
         (t/is (= [0 1] (map :block-idx blocks)))
         (let [{:keys [tables]} (first blocks)
               events (tx-sink/read-l0-events allocator bp tables)

--- a/src/test/clojure/xtdb/tx_sink_test.clj
+++ b/src/test/clojure/xtdb/tx_sink_test.clj
@@ -427,8 +427,7 @@
               msgs (->> (.getMessages output-log) (map decode-record))]
           (t/is (= (util/->clj msgs) (util/->clj original-messages))))))))
 
-(t/deftest test-initial-scan-skips-unflushed-transactions
-  ; NOTE: This behavior will change with #5055
+(t/deftest test-initial-scan-catches-up-to-latest-block
   (util/with-tmp-dirs #{node-dir}
     (let [original-messages
           (with-open [node (xtn/start-node {:storage [:local {:path (.resolve node-dir "storage")}]
@@ -462,8 +461,7 @@
                                                   :format :transit+json}})]
         (xt-log/sync-node node #xt/duration "PT5S")
         (let [^RecordingLog output-log (tu/get-output-log node)]
-          (t/is (= original-messages (.getMessages output-log))
-                "No new messages should be output"))))))
+          (t/is (= 3 (count (.getMessages output-log)))))))))
 
 (t/deftest test-initial-scan-reads-garbage-l0s
   (util/with-tmp-dirs #{node-dir}

--- a/src/test/clojure/xtdb/tx_sink_test.clj
+++ b/src/test/clojure/xtdb/tx_sink_test.clj
@@ -42,7 +42,6 @@
                              :table "docs"
                              :ops [{:op :put
                                     :iid (util/->iid :doc1)
-                                    :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
                                     :doc {:xt/id :doc1, :value "test"}}]}
@@ -51,7 +50,6 @@
                              :table "txs"
                              :ops [{:op :put
                                     :iid (util/->iid 0)
-                                    :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
                                     :doc {:xt/id 0
@@ -209,7 +207,6 @@
         (t/testing "all rows have required temporal fields"
           (t/is (every? :iid rows))
           (t/is (every? :valid-from rows))
-          (t/is (every? :system-from rows))
           (t/is (every? #(contains? % :valid-to) rows)))))))
 
 (t/deftest test-read-l0-events

--- a/src/test/clojure/xtdb/tx_sink_test.clj
+++ b/src/test/clojure/xtdb/tx_sink_test.clj
@@ -48,6 +48,7 @@
                              :table "docs"
                              :ops [{:op :put
                                     :iid (util/->iid :doc1)
+                                    :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
                                     :doc {"_id" :doc1, "value" "test"}}]}
@@ -56,6 +57,7 @@
                              :table "txs"
                              :ops [{:op :put
                                     :iid (util/->iid 0)
+                                    :system-from #xt/instant "2020-01-01T00:00Z"
                                     :valid-from  #xt/instant "2020-01-01T00:00Z"
                                     :valid-to nil
                                     :doc {"_id" 0
@@ -213,4 +215,5 @@
         (t/testing "all rows have required temporal fields"
           (t/is (every? :iid rows))
           (t/is (every? :valid-from rows))
+          (t/is (every? :system-from rows))
           (t/is (every? #(contains? % :valid-to) rows)))))))

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -35,6 +35,7 @@
            (xtdb.test.log RecordingLog$Factory)
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader Vector VectorType)
+           [xtdb.database Database Database$Catalog]
            xtdb.database.Database$Catalog
            (xtdb.indexer LiveTable)
            (xtdb.log.proto TemporalMetadata TemporalMetadata$Builder)
@@ -409,3 +410,15 @@
     (when (zero? (mod i 100))
       (println (format "Run %d/%d" i n)))
     (t/test-vars [test-var])))
+
+(defn database-or-null ^Database [node db-name]
+  (let [^Database$Catalog db-cat (util/component node :xtdb/db-catalog)]
+    (-> db-cat
+        (.databaseOrNull db-name))))
+
+(defn get-output-log
+  ([node] (get-output-log node "xtdb"))
+  ([node db-name]
+   (-> (database-or-null node db-name)
+       (.getTxSink)
+       :output-log)))

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -422,3 +422,8 @@
    (-> (database-or-null node db-name)
        (.getTxSink)
        :output-log)))
+
+(defn get-trie-cat
+  ([node] (get-trie-cat node "xtdb"))
+  ([node db-name]
+   (.getTrieCatalog (database-or-null node db-name))))


### PR DESCRIPTION
Currently TxSink will skip messages in two scenarios:
1. When the `latestSubmittedTx` from the object store is later than the TxId from the last message on the output-log
2. When there is no last message on the output log (i.e. we're starting up for the first time)

<details><summary>Visual description</summary>

<img width="1055" height="415" alt="image" src="https://github.com/user-attachments/assets/ace8fd10-1262-44ef-8e02-0f666ae7b8ff" />

</details>


This PR aims to fix that by in both scenarios reading events from the object store.
In case 1 we read the last message from the output-log and see what blocks we need to read in order to catch up.
In case 2 we default to skipping reading from the beginning of time unless you specify `initialScan: true` in the txSink config:

```yaml
txSink:
  ...
  initialScan: true ; defaults to false
```

We read from the object store instead of from the log because:
- The log may have been truncated so we can't rely on it
- It might be quicker to read from L0 files instead of processing the whole transaction (not confirmed this though)

---

> [!WARNING]
> There is a breaking change related to the output format of `:doc`s in the output. They now output as "proper" transit, the biggest  change is that keys are now keywords and `"_id"` is now `:xt/id`
> Here's an example of how a transaction:
> ```sql
> BEGIN TRANSACTION;
>   INSERT INTO docs RECORDS {_id: 1, a: 1, b: {c: [1, 2, 3], d: 'test'}}, {_id: 2, a: 2}, {_id: 3, a: 3};
>   UPDATE docs SET a = 4 WHERE _id = 1;
>   DELETE FROM docs WHERE _id = 1;
>   ERASE FROM docs WHERE _id = 1;
>   INSERT INTO other RECORDS {_id: 1};
> COMMIT;
> ```
> Would output:
> ```clj
> {:transaction {:id #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-02T00:00:00Z"}},
>  :system-time #xt/instant "2020-01-02T00:00:00Z",
>  :source {:db xtdb, :block-idx 0},
>  :tables [{:db xtdb, :schema public, :table docs,
>            :ops [{:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc {:xt/id 1, :a 1, :b {:c [1 2 3], :d test}}}
>                  {:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc {:xt/id 2, :a 2}}
>                  {:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc {:xt/id 3, :a 3}}
>                  {:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc {:xt/id 1, :a 4, :b {:c [1 2 3], :d test}}}
>                  {:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :delete}]}
>           {:db xtdb, :schema public, :table other,
>            :ops [{:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc #:xt{:id 1}}]}
>           {:db xtdb, :schema xt, :table txs,
>            :ops [{:iid <iid>, :valid-from #xt/instant "2020-01-02T00:00:00Z", :valid-to nil, :op :put, :doc {:xt/id 1, :system-time #xt/zdt "2020-01-02T00:00Z[UTC]", :committed true}}]}]}
> ```
> Particularly note the different format of `:doc` and the addition of `:block-idx` to the `:source`

> [!NOTE]
> The order of output `:opt` is only guaranteed between *iid*s, even within the same transaction.
> For example:
> ```sql
> BEGIN TRANSACTION;
>   INSERT INTO docs RECORDS {_id: 'a', v: 0};
>   INSERT INTO docs RECORDS {_id: 'a', v: 1};
>   INSERT INTO docs RECORDS {_id: 'b'};
> COMMIT
> ```
> Could output:
> ```clj
> {...
>  :tables [{...
>            :table "docs"
>            :opt [{... :doc {:xt/id "a" :v 0}}
>                   {... :doc {:xt/id "a" :v 1}}
>                   {... :doc {:xt/id "b"}}]}]}
> ; or
> {...
>  :tables [{...
>            :table "docs"
>            :opt [{... :doc {:xt/id "b"}}
>                   {... :doc {:xt/id "a" :v 0}}
>                   {... :doc {:xt/id "a" :v 1}}]}]}
> ```
> `:opt` for the same `iid` will always be in the same order as in the transaction.

---

Changes:
- When configured with `initial-scan` TxSink now scans `L0` files from the beginning of time out to the output-log
- When TxSink starts up and the previous message is from *before* the end of the previous block, reads events from `L0` files to catch up with the log
- Refactors `read-relation-rows` which also changes the output format of `:doc`
  - Used to output string columns `"_id"`, now outputs keyword columns `:xt/id`
- Make the TxSink node a read-only node

Fixes: #5054, #5055 