### PR TITLE
Fix to ensure identical structs are deduplicated (#5113) 

### DIFF
--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -2142,3 +2142,20 @@
   (t/is (false? (project1 '(=== "foo" "bar") {})))
   (t/is (true? (project1 '(=== a a) {:a nil})) "null === null")
   (t/is (nil? (project1 '(== a a) {:a nil})) "null == null returns null"))
+
+(t/deftest test-struct-equality
+  (t/testing "non-strict equality (==)"
+    (t/is (true? (project1 '(== {} {}) {})))
+    (t/is (true? (project1 '(== {:a 1, :b 2} {:a 1, :b 2}) {})))
+    (t/is (false? (project1 '(== {:a 1, :b 2} {:a 1, :b 3}) {})))
+    (t/is (false? (project1 '(== {:a 1} {:a 1, :b 2}) {})))
+    (t/is (false? (project1 '(== {:a 1, :b 2} {:a 1}) {})))
+    (t/is (true? (project1 '(== {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3.0}) {})) "int == float"))
+
+  (t/testing "strict equality (===)"
+    (t/is (true? (project1 '(=== {} {}) {})))
+    (t/is (true? (project1 '(=== {:a 1, :b 2} {:a 1, :b 2}) {})))
+    (t/is (false? (project1 '(=== {:a 1, :b 2} {:a 1, :b 3}) {})))
+    (t/is (false? (project1 '(=== {:a 1} {:a 1, :b 2}) {})))
+    (t/is (false? (project1 '(=== {:a 1, :b 2} {:a 1}) {})))
+    (t/is (false? (project1 '(=== {:a 1, :b 2, :c 3} {:a 1, :b 2, :c 3.0}) {})) "int !== float")))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -3115,3 +3115,12 @@ UNION ALL
     (xt/execute-tx tu/*node* [["UPDATE docs SET i = ? WHERE _id = ?"  #xt/interval "P12MT2S" 1]])
     (t/is (= 2 (count (xt/q tu/*node* "SELECT * FROM docs FOR VALID_TIME ALL"))))
     (t/is (= [{:xt/id 1, :i #xt/interval "P12MT2S"}] (xt/q tu/*node* "FROM docs")))))
+
+(t/deftest update-dedup-structs-5113
+  (t/testing "update with identical struct should be deduplicated"
+    (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :a {:x 0}}]])
+    (t/is (= [{:xt/id 1, :a {:x 0}}] (xt/q tu/*node* "FROM docs")))
+
+    (xt/execute-tx tu/*node* [[:sql "UPDATE docs SET a = ? WHERE _id = 1" [{:x 0}]]])
+    (t/is (= [{:xt/id 1, :a {:x 0}}] (xt/q tu/*node* "FROM docs")))
+    (t/is (= 1 (count (xt/q tu/*node* "SELECT * FROM docs FOR VALID_TIME ALL"))))))


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions?query=branch%3A5113-update-dedupe-structs++

We were seeing in #5113 that identical structs were never being de-duplicated and any UPDATE with a struct would create a new document version.

This was because we had no specific `[:=== :struct :struct]` implementation - we therefore fell back to the === :any implementation.
- [:=== :any :any] uses clojure.core/= under the hood, which would fail for identical structs due to them containing ValueBox fields at runtime (equality would check object identity rather contents and fail as a result)
- We would essentially never de-duplicate structs as a result.

This PR adds an implementation of `[:=== :struct :struct]`:
- Identical to `== :struct :struct`, though comparing fields with `===`.   
- Also adds a set of tests around struct equality and a test that 5113 itself is fixed.
                      